### PR TITLE
Add some test for `make:enum` when `Enums` or `Enumeratiosn` folder alredy exists.

### DIFF
--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -38,4 +38,54 @@ class EnumMakeCommandTest extends TestCase
             'enum IntEnum: int',
         ], 'app/IntEnum.php');
     }
+
+    public function testItCanGenerateEnumFileInEnumsFolder()
+    {
+        $enumsFolderPath = app_path('Enums');
+
+        $isFolderCreated = false;
+        if (!is_dir($enumsFolderPath)) {
+            mkdir($enumsFolderPath, 0777, true);
+            $isFolderCreated = true;
+        }
+
+        $this->artisan('make:enum', ['name' => 'OrderStatusEnum'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums;',
+            'enum OrderStatusEnum',
+        ], 'app/Enums/OrderStatusEnum.php');
+
+        unlink($enumsFolderPath.'/OrderStatusEnum.php');
+
+        if ($isFolderCreated) {
+            rmdir($enumsFolderPath);
+        }
+    }
+
+    public function testItCanGenerateEnumFileInEnumerationsFolder()
+    {
+        $enumerationsFolderPath = app_path('Enumerations');
+
+        $isFolderCreated = false;
+        if (!is_dir($enumerationsFolderPath)) {
+            mkdir($enumerationsFolderPath, 0777, true);
+            $isFolderCreated = true;
+        }
+
+        $this->artisan('make:enum', ['name' => 'OrderStatusEnum'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enumerations;',
+            'enum OrderStatusEnum',
+        ], 'app/Enumerations/OrderStatusEnum.php');
+
+        unlink($enumerationsFolderPath.'/OrderStatusEnum.php');
+
+        if ($isFolderCreated) {
+            rmdir($enumerationsFolderPath);
+        }
+    }
 }

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -44,7 +44,7 @@ class EnumMakeCommandTest extends TestCase
         $enumsFolderPath = app_path('Enums');
 
         $isFolderCreated = false;
-        if (!is_dir($enumsFolderPath)) {
+        if (! is_dir($enumsFolderPath)) {
             mkdir($enumsFolderPath, 0777, true);
             $isFolderCreated = true;
         }
@@ -69,7 +69,7 @@ class EnumMakeCommandTest extends TestCase
         $enumerationsFolderPath = app_path('Enumerations');
 
         $isFolderCreated = false;
-        if (!is_dir($enumerationsFolderPath)) {
+        if (! is_dir($enumerationsFolderPath)) {
             mkdir($enumerationsFolderPath, 0777, true);
             $isFolderCreated = true;
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Added some tests for this merged pull request #50411. This pr stated that if `Enums` or `Enumerations` folder exists inside `app` directory then `make:enum` `command` will create enums files inside this directories.

