### PR TITLE
[11.x] improvement test for repeat method

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
+use ValueError;
 
 class SupportStrTest extends TestCase
 {
@@ -1196,11 +1197,13 @@ class SupportStrTest extends TestCase
 
     public function testRepeat()
     {
-        $this->assertEquals('', Str::repeat('Hello', -2));
-        $this->assertSame('',Str::repeat('Hello', 0));
-        $this->assertSame('Hello',Str::repeat('Hello', 1));
+        $this->assertSame('', Str::repeat('Hello', 0));
+        $this->assertSame('Hello', Str::repeat('Hello', 1));
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
+
+        $this->expectException(ValueError::class);
+        Str::repeat('Hello', -2);
     }
 
     #[DataProvider('specialCharacterProvider')]

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1196,6 +1196,9 @@ class SupportStrTest extends TestCase
 
     public function testRepeat()
     {
+        $this->assertEquals('', Str::repeat('Hello', -2));
+        $this->assertSame('',Str::repeat('Hello', 0));
+        $this->assertSame('Hello',Str::repeat('Hello', 1));
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1201,7 +1201,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('Hello', Str::repeat('Hello', 1));
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
+    }
 
+    public function testRepeatWhenTimesIsNegative()
+    {
         $this->expectException(ValueError::class);
         Str::repeat('Hello', -2);
     }


### PR DESCRIPTION
This PR, improvement test for repeat method , 

when `$times` parameter is negative ( result must be `ValueError` Exception)
```php
$this->assertSame('', Str::repeat('Hello', -2)); 
```

when `$times` parameter is 0 ( result must be empty string)
```php
$this->assertSame('', Str::repeat('Hello', 0));
```

when `$times` parameter is 1 ( result must be equal to input)
```php
$this->assertSame('Hello', Str::repeat('Hello', 1));
```
