### PR TITLE
Introduce the getGuardName method to find out the guard where the use.

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -330,6 +330,21 @@ class AuthManager implements FactoryContract
     }
 
     /**
+     * Get the guard that authenticates the user's use.
+     * 
+     * @return string|null
+     */
+    public function getGuardName()
+    {
+        foreach (array_keys($this->app['config']['auth.guards']) as $guard) {
+            if ($this->guard($guard)->check()) {
+                return $guard;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Dynamically call the default driver instance.
      *
      * @param  string  $method


### PR DESCRIPTION
…r logged in.

When a user uses multiple guards, we sometimes need to find out which guard the user logged in to. We need this method to get the guard name where the user logged in.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
