### PR TITLE
[11.x] Add some test for make:enum when Enums or Enumerations folder already exists

### DIFF
--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -6,6 +6,13 @@ use Illuminate\Tests\Integration\Generators\TestCase;
 
 class EnumMakeCommandTest extends TestCase
 {
+    protected $files = [
+        'app/IntEnum.php',
+        'app/StatusEnum.php',
+        'app/StringEnum.php',
+        'app/*/OrderStatusEnum.php',
+    ];
+
     public function testItCanGenerateEnumFile()
     {
         $this->artisan('make:enum', ['name' => 'StatusEnum'])
@@ -43,11 +50,10 @@ class EnumMakeCommandTest extends TestCase
     {
         $enumsFolderPath = app_path('Enums');
 
-        $isFolderCreated = false;
-        if (! is_dir($enumsFolderPath)) {
-            mkdir($enumsFolderPath, 0777, true);
-            $isFolderCreated = true;
-        }
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($enumsFolderPath);
 
         $this->artisan('make:enum', ['name' => 'OrderStatusEnum'])
             ->assertExitCode(0);
@@ -57,22 +63,17 @@ class EnumMakeCommandTest extends TestCase
             'enum OrderStatusEnum',
         ], 'app/Enums/OrderStatusEnum.php');
 
-        unlink($enumsFolderPath.'/OrderStatusEnum.php');
-
-        if ($isFolderCreated) {
-            rmdir($enumsFolderPath);
-        }
+        $files->deleteDirectory($enumsFolderPath);
     }
 
     public function testItCanGenerateEnumFileInEnumerationsFolder()
     {
         $enumerationsFolderPath = app_path('Enumerations');
 
-        $isFolderCreated = false;
-        if (! is_dir($enumerationsFolderPath)) {
-            mkdir($enumerationsFolderPath, 0777, true);
-            $isFolderCreated = true;
-        }
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($enumerationsFolderPath);
 
         $this->artisan('make:enum', ['name' => 'OrderStatusEnum'])
             ->assertExitCode(0);
@@ -82,10 +83,6 @@ class EnumMakeCommandTest extends TestCase
             'enum OrderStatusEnum',
         ], 'app/Enumerations/OrderStatusEnum.php');
 
-        unlink($enumerationsFolderPath.'/OrderStatusEnum.php');
-
-        if ($isFolderCreated) {
-            rmdir($enumerationsFolderPath);
-        }
+        $files->deleteDirectory($enumerationsFolderPath);
     }
 }

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -38,4 +38,54 @@ class EnumMakeCommandTest extends TestCase
             'enum IntEnum: int',
         ], 'app/IntEnum.php');
     }
+
+    public function testItCanGenerateEnumFileInEnumsFolder()
+    {
+        $enumsFolderPath = app_path('Enums');
+
+        $isFolderCreated = false;
+        if (! is_dir($enumsFolderPath)) {
+            mkdir($enumsFolderPath, 0777, true);
+            $isFolderCreated = true;
+        }
+
+        $this->artisan('make:enum', ['name' => 'OrderStatusEnum'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums;',
+            'enum OrderStatusEnum',
+        ], 'app/Enums/OrderStatusEnum.php');
+
+        unlink($enumsFolderPath.'/OrderStatusEnum.php');
+
+        if ($isFolderCreated) {
+            rmdir($enumsFolderPath);
+        }
+    }
+
+    public function testItCanGenerateEnumFileInEnumerationsFolder()
+    {
+        $enumerationsFolderPath = app_path('Enumerations');
+
+        $isFolderCreated = false;
+        if (! is_dir($enumerationsFolderPath)) {
+            mkdir($enumerationsFolderPath, 0777, true);
+            $isFolderCreated = true;
+        }
+
+        $this->artisan('make:enum', ['name' => 'OrderStatusEnum'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enumerations;',
+            'enum OrderStatusEnum',
+        ], 'app/Enumerations/OrderStatusEnum.php');
+
+        unlink($enumerationsFolderPath.'/OrderStatusEnum.php');
+
+        if ($isFolderCreated) {
+            rmdir($enumerationsFolderPath);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Added some tests for this merged pull request #50411. This pr stated that if `Enums` or `Enumerations` folder exists inside `app` directory then `make:enum` command will create enums files inside these directories.
