### PR TITLE
[11.x] Add pull methods to Context

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -120,6 +120,34 @@ class Repository
     }
 
     /**
+     * Retrieve the given key's value and then forget it.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function pull($key, $default = null)
+    {
+        return tap($this->get($key, $default), function () use ($key) {
+            $this->forget($key);
+        });
+    }
+
+    /**
+     * Retrieve the given key's hidden value and then forget it.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function pullHidden($key, $default = null)
+    {
+        return tap($this->getHidden($key, $default), function () use ($key) {
+            $this->forgetHidden($key);
+        });
+    }
+
+    /**
      * Retrieve only the values of the given keys.
      *
      * @param  array<int, string>  $keys

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -9,6 +9,8 @@ namespace Illuminate\Support\Facades;
  * @method static array allHidden()
  * @method static mixed get(string $key, mixed $default = null)
  * @method static mixed getHidden(string $key, mixed $default = null)
+ * @method static mixed pull(string $key, mixed $default = null)
+ * @method static mixed pullHidden(string $key, mixed $default = null)
  * @method static array only(array $keys)
  * @method static array onlyHidden(array $keys)
  * @method static \Illuminate\Log\Context\Repository add(string|array $key, mixed $value = null)

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -354,6 +354,19 @@ class ContextTest extends TestCase
         Context::pushHidden('foo', 2);
     }
 
+    public function test_it_can_pull()
+    {
+        Context::add('foo', 'data');
+
+        $this->assertSame('data', Context::pull('foo'));
+        $this->assertNull(Context::get('foo'));
+
+        Context::addHidden('foo', 'data');
+
+        $this->assertSame('data', Context::pullHidden('foo'));
+        $this->assertNull(Context::getHidden('foo'));
+    }
+
     public function test_it_adds_context_to_logged_exceptions()
     {
         $path = storage_path('logs/laravel.log');

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -114,7 +114,7 @@ class ContextTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function test_it_can_serilize_values()
+    public function test_it_can_serialize_values()
     {
         Context::add([
             'string' => 'string',


### PR DESCRIPTION
Many features like Session and Collections have a `pull` method that gets the data and immediately deletes it.
Context missed that functionality, while its use cases can mimic session use cases.

A simple use case could be capturing context for database logging, and pulling it because the additional context is no longer needed inside file logging.

Although highly unlikely, this feature can be breaking if a macro is added with the same name and different functionality.