### PR TITLE
[11.x] More clearer error report when Job is incompleted

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -120,7 +120,7 @@ class Dispatcher implements QueueingDispatcher
             $callback = function ($command) use ($handler) {
                 $method = method_exists($handler, 'handle') ? 'handle' : (method_exists($command, '__invoke') ? '__invoke' : null);
 
-                if (!$method) {
+                if (! $method) {
                     throw new Exception('Job is incompleted: No handle or __invoke method.');
                 }
 
@@ -130,7 +130,7 @@ class Dispatcher implements QueueingDispatcher
             $callback = function ($command) {
                 $method = method_exists($command, 'handle') ? 'handle' : (method_exists($command, '__invoke') ? '__invoke' : null);
 
-                if (!$method) {
+                if (! $method) {
                     throw new Exception('Job is incompleted: No handle or __invoke method.');
                 }
 

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -117,13 +117,21 @@ class Dispatcher implements QueueingDispatcher
 
         if ($handler || $handler = $this->getCommandHandler($command)) {
             $callback = function ($command) use ($handler) {
-                $method = method_exists($handler, 'handle') ? 'handle' : '__invoke';
+                $method = method_exists($command, 'handle') ? 'handle' : (method_exists($command, '__invoke') ? '__invoke' : null);
+
+                if (!$method) {
+                    throw new Exception('Job is incompleted: No handle or __invoke method.');
+                }
 
                 return $handler->{$method}($command);
             };
         } else {
             $callback = function ($command) {
-                $method = method_exists($command, 'handle') ? 'handle' : '__invoke';
+                $method = method_exists($command, 'handle') ? 'handle' : (method_exists($command, '__invoke') ? '__invoke' : null);
+
+                if (!$method) {
+                    throw new Exception('Job is incompleted: No handle or __invoke method.');
+                }
 
                 return $this->container->call([$command, $method]);
             };

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -118,7 +118,7 @@ class Dispatcher implements QueueingDispatcher
 
         if ($handler || $handler = $this->getCommandHandler($command)) {
             $callback = function ($command) use ($handler) {
-                $method = method_exists($command, 'handle') ? 'handle' : (method_exists($command, '__invoke') ? '__invoke' : null);
+                $method = method_exists($handler, 'handle') ? 'handle' : (method_exists($command, '__invoke') ? '__invoke' : null);
 
                 if (!$method) {
                     throw new Exception('Job is incompleted: No handle or __invoke method.');

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Bus;
 
+use Exception;
 use Closure;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Container\Container;


### PR DESCRIPTION
When you dispatched a `ShouldQueue` without `handle`
```
class BaseQueue implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public int $tries = 1;
    public int $maxExceptions = 1;

    // no `public function handle(): void`
}
```
Then error will show like this:
```
Error: Call to undefined method App\Jobs\Base\BaseQueue::__invoke() in vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36
#4 vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(128): Illuminate\Container\Container->call()
```
We want it be shown like this:
```
Job is incompleted: No handle or __invoke method.
```
The benefit to end users:
- More quickly locate which file to fix, `Oh, my Job is incompleted`

The reasons it does not break any existing features:
- Only a method check

Attention:
- I cannot find how to make a test file just like your team does, but this runs correctly and gives correct error information in my own workflow.
- ⚠️ I edit it directly on GitHub Web, didn't clone so i am not sure if there is any format or lint issue, please check it again.