### PR TITLE
[11.x] Remove redundant casting types

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -132,7 +132,7 @@ class Response implements ArrayAccess, Stringable
      */
     public function status()
     {
-        return (int) $this->response->getStatusCode();
+        return $this->response->getStatusCode();
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -407,7 +407,7 @@ trait FormatsMessages
             8 => 'eighth',
             9 => 'ninth',
             10 => 'tenth',
-        ][(int) $value] ?? 'other';
+        ][$value] ?? 'other';
     }
 
     /**


### PR DESCRIPTION
This PR removes unnecessary casting types. 

### FormatsMessages.php trait

```php
protected function numberToIndexOrPositionWord(int $value)
{
    return [
        1 => 'first',
        2 => 'second',
        3 => 'third',
        4 => 'fourth',
        5 => 'fifth',
        6 => 'sixth',
        7 => 'seventh',
        8 => 'eighth',
        9 => 'ninth',
        10 => 'tenth',
    ][(int) $value] ?? 'other';
}
```

In this method, the casting operation for the `$value` has been removed. This action has been taken because the input data type is explicitly declared as `int` (using `int $value`), so there is no need for additional casting to `int`. 


### Response.php
```php
/**
   * Get the status code of the response.
   *
   * @return int
   */
  public function status()
  {
      return (int) $this->response->getStatusCode();
  }
```
The `$response` is of type `ResponseInterface`, and in this interface, the `getStatusCode` method explicitly returns an integer.

![image](https://github.com/laravel/framework/assets/36761585/47ab3fb2-5e87-44ff-b836-12b7640a7ac9)


