### PR TITLE
[11.x] Add `@throws` to doc block for resolve method

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -94,6 +94,7 @@ abstract class MultipleInstanceManager
      * @return mixed
      *
      * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      */
     protected function resolve($name)
     {


### PR DESCRIPTION
This PR, fixes doc block for `resolve` method in `MultipleInstanceManager.php`