### PR TITLE
[11.x] Add DeleteWhenMissingModels attribute

### DIFF
--- a/src/Illuminate/Queue/Attributes/DeleteWhenMissingModels.php
+++ b/src/Illuminate/Queue/Attributes/DeleteWhenMissingModels.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class DeleteWhenMissingModels
+{
+    //
+}

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Pipeline\Pipeline;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use ReflectionClass;
 use RuntimeException;
 
@@ -218,8 +219,10 @@ class CallQueuedHandler
         $class = $job->resolveName();
 
         try {
-            $shouldDelete = (new ReflectionClass($class))
-                    ->getDefaultProperties()['deleteWhenMissingModels'] ?? false;
+            $reflectionClass = new ReflectionClass($class);
+
+            $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+                ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
         } catch (Exception) {
             $shouldDelete = false;
         }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\InteractsWithQueue;
@@ -117,6 +118,27 @@ class CallQueuedHandlerTest extends TestCase
 
         Event::assertNotDispatched(JobFailed::class);
     }
+
+    public function testJobIsDeletedIfHasDeleteAttribute()
+    {
+        Event::fake();
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('getConnectionName')->andReturn('connection');
+        $job->shouldReceive('resolveName')->andReturn(CallQueuedHandlerAttributeExceptionThrower::class);
+        $job->shouldReceive('markAsFailed')->never();
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('failed')->never();
+
+        $instance->call($job, [
+            'command' => serialize(new CallQueuedHandlerAttributeExceptionThrower()),
+        ]);
+
+        Event::assertNotDispatched(JobFailed::class);
+    }
 }
 
 class CallQueuedHandlerTestJob
@@ -168,6 +190,20 @@ class CallQueuedHandlerExceptionThrower
 {
     public $deleteWhenMissingModels = true;
 
+    public function handle()
+    {
+        //
+    }
+
+    public function __wakeup()
+    {
+        throw new ModelNotFoundException('Foo');
+    }
+}
+
+#[DeleteWhenMissingModels]
+class CallQueuedHandlerAttributeExceptionThrower
+{
     public function handle()
     {
         //


### PR DESCRIPTION
## Idea behind this PR
This PR offers an alternative to defining the "magic" `deleteWhenMissingModels`. I often struggle to remember
the name of this property. I either look through the framework code or look up documentation. I believe
attributes provide a better way to define these side effects. And IDEs can autocomplete them more easily.

Before:
```php
<?php

namespace Acme;

class Job
{
    public $deleteWhenMissingModels = true;
}
```

After:
```php
<?php

namespace Acme;

use Illuminate\Queue\Attributes\DeleteWhenMissingModels;

#[DeleteWhenMissingModels]
class Job
{
    //
}
```

## Breaking changes
None come to mind.

## Personal suggestion
I personally feel the `deleteWhenMissingModels` property should be removed in the future in favor of this
attribute. I don't think it makes sense to maintain two approaches to do this. I guess this would look like
a deprecation in 12.x and removal in 13.x? As there is no way to deprecate something that isn't defined
in the framework itself but only referenced, I think a note in the upgrade guide would have to be enough.
A slight breaking change when switching over from the property to the attribute would be that attributes
are not inherited along with classes (jobs) themselves. So if you extend a job with the `deleteWhenMissingModels`
property and that gets replaced by the attribute it would break the behaviour of the "child job".
That might be worth noting in the docs

## Docs
If this PR gets merged I think it should also be reflected in the documentation. I will create a PR there as well.