### PR TITLE
[11.x] Add strict-mode safe hasAttribute method to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -434,6 +434,25 @@ trait HasAttributes
     }
 
     /**
+     * Determine whether an attribute exists on the model.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function hasAttribute($key)
+    {
+        if (! $key) {
+            return false;
+        }
+
+        return array_key_exists($key, $this->attributes) ||
+            array_key_exists($key, $this->casts) ||
+            $this->hasGetMutator($key) ||
+            $this->hasAttributeMutator($key) ||
+            $this->isClassCastable($key);
+    }
+
+    /**
      * Get an attribute from the model.
      *
      * @param  string  $key
@@ -448,11 +467,7 @@ trait HasAttributes
         // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            array_key_exists($key, $this->casts) ||
-            $this->hasGetMutator($key) ||
-            $this->hasAttributeMutator($key) ||
-            $this->isClassCastable($key)) {
+        if ($this->hasAttribute($key)) {
             return $this->getAttributeValue($key);
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -20,6 +20,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
     {
         $relation = $this->getRelation();
         $model1 = m::mock(Model::class);
+        $model1->shouldReceive('hasAttribute')->passthru();
         $model1->shouldReceive('getAttribute')->with('parent_key')->andReturn(1);
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
@@ -28,6 +29,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
 
         $model2 = m::mock(Model::class);
+        $model2->shouldReceive('hasAttribute')->passthru();
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
         $model2->shouldReceive('hasGetMutator')->andReturn(false);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3023,6 +3023,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($user->getOriginal('name'));
         $this->assertNull($user->getAttribute('name'));
     }
+
+    public function testHasAttribute()
+    {
+        $user = new EloquentModelStub([
+            'name' => 'Mateus',
+        ]);
+
+        $this->assertTrue($user->hasAttribute('name'));
+        $this->assertTrue($user->hasAttribute('password'));
+        $this->assertTrue($user->hasAttribute('castedFloat'));
+        $this->assertFalse($user->hasAttribute('nonexistent'));
+        $this->assertFalse($user->hasAttribute('belongsToStub'));
+    }
 }
 
 class EloquentTestObserverStub


### PR DESCRIPTION
Right now, it's a bit hard to safely check whether an attribute exists if you're using strict mode because it'll throw an exception in case it doesn't exist.

This PR just extracts some logic into a `hasAttribute` method. Might be useful here https://github.com/laravel/framework/pull/50908 if it gets moved forward. 