### PR TITLE
[11.x] Add option --extends to make:class command

### DIFF
--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -30,6 +30,18 @@ class ClassMakeCommand extends GeneratorCommand
      */
     protected $type = 'Class';
 
+    protected function replaceClass($stub, $name)
+    {
+        $stub = parent::replaceClass($stub, $name);
+
+        $extends = '';
+        if ($this->option('extends')) {
+            $extends = 'extends ' . $this->option('extends');
+        }
+
+        return str_replace(['dummy:extends', '{{ extends }}'], $extends, $stub);
+    }
+
     /**
      * Get the stub file for the generator.
      *
@@ -76,6 +88,7 @@ class ClassMakeCommand extends GeneratorCommand
         return [
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable class'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the class already exists'],
+            ['extends', null, InputOption::VALUE_OPTIONAL, 'Namespaced class name to extend'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/class.invokable.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.invokable.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-class {{ class }}
+class {{ class }} {{ extends }}
 {
     /**
      * Create a new class instance.

--- a/src/Illuminate/Foundation/Console/stubs/class.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-class {{ class }}
+class {{ class }} {{ extends }}
 {
     /**
      * Create a new class instance.


### PR DESCRIPTION
It's a common use-case for people to generate a class that extends some other class from Laravel framework or elsewhere.

My personal example - generate a custom class extending Filament's Login class:

```sh
php artisan make:class Filament/Pages/Auth/CustomEditProfile --extends=\\Filament\\Pages\\Auth\\EditProfile
```

Reference: [Filament docs about it](https://filamentphp.com/docs/3.x/panels/users#customizing-the-authentication-features)

The result is `app/Filament/Pages/Auth/CustomEditProfile.php` class:

```php
namespace App\Filament\Pages\Auth;

class CustomEditProfile extends \Filament\Pages\Auth\EditProfile
{
    // ...
```

Pretty sure other people have this use-case with other classes, too.

---

I also had an idea to add the classname in the `use` on top: 

```php
namespace App\Filament\Pages\Auth;

use Filament\Pages\Auth\EditProfile;

class CustomEditProfile extends EditProfile
{
    // ...
```

But thought it would be too complicated change for the stubs, so left with the full namespaced path in the `extends` part.

But if you tell me to, I can try to work on the `use` replacement, too.