### PR TITLE
[11.x] Add option to report throttled exception in ThrottlesExceptions middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -119,19 +119,6 @@ class ThrottlesExceptions
     }
 
     /**
-     * Report exceptions and optionally specify a callback that should determine if the exception should be reported.
-     *
-     * @param  callable|null  $callback
-     * @return $this
-     */
-    public function report(?callable $callback = null)
-    {
-        $this->reportCallback = $callback ?? fn () => true;
-
-        return $this;
-    }
-
-    /**
      * Specify a callback that should determine if rate limiting behavior should apply.
      *
      * @param  callable  $callback
@@ -208,6 +195,19 @@ class ThrottlesExceptions
     public function byJob()
     {
         $this->byJob = true;
+
+        return $this;
+    }
+
+    /**
+     * Report exceptions and optionally specify a callback that determines if the exception should be reported.
+     *
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function report(?callable $callback = null)
+    {
+        $this->reportCallback = $callback ?? fn () => true;
 
         return $this;
     }

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -54,6 +54,10 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
                 throw $throwable;
             }
 
+            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable)) {
+                report($throwable);
+            }
+
             $this->limiter->acquire();
 
             return $job->release($this->retryAfterMinutes * 60);

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Queue;
 use Exception;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\CallQueuedHandler;
@@ -14,6 +15,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
 
 class ThrottlesExceptionsWithRedisTest extends TestCase
 {
@@ -115,6 +117,36 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         ]);
 
         $this->assertTrue($class::$handled);
+    }
+
+    public function testReportingExceptions()
+    {
+        $this->spy(ExceptionHandler::class)
+            ->shouldReceive('report')
+            ->twice()
+            ->with(m::type(RuntimeException::class));
+
+        $job = new class
+        {
+            public function release()
+            {
+                return $this;
+            }
+        };
+        $next = function () {
+            throw new RuntimeException('Whoops!');
+        };
+
+        $middleware = new ThrottlesExceptionsWithRedis();
+
+        $middleware->report();
+        $middleware->handle($job, $next);
+
+        $middleware->report(fn () => true);
+        $middleware->handle($job, $next);
+
+        $middleware->report(fn () => false);
+        $middleware->handle($job, $next);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Description
This PR adds an option to the `ThrottlesExceptions` (and `ThrottlesExceptionsWithRedis`) middleware to have the throttled exception be reported. This will allow you to see the exception in your logging and be aware that something is not going as expected.

### Usage
Report every throttled exception:
```php
use Illuminate\Queue\Middleware\ThrottlesExceptions;

/**
 * Get the middleware the job should pass through.
 *
 * @return array<int, object>
 */
public function middleware(): array
{
    return [(new ThrottlesExceptions(10, 10))->report()];
}
```

Report only specific throttled exceptions:
```php
use Illuminate\Http\Client\HttpClientException;
use Illuminate\Queue\Middleware\ThrottlesExceptions;

/**
 * Get the middleware the job should pass through.
 *
 * @return array<int, object>
 */
public function middleware(): array
{
    return [(new ThrottlesExceptions(10, 10))->report(fn (Throwable $throwable) => $throwable instanceof HttpClientException)];
}
```

N.B. I'll make a PR to the docs once this gets merged.

## Motivation and context
I had one specific job that kept failing because of the max tries/timeout that was reached. I couldn't see why because I only saw the `MaxAttemptsExceededException` in my logging and nothing else. After debugging and seeing that the `ThrottlesExceptions` middleware we used, [discards the exception](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php#L99-L107), I disabled the middleware and I got the actual exception; it was trying to insert null in a non-nullable column. Afterwards I configured the middleware to only throttle specific exceptions, but that posibility wasn't documented, so I wasn't aware of this feature. So I also opened https://github.com/laravel/docs/pull/9551 to document that. However, I still think this reporting feature is worth it and saves you a lot of debugging time!