### PR TITLE
[11.x] Add a new helper for context

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
@@ -285,6 +286,36 @@ if (! function_exists('config_path')) {
     function config_path($path = '')
     {
         return app()->configPath($path);
+    }
+}
+
+if (!function_exists('context')) {
+    /**
+     * Get / set the specified context value.
+     *
+     * @param  array|string|null  $key
+     * @param  mixed  $default
+     * @return mixed|\Illuminate\Log\Context\Repository
+     *
+     * @throws \InvalidArgumentException
+     */
+    function context($key, $default = null)
+    {
+        if (is_null($key)) {
+            return app(ContextRepository::class);
+        }
+
+        if (is_array($key)) {
+            if (count($key) !== 1) {
+                throw new InvalidArgumentException(
+                    'When setting a value in the context, you must pass only one array of key / value pairs.'
+                );
+            }
+
+            return app(ContextRepository::class)->add($key);
+        }
+
+        return app(ContextRepository::class)->get($key, $default);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -299,15 +299,11 @@ if (! function_exists('context')) {
      */
     function context($key, $default = null)
     {
-        if (is_null($key)) {
-            return app(ContextRepository::class);
-        }
-
-        if (is_array($key)) {
-            return app(ContextRepository::class)->add($key);
-        }
-
-        return app(ContextRepository::class)->get($key, $default);
+        return match (true) {
+            is_null($key) => app(ContextRepository::class),
+            is_array($key) => app(ContextRepository::class)->add($key),
+            default => app(ContextRepository::class)->get($key, $default),
+        };
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -289,7 +289,7 @@ if (! function_exists('config_path')) {
     }
 }
 
-if (!function_exists('context')) {
+if (! function_exists('context')) {
     /**
      * Get / set the specified context value.
      *

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -296,8 +296,6 @@ if (! function_exists('context')) {
      * @param  array|string|null  $key
      * @param  mixed  $default
      * @return mixed|\Illuminate\Log\Context\Repository
-     *
-     * @throws \InvalidArgumentException
      */
     function context($key, $default = null)
     {
@@ -306,12 +304,6 @@ if (! function_exists('context')) {
         }
 
         if (is_array($key)) {
-            if (count($key) !== 1) {
-                throw new InvalidArgumentException(
-                    'When setting a value in the context, you must pass only one array of key / value pairs.'
-                );
-            }
-
             return app(ContextRepository::class)->add($key);
         }
 


### PR DESCRIPTION
This PR introduces a new helper function for managing context in applications.

Example usage:

```php
context(['user' => auth()->user()]); // Add user information to the context

$context = context(); // Retrieve the context object

$user = context('user'); // Retrieve user information from the context
```

This enhancement simplifies the management of contextual data within the application, making it more efficient and readable.