### PR TITLE
[11.x] add function to get faked events

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -60,16 +60,6 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
-     * Get the events that have been pushed.
-     *
-     * @return array
-     */
-    public function pushedEvents()
-    {
-        return $this->events;
-    }
-
-    /**
      * Specify the events that should be dispatched instead of faked.
      *
      * @param  array|string  $eventsToDispatch
@@ -412,6 +402,16 @@ class EventFake implements Dispatcher, Fake
     public function until($event, $payload = [])
     {
         return $this->dispatch($event, $payload, true);
+    }
+
+    /**
+     * Get the events that have been dispatched.
+     *
+     * @return array
+     */
+    public function dispatchedEvents()
+    {
+        return $this->events;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -60,6 +60,16 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
+     * Get the events that have been pushed.
+     *
+     * @return array
+     */
+    public function pushedEvents()
+    {
+        return $this->events;
+    }
+
+    /**
      * Specify the events that should be dispatched instead of faked.
      *
      * @param  array|string  $eventsToDispatch


### PR DESCRIPTION
this function will return an array of all Events that have been faked.

this can be helpful when originally writing the tests to get a grasp of which events you may need to intercept.

both the `QueueFake` and `NotificationFake` have similar methods to let you see what has been intercepted by the fake.

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Support/Testing/Fakes/QueueFake.php#L512 https://github.com/laravel/framework/blob/11.x/src/Illuminate/Support/Testing/Fakes/NotificationFake.php#L357