### PR TITLE
[11.x] Remove redundant `getDefaultNamespace` method in some classes (class, interface and trait commands)

### DIFF
--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -56,17 +56,6 @@ class ClassMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace;
-    }
-
-    /**
      * Get the console command arguments.
      *
      * @return array

--- a/src/Illuminate/Foundation/Console/InterfaceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/InterfaceMakeCommand.php
@@ -41,17 +41,6 @@ class InterfaceMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace;
-    }
-
-    /**
      * Get the console command arguments.
      *
      * @return array

--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -54,17 +54,6 @@ class TraitMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace;
-    }
-
-    /**
      * Get the console command arguments.
      *
      * @return array


### PR DESCRIPTION

In the following classes:
- `ClassMakeCommand.php`
- `InterfaceMakeCommand.php`
- `TraitMakeCommand.php`

Since the method `getDefaultNamespace` exists exactly in the parent class, it is unnecessary. Overrides should only be applied when they differ from the parent class ( OOP principle)

