### PR TITLE
[11.x] Remove redundant code from MariaDbGrammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -324,41 +324,54 @@ class MySqlGrammar extends Grammar
 
         if (($connection->isMaria() && version_compare($version, '10.5.2', '<')) ||
             (! $connection->isMaria() && version_compare($version, '8.0.3', '<'))) {
-            $column = collect($connection->getSchemaBuilder()->getColumns($blueprint->getTable()))
-                ->firstWhere('name', $command->from);
-
-            $modifiers = $this->addModifiers($column['type'], $blueprint, new ColumnDefinition([
-                'change' => true,
-                'type' => match ($column['type_name']) {
-                    'bigint' => 'bigInteger',
-                    'int' => 'integer',
-                    'mediumint' => 'mediumInteger',
-                    'smallint' => 'smallInteger',
-                    'tinyint' => 'tinyInteger',
-                    default => $column['type_name'],
-                },
-                'nullable' => $column['nullable'],
-                'default' => $column['default'] && str_starts_with(strtolower($column['default']), 'current_timestamp')
-                    ? new Expression($column['default'])
-                    : $column['default'],
-                'autoIncrement' => $column['auto_increment'],
-                'collation' => $column['collation'],
-                'comment' => $column['comment'],
-                'virtualAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'virtual'
-                    ? $column['generation']['expression'] : null,
-                'storedAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'stored'
-                    ? $column['generation']['expression'] : null,
-            ]));
-
-            return sprintf('alter table %s change %s %s %s',
-                $this->wrapTable($blueprint),
-                $this->wrap($command->from),
-                $this->wrap($command->to),
-                $modifiers
-            );
+            return $this->compileLegacyRenameColumn($blueprint, $command, $connection);
         }
 
         return parent::compileRenameColumn($blueprint, $command, $connection);
+    }
+
+    /**
+     * Compile a rename column command for legacy versions.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string
+     */
+    protected function compileLegacyRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
+    {
+        $column = collect($connection->getSchemaBuilder()->getColumns($blueprint->getTable()))
+            ->firstWhere('name', $command->from);
+
+        $modifiers = $this->addModifiers($column['type'], $blueprint, new ColumnDefinition([
+            'change' => true,
+            'type' => match ($column['type_name']) {
+                'bigint' => 'bigInteger',
+                'int' => 'integer',
+                'mediumint' => 'mediumInteger',
+                'smallint' => 'smallInteger',
+                'tinyint' => 'tinyInteger',
+                default => $column['type_name'],
+            },
+            'nullable' => $column['nullable'],
+            'default' => $column['default'] && str_starts_with(strtolower($column['default']), 'current_timestamp')
+                ? new Expression($column['default'])
+                : $column['default'],
+            'autoIncrement' => $column['auto_increment'],
+            'collation' => $column['collation'],
+            'comment' => $column['comment'],
+            'virtualAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'virtual'
+                ? $column['generation']['expression'] : null,
+            'storedAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'stored'
+                ? $column['generation']['expression'] : null,
+        ]));
+
+        return sprintf('alter table %s change %s %s %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->from),
+            $this->wrap($command->to),
+            $modifiers
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -331,7 +331,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile a rename column command for legacy versions.
+     * Compile a rename column command for legacy versions of MySQL.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
+use Illuminate\Database\Schema\Grammars\MariaDbGrammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
@@ -229,7 +230,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             "alter table `users` change `name` `title` varchar(255) collate 'utf8mb4_unicode_ci' null default 'foo'",
             "alter table `users` change `id` `key` bigint unsigned not null auto_increment comment 'lorem ipsum'",
             'alter table `users` change `generated` `new_generated` int as (expression) stored not null',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MariaDbGrammar));
     }
 
     public function testDropColumn()


### PR DESCRIPTION
Related to #50146, the code for renaming column on legacy versions of `MariaDbGrammar` must be identical to the code on `MySqlGrammar`. On #50329, I forgot to apply the changes to `MariaDbGrammar` as well as `MySqlGrammar`. This PR removes the redundant code and makes sure that this doesn't happen again in the future.