### PR TITLE
[11.x] Fix: error when using `orderByRaw` in query before using `cursorPaginate`

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -206,6 +206,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     public function getParametersForItem($item)
     {
         return collect($this->parameters)
+            ->filter()
             ->flip()
             ->map(function ($_, $parameterName) use ($item) {
                 if ($item instanceof JsonResource) {


### PR DESCRIPTION
When using `orderByRaw` with a custom query, you get this error message:

```
Error: array_flip(): Can only flip string and integer values, entry skipped
```

This is because `orderByRaw` will add `null` to `$this->parameters` resulting in the above error.

Adding `filter` ensures that `null` entries are automatically removed before the `flip` operation. 