### PR TITLE
[11.x] Remove redundant implementation of ConnectorInterface in MariaDbConnector

### DIFF
--- a/src/Illuminate/Database/Connectors/MariaDbConnector.php
+++ b/src/Illuminate/Database/Connectors/MariaDbConnector.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Connectors;
 
 use PDO;
 
-class MariaDbConnector extends MySqlConnector implements ConnectorInterface
+class MariaDbConnector extends MySqlConnector
 {
     /**
      * Get the sql_mode value.


### PR DESCRIPTION
In this PR, implementation of the `ConnectorInterface` from the `MariaDbConnector` class has been removed. 

Class `MySqlConnector` itself implements the `ConnectorInterface`. Therefore, any class that inherits from `MySqlConnector` also has this interface.

```php
class MySqlConnector extends Connector implements ConnectorInterface
{
 // ...
}
```

```php
class MariaDbConnector extends MySqlConnector
{
}
```