### PR TITLE
[10.x] Binding order is incorrect when using cursor paginate with multiple unions with a where

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -395,12 +395,14 @@ trait BuildsQueries
                     );
 
                     $unionBuilders->each(function ($unionBuilder) use ($previousColumn, $cursor) {
+                        $unionWheres = $unionBuilder->getRawBindings()['where'];
                         $unionBuilder->where(
                             $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
                             '=',
                             $cursor->parameter($previousColumn)
                         );
 
+                        $this->addBinding($unionWheres, 'union');
                         $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
                     });
                 }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -395,14 +395,12 @@ trait BuildsQueries
                     );
 
                     $unionBuilders->each(function ($unionBuilder) use ($previousColumn, $cursor) {
-                        $unionWheres = $unionBuilder->getRawBindings()['where'];
                         $unionBuilder->where(
                             $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
                             '=',
                             $cursor->parameter($previousColumn)
                         );
 
-                        $this->addBinding($unionWheres, 'union');
                         $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
                     });
                 }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -378,14 +378,12 @@ trait BuildsQueries
 
         $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
 
-        // Reset the union bindings so we can add the cursor where in the correct position.
-        if (isset($this->unions)) {
-            $this->setBindings([], 'union');
-        }
-
         if (! is_null($cursor)) {
+            // Reset the union bindings so we can add the cursor where in the correct position.
+            $this->setBindings([], 'union');
+
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
-                $unionBuilders = isset($builder->unions) ? collect($builder->unions)->pluck('query') : collect();
+                $unionBuilders = $builder->getUnionBuilders();
 
                 if (! is_null($previousColumn)) {
                     $originalColumn = $this->getOriginalColumnNameForCursorPagination($this, $previousColumn);

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -379,7 +379,7 @@ trait BuildsQueries
         $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
 
         // Reset the union bindings so we can add the cursor where in the correct position.
-        $this->bindings['union'] = [];
+        $this->setBindings([], 'union');
 
         if (! is_null($cursor)) {
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -379,7 +379,9 @@ trait BuildsQueries
         $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
 
         // Reset the union bindings so we can add the cursor where in the correct position.
-        $this->setBindings([], 'union');
+        if (isset($this->unions)) {
+            $this->setBindings([], 'union');
+        }
 
         if (! is_null($cursor)) {
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -379,7 +379,7 @@ trait BuildsQueries
         $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
 
         if (! is_null($cursor)) {
-            // Reset the union bindings so we can add the cursor where in the correct position.
+            // Reset the union bindings so we can add the cursor where in the correct position...
             $this->setBindings([], 'union');
 
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
@@ -394,10 +394,6 @@ trait BuildsQueries
                         $cursor->parameter($previousColumn)
                     );
 
-                    // It looks like there is no scenario where both
-                    //  - previousColumn is set
-                    //  - and the $builder has unions
-                    //  when previousColumn is set, the builder is a fresh instance in a where clause.
                     $unionBuilders->each(function ($unionBuilder) use ($previousColumn, $cursor) {
                         $unionBuilder->where(
                             $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
@@ -428,6 +424,7 @@ trait BuildsQueries
 
                     $unionBuilders->each(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
                         $unionWheres = $unionBuilder->getRawBindings()['where'];
+
                         $unionBuilder->where(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions, $unionWheres) {
                             $unionBuilder->where(
                                 $this->getOriginalColumnNameForCursorPagination($this, $column),

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1016,7 +1016,7 @@ class Builder implements BuilderContract
     /**
      * Get the Eloquent Builders that are used in the union of the query.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     protected function getUnionBuilders()
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -108,6 +108,7 @@ class Builder implements BuilderContract
         'getbindings',
         'getconnection',
         'getgrammar',
+        'getrawbindings',
         'implode',
         'insert',
         'insertgetid',

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1012,6 +1012,11 @@ class Builder implements BuilderContract
             ->values();
     }
 
+    protected function getUnionBuilders()
+    {
+        return isset($this->query->unions) ? collect($this->query->unions)->pluck('query') : collect();
+    }
+
     /**
      * Save a new model and return the instance.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1014,16 +1014,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the Eloquent Builders that are used in the union of the query.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    protected function getUnionBuilders()
-    {
-        return isset($this->query->unions) ? collect($this->query->unions)->pluck('query') : collect();
-    }
-
-    /**
      * Save a new model and return the instance.
      *
      * @param  array  $attributes
@@ -1708,6 +1698,18 @@ class Builder implements BuilderContract
         }
 
         return $results;
+    }
+
+    /**
+     * Get the Eloquent builder instances that are used in the union of the query.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getUnionBuilders()
+    {
+        return isset($this->query->unions)
+            ? collect($this->query->unions)->pluck('query')
+            : collect();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1013,6 +1013,11 @@ class Builder implements BuilderContract
             ->values();
     }
 
+    /**
+     * Get the Eloquent Builders that are used in the union of the query.
+     *
+     * @return Collection
+     */
     protected function getUnionBuilders()
     {
         return isset($this->query->unions) ? collect($this->query->unions)->pluck('query') : collect();

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1701,18 +1701,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the Eloquent builder instances that are used in the union of the query.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    protected function getUnionBuilders()
-    {
-        return isset($this->query->unions)
-            ? collect($this->query->unions)->pluck('query')
-            : collect();
-    }
-
-    /**
      * Apply query-time casts to the model instance.
      *
      * @param  array  $casts
@@ -1738,6 +1726,18 @@ class Builder implements BuilderContract
         return $this->getQuery()->getConnection()->transactionLevel() > 0
             ? $this->getQuery()->getConnection()->transaction($scope)
             : $scope();
+    }
+
+    /**
+     * Get the Eloquent builder instances that are used in the union of the query.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getUnionBuilders()
+    {
+        return isset($this->query->unions)
+            ? collect($this->query->unions)->pluck('query')
+            : collect();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2975,7 +2975,7 @@ class Builder implements BuilderContract
     /**
      * Get the Query Builders that are used in the union of the query.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     protected function getUnionBuilders()
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2972,6 +2972,11 @@ class Builder implements BuilderContract
             ->values();
     }
 
+    /**
+     * Get the Query Builders that are used in the union of the query.
+     *
+     * @return Collection
+     */
     protected function getUnionBuilders()
     {
         return isset($this->unions) ? collect($this->unions)->pluck('query') : collect();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2973,16 +2973,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the Query Builders that are used in the union of the query.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    protected function getUnionBuilders()
-    {
-        return isset($this->unions) ? collect($this->unions)->pluck('query') : collect();
-    }
-
-    /**
      * Get the count of the total records for the paginator.
      *
      * @param  array  $columns
@@ -3823,6 +3813,18 @@ class Builder implements BuilderContract
     public function raw($value)
     {
         return $this->connection->raw($value);
+    }
+
+    /**
+     * Get the query builder instances that are used in the union of the query.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getUnionBuilders()
+    {
+        return isset($this->unions)
+            ? collect($this->unions)->pluck('query')
+            : collect();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2972,6 +2972,11 @@ class Builder implements BuilderContract
             ->values();
     }
 
+    protected function getUnionBuilders()
+    {
+        return isset($this->unions) ? collect($this->unions)->pluck('query') : collect();
+    }
+
     /**
      * Get the count of the total records for the paginator.
      *

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5351,9 +5351,9 @@ SQL;
         $cursorName = 'cursor-name';
         $cursor = new Cursor(['id' => 1, 'created_at' => $ts, 'type' => 'news']);
         $builder = $this->getMockQueryBuilder();
-        $builder->select('id', 'start_time as created_at', 'type')->from('videos');
-        $builder->union($this->getBuilder()->select('id', 'created_at', 'type')->from('news')->where('extra', 'first'));
-        $builder->union($this->getBuilder()->select('id', 'created_at', 'type')->from('podcasts')->where('extra', 'second'));
+        $builder->select('id', 'start_time as created_at', 'type')->from('videos')->where('extra', 'first');
+        $builder->union($this->getBuilder()->select('id', 'created_at', 'type')->from('news')->where('extra', 'second'));
+        $builder->union($this->getBuilder()->select('id', 'created_at', 'type')->from('podcasts')->where('extra', 'third'));
         $builder->orderBy('id')->orderByDesc('created_at')->orderBy('type');
 
         $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
@@ -5371,10 +5371,10 @@ SQL;
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
             $this->assertEquals(
-                '(select "id", "start_time" as "created_at", "type" from "videos" where ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "news" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "podcasts" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) order by "id" asc, "created_at" desc, "type" asc limit 17',
+                '(select "id", "start_time" as "created_at", "type" from "videos" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "news" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) union (select "id", "created_at", "type" from "podcasts" where "extra" = ? and ("id" > ? or ("id" = ? and ("start_time" < ? or ("start_time" = ? and ("type" > ?)))))) order by "id" asc, "created_at" desc, "type" asc limit 17',
                 $builder->toSql());
-            $this->assertEquals([1, 1, $ts, $ts, 'news'], $builder->bindings['where']);
-            $this->assertEquals(['first', 1, 1, $ts, $ts, 'news', 'second', 1, 1, $ts, $ts, 'news'], $builder->bindings ['union']);
+            $this->assertEquals(['first', 1, 1, $ts, $ts, 'news'], $builder->bindings['where']);
+            $this->assertEquals(['second', 1, 1, $ts, $ts, 'news', 'third', 1, 1, $ts, $ts, 'news'], $builder->bindings ['union']);
 
             return $results;
         });

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5293,6 +5293,55 @@ SQL;
         ]), $result);
     }
 
+    public function testCursorPaginateWithMultipleUnionsAndMultipleWheres()
+    {
+        $ts = now()->toDateTimeString();
+
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['created_at' => $ts]);
+        $builder = $this->getMockQueryBuilder();
+        $builder->select('id', 'start_time as created_at')->selectRaw("'video' as type")->from('videos');
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'news' as type")->from('news')->where('extra', 'first'));
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'podcast' as type")->from('podcasts')->where('extra', 'second'));
+        $builder->orderBy('created_at');
+
+        $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
+            return new Builder($builder->connection, $builder->grammar, $builder->processor);
+        });
+
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([
+            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
+            ['id' => 3, 'created_at' => now(), 'type' => 'podcasts'],
+        ]);
+
+        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
+            $this->assertEquals(
+                '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where "extra" = ? and ("start_time" > ?)) union (select "id", "created_at", \'podcast\' as type from "podcasts" where "extra" = ? and ("start_time" > ?)) order by "created_at" asc limit 17',
+                $builder->toSql());
+            $this->assertEquals([$ts], $builder->bindings['where']);
+            $this->assertEquals(['first', $ts, 'second', $ts], $builder->bindings['union']);
+
+            return $results;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['created_at'],
+        ]), $result);
+    }
+
     public function testCursorPaginateWithUnionWheresWithRawOrderExpression()
     {
         $ts = now()->toDateTimeString();

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -167,6 +167,37 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         );
     }
 
+    public function testPaginationWithMultipleUnionAndMultipleWhereClauses()
+    {
+        TestPost::create(['title' => 'Post A', 'user_id' => 100]);
+        TestPost::create(['title' => 'Post B', 'user_id' => 101]);
+
+        $table1 = TestPost::select(['id', 'title', 'user_id'])->where('user_id', 100);
+        $table2 = TestPost::select(['id', 'title', 'user_id'])->where('user_id', 101);
+        $table3 = TestPost::select(['id', 'title', 'user_id'])->where('user_id', 101);
+
+        $columns = ['id'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['id' => 1]);
+
+        $result = $table1->toBase()
+            ->union($table2->toBase())
+            ->union($table3->toBase())
+            ->orderBy('id', 'asc')
+            ->cursorPaginate(1, $columns, $cursorName, $cursor);
+
+        $this->assertSame(['id'], $result->getOptions()['parameters']);
+
+        // Post B is the result of the second query.
+        $postB = $table2->where('id', '>', 1)->first();
+        $this->assertEquals('Post B', $postB->title);
+
+        // So the cursor paginated query should at least have 1 result
+        $this->assertCount(1, $result->items());
+        // And it should be Post B
+        $this->assertEquals('Post B', current($result->items())->title);
+    }
+
     public function testPaginationWithAliasedOrderBy()
     {
         for ($i = 1; $i <= 6; $i++) {

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -188,14 +188,11 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $this->assertSame(['id'], $result->getOptions()['parameters']);
 
-        // Post B is the result of the second query.
         $postB = $table2->where('id', '>', 1)->first();
-        $this->assertEquals('Post B', $postB->title);
+        $this->assertEquals('Post B', $postB->title, 'Expect `Post B` is the result of the second query');
 
-        // So the cursor paginated query should at least have 1 result
-        $this->assertCount(1, $result->items());
-        // And it should be Post B
-        $this->assertEquals('Post B', current($result->items())->title);
+        $this->assertCount(1, $result->items(), 'Expect cursor paginated query should have 1 result');
+        $this->assertEquals('Post B', current($result->items())->title, 'Expect the paginated query would return `Post B`');
     }
 
     public function testPaginationWithAliasedOrderBy()


### PR DESCRIPTION
When using `cursorPaginate` on a query that has multiple unions with their own where clause, the binding order is incorrect.

This happens because:

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Concerns/BuildsQueries.php#L436
adds the bindings for the cursor `where` to the end of the bindings and not in the position that they should be.

The result is a query that binds the wrong values to the wrong parameters in the query.

This PR recreates the union bindings in the cursor paginate logic so that the cursor `where` binding is in the correct position.

This PR is similar to https://github.com/laravel/framework/pull/50810 but does not change the structure of the union binding to address the fear of a breaking change.
Instead it is only applied in the context of cursor pagination.