### PR TITLE
[11.x] Add context `hasAny` and `hasAnyHidden` methods

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Log\Context\Events\ContextDehydrating as Dehydrating;
 use Illuminate\Log\Context\Events\ContextHydrated as Hydrated;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
@@ -72,9 +73,7 @@ class Repository
      */
     public function hasAny($keys)
     {
-        return collect(is_array($keys) ? $keys : func_get_args())
-            ->filter(fn ($key) => ! is_null($this->get($key)))
-            ->count() >= 1;
+        return Arr::hasAny($this->all(), is_array($keys) ? $keys : func_get_args());
     }
 
     /**
@@ -96,9 +95,7 @@ class Repository
      */
     public function hasAnyHidden($keys)
     {
-        return collect(is_array($keys) ? $keys : func_get_args())
-            ->filter(fn ($key) => ! is_null($this->getHidden($key)))
-            ->count() >= 1;
+        return Arr::hasAny($this->allHidden(), is_array($keys) ? $keys : func_get_args());
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -74,7 +74,7 @@ class Repository
     {
         return collect(is_array($keys) ? $keys : func_get_args())
             ->filter(fn ($key) => ! is_null($this->get($key)))
-            ->count() >= 1;
+            ->isNotEmpty();
     }
 
     /**
@@ -98,7 +98,7 @@ class Repository
     {
         return collect(is_array($keys) ? $keys : func_get_args())
             ->filter(fn ($key) => ! is_null($this->getHidden($key)))
-            ->count() >= 1;
+            ->isNotEmpty();
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Log\Context\Events\ContextDehydrating as Dehydrating;
 use Illuminate\Log\Context\Events\ContextHydrated as Hydrated;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
@@ -73,11 +72,9 @@ class Repository
      */
     public function hasAny($keys)
     {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        $input = $this->all();
-
-        return Arr::hasAny($input, $keys);
+        return collect(is_array($keys) ? $keys : func_get_args())
+            ->filter(fn ($key) => ! is_null($this->get($key)))
+            ->count() >= 1;
     }
 
     /**
@@ -99,11 +96,9 @@ class Repository
      */
     public function hasAnyHidden($keys)
     {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        $input = $this->allHidden();
-
-        return Arr::hasAny($input, $keys);
+        return collect(is_array($keys) ? $keys : func_get_args())
+            ->filter(fn ($key) => ! is_null($this->getHidden($key)))
+            ->count() >= 1;
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -72,9 +72,7 @@ class Repository
      */
     public function hasAny($keys)
     {
-        return collect(is_array($keys) ? $keys : func_get_args())
-            ->filter(fn ($key) => ! is_null($this->get($key)))
-            ->isNotEmpty();
+        return collect($this->data)->hasAny(is_array($keys) ? $keys : func_get_args());
     }
 
     /**
@@ -96,9 +94,7 @@ class Repository
      */
     public function hasAnyHidden($keys)
     {
-        return collect(is_array($keys) ? $keys : func_get_args())
-            ->filter(fn ($key) => ! is_null($this->getHidden($key)))
-            ->isNotEmpty();
+        return collect($this->hidden)->hasAny(is_array($keys) ? $keys : func_get_args());
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Log\Context\Events\ContextDehydrating as Dehydrating;
 use Illuminate\Log\Context\Events\ContextHydrated as Hydrated;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -73,7 +73,9 @@ class Repository
      */
     public function hasAny($keys)
     {
-        return Arr::hasAny($this->all(), is_array($keys) ? $keys : func_get_args());
+        return collect(is_array($keys) ? $keys : func_get_args())
+            ->filter(fn ($key) => ! is_null($this->get($key)))
+            ->count() >= 1;
     }
 
     /**
@@ -95,7 +97,9 @@ class Repository
      */
     public function hasAnyHidden($keys)
     {
-        return Arr::hasAny($this->allHidden(), is_array($keys) ? $keys : func_get_args());
+        return collect(is_array($keys) ? $keys : func_get_args())
+            ->filter(fn ($key) => ! is_null($this->getHidden($key)))
+            ->count() >= 1;
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Log\Context\Events\ContextDehydrating as Dehydrating;
 use Illuminate\Log\Context\Events\ContextHydrated as Hydrated;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
@@ -62,6 +63,21 @@ class Repository
     public function has($key)
     {
         return array_key_exists($key, $this->data);
+    }
+
+    /**
+     * Determine if the context contains any of the given keys.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function hasAny($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $input = $this->all();
+
+        return Arr::hasAny($input, $keys);
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -92,6 +92,21 @@ class Repository
     }
 
     /**
+     * Determine if the context contains any of the given keys.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function hasAnyHidden($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $input = $this->allHidden();
+
+        return Arr::hasAny($input, $keys);
+    }
+
+    /**
      * Retrieve all the context data.
      *
      * @return array<string, mixed>

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -217,6 +217,17 @@ class ContextTest extends TestCase
         $this->assertFalse(Context::hasAny('unset'));
     }
 
+    public function test_it_can_check_if_context_has_any_hidden_been_set()
+    {
+        Context::addHidden('one', '1');
+        Context::addHidden('two', '2');
+        Context::addHidden('foo', 'bar');
+
+        $this->assertTrue(Context::hasAnyHidden(['foo', 'one', 'two']));
+        $this->assertTrue(Context::hasAnyHidden('two'));
+        $this->assertFalse(Context::hasAnyHidden('unset'));
+    }
+
     public function test_it_can_get_all_values()
     {
         Context::add('foo', 'bar');

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -206,6 +206,17 @@ class ContextTest extends TestCase
         $this->assertFalse(Context::has('unset'));
     }
 
+    public function test_it_can_check_if_context_has_any_been_set()
+    {
+        Context::add('one', '1');
+        Context::add('two', '2');
+        Context::add('foo', 'bar');
+
+        $this->assertTrue(Context::hasAny(['foo', 'one', 'two']));
+        $this->assertTrue(Context::hasAny('two'));
+        $this->assertFalse(Context::hasAny('unset'));
+    }
+
     public function test_it_can_get_all_values()
     {
         Context::add('foo', 'bar');


### PR DESCRIPTION
This PR enhances the `Context` by introducing two new methods: `hasAny` and `hasAnyHidden`. These methods simplify conditional checks within the codebase by allowing developers to determine if any of the specified keys are present in the context array.

**Before:**

Before this PR, developers had to individually check for each key's existence in the context array. This resulted in code that was less concise and potentially more error-prone. For instance:

```php
if (Context::has('user') || Context::has('is_admin')) {
    // Code block...
}
```

**After:**

With the introduction of `hasAny` and `hasAnyHidden`, developers can streamline their conditional checks by passing an array of keys to these methods. For example:

```php
if (Context::hasAny(['user', 'is_admin'])) {
    // Code block...
}
```

This new approach enhances code readability, reduces redundancy, and improves maintainability, ultimately contributing to a more efficient development workflow.