### PR TITLE
[11.x] Optimize SetCacheHeaders to ensure error responses aren't cached

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -50,10 +50,9 @@ class SetCacheHeaders
             $options = $this->parseOptions($options);
         }
 
-        if (isset($options['if_successful']) && ! $response->isSuccessful()) {
+        if (! $response->isSuccessful()) {
             return $response;
         }
-        unset($options['if_successful']);
 
         if (isset($options['etag']) && $options['etag'] === true) {
             $options['etag'] = $response->getEtag() ?? md5($response->getContent());

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -50,6 +50,11 @@ class SetCacheHeaders
             $options = $this->parseOptions($options);
         }
 
+        if (isset($options['if_successful']) && ! $response->isSuccessful()) {
+            return $response;
+        }
+        unset($options['if_successful']);
+
         if (isset($options['etag']) && $options['etag'] === true) {
             $options['etag'] = $response->getEtag() ?? md5($response->getContent());
         }


### PR DESCRIPTION
**Problem:**
Currently, error responses can be cached by the `cache.headers` middleware, leading to outdated errors for users.

**Solution:**
This PR conditionally apply caching only when the response has a successful HTTP status code.

**Changes:**
* Modified the `SetCacheHeaders` middleware to only cache if the response is successful.

**Backward Compatibility:**
This change is fully backward-compatible.

**Documentation:**
The Laravel documentation will need to be updated to reflect the new directive.