### PR TITLE
[11.x] Adding withAttribute and loadAttribute methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -830,6 +830,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Eager load related column value on the model.
+     *
+     * @param  array|string  $relations
+     * @param  string  $column
+     * @return $this
+     */
+    public function loadAttribute($relations, $column)
+    {
+        return $this->loadAggregate($relations, $column, 'attribute');
+    }
+
+    /**
      * Eager load relationship column aggregation on the polymorphic relation of a model.
      *
      * @param  string  $relation

--- a/tests/Integration/Database/EloquentModelLoadAttributeTest.php
+++ b/tests/Integration/Database/EloquentModelLoadAttributeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelLoadAttributeTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelLoadAttributeTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('base_models', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('related1s', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('base_model_id');
+            $table->string('column_name');
+        });
+
+        Schema::create('related2s', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('base_model_id');
+            $table->string('column_name');
+        });
+
+        BaseModel::create();
+
+        Related1::create(['base_model_id' => 1, 'column_name' => 'value1']);
+        Related1::create(['base_model_id' => 1, 'column_name' => 'value12']);
+        Related2::create(['base_model_id' => 1, 'column_name' => 'value2']);
+    }
+
+    public function testLoadAttributeSingleRelation()
+    {
+        $model = BaseModel::first();
+
+        DB::enableQueryLog();
+
+        $model->loadAttribute('related1', 'column_name');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertEquals('value1', $model->related1_attribute_column_name);
+    }
+
+    public function testLoadAttributeMultipleRelations()
+    {
+        $model = BaseModel::first();
+
+        DB::enableQueryLog();
+
+        $model->loadAttribute(['related1', 'related2'], 'column_name');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertEquals('value1', $model->related1_attribute_column_name);
+        $this->assertEquals('value2', $model->related2_attribute_column_name);
+    }
+}
+
+class BaseModel extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function related1()
+    {
+        return $this->hasMany(Related1::class);
+    }
+
+    public function related2()
+    {
+        return $this->hasMany(Related2::class);
+    }
+}
+
+class Related1 extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function parent()
+    {
+        return $this->belongsTo(BaseModel::class);
+    }
+}
+
+class Related2 extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function parent()
+    {
+        return $this->belongsTo(BaseModel::class);
+    }
+}

--- a/tests/Integration/Database/EloquentWithAttributeTest.php
+++ b/tests/Integration/Database/EloquentWithAttributeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentWithAttributeTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentWithAttributeTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('one', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('two', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+            $table->string('column_name');
+        });
+    }
+
+    public function testItBasic()
+    {
+        $one = Model1::create();
+        $one->twos()->create(['column_name' => 'value']);
+
+        $results = Model1::withAttribute('twos', 'column_name');
+
+        $this->assertEquals([
+            ['id' => 1, 'twos_attribute_column_name' => 'value'],
+        ], $results->get()->toArray());
+    }
+
+    public function testSorting()
+    {
+        $one = Model1::create();
+        $one->twos()->createMany([
+            ['column_name' => 'value1'],
+            ['column_name' => 'value2'],
+            ['column_name' => 'value3'],
+            ['column_name' => 'value4'],
+        ]);
+
+        $results = Model1::withAttribute(['twos' => fn ($q) => $q->latest('id')], 'column_name');
+
+        $this->assertEquals([
+            ['id' => 1, 'twos_attribute_column_name' => 'value4'],
+        ], $results->get()->toArray());
+    }
+}
+
+class Model1 extends Model
+{
+    public $table = 'one';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos()
+    {
+        return $this->hasMany(Model2::class, 'one_id');
+    }
+}
+
+class Model2 extends Model
+{
+    public $table = 'two';
+    public $timestamps = false;
+    protected $guarded = [];
+}


### PR DESCRIPTION
Despite lacking official documentation, the community skillfully employs `withAggregate` and `loadAggregate`, influenced by content creators, showcasing their effectiveness and widespread adoption, particularly in retrieving specific attributes from `HasOne`/`BelongsTo` relationships.

some resources:
 - https://laraveldaily.com/tip/withaggregate-method
 - https://laravel-code.tips/use-the-withaggregate-method-to-add-related-values-to-eloquent-queries-using-subselects/
 - https://twitter.com/pascalbaljet/status/1457702666352594947
 - https://x.com/MrPunyapal/status/1716850065271333332?s=20

However, while these methods excel in many scenarios, they fall short when it comes to ordering, as illustrated by the inability to retrieve the last comment efficiently:

```php
Post::withAggregate(['comments as last_comment' => fn($q) => $q->latest()], 'content')->get();
```

This code retrieves the first comment instead of the last, limiting the method's efficiency. Additionally, the name `withAggregate` fails to convey its purpose adequately when retrieving a single attribute or column.

To address these shortcomings, I propose the introduction of `withAttribute` and `loadAttribute`, which leverage the functionality of `withAggregate` but offer the ability to specify ordering:

```php
Post::withAttribute(['comments as last_comment' => fn($q) => $q->latest()], 'content')->get();
```

With this enhancement, retrieving the last comment becomes straightforward and intuitive.

Examples: 

```php
$post = Post::withAttribute('category', 'name')->first();
$post->category_attribute_name;

$post = Post::first();
$post->loadAttribute('category', 'name');
$post->category_attribute_name;
```