### PR TITLE
[11.x] Throw exception if named rate limiter and model property do not exist

### DIFF
--- a/src/Illuminate/Routing/Exceptions/InvalidNamedRateLimiterException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidNamedRateLimiterException.php
@@ -16,4 +16,16 @@ class InvalidNamedRateLimiterException extends Exception
     {
         return new static("Named rate limiter [{$limiter}] is not defined.");
     }
+
+    /**
+     * Create a new exception for an invalid rate limiter based on a model property.
+     *
+     * @param  string $limiter
+     * @param  class-string $model
+     * @return static
+     */
+    public static function forLimiterAndUser(string $limiter, string $model)
+    {
+        return new static("Named rate limiter [{$model}::{$limiter}] is not defined.");
+    }
 }

--- a/src/Illuminate/Routing/Exceptions/InvalidNamedRateLimiterException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidNamedRateLimiterException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use Exception;
+
+class InvalidNamedRateLimiterException extends Exception
+{
+    /**
+     * Create a new exception for invalid named rate limiter.
+     *
+     * @param  string  $limiter
+     * @return static
+     */
+    public static function forLimiter(string $limiter)
+    {
+        return new static("Named rate limiter [{$limiter}] is not defined.");
+    }
+}

--- a/src/Illuminate/Routing/Exceptions/MissingRateLimiterException.php
+++ b/src/Illuminate/Routing/Exceptions/MissingRateLimiterException.php
@@ -4,7 +4,7 @@ namespace Illuminate\Routing\Exceptions;
 
 use Exception;
 
-class InvalidNamedRateLimiterException extends Exception
+class MissingRateLimiterException extends Exception
 {
     /**
      * Create a new exception for invalid named rate limiter.
@@ -14,7 +14,7 @@ class InvalidNamedRateLimiterException extends Exception
      */
     public static function forLimiter(string $limiter)
     {
-        return new static("Named rate limiter [{$limiter}] is not defined.");
+        return new static("Rate limiter [{$limiter}] is not defined.");
     }
 
     /**
@@ -26,6 +26,6 @@ class InvalidNamedRateLimiterException extends Exception
      */
     public static function forLimiterAndUser(string $limiter, string $model)
     {
-        return new static("Named rate limiter [{$model}::{$limiter}] is not defined.");
+        return new static("Rate limiter [{$model}::{$limiter}] is not defined.");
     }
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -196,7 +196,11 @@ class ThrottleRequests
         // If by this time we still don't have a numeric value, it means there was no matching rate limiter,
         // and that the attribute in the authenticated model either did not exist or was invalid.
         if (! is_numeric($maxAttempts)) {
-            throw InvalidNamedRateLimiterException::forLimiter($maxAttempts);
+            if (is_null($request->user())) {
+                throw InvalidNamedRateLimiterException::forLimiter($maxAttempts);
+            }
+
+            throw InvalidNamedRateLimiterException::forLimiterAndUser($maxAttempts, get_class($request->user()));
         }
 
         return (int) $maxAttempts;

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -187,8 +187,7 @@ class ThrottleRequests
 
         if (
             ! is_numeric($maxAttempts) &&
-            $request->user() &&
-            $request->user()->hasAttribute($maxAttempts)
+            $request->user()?->hasAttribute($maxAttempts)
         ) {
             $maxAttempts = $request->user()->{$maxAttempts};
         }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -188,7 +188,7 @@ class ThrottleRequests
         if (
             ! is_numeric($maxAttempts) &&
             $request->user() &&
-            array_key_exists($maxAttempts, $request->user()->getAttributes())
+            $request->user()->hasAttribute($maxAttempts)
         ) {
             $maxAttempts = $request->user()->{$maxAttempts};
         }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -7,7 +7,7 @@ use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
-use Illuminate\Routing\Exceptions\InvalidNamedRateLimiterException;
+use Illuminate\Routing\Exceptions\MissingRateLimiterException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\InteractsWithTime;
 use RuntimeException;
@@ -79,7 +79,7 @@ class ThrottleRequests
      * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
-     * @throws \Illuminate\Routing\Exceptions\InvalidNamedRateLimiterException
+     * @throws \Illuminate\Routing\Exceptions\MissingRateLimiterException
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
@@ -177,7 +177,7 @@ class ThrottleRequests
      * @param  \Illuminate\Http\Request  $request
      * @param  int|string  $maxAttempts
      * @return int
-     * @throws \Illuminate\Routing\Exceptions\InvalidNamedRateLimiterException
+     * @throws \Illuminate\Routing\Exceptions\MissingRateLimiterException
      */
     protected function resolveMaxAttempts($request, $maxAttempts)
     {
@@ -185,21 +185,17 @@ class ThrottleRequests
             $maxAttempts = explode('|', $maxAttempts, 2)[$request->user() ? 1 : 0];
         }
 
-        if (
-            ! is_numeric($maxAttempts) &&
+        if (! is_numeric($maxAttempts) &&
             $request->user()?->hasAttribute($maxAttempts)
         ) {
             $maxAttempts = $request->user()->{$maxAttempts};
         }
 
-        // If by this time we still don't have a numeric value, it means there was no matching rate limiter,
-        // and that the attribute in the authenticated model either did not exist or was invalid.
+        // If we still don't have a numeric value, there was no matching rate limiter...
         if (! is_numeric($maxAttempts)) {
-            if (is_null($request->user())) {
-                throw InvalidNamedRateLimiterException::forLimiter($maxAttempts);
-            }
-
-            throw InvalidNamedRateLimiterException::forLimiterAndUser($maxAttempts, get_class($request->user()));
+            is_null($request->user())
+                ? throw MissingRateLimiterException::forLimiter($maxAttempts)
+                : throw MissingRateLimiterException::forLimiterAndUser($maxAttempts, get_class($request->user()));
         }
 
         return (int) $maxAttempts;
@@ -287,9 +283,9 @@ class ThrottleRequests
      * @return array
      */
     protected function getHeaders($maxAttempts,
-                                  $remainingAttempts,
-                                  $retryAfter = null,
-                                  ?Response $response = null)
+        $remainingAttempts,
+        $retryAfter = null,
+        ?Response $response = null)
     {
         if ($response &&
             ! is_null($response->headers->get('X-RateLimit-Remaining')) &&

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -245,7 +245,7 @@ class ThrottleRequestsTest extends TestCase
     public function testItFailsIfNamedLimiterDoesNotExist()
     {
         $this->expectException(MissingRateLimiterException::class);
-        $this->expectExceptionMessage('Named rate limiter [test] is not defined.');
+        $this->expectExceptionMessage('Rate limiter [test] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
 
@@ -255,7 +255,7 @@ class ThrottleRequestsTest extends TestCase
     public function testItFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
     {
         $this->expectException(MissingRateLimiterException::class);
-        $this->expectExceptionMessage('Named rate limiter [' . User::class . '::rateLimiting] is not defined.');
+        $this->expectExceptionMessage('Rate limiter [' . User::class . '::rateLimiting] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(['auth', ThrottleRequests::using('rateLimiting')]);
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -255,9 +255,7 @@ class ThrottleRequestsTest extends TestCase
 
         Route::get('/', fn () => 'ok')->middleware(['auth', ThrottleRequests::using('rateLimiting')]);
 
-        $user = User::make()->forceFill([
-            'rateLimiting' => 1,
-        ]);
+        $user = User::make()->forceFill([]);
 
         $this->withoutExceptionHandling()->actingAs($user)->get('/');
     }

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -245,10 +245,10 @@ class ThrottleRequestsTest extends TestCase
 
         Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
 
-        $this->get('/');
+        $this->withoutExceptionHandling()->get('/');
     }
 
-    public function itFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
+    public function testItFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
     {
         $this->expectException(InvalidNamedRateLimiterException::class);
         $this->expectExceptionMessage('Named rate limiter [rateLimiting] is not defined.');
@@ -259,7 +259,7 @@ class ThrottleRequestsTest extends TestCase
             'rateLimiting' => 1,
         ]);
 
-        $this->get('/');
+        $this->withoutExceptionHandling()->actingAs($user)->get('/');
     }
 
     public function testItFallbacksToUserPropertyWhenThereIsNoNamedLimiterWhenAuthenticated()

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -255,7 +255,7 @@ class ThrottleRequestsTest extends TestCase
     public function testItFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
     {
         $this->expectException(InvalidNamedRateLimiterException::class);
-        $this->expectExceptionMessage('Named rate limiter [rateLimiting] is not defined.');
+        $this->expectExceptionMessage('Named rate limiter [' . User::class . '::rateLimiting] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(['auth', ThrottleRequests::using('rateLimiting')]);
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
-use Illuminate\Routing\Exceptions\InvalidNamedRateLimiterException;
+use Illuminate\Routing\Exceptions\MissingRateLimiterException;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
@@ -244,7 +244,7 @@ class ThrottleRequestsTest extends TestCase
 
     public function testItFailsIfNamedLimiterDoesNotExist()
     {
-        $this->expectException(InvalidNamedRateLimiterException::class);
+        $this->expectException(MissingRateLimiterException::class);
         $this->expectExceptionMessage('Named rate limiter [test] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
@@ -254,7 +254,7 @@ class ThrottleRequestsTest extends TestCase
 
     public function testItFailsIfNamedLimiterDoesNotExistAndAuthenticatedUserDoesNotHaveFallbackProperty()
     {
-        $this->expectException(InvalidNamedRateLimiterException::class);
+        $this->expectException(MissingRateLimiterException::class);
         $this->expectExceptionMessage('Named rate limiter [' . User::class . '::rateLimiting] is not defined.');
 
         Route::get('/', fn () => 'ok')->middleware(['auth', ThrottleRequests::using('rateLimiting')]);


### PR DESCRIPTION
Based on what we talked regarding https://github.com/laravel/framework/pull/50818

Handling strict mode is a bit annoying — if you have it set, it'd throw a bit of a cryptic error message since it'd fail with a different error. Another thing is that the `array_key_exists` solution doesn't deal with custom attributes.
Maybe it's an opportunity to introduce a strict-safe `hasAttribute` method within Eloquent?