### PR TITLE
[11.x] Adding withAttribute method 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -629,7 +629,7 @@ trait QueriesRelationships
 
             $relation = $this->getRelationWithoutConstraints($name);
 
-            if ($function) {
+            if ($function && $function !== 'attribute') {
                 if ($this->getQuery()->getGrammar()->isExpression($column)) {
                     $aggregateColumn = $this->getQuery()->getGrammar()->getValue($column);
                 } else {
@@ -659,8 +659,8 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            // we can allow orderings on the sub-select if the function is null
-            if ($function !== null) {
+            // we can allow orderings on the sub-select if the function is 'attribute'
+            if ($function !== 'attribute') {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }
@@ -790,7 +790,7 @@ trait QueriesRelationships
      */
     public function withAttribute($relation, $column)
     {
-        return $this->withAggregate($relation, $column);
+        return $this->withAggregate($relation, $column, 'attribute');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,7 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            if ($function !== null && is_countable($query->orders) && count($query->orders) !== 1) {
+            if ($function !== null) {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -629,7 +629,7 @@ trait QueriesRelationships
 
             $relation = $this->getRelationWithoutConstraints($name);
 
-            if ($function && $function !== 'attribute') {
+            if ($function) {
                 if ($this->getQuery()->getGrammar()->isExpression($column)) {
                     $aggregateColumn = $this->getQuery()->getGrammar()->getValue($column);
                 } else {
@@ -659,8 +659,8 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            // we can allow orderings on the sub-select if the function is 'attribute'
-            if ($function !== 'attribute') {
+            // we can allow orderings on the sub-select if the function is 'null'
+            if ($function !== null) {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }
@@ -684,7 +684,7 @@ trait QueriesRelationships
                 )->withCasts([$alias => 'bool']);
             } else {
                 $this->selectSub(
-                    is_null($function) || $function === 'attribute' ? $query->limit(1) : $query,
+                    $function ? $query : $query->limit(1),
                     $alias
                 );
             }
@@ -790,7 +790,7 @@ trait QueriesRelationships
      */
     public function withAttribute($relation, $column)
     {
-        return $this->withAggregate($relation, $column, 'attribute');
+        return $this->withAggregate($relation, $column);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,8 +659,8 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            // we can allow orderings on the sub-select if the function is 'attribute'
-            if ($function !== 'attribute') {
+            // we can allow orderings on the sub-select if the function is null
+            if ($function !== null) {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }
@@ -790,7 +790,7 @@ trait QueriesRelationships
      */
     public function withAttribute($relation, $column)
     {
-        return $this->withAggregate($relation, $column, 'attribute');
+        return $this->withAggregate($relation, $column);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,6 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
+            // we can allow orderings on the sub-select if the function is 'attribute'
             if ($function !== 'attribute') {
                 $query->orders = null;
                 $query->setBindings([], 'order');

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,7 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            $query->orders = null;
+            $query->orders = is_countable($query->orders) && count($query->orders) > 1 ? [$query->orders[0]] : $query->orders;
             $query->setBindings([], 'order');
 
             if (count($query->columns) > 1) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -781,6 +781,18 @@ trait QueriesRelationships
     }
 
     /**
+     * Add subselect queries to include the column of the relation.
+     *
+     * @param  string|array  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function withAttribute($relation, $column)
+    {
+        return $this->withAggregate($relation, $column);
+    }
+
+    /**
      * Add the "has" condition where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,8 +659,10 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            $query->orders = is_countable($query->orders) && count($query->orders) > 1 ? [$query->orders[0]] : $query->orders;
-            $query->setBindings([], 'order');
+            if (is_countable($query->orders) && count($query->orders) !== 1) {
+                $query->orders = null;
+                $query->setBindings([], 'order');
+            }
 
             if (count($query->columns) > 1) {
                 $query->columns = [$query->columns[0]];

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -684,7 +684,7 @@ trait QueriesRelationships
                 )->withCasts([$alias => 'bool']);
             } else {
                 $this->selectSub(
-                    $function ? $query : $query->limit(1),
+                    is_null($function) || $function === 'attribute' ? $query->limit(1) : $query,
                     $alias
                 );
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -629,7 +629,7 @@ trait QueriesRelationships
 
             $relation = $this->getRelationWithoutConstraints($name);
 
-            if ($function) {
+            if ($function && $function !== 'attribute') {
                 if ($this->getQuery()->getGrammar()->isExpression($column)) {
                     $aggregateColumn = $this->getQuery()->getGrammar()->getValue($column);
                 } else {
@@ -659,8 +659,8 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            // we can allow orderings on the sub-select if the function is 'null'
-            if ($function !== null) {
+            // we can allow orderings on the sub-select if the function is 'attribute'
+            if ($function !== 'attribute') {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }
@@ -684,7 +684,7 @@ trait QueriesRelationships
                 )->withCasts([$alias => 'bool']);
             } else {
                 $this->selectSub(
-                    $function ? $query : $query->limit(1),
+                    is_null($function) || $function === 'attribute' ? $query->limit(1) : $query,
                     $alias
                 );
             }
@@ -790,7 +790,7 @@ trait QueriesRelationships
      */
     public function withAttribute($relation, $column)
     {
-        return $this->withAggregate($relation, $column);
+        return $this->withAggregate($relation, $column, 'attribute');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,7 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            if (is_countable($query->orders) && count($query->orders) !== 1) {
+            if ($function !== null && is_countable($query->orders) && count($query->orders) !== 1) {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,7 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            if ($function !== null) {
+            if ($function !== 'attribute') {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }
@@ -789,7 +789,7 @@ trait QueriesRelationships
      */
     public function withAttribute($relation, $column)
     {
-        return $this->withAggregate($relation, $column);
+        return $this->withAggregate($relation, $column, 'attribute');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -838,7 +838,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function loadAttribute($relations, $column)
     {
-        return $this->loadAggregate($relations, $column, 'attribute');
+        return $this->loadAggregate($relations, $column);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -838,7 +838,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function loadAttribute($relations, $column)
     {
-        return $this->loadAggregate($relations, $column);
+        return $this->loadAggregate($relations, $column, 'attribute');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -830,6 +830,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Eager load related column value on the model.
+     *
+     * @param  array|string  $relations
+     * @param  string  $column
+     * @return $this
+     */
+    public function loadAttribute($relations, $column)
+    {
+        return $this->loadAggregate($relations, $column, 'attribute');
+    }
+
+    /**
      * Eager load relationship column aggregation on the polymorphic relation of a model.
      *
      * @param  string  $relation

--- a/tests/Integration/Database/EloquentModelLoadAttributeTest.php
+++ b/tests/Integration/Database/EloquentModelLoadAttributeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelLoadSumTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelLoadAttributeTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('base_models', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('related1s', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('base_model_id');
+            $table->string('column_name');
+        });
+
+        Schema::create('related2s', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('base_model_id');
+            $table->string('column_name');
+        });
+
+        BaseModel::create();
+
+        Related1::create(['base_model_id' => 1, 'column_name' => 'value1']);
+        Related1::create(['base_model_id' => 1, 'column_name' => 'value12']);
+        Related2::create(['base_model_id' => 1, 'column_name' => 'value2']);
+    }
+
+    public function testLoadSumSingleRelation()
+    {
+        $model = BaseModel::first();
+
+        DB::enableQueryLog();
+
+        $model->loadSum('related1', 'column_name');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertEquals('value1', $model->related1_attribute_column_name);
+    }
+
+    public function testLoadSumMultipleRelations()
+    {
+        $model = BaseModel::first();
+
+        DB::enableQueryLog();
+
+        $model->loadSum(['related1', 'related2'], 'column_name');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertEquals('value1', $model->related1_attribute_column_name);
+        $this->assertEquals('value2', $model->related2_attribute_column_name);
+    }
+}
+
+class BaseModel extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function related1()
+    {
+        return $this->hasMany(Related1::class);
+    }
+
+    public function related2()
+    {
+        return $this->hasMany(Related2::class);
+    }
+}
+
+class Related1 extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function parent()
+    {
+        return $this->belongsTo(BaseModel::class);
+    }
+}
+
+class Related2 extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function parent()
+    {
+        return $this->belongsTo(BaseModel::class);
+    }
+}

--- a/tests/Integration/Database/EloquentModelLoadAttributeTest.php
+++ b/tests/Integration/Database/EloquentModelLoadAttributeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelLoadSumTest;
+namespace Illuminate\Tests\Integration\Database\EloquentModelLoadAttributeTest;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
@@ -35,25 +35,25 @@ class EloquentModelLoadAttributeTest extends DatabaseTestCase
         Related2::create(['base_model_id' => 1, 'column_name' => 'value2']);
     }
 
-    public function testLoadSumSingleRelation()
+    public function testLoadAttributeSingleRelation()
     {
         $model = BaseModel::first();
 
         DB::enableQueryLog();
 
-        $model->loadSum('related1', 'column_name');
+        $model->loadAttribute('related1', 'column_name');
 
         $this->assertCount(1, DB::getQueryLog());
         $this->assertEquals('value1', $model->related1_attribute_column_name);
     }
 
-    public function testLoadSumMultipleRelations()
+    public function testLoadAttributeMultipleRelations()
     {
         $model = BaseModel::first();
 
         DB::enableQueryLog();
 
-        $model->loadSum(['related1', 'related2'], 'column_name');
+        $model->loadAttribute(['related1', 'related2'], 'column_name');
 
         $this->assertCount(1, DB::getQueryLog());
         $this->assertEquals('value1', $model->related1_attribute_column_name);

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -25,7 +25,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
     public function testItBasic()
     {
         $one = Model1::create();
-        $one->twos()->Create(['attribute' => 'value']);
+        $one->twos()->Create(['column' => 'value']);
 
         $results = Model1::withAttribute('twos', 'column');
 

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -45,7 +45,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
 
         $this->assertEquals([
-            ['id' => 4, 'twos_column_name' => 'value4'],
+            ['id' => 1, 'twos_column_name' => 'value4'],
         ], $results->get()->toArray());
     }
 }

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -18,19 +18,19 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         Schema::create('two', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
-            $table->string('column');
+            $table->string('column_name');
         });
     }
 
     public function testItBasic()
     {
         $one = Model1::create();
-        $one->twos()->Create(['column' => 'value']);
+        $one->twos()->Create(['column_name' => 'value']);
 
-        $results = Model1::withAttribute('twos', 'column');
+        $results = Model1::withAttribute('twos', 'column_name');
 
         $this->assertEquals([
-            ['id' => 1, 'twos_attribute_column' => 'value'],
+            ['id' => 1, 'twos_attribute_column_name' => 'value'],
         ], $results->get()->toArray());
     }
 }

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -47,7 +47,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
 
         $this->assertEquals([
-            ['id' => 4, 'twos_attribute_column_name' => 'value4']
+            ['id' => 4, 'twos_attribute_column_name' => 'value4'],
         ], $results->get()->toArray());
     }
 }

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -30,7 +30,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $results = Model1::withAttribute('twos', 'column_name');
 
         $this->assertEquals([
-            ['id' => 1, 'twos_column_name' => 'value'],
+            ['id' => 1, 'twos_attribute_column_name' => 'value'],
         ], $results->get()->toArray());
     }
 
@@ -45,7 +45,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
 
         $this->assertEquals([
-            ['id' => 1, 'twos_column_name' => 'value4'],
+            ['id' => 1, 'twos_attribute_column_name' => 'value4'],
         ], $results->get()->toArray());
     }
 }

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentwithAttributeTest;
+namespace Illuminate\Tests\Integration\Database\EloquentWithAttributeTest;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -30,7 +30,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $results = Model1::withAttribute('twos', 'column_name');
 
         $this->assertEquals([
-            ['id' => 1, 'twos_attribute_column_name' => 'value'],
+            ['id' => 1, 'twos_column_name' => 'value'],
         ], $results->get()->toArray());
     }
 
@@ -45,7 +45,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
 
         $this->assertEquals([
-            ['id' => 4, 'twos_attribute_column_name' => 'value4'],
+            ['id' => 4, 'twos_column_name' => 'value4'],
         ], $results->get()->toArray());
     }
 }

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -37,10 +37,12 @@ class EloquentWithAttributeTest extends DatabaseTestCase
     public function testSorting()
     {
         $one = Model1::create();
-        $one->twos()->create(['column_name' => 'value1']);
-        $one->twos()->create(['column_name' => 'value2']);
-        $one->twos()->create(['column_name' => 'value3']);
-        $one->twos()->create(['column_name' => 'value4']);
+        $one->twos()->createMany([
+            ['column_name' => 'value1'],
+            ['column_name' => 'value2'],
+            ['column_name' => 'value3'],
+            ['column_name' => 'value4'],
+        ]);
 
         $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
 

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -37,12 +37,10 @@ class EloquentWithAttributeTest extends DatabaseTestCase
     public function testSorting()
     {
         $one = Model1::create();
-        $one->twos()->createMany([
-            ['column_name' => 'value1'],
-            ['column_name' => 'value2'],
-            ['column_name' => 'value3'],
-            ['column_name' => 'value4'],
-        ]);
+        $one->twos()->create(['column_name' => 'value1']);
+        $one->twos()->create(['column_name' => 'value2']);
+        $one->twos()->create(['column_name' => 'value3']);
+        $one->twos()->create(['column_name' => 'value4']);
 
         $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
 

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -18,7 +18,7 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         Schema::create('two', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
-            $table->string('attribute');
+            $table->string('column');
         });
     }
 
@@ -27,10 +27,10 @@ class EloquentWithAttributeTest extends DatabaseTestCase
         $one = Model1::create();
         $one->twos()->Create(['attribute' => 'value']);
 
-        $results = Model1::withAttribute('twos', 'attribute');
+        $results = Model1::withAttribute('twos', 'column');
 
         $this->assertEquals([
-            ['id' => 1, 'twos_attribute' => 'value'],
+            ['id' => 1, 'twos_attribute_column' => 'value'],
         ], $results->get()->toArray());
     }
 }

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentwithAttributeTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentWithAttributeTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('one', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('two', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+            $table->string('attribute');
+        });
+    }
+
+    public function testItBasic()
+    {
+        $one = Model1::create();
+        $one->twos()->Create(['attribute' => 'value']);
+
+        $results = Model1::withAttribute('twos', 'attribute');
+
+        $this->assertEquals([
+            ['id' => 1, 'twos_attribute' => 'value'],
+        ], $results->get()->toArray());
+    }
+}
+
+class Model1 extends Model
+{
+    public $table = 'one';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos()
+    {
+        return $this->hasMany(Model2::class, 'one_id');
+    }
+}
+
+class Model2 extends Model
+{
+    public $table = 'two';
+    public $timestamps = false;
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -25,12 +25,29 @@ class EloquentWithAttributeTest extends DatabaseTestCase
     public function testItBasic()
     {
         $one = Model1::create();
-        $one->twos()->Create(['column_name' => 'value']);
+        $one->twos()->create(['column_name' => 'value']);
 
         $results = Model1::withAttribute('twos', 'column_name');
 
         $this->assertEquals([
             ['id' => 1, 'twos_attribute_column_name' => 'value'],
+        ], $results->get()->toArray());
+    }
+
+    public function testSorting()
+    {
+        $one = Model1::create();
+        $one->twos()->createMany([
+            ['column_name' => 'value1'],
+            ['column_name' => 'value2'],
+            ['column_name' => 'value3'],
+            ['column_name' => 'value4'],
+        ]);
+
+        $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
+
+        $this->assertEquals([
+            ['id' => 4, 'twos_attribute_column_name' => 'value4']
         ], $results->get()->toArray());
     }
 }


### PR DESCRIPTION
Despite lacking official documentation, the community skillfully employs `withAggregate` and `loadAggregate`, influenced by content creators, showcasing their effectiveness and widespread adoption, particularly in retrieving specific attributes from `HasOne`/`BelongsTo` relationships.

some resources:
 - https://laraveldaily.com/tip/withaggregate-method
 - https://laravel-code.tips/use-the-withaggregate-method-to-add-related-values-to-eloquent-queries-using-subselects/
 - https://twitter.com/pascalbaljet/status/1457702666352594947
 - https://x.com/MrPunyapal/status/1716850065271333332?s=20

However, while these methods excel in many scenarios, they fall short when it comes to ordering, as illustrated by the inability to retrieve the last comment efficiently:

```php
Post::withAggregate(['comments as last_comment' => fn($q) => $q->latest()], 'content')->get();
```

This code retrieves the first comment instead of the last, limiting the method's efficiency. Additionally, the name `withAggregate` fails to convey its purpose adequately when retrieving a single attribute or column.

To address these shortcomings, I propose the introduction of `withAttribute` and `loadAttribute`, which leverage the functionality of `withAggregate` but offer the ability to specify ordering:

```php
Post::withAttribute(['comments as last_comment' => fn($q) => $q->latest()], 'content')->get();
```

With this enhancement, retrieving the last comment becomes straightforward and intuitive.