### PR TITLE
[11.x] Modify doc blocks for getGateArguments

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -62,7 +62,7 @@ class Authorize
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  array|null  $models
-     * @return \Illuminate\Database\Eloquent\Model|array|string
+     * @return array
      */
     protected function getGateArguments($request, $models)
     {


### PR DESCRIPTION
This  PR, fixes `@return` for `getGateArguments` method in `Authorize.php`

```php
// Before
 /**
   * Get the arguments parameter for the gate.
   *
   * @param  \Illuminate\Http\Request  $request
   * @param  array|null  $models
   * @return \Illuminate\Database\Eloquent\Model|array|string
   */
  protected function getGateArguments($request, $models)
  {
      if (is_null($models)) {
          return [];
      }

      return collect($models)->map(function ($model) use ($request) {
          return $model instanceof Model ? $model : $this->getModel($request, $model);
      })->all();
  }
```

If `$models` is null in the `getGateArguments` method, an empty array is returned; otherwise, an array is still returned because the `all()` method in collections returns an array.

```php
/**
   * Get all of the items in the collection.
   *
   * @return array<TKey, TValue>
   */
  public function all()
  {
      return $this->items;
  }
```
In the `all()` method, `$this->items` is always an array. Therefore, we can change the `@return` for the `getGateArguments` method to an array.

```php
// After
 /**
   * Get the arguments parameter for the gate.
   *
   * @param  \Illuminate\Http\Request  $request
   * @param  array|null  $models
   * @return array
   */
```

