### PR TITLE
[11.x] Add session `hasAny` method

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -283,7 +283,7 @@ class Store implements Session
     }
 
     /**
-     * Checks if a key is present and not null.
+     * Determine if a key is present and not null.
      *
      * @param  string|array  $key
      * @return bool
@@ -296,7 +296,7 @@ class Store implements Session
     }
 
     /**
-     * Checks if any of the keys are present and not null.
+     * Determine if any of the given keys are present and not null.
      *
      * @param  string|array  $key
      * @return bool

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -296,6 +296,19 @@ class Store implements Session
     }
 
     /**
+     * Checks if any of the keys are present and not null.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function hasAny($key)
+    {
+        return collect(is_array($key) ? $key : func_get_args())->filter(function ($key) {
+            return ! is_null($this->get($key));
+        })->count() >= 1;
+    }
+
+    /**
      * Get an item from the session.
      *
      * @param  string  $key

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -521,6 +521,22 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->has('foo', 'bar'));
     }
 
+    public function testKeyHasAny()
+    {
+        $session = $this->getSession();
+        $session->put('first_name', 'Mahmoud');
+        $session->put('last_name', 'Ramadan');
+
+        $this->assertTrue($session->hasAny('first_name'));
+        $this->assertTrue($session->hasAny('first_name', 'last_name'));
+        $this->assertTrue($session->hasAny(['first_name', 'last_name']));
+        $this->assertTrue($session->hasAny(['first_name', 'middle_name']));
+
+        $this->assertFalse($session->hasAny('middle_name'));
+        $this->assertFalse($session->hasAny('foo', 'bar'));
+        $this->assertFalse($session->hasAny(['foo', 'bar']));
+    }
+
     public function testKeyExists()
     {
         $session = $this->getSession();


### PR DESCRIPTION
Laravel ships with the session  `has` method that checks if the passed key is present but, sometimes we need to check if any of the given keys are present. Let's check out the old code and what the code will look like after merging this PR:

## Previously

```PHP
if (session()->has('first_name') || session()->has('last_name')) {
    // do something...
}
```

## Later

```PHP
if (session()->hasAny(['first_name', 'last_name'])) {
    // do something...
}
```

> [!IMPORTANT]
> I know that there is a collection `hasAny` method but, In my opinion, it's not the better approach for two reasons:
> 1. According to performance, I must check if any passed keys are included in all session keys instead of checking specific keys.
> 2. According to empty value checking, I also needed to check if these keys were not null, so I used the collection `filter` method to count the filtered items.