### PR TITLE
[11.x] remove orders only if $function is set

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,7 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            if ($function){
+            if ($function) {
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,8 +659,10 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            $query->orders = null;
-            $query->setBindings([], 'order');
+            if($function){
+                $query->orders = null;
+                $query->setBindings([], 'order');
+            }
 
             if (count($query->columns) > 1) {
                 $query->columns = [$query->columns[0]];

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -659,7 +659,7 @@ trait QueriesRelationships
             // If the query contains certain elements like orderings / more than one column selected
             // then we will remove those elements from the query so that it will execute properly
             // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
-            if($function){
+            if ($function){
                 $query->orders = null;
                 $query->setBindings([], 'order');
             }


### PR DESCRIPTION
```php
Post::withAggregate(['comments as last_comment' => fn($q) => $q->latest()], 'content')->get();
```

This code retrieves the first comment instead of the last, as we are intentionally removing orders. by doing this minor change, it retrieves the last comment as desired.