### PR TITLE
[11.x] Add setters to cache stores

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -123,4 +123,15 @@ class ApcStore extends TaggableStore
     {
         return $this->prefix;
     }
+
+    /**
+     * Set the cache key prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+    }
 }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -388,6 +388,17 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Set the cache key prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
      * Serialize the given value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -381,6 +381,19 @@ class FileStore implements Store, LockProvider
     }
 
     /**
+     * Set the working directory of the cache.
+     *
+     * @param  string  $directory
+     * @return $this
+     */
+    public function setDirectory($directory)
+    {
+        $this->directory = $directory;
+
+        return $this;
+    }
+
+    /**
      * Set the cache directory where locks should be stored.
      *
      * @param  string|null  $lockDirectory


### PR DESCRIPTION
This makes it so that each cache store that respects the `cache.prefix` config also has a setter for the prefix. The prefix can be useful to change at runtime to separate cache data further, e.g. by tenants instead of just by application.