### PR TITLE
[11.x] Fixes auto-discovery for commands outside of app's namespace

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -650,7 +650,7 @@ class Kernel implements KernelContract
      */
     protected function getFileNamespacePath(SplFileInfo $file): array
     {
-        $matchingNamespaces = array_filter($this->availableNamespaces(), function ($path) use ($file) {
+        $matchingNamespaces = array_filter($this->getAvailableNamespaces(), function ($path) use ($file) {
             return Str::contains($file->getRealPath(), $path);
         });
 
@@ -671,7 +671,7 @@ class Kernel implements KernelContract
      *
      * @return array
      */
-    protected function availableNamespaces(): array
+    protected function getAvailableNamespaces(): array
     {
         $composer = json_decode(file_get_contents($this->app->basePath('composer.json')), true);
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -2,11 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
-use ErrorException;
-use ReflectionException;
 use Carbon\CarbonInterval;
 use Closure;
 use DateTimeInterface;
+use ErrorException;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Command;
 use Illuminate\Console\Events\CommandFinished;
@@ -22,6 +21,7 @@ use Illuminate\Support\Env;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionException;
 use SplFileInfo;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -641,11 +641,11 @@ class Kernel implements KernelContract
     {
         $this->app[ExceptionHandler::class]->renderForConsole($output, $e);
     }
+
     /**
      * Returns a tuple with the namespace and path of the file.
      *
      * @param SplFileInfo $file
-     *
      * @return array
      */
     protected function getFileNamespacePath(SplFileInfo $file): array


### PR DESCRIPTION
The goal of this PR is to fix the hardcoded app namespace in the Console Kernel.

At the moment adding paths from outside the app/ folder doesn't work at all.

```
        $this->load([
            __DIR__ . '/Commands',
            base_path('src/Modules'),
        ]);
```

The reason for that is that the Kernel assumes the namespace for the class to start with App.

I'm not sure if this should target 11.x or master.

For my selfish reasons, I'd want it out as soon as possible, but the "getAvailableNamespaces" command is a slightly modified version of a method copied from Application.

Preferably Application interface would be extended to allow listing of all available namespaces alongside the primary one. Lemme know which path is desirable and I'll adjust it.

I'll add tests after this gets green lighted.