### PR TITLE
[11.x] Adds static resolver for command class names

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -485,7 +485,6 @@ class Kernel implements KernelContract
         if (! $this->commandsLoaded) {
             $this->commands();
 
-
             if ($this->shouldDiscoverCommands()) {
                 $this->discoverCommands();
             }

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Console;
 
 use SplFileInfo;
+use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Console\Application;
@@ -93,7 +94,11 @@ class ConsoleApplicationTest extends TestCase
 
         $kernel::guessCommandClassesUsing($callback);
 
-        $kernel->addCommandPaths([__DIR__ . '/Fixtures']);
+        $instance = new ReflectionClass($kernel);
+        $property = $instance->getProperty('commandClassResolver');
+        $property->setAccessible(true);
+
+        $this->assertSame($callback, $property->getValue($kernel));
     }
 
     public function testResolvingCommandsWithAliasViaProperty()

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -75,14 +75,7 @@ class ConsoleApplicationTest extends TestCase
 
     public function testCommandClassResolverCanBeUpdated()
     {
-        $container = $this->getMockBuilder(FoundationApplication::class)
-            ->disableOriginalConstructor()
-            ->setConstructorArgs([__DIR__])
-            ->getMock();
-
-        $app = spy(new Application($container, new EventsDispatcher($container), "1"));
-        $container->instance(Application::class, $app);
-
+        $container = new FoundationApplication();
         $dispatcher = new EventsDispatcher($container);
 
         $kernel = new Kernel($container, $dispatcher);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -85,8 +85,7 @@ class ConsoleApplicationTest extends TestCase
 
         $dispatcher = new EventsDispatcher($container);
 
-        $kernel = spy(new Kernel($container, $dispatcher))
-            ->shouldAllowMockingProtectedMethods();
+        $kernel = new Kernel($container, $dispatcher);
 
         $callback = function (SplFileInfo $file) {
             return "Illuminate\\Tests\\Console\\Fixtures\\" . Str::before(ucfirst($file->getFilename()), '.php');

--- a/tests/Console/Fixtures/FooCommand.php
+++ b/tests/Console/Fixtures/FooCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Console\Command;
+
+final class FooCommand extends Command
+{
+    protected $name = 'foo:command';
+
+}

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -116,9 +116,10 @@ class ConsoleApplicationTest extends TestCase
 
         $app->singleton(
             ConsoleKernelContract::class,
-            fn () => tap((new \Illuminate\Foundation\Console\Kernel($app, $app->make('events')))->addCommandPaths([
-                __DIR__.'/Fixtures',
-            ])),
+            fn () => (new \Illuminate\Foundation\Console\Kernel($app, $app->make('events')))
+                ->addCommandPaths([
+                    __DIR__ . '/Fixtures',
+                ]),
         );
 
         return $app;

--- a/tests/Integration/Console/Fixtures/FooCommand.php
+++ b/tests/Integration/Console/Fixtures/FooCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Illuminate\Tests\Console\Fixtures;
+namespace Illuminate\Tests\Integration\Console\Fixtures;
 
 use Illuminate\Console\Command;
 
@@ -10,4 +10,8 @@ final class FooCommand extends Command
 {
     protected $name = 'foo:command';
 
+    public function __invoke()
+    {
+
+    }
 }


### PR DESCRIPTION
The goal of this PR is to fix the hardcoded app namespace in the Console Kernel.

At the moment adding paths from outside the app/ folder doesn't work at all.

        $this->load([
            __DIR__ . '/Commands',
            base_path('src/Modules'),
        ]);

The reason for that is that the Kernel assumes the namespace for the class to start with App.

The way it's handled in most places is through a static resolver that can be configured. I went with the same approach here.

This is an iteration to #50866 that got closed without any information - I'm assuming this was because of the type of changes - this way is less intrusive  - would appreciate any feedback here!