### PR TITLE
[11.x] Simplify condition structure and add `@throw` to docblock for resolve method

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
-use RuntimeException;
 
 abstract class MultipleInstanceManager
 {
@@ -64,7 +63,7 @@ abstract class MultipleInstanceManager
     abstract public function getInstanceConfig($name);
 
     /**
-     * Get an instance instance by name.
+     * Get an instance by name.
      *
      * @param  string|null  $name
      * @return mixed

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
+use RuntimeException;
 
 abstract class MultipleInstanceManager
 {
@@ -104,7 +105,7 @@ abstract class MultipleInstanceManager
         }
 
         if (! array_key_exists('driver', $config)) {
-            throw new \RuntimeException("Instance [{$name}] does not specify a driver.");
+            throw new RuntimeException("Instance [{$name}] does not specify a driver.");
         }
 
         if (isset($this->customCreators[$config['driver']])) {

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -94,6 +94,7 @@ abstract class MultipleInstanceManager
      * @return mixed
      *
      * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      */
     protected function resolve($name)
     {
@@ -104,20 +105,20 @@ abstract class MultipleInstanceManager
         }
 
         if (! array_key_exists('driver', $config)) {
-            throw new RuntimeException("Instance [{$name}] does not specify a driver.");
+            throw new \RuntimeException("Instance [{$name}] does not specify a driver.");
         }
 
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
-        } else {
-            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
-
-            if (method_exists($this, $driverMethod)) {
-                return $this->{$driverMethod}($config);
-            } else {
-                throw new InvalidArgumentException("Instance driver [{$config['driver']}] is not supported.");
-            }
         }
+
+        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+
+        if (method_exists($this, $driverMethod)) {
+            return $this->{$driverMethod}($config);
+        }
+
+        throw new InvalidArgumentException("Instance driver [{$config['driver']}] is not supported.");
     }
 
     /**


### PR DESCRIPTION
This PR updates the `resolve` method to exception handling by including `RuntimeException` in its throws clause within the doc block and simplifying the conditional structure.

We encounter the following code snippet in the resolve method:

```php
if (! array_key_exists('driver', $config)) {
    throw new \RuntimeException("Instance [{$name}] does not specify a driver.");
}
```

Therefore, we can add the `@throws RuntimeException` to the doc block


### Simplifying the conditional structure

```php
if (isset($this->customCreators[$config['driver']])) {
    return $this->callCustomCreator($config);
} else {
    $driverMethod = 'create'.ucfirst($config['driver']).'Driver';

    if (method_exists($this, $driverMethod)) {
        return $this->{$driverMethod}($config);
    } else {
        throw new InvalidArgumentException("Instance driver [{$config['driver']}] is not supported.");
    }
}
```

In the above code, if the first if statement is executed, the else part will never be executed because a value is returned in this if, the same scenario happens in the else part as well. Therefore, we can simplify it a bit:

```php
if (isset($this->customCreators[$config['driver']])) {
    return $this->callCustomCreator($config);
}

$driverMethod = 'create'.ucfirst($config['driver']).'Driver';

if (method_exists($this, $driverMethod)) {
    return $this->{$driverMethod}($config);
}

throw new InvalidArgumentException("Instance driver [{$config['driver']}] is not supported.");
```

