### PR TITLE
[11.x] Fix `Middleware::trustHosts(subdomains: true)`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -608,15 +608,15 @@ class Middleware
     /**
      * Indicate that the trusted host middleware should be enabled.
      *
-     * @param  array<int, string>|null  $at
+     * @param  array<int, string>|(callable(): array<int, string>)|null  $at
      * @param  bool  $subdomains
      * @return $this
      */
-    public function trustHosts(array $at = null, bool $subdomains = true)
+    public function trustHosts(array|callable $at = null, bool $subdomains = true)
     {
         $this->trustHosts = true;
 
-        if (is_array($at)) {
+        if (! is_null($at)) {
             TrustHosts::at($at, $subdomains);
         }
 

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -22,7 +22,7 @@ class TrustHosts
     protected static $alwaysTrust;
 
     /**
-     * Whether to trust subdomains of the application url.
+     * Indicates whether subdomains of the application URL should be trusted.
      *
      * @var bool|null
      */

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -222,16 +222,25 @@ class MiddlewareTest extends TestCase
         $configuration->trustHosts(at: ['my.test']);
         $this->assertEquals(['my.test', '^(.+\.)?laravel\.test$'], $middleware->hosts());
 
-        $configuration->trustHosts(at: ['my.test']);
+        $configuration->trustHosts(at: static fn () => ['my.test']);
         $this->assertEquals(['my.test', '^(.+\.)?laravel\.test$'], $middleware->hosts());
 
         $configuration->trustHosts(at: ['my.test'], subdomains: false);
         $this->assertEquals(['my.test'], $middleware->hosts());
 
+        $configuration->trustHosts(at: static fn () => ['my.test'], subdomains: false);
+        $this->assertEquals(['my.test'], $middleware->hosts());
+
         $configuration->trustHosts(at: []);
         $this->assertEquals(['^(.+\.)?laravel\.test$'], $middleware->hosts());
 
+        $configuration->trustHosts(at: static fn () => []);
+        $this->assertEquals(['^(.+\.)?laravel\.test$'], $middleware->hosts());
+
         $configuration->trustHosts(at: [], subdomains: false);
+        $this->assertEquals([], $middleware->hosts());
+
+        $configuration->trustHosts(at: static fn () => [], subdomains: false);
         $this->assertEquals([], $middleware->hosts());
     }
 

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Foundation\Configuration;
 
-use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Foundation\Application;

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -219,9 +219,6 @@ class MiddlewareTest extends TestCase
         $configuration->trustHosts();
         $this->assertEquals(['^(.+\.)?laravel\.test$'], $middleware->hosts());
 
-        app()['config'] = Mockery::mock(Repository::class);
-        app()['config']->shouldReceive('get')->with('app.url', null)->times(3)->andReturn('http://laravel.test');
-
         $configuration->trustHosts(at: ['my.test']);
         $this->assertEquals(['my.test', '^(.+\.)?laravel\.test$'], $middleware->hosts());
 


### PR DESCRIPTION
Fixes #50845

This PR fixes 2 problems with `Middleware::trustHosts()`:

8e0eb6451b535da63fddddc57ae9290054890316:

When `Middleware::trustHosts()` is called with hosts (e.g. `$middleware->trustHosts(['127.0.0.1'])`) it immediately tries to configure the `TrustHosts` middleware. The `TrustHosts` middleware itself is reliant on the application's config, so it cannot be configured this early in the bootstrapping process. This is fixed by only setting what we need to do, but not doing it until a request happens.

a6171fdb48b6c18092962a467ce2caac78257fdf:

Its not uncommon to rely on certain container services when deciding on what hosts to trust, but because the `Middleware::trustHosts()` method only accepts an already resolved array and happens so early in the bootstrapping process we cannot use those services yet.

This is fixed by allowing developers to pass a callback that "lazily" resolves the hosts. This enables the following:

```php
$middleware->trustHosts(fn () => config('app.allowed_hosts'));
```