### PR TITLE
[11.x] Allow customizing TrimStrings::$except

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -62,7 +62,7 @@ class TrimStrings extends TransformsRequest
     {
         $except = array_merge($this->except, static::$neverTrim);
 
-        if ($this->skipTrim($key, $except) || ! is_string($value)) {
+        if ($this->shouldSkip($key, $except) || ! is_string($value)) {
             return $value;
         }
 
@@ -71,8 +71,12 @@ class TrimStrings extends TransformsRequest
 
     /**
      * Determine if the given key should be skipped.
+     *
+     * @param  string  $key
+     * @param  array  $except
+     * @return bool
      */
-    protected function skipTrim($key, $except)
+    protected function shouldSkip($key, $except)
     {
         return in_array($key, $except, true);
     }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -62,11 +62,19 @@ class TrimStrings extends TransformsRequest
     {
         $except = array_merge($this->except, static::$neverTrim);
 
-        if (in_array($key, $except, true) || ! is_string($value)) {
+        if ($this->skipTrim($key, $except) || ! is_string($value)) {
             return $value;
         }
 
         return Str::trim($value);
+    }
+
+    /**
+     * Determine if the given key should be skipped.
+     */
+    protected function skipTrim($key, $except)
+    {
+        return in_array($key, $except, true);
     }
 
     /**


### PR DESCRIPTION
I've noticed that `TrimStrings::$except` does not support array values like `users.*.email`.
This pull request extracts new methods to allow developers to customize this behavior.
This change is fully backwards compatible.