### PR TITLE
[11.x] Explicit nullable parameter declarations to fix PHP 8.4 deprecation

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -29,7 +29,7 @@ class AuthorizationException extends Exception
      * @param  \Throwable|null  $previous
      * @return void
      */
-    public function __construct($message = null, $code = null, Throwable $previous = null)
+    public function __construct($message = null, $code = null, ?Throwable $previous = null)
     {
         parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -100,7 +100,7 @@ class Gate implements GateContract
         array $policies = [],
         array $beforeCallbacks = [],
         array $afterCallbacks = [],
-        callable $guessPolicyNamesUsingCallback = null)
+        ?callable $guessPolicyNamesUsingCallback = null)
     {
         $this->policies = $policies;
         $this->container = $container;
@@ -224,7 +224,7 @@ class Gate implements GateContract
      * @param  array|null  $abilities
      * @return $this
      */
-    public function resource($name, $class, array $abilities = null)
+    public function resource($name, $class, ?array $abilities = null)
     {
         $abilities = $abilities ?: [
             'viewAny' => 'viewAny',

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -45,7 +45,7 @@ class PasswordBroker implements PasswordBrokerContract
      * @param  \Closure|null  $callback
      * @return string
      */
-    public function sendResetLink(array $credentials, Closure $callback = null)
+    public function sendResetLink(array $credentials, ?Closure $callback = null)
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -33,7 +33,7 @@ class RequestGuard implements Guard
      * @param  \Illuminate\Contracts\Auth\UserProvider|null  $provider
      * @return void
      */
-    public function __construct(callable $callback, Request $request, UserProvider $provider = null)
+    public function __construct(callable $callback, Request $request, ?UserProvider $provider = null)
     {
         $this->request = $request;
         $this->callback = $callback;

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -131,8 +131,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     public function __construct($name,
                                 UserProvider $provider,
                                 Session $session,
-                                Request $request = null,
-                                Timebox $timebox = null,
+                                ?Request $request = null,
+                                ?Timebox $timebox = null,
                                 bool $rehashOnLogin = true)
     {
         $this->name = $name;

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -64,7 +64,7 @@ class BroadcastManager implements FactoryContract
      * @param  array|null  $attributes
      * @return void
      */
-    public function routes(array $attributes = null)
+    public function routes(?array $attributes = null)
     {
         if ($this->app instanceof CachesRoutes && $this->app->routesAreCached()) {
             return;
@@ -86,7 +86,7 @@ class BroadcastManager implements FactoryContract
      * @param  array|null  $attributes
      * @return void
      */
-    public function userRoutes(array $attributes = null)
+    public function userRoutes(?array $attributes = null)
     {
         if ($this->app instanceof CachesRoutes && $this->app->routesAreCached()) {
             return;
@@ -110,7 +110,7 @@ class BroadcastManager implements FactoryContract
      * @param  array|null  $attributes
      * @return void
      */
-    public function channelRoutes(array $attributes = null)
+    public function channelRoutes(?array $attributes = null)
     {
         $this->routes($attributes);
     }

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -450,7 +450,7 @@ class Batch implements Arrayable, JsonSerializable
      * @param  \Throwable|null  $e
      * @return void
      */
-    protected function invokeHandlerCallback($handler, Batch $batch, Throwable $e = null)
+    protected function invokeHandlerCallback($handler, Batch $batch, ?Throwable $e = null)
     {
         try {
             return $handler($batch, $e);

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -58,7 +58,7 @@ class Dispatcher implements QueueingDispatcher
      * @param  \Closure|null  $queueResolver
      * @return void
      */
-    public function __construct(Container $container, Closure $queueResolver = null)
+    public function __construct(Container $container, ?Closure $queueResolver = null)
     {
         $this->container = $container;
         $this->queueResolver = $queueResolver;

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -15,7 +15,7 @@ class RedisTagSet extends TagSet
      * @param  string  $updateWhen
      * @return void
      */
-    public function addEntry(string $key, int $ttl = null, $updateWhen = null)
+    public function addEntry(string $key, ?int $ttl = null, $updateWhen = null)
     {
         $ttl = is_null($ttl) ? -1 : Carbon::now()->addSeconds($ttl)->getTimestamp();
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -190,7 +190,7 @@ class Arr
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
-    public static function first($array, callable $callback = null, $default = null)
+    public static function first($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             if (empty($array)) {
@@ -221,7 +221,7 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function last($array, callable $callback = null, $default = null)
+    public static function last($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             return empty($array) ? value($default) : end($array);

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -381,7 +381,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter(?callable $callback = null)
     {
         if ($callback) {
             return new static(Arr::where($this->items, $callback));
@@ -399,7 +399,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
-    public function first(callable $callback = null, $default = null)
+    public function first(?callable $callback = null, $default = null)
     {
         return Arr::first($this->items, $callback, $default);
     }
@@ -747,7 +747,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
-    public function last(callable $callback = null, $default = null)
+    public function last(?callable $callback = null, $default = null)
     {
         return Arr::last($this->items, $callback, $default);
     }

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -38,7 +38,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $callback
      * @return static
      */
-    public static function times($number, callable $callback = null);
+    public static function times($number, ?callable $callback = null);
 
     /**
      * Create a collection with the given range.
@@ -297,7 +297,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable(TValue): bool)|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null);
+    public function filter(?callable $callback = null);
 
     /**
      * Apply the callback if the given "value" is (or resolves to) truthy.
@@ -309,7 +309,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
      */
-    public function when($value, callable $callback = null, callable $default = null);
+    public function when($value, ?callable $callback = null, ?callable $default = null);
 
     /**
      * Apply the callback if the collection is empty.
@@ -320,7 +320,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TWhenEmptyReturnType)|null  $default
      * @return $this|TWhenEmptyReturnType
      */
-    public function whenEmpty(callable $callback, callable $default = null);
+    public function whenEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the collection is not empty.
@@ -331,7 +331,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TWhenNotEmptyReturnType)|null  $default
      * @return $this|TWhenNotEmptyReturnType
      */
-    public function whenNotEmpty(callable $callback, callable $default = null);
+    public function whenNotEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the given "value" is (or resolves to) truthy.
@@ -343,7 +343,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType
      */
-    public function unless($value, callable $callback, callable $default = null);
+    public function unless($value, callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is empty.
@@ -354,7 +354,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TUnlessEmptyReturnType)|null  $default
      * @return $this|TUnlessEmptyReturnType
      */
-    public function unlessEmpty(callable $callback, callable $default = null);
+    public function unlessEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is not empty.
@@ -365,7 +365,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TUnlessNotEmptyReturnType)|null  $default
      * @return $this|TUnlessNotEmptyReturnType
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null);
+    public function unlessNotEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Filter items by the given key value pair.
@@ -477,7 +477,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
-    public function first(callable $callback = null, $default = null);
+    public function first(?callable $callback = null, $default = null);
 
     /**
      * Get the first item by the given key value pair.
@@ -645,7 +645,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
-    public function last(callable $callback = null, $default = null);
+    public function last(?callable $callback = null, $default = null);
 
     /**
      * Run a map over each of the items.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -428,7 +428,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter(?callable $callback = null)
     {
         if (is_null($callback)) {
             $callback = fn ($value) => (bool) $value;
@@ -452,7 +452,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
-    public function first(callable $callback = null, $default = null)
+    public function first(?callable $callback = null, $default = null)
     {
         $iterator = $this->getIterator();
 
@@ -732,7 +732,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
-    public function last(callable $callback = null, $default = null)
+    public function last(?callable $callback = null, $default = null)
     {
         $needle = $placeholder = new stdClass;
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -163,7 +163,7 @@ trait EnumeratesValues
      * @param  (callable(int): TTimesValue)|null  $callback
      * @return static<int, TTimesValue>
      */
-    public static function times($number, callable $callback = null)
+    public static function times($number, ?callable $callback = null)
     {
         if ($number < 1) {
             return new static;
@@ -530,7 +530,7 @@ trait EnumeratesValues
      * @param  (callable($this): TWhenEmptyReturnType)|null  $default
      * @return $this|TWhenEmptyReturnType
      */
-    public function whenEmpty(callable $callback, callable $default = null)
+    public function whenEmpty(callable $callback, ?callable $default = null)
     {
         return $this->when($this->isEmpty(), $callback, $default);
     }
@@ -544,7 +544,7 @@ trait EnumeratesValues
      * @param  (callable($this): TWhenNotEmptyReturnType)|null  $default
      * @return $this|TWhenNotEmptyReturnType
      */
-    public function whenNotEmpty(callable $callback, callable $default = null)
+    public function whenNotEmpty(callable $callback, ?callable $default = null)
     {
         return $this->when($this->isNotEmpty(), $callback, $default);
     }
@@ -558,7 +558,7 @@ trait EnumeratesValues
      * @param  (callable($this): TUnlessEmptyReturnType)|null  $default
      * @return $this|TUnlessEmptyReturnType
      */
-    public function unlessEmpty(callable $callback, callable $default = null)
+    public function unlessEmpty(callable $callback, ?callable $default = null)
     {
         return $this->whenNotEmpty($callback, $default);
     }
@@ -572,7 +572,7 @@ trait EnumeratesValues
      * @param  (callable($this): TUnlessNotEmptyReturnType)|null  $default
      * @return $this|TUnlessNotEmptyReturnType
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null)
+    public function unlessNotEmpty(callable $callback, ?callable $default = null)
     {
         return $this->whenEmpty($callback, $default);
     }

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -18,7 +18,7 @@ trait Conditionable
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
      */
-    public function when($value = null, callable $callback = null, callable $default = null)
+    public function when($value = null, ?callable $callback = null, ?callable $default = null)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
@@ -50,7 +50,7 @@ trait Conditionable
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType
      */
-    public function unless($value = null, callable $callback = null, callable $default = null)
+    public function unless($value = null, ?callable $callback = null, ?callable $default = null)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1140,7 +1140,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function beforeResolving($abstract, Closure $callback = null)
+    public function beforeResolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -1160,7 +1160,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function resolving($abstract, Closure $callback = null)
+    public function resolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -1180,7 +1180,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function afterResolving($abstract, Closure $callback = null)
+    public function afterResolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -1419,7 +1419,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return \Illuminate\Contracts\Container\Container|static
      */
-    public static function setInstance(ContainerContract $container = null)
+    public static function setInstance(?ContainerContract $container = null)
     {
         return static::$instance = $container;
     }

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -29,7 +29,7 @@ interface Gate
      * @param  array|null  $abilities
      * @return $this
      */
-    public function resource($name, $class, array $abilities = null);
+    public function resource($name, $class, ?array $abilities = null);
 
     /**
      * Define a policy class for a given class type.

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -48,7 +48,7 @@ interface PasswordBroker
      * @param  \Closure|null  $callback
      * @return string
      */
-    public function sendResetLink(array $credentials, Closure $callback = null);
+    public function sendResetLink(array $credentials, ?Closure $callback = null);
 
     /**
      * Reset the password for the given token.

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -197,7 +197,7 @@ interface Container extends ContainerInterface
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function beforeResolving($abstract, Closure $callback = null);
+    public function beforeResolving($abstract, ?Closure $callback = null);
 
     /**
      * Register a new resolving callback.
@@ -206,7 +206,7 @@ interface Container extends ContainerInterface
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function resolving($abstract, Closure $callback = null);
+    public function resolving($abstract, ?Closure $callback = null);
 
     /**
      * Register a new after resolving callback.
@@ -215,5 +215,5 @@ interface Container extends ContainerInterface
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function afterResolving($abstract, Closure $callback = null);
+    public function afterResolving($abstract, ?Closure $callback = null);
 }

--- a/src/Illuminate/Contracts/Notifications/Dispatcher.php
+++ b/src/Illuminate/Contracts/Notifications/Dispatcher.php
@@ -21,5 +21,5 @@ interface Dispatcher
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null);
+    public function sendNow($notifiables, $notification, ?array $channels = null);
 }

--- a/src/Illuminate/Contracts/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Process/InvokedProcess.php
@@ -60,5 +60,5 @@ interface InvokedProcess
      * @param  callable|null  $output
      * @return \Illuminate\Console\Process\ProcessResult
      */
-    public function wait(callable $output = null);
+    public function wait(?callable $output = null);
 }

--- a/src/Illuminate/Contracts/Process/ProcessResult.php
+++ b/src/Illuminate/Contracts/Process/ProcessResult.php
@@ -68,7 +68,7 @@ interface ProcessResult
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throw(callable $callback = null);
+    public function throw(?callable $callback = null);
 
     /**
      * Throw an exception if the process failed and the given condition is true.
@@ -77,5 +77,5 @@ interface ProcessResult
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throwIf(bool $condition, callable $callback = null);
+    public function throwIf(bool $condition, ?callable $callback = null);
 }

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -27,7 +27,7 @@ class Manager
      * @param  \Illuminate\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -202,7 +202,7 @@ class Builder implements BuilderContract
      * @param  array|null  $scopes
      * @return $this
      */
-    public function withoutGlobalScopes(array $scopes = null)
+    public function withoutGlobalScopes(?array $scopes = null)
     {
         if (! is_array($scopes)) {
             $scopes = array_keys($this->scopes);
@@ -524,7 +524,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
      */
-    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;
@@ -627,7 +627,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|static|mixed
      */
-    public function firstOr($columns = ['*'], Closure $callback = null)
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -39,7 +39,7 @@ class Attribute
      * @param  callable|null  $set
      * @return void
      */
-    public function __construct(callable $get = null, callable $set = null)
+    public function __construct(?callable $get = null, ?callable $set = null)
     {
         $this->get = $get;
         $this->set = $set;
@@ -52,7 +52,7 @@ class Attribute
      * @param  callable|null  $set
      * @return static
      */
-    public static function make(callable $get = null, callable $set = null): static
+    public static function make(?callable $get = null, ?callable $set = null): static
     {
         return new static($get, $set);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -29,7 +29,7 @@ trait QueriesRelationships
      *
      * @throws \RuntimeException
      */
-    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             if (str_contains($relation, '.')) {
@@ -122,7 +122,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
+    public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->has($relation, '<', 1, $boolean, $callback);
     }
@@ -147,7 +147,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }
@@ -163,7 +163,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function withWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
             ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
@@ -178,7 +178,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'or', $callback);
     }
@@ -190,7 +190,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHave($relation, Closure $callback = null)
+    public function whereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'and', $callback);
     }
@@ -202,7 +202,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHave($relation, Closure $callback = null)
+    public function orWhereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
     }
@@ -218,7 +218,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             $relation = $this->getRelationWithoutConstraints($relation);
@@ -301,7 +301,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
+    public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
     }
@@ -328,7 +328,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'and', $callback);
     }
@@ -343,7 +343,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'or', $callback);
     }
@@ -356,7 +356,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function whereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'and', $callback);
     }
@@ -369,7 +369,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function orWhereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'or', $callback);
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1722,7 +1722,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array|null  $except
      * @return static
      */
-    public function replicate(array $except = null)
+    public function replicate(?array $except = null)
     {
         $defaults = array_values(array_filter([
             $this->getKeyName(),
@@ -1750,7 +1750,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array|null  $except
      * @return static
      */
-    public function replicateQuietly(array $except = null)
+    public function replicateQuietly(?array $except = null)
     {
         return static::withoutEvents(fn () => $this->replicate($except));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -754,7 +754,7 @@ class BelongsToMany extends Relation
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
      */
-    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;
@@ -828,7 +828,7 @@ class BelongsToMany extends Relation
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|static|mixed
      */
-    public function firstOr($columns = ['*'], Closure $callback = null)
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -123,7 +123,7 @@ class HasManyThrough extends Relation
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @return void
      */
-    protected function performJoin(Builder $query = null)
+    protected function performJoin(?Builder $query = null)
     {
         $query = $query ?: $this->query;
 
@@ -364,7 +364,7 @@ class HasManyThrough extends Relation
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|static|mixed
      */
-    public function firstOr($columns = ['*'], Closure $callback = null)
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;
@@ -451,7 +451,7 @@ class HasManyThrough extends Relation
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
      */
-    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -461,7 +461,7 @@ abstract class Relation implements BuilderContract
      * @param  bool  $merge
      * @return array
      */
-    public static function morphMap(array $map = null, $merge = true)
+    public static function morphMap(?array $map = null, $merge = true)
     {
         $map = static::buildMorphMapFromModels($map);
 
@@ -479,7 +479,7 @@ abstract class Relation implements BuilderContract
      * @param  string[]|null  $models
      * @return array|null
      */
-    protected static function buildMorphMapFromModels(array $models = null)
+    protected static function buildMorphMapFromModels(?array $models = null)
     {
         if (is_null($models) || ! array_is_list($models)) {
             return $models;

--- a/src/Illuminate/Database/MariaDbConnection.php
+++ b/src/Illuminate/Database/MariaDbConnection.php
@@ -77,7 +77,7 @@ class MariaDbConnection extends MySqlConnection
      * @param  callable|null  $processFactory
      * @return \Illuminate\Database\Schema\MariaDbSchemaState
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new MariaDbSchemaState($this, $files, $processFactory);
     }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -90,7 +90,7 @@ class Migrator
     public function __construct(MigrationRepositoryInterface $repository,
                                 Resolver $resolver,
                                 Filesystem $files,
-                                Dispatcher $dispatcher = null)
+                                ?Dispatcher $dispatcher = null)
     {
         $this->files = $files;
         $this->events = $dispatcher;

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -105,7 +105,7 @@ class MySqlConnection extends Connection
      * @param  callable|null  $processFactory
      * @return \Illuminate\Database\Schema\MySqlSchemaState
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new MySqlSchemaState($this, $files, $processFactory);
     }

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -92,7 +92,7 @@ class PostgresConnection extends Connection
      * @param  callable|null  $processFactory
      * @return \Illuminate\Database\Schema\PostgresSchemaState
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new PostgresSchemaState($this, $files, $processFactory);
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -247,8 +247,8 @@ class Builder implements BuilderContract
      * @return void
      */
     public function __construct(ConnectionInterface $connection,
-                                Grammar $grammar = null,
-                                Processor $processor = null)
+                                ?Grammar $grammar = null,
+                                ?Processor $processor = null)
     {
         $this->connection = $connection;
         $this->grammar = $grammar ?: $connection->getQueryGrammar();
@@ -2814,7 +2814,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @return mixed|static
      */
-    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -114,7 +114,7 @@ class SQLiteConnection extends Connection
      *
      * @throws \RuntimeException
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new SqliteSchemaState($this, $files, $processFactory);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -86,7 +86,7 @@ class Blueprint
      * @param  string  $prefix
      * @return void
      */
-    public function __construct($table, Closure $callback = null, $prefix = '')
+    public function __construct($table, ?Closure $callback = null, $prefix = '')
     {
         $this->table = $table;
         $this->prefix = $prefix;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -571,7 +571,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Schema\Blueprint
      */
-    protected function createBlueprint($table, Closure $callback = null)
+    protected function createBlueprint($table, ?Closure $callback = null)
     {
         $prefix = $this->connection->getConfig('prefix_indexes')
                     ? $this->connection->getConfig('prefix')

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -51,7 +51,7 @@ abstract class SchemaState
      * @param  callable|null  $processFactory
      * @return void
      */
-    public function __construct(Connection $connection, Filesystem $files = null, callable $processFactory = null)
+    public function __construct(Connection $connection, ?Filesystem $files = null, ?callable $processFactory = null)
     {
         $this->connection = $connection;
 

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -124,7 +124,7 @@ class SqlServerConnection extends Connection
      *
      * @throws \RuntimeException
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         throw new RuntimeException('Schema dumping is not supported when using SQL Server.');
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -72,7 +72,7 @@ class Dispatcher implements DispatcherContract
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(ContainerContract $container = null)
+    public function __construct(?ContainerContract $container = null)
     {
         $this->container = $container ?: new Container;
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -224,7 +224,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  string|null  $basePath
      * @return \Illuminate\Foundation\Configuration\ApplicationBuilder
      */
-    public static function configure(string $basePath = null)
+    public static function configure(?string $basePath = null)
     {
         $basePath = match (true) {
             is_string($basePath) => $basePath,

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -518,7 +518,7 @@ class Middleware
      * @param  callable|string  $users
      * @return $this
      */
-    public function redirectTo(callable|string $guests = null, callable|string $users = null)
+    public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)
     {
         $guests = is_string($guests) ? fn () => $guests : $guests;
         $users = is_string($users) ? fn () => $users : $users;
@@ -612,7 +612,7 @@ class Middleware
      * @param  bool  $subdomains
      * @return $this
      */
-    public function trustHosts(array|callable $at = null, bool $subdomains = true)
+    public function trustHosts(array|callable|null $at = null, bool $subdomains = true)
     {
         $this->trustHosts = true;
 
@@ -630,7 +630,7 @@ class Middleware
      * @param  int|null  $headers
      * @return $this
      */
-    public function trustProxies(array|string $at = null, int $headers = null)
+    public function trustProxies(array|string|null $at = null, ?int $headers = null)
     {
         if (! is_null($at)) {
             TrustProxies::at($at);

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -232,7 +232,7 @@ class AboutCommand extends Command
      * @param  string|null  $value
      * @return void
      */
-    public static function add(string $section, $data, string $value = null)
+    public static function add(string $section, $data, ?string $value = null)
     {
         static::$customDataResolvers[] = fn () => static::addToSection($section, $data, $value);
     }
@@ -245,7 +245,7 @@ class AboutCommand extends Command
      * @param  string|null  $value
      * @return void
      */
-    protected static function addToSection(string $section, $data, string $value = null)
+    protected static function addToSection(string $section, $data, ?string $value = null)
     {
         if (is_array($data)) {
             foreach ($data as $key => $value) {
@@ -279,7 +279,7 @@ class AboutCommand extends Command
      * @param  (\Closure(mixed):(mixed))|null  $json
      * @return \Closure(bool):mixed
      */
-    public static function format($value, Closure $console = null, Closure $json = null)
+    public static function format($value, ?Closure $console = null, ?Closure $json = null)
     {
         return function ($isJson) use ($value, $console, $json) {
             if ($isJson === true && $json instanceof Closure) {

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -226,7 +226,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  array|null  $keys
      * @return \Illuminate\Support\ValidatedInput|array
      */
-    public function safe(array $keys = null)
+    public function safe(?array $keys = null)
     {
         return is_array($keys)
                     ? $this->validator->safe()->only($keys)

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -58,7 +58,7 @@ trait InteractsWithContainer
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
-    protected function mock($abstract, Closure $mock = null)
+    protected function mock($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
@@ -70,7 +70,7 @@ trait InteractsWithContainer
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
-    protected function partialMock($abstract, Closure $mock = null)
+    protected function partialMock($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }
@@ -82,7 +82,7 @@ trait InteractsWithContainer
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
-    protected function spy($abstract, Closure $mock = null)
+    protected function spy($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -18,7 +18,7 @@ trait ValidatesRequests
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validateWith($validator, Request $request = null)
+    public function validateWith($validator, ?Request $request = null)
     {
         $request = $request ?: request();
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -84,7 +84,7 @@ class Factory
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(Dispatcher $dispatcher = null)
+    public function __construct(?Dispatcher $dispatcher = null)
     {
         $this->dispatcher = $dispatcher;
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -222,7 +222,7 @@ class PendingRequest
      * @param  array  $middleware
      * @return void
      */
-    public function __construct(Factory $factory = null, $middleware = [])
+    public function __construct(?Factory $factory = null, $middleware = [])
     {
         $this->factory = $factory;
         $this->middleware = new Collection($middleware);
@@ -691,7 +691,7 @@ class PendingRequest
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throw(callable $callback = null)
+    public function throw(?callable $callback = null)
     {
         $this->throwCallback = $callback ?: fn () => null;
 

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -36,7 +36,7 @@ class Pool
      * @param  \Illuminate\Http\Client\Factory|null  $factory
      * @return void
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory();
         $this->handler = Utils::chooseHandler();

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -122,7 +122,7 @@ trait InteractsWithInput
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenHas($key, callable $callback, callable $default = null)
+    public function whenHas($key, callable $callback, ?callable $default = null)
     {
         if ($this->has($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;
@@ -200,7 +200,7 @@ trait InteractsWithInput
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenFilled($key, callable $callback, callable $default = null)
+    public function whenFilled($key, callable $callback, ?callable $default = null)
     {
         if ($this->filled($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;
@@ -234,7 +234,7 @@ trait InteractsWithInput
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenMissing($key, callable $callback, callable $default = null)
+    public function whenMissing($key, callable $callback, ?callable $default = null)
     {
         if ($this->missing($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;

--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -16,7 +16,7 @@ class PostTooLargeException extends HttpException
      * @param  int  $code
      * @return void
      */
-    public function __construct($message = '', Throwable $previous = null, array $headers = [], $code = 0)
+    public function __construct($message = '', ?Throwable $previous = null, array $headers = [], $code = 0)
     {
         parent::__construct(413, $message, $previous, $headers, $code);
     }

--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -16,7 +16,7 @@ class ThrottleRequestsException extends TooManyRequestsHttpException
      * @param  int  $code
      * @return void
      */
-    public function __construct($message = '', Throwable $previous = null, array $headers = [], $code = 0)
+    public function __construct($message = '', ?Throwable $previous = null, array $headers = [], $code = 0)
     {
         parent::__construct(null, $message, $previous, $code, $headers);
     }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -71,7 +71,7 @@ class RedirectResponse extends BaseRedirectResponse
      * @param  array|null  $input
      * @return $this
      */
-    public function withInput(array $input = null)
+    public function withInput(?array $input = null)
     {
         $this->session->flashInput($this->removeFilesFromInput(
             ! is_null($input) ? $input : $this->request->input()

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -501,7 +501,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @return static
      */
     #[\Override]
-    public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null): static
+    public function duplicate(?array $query = null, ?array $request = null, ?array $attributes = null, ?array $cookies = null, ?array $files = null, ?array $server = null): static
     {
         return parent::duplicate($query, $request, $attributes, $cookies, $this->filterFiles($files), $server);
     }

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -43,7 +43,7 @@ class Logger implements LoggerInterface
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(LoggerInterface $logger, Dispatcher $dispatcher = null)
+    public function __construct(LoggerInterface $logger, ?Dispatcher $dispatcher = null)
     {
         $this->logger = $logger;
         $this->dispatcher = $dispatcher;

--- a/src/Illuminate/Mail/Mailables/Address.php
+++ b/src/Illuminate/Mail/Mailables/Address.php
@@ -25,7 +25,7 @@ class Address
      * @param  string|null  $name
      * @return void
      */
-    public function __construct(string $address, string $name = null)
+    public function __construct(string $address, ?string $name = null)
     {
         $this->address = $address;
         $this->name = $name;

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -64,7 +64,7 @@ class Content
      *
      * @named-arguments-supported
      */
-    public function __construct(string $view = null, string $html = null, string $text = null, $markdown = null, array $with = [], string $htmlString = null)
+    public function __construct(?string $view = null, ?string $html = null, ?string $text = null, $markdown = null, array $with = [], ?string $htmlString = null)
     {
         $this->view = $view;
         $this->html = $html;

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -89,7 +89,7 @@ class Envelope
      *
      * @named-arguments-supported
      */
-    public function __construct(Address|string $from = null, $to = [], $cc = [], $bcc = [], $replyTo = [], string $subject = null, array $tags = [], array $metadata = [], Closure|array $using = [])
+    public function __construct(Address|string|null $from = null, $to = [], $cc = [], $bcc = [], $replyTo = [], ?string $subject = null, array $tags = [], array $metadata = [], Closure|array $using = [])
     {
         $this->from = is_string($from) ? new Address($from) : $from;
         $this->to = $this->normalizeAddresses($to);
@@ -266,7 +266,7 @@ class Envelope
      * @param  string|null  $name
      * @return bool
      */
-    public function isFrom(string $address, string $name = null)
+    public function isFrom(string $address, ?string $name = null)
     {
         if (is_null($name)) {
             return $this->from->address === $address;
@@ -283,7 +283,7 @@ class Envelope
      * @param  string|null  $name
      * @return bool
      */
-    public function hasTo(string $address, string $name = null)
+    public function hasTo(string $address, ?string $name = null)
     {
         return $this->hasRecipient($this->to, $address, $name);
     }
@@ -295,7 +295,7 @@ class Envelope
      * @param  string|null  $name
      * @return bool
      */
-    public function hasCc(string $address, string $name = null)
+    public function hasCc(string $address, ?string $name = null)
     {
         return $this->hasRecipient($this->cc, $address, $name);
     }
@@ -307,7 +307,7 @@ class Envelope
      * @param  string|null  $name
      * @return bool
      */
-    public function hasBcc(string $address, string $name = null)
+    public function hasBcc(string $address, ?string $name = null)
     {
         return $this->hasRecipient($this->bcc, $address, $name);
     }
@@ -319,7 +319,7 @@ class Envelope
      * @param  string|null  $name
      * @return bool
      */
-    public function hasReplyTo(string $address, string $name = null)
+    public function hasReplyTo(string $address, ?string $name = null)
     {
         return $this->hasRecipient($this->replyTo, $address, $name);
     }

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -40,7 +40,7 @@ class Headers
      *
      * @named-arguments-supported
      */
-    public function __construct(string $messageId = null, array $references = [], array $text = [])
+    public function __construct(?string $messageId = null, array $references = [], array $text = [])
     {
         $this->messageId = $messageId;
         $this->references = $references;

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -97,7 +97,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $events
      * @return void
      */
-    public function __construct(string $name, Factory $views, TransportInterface $transport, Dispatcher $events = null)
+    public function __construct(string $name, Factory $views, TransportInterface $transport, ?Dispatcher $events = null)
     {
         $this->name = $name;
         $this->views = $views;

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -31,7 +31,7 @@ class ArrayTransport implements Stringable, TransportInterface
     /**
      * {@inheritdoc}
      */
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         return $this->messages[] = new SentMessage($message, $envelope ?? Envelope::create($message));
     }

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -33,7 +33,7 @@ class LogTransport implements Stringable, TransportInterface
     /**
      * {@inheritdoc}
      */
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         $string = Str::of($message->toString());
 

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -47,7 +47,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null)
+    public function sendNow($notifiables, $notification, ?array $channels = null)
     {
         (new NotificationSender(
             $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -87,7 +87,7 @@ class NotificationSender
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null)
+    public function sendNow($notifiables, $notification, ?array $channels = null)
     {
         $notifiables = $this->formatNotifiables($notifiables);
 

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -25,7 +25,7 @@ trait RoutesNotifications
      * @param  array|null  $channels
      * @return void
      */
-    public function notifyNow($instance, array $channels = null)
+    public function notifyNow($instance, ?array $channels = null)
     {
         app(Dispatcher::class)->sendNow($this, $instance, $channels);
     }

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -73,7 +73,7 @@ class SendQueuedNotifications implements ShouldQueue
      * @param  array|null  $channels
      * @return void
      */
-    public function __construct($notifiables, $notification, array $channels = null)
+    public function __construct($notifiables, $notification, ?array $channels = null)
     {
         $this->channels = $channels;
         $this->notification = $notification;

--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -28,7 +28,7 @@ class Hub implements HubContract
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->container = $container;
     }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -47,7 +47,7 @@ class Pipeline implements PipelineContract
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->container = $container;
     }

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -85,7 +85,7 @@ class Factory
      * @param  \Closure|array|null  $callback
      * @return $this
      */
-    public function fake(Closure|array $callback = null)
+    public function fake(Closure|array|null $callback = null)
     {
         $this->recording = true;
 

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -258,7 +258,7 @@ class FakeInvokedProcess implements InvokedProcessContract
      * @param  callable|null  $output
      * @return \Illuminate\Contracts\Process\ProcessResult
      */
-    public function wait(callable $output = null)
+    public function wait(?callable $output = null)
     {
         $this->outputHandler = $output ?: $this->outputHandler;
 

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -175,7 +175,7 @@ class FakeProcessResult implements ProcessResultContract
      *
      * @throws \Illuminate\Process\Exceptions\ProcessFailedException
      */
-    public function throw(callable $callback = null)
+    public function throw(?callable $callback = null)
     {
         if ($this->successful()) {
             return $this;
@@ -199,7 +199,7 @@ class FakeProcessResult implements ProcessResultContract
      *
      * @throws \Throwable
      */
-    public function throwIf(bool $condition, callable $callback = null)
+    public function throwIf(bool $condition, ?callable $callback = null)
     {
         if ($condition) {
             return $this->throw($callback);

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -108,7 +108,7 @@ class InvokedProcess implements InvokedProcessContract
      *
      * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
      */
-    public function wait(callable $output = null)
+    public function wait(?callable $output = null)
     {
         try {
             $this->process->wait($output);

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -241,7 +241,7 @@ class PendingProcess
      * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
      * @throws \RuntimeException
      */
-    public function run(array|string $command = null, callable $output = null)
+    public function run(array|string|null $command = null, ?callable $output = null)
     {
         $this->command = $command ?: $this->command;
 
@@ -271,7 +271,7 @@ class PendingProcess
      *
      * @throws \RuntimeException
      */
-    public function start(array|string $command = null, callable $output = null)
+    public function start(array|string|null $command = null, ?callable $output = null)
     {
         $this->command = $command ?: $this->command;
 

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -116,7 +116,7 @@ class ProcessResult implements ProcessResultContract
      *
      * @throws \Illuminate\Process\Exceptions\ProcessFailedException
      */
-    public function throw(callable $callback = null)
+    public function throw(?callable $callback = null)
     {
         if ($this->successful()) {
             return $this;
@@ -140,7 +140,7 @@ class ProcessResult implements ProcessResultContract
      *
      * @throws \Throwable
      */
-    public function throwIf(bool $condition, callable $callback = null)
+    public function throwIf(bool $condition, ?callable $callback = null)
     {
         if ($condition) {
             return $this->throw($callback);

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -28,7 +28,7 @@ class Manager
      * @param  \Illuminate\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -111,7 +111,7 @@ class Worker
                                 Dispatcher $events,
                                 ExceptionHandler $exceptions,
                                 callable $isDownForMaintenance,
-                                callable $resetScope = null)
+                                ?callable $resetScope = null)
     {
         $this->events = $events;
         $this->manager = $manager;

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -36,7 +36,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  array  $config
      * @return void
      */
-    public function __construct($client, callable $connector = null, array $config = [])
+    public function __construct($client, ?callable $connector = null, array $config = [])
     {
         $this->client = $client;
         $this->config = $config;
@@ -396,7 +396,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  callable|null  $callback
      * @return \Redis|array
      */
-    public function pipeline(callable $callback = null)
+    public function pipeline(?callable $callback = null)
     {
         $pipeline = $this->client()->pipeline();
 
@@ -411,7 +411,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  callable|null  $callback
      * @return \Redis|array
      */
-    public function transaction(callable $callback = null)
+    public function transaction(?callable $callback = null)
     {
         $transaction = $this->client()->multi();
 

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
@@ -125,7 +125,7 @@ class ConcurrencyLimiterBuilder
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
      */
-    public function then(callable $callback, callable $failure = null)
+    public function then(callable $callback, ?callable $failure = null)
     {
         try {
             return (new ConcurrencyLimiter(

--- a/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
@@ -125,7 +125,7 @@ class DurationLimiterBuilder
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
      */
-    public function then(callable $callback, callable $failure = null)
+    public function then(callable $callback, ?callable $failure = null)
     {
         try {
             return (new DurationLimiter(

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -140,7 +140,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  \Illuminate\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Dispatcher $events, Container $container = null)
+    public function __construct(Dispatcher $events, ?Container $container = null)
     {
         $this->events = $events;
         $this->routes = new RouteCollection;
@@ -1161,7 +1161,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function model($key, $class, Closure $callback = null)
+    public function model($key, $class, ?Closure $callback = null)
     {
         $this->bind($key, RouteBinding::forModel($this->container, $class, $callback));
     }

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -59,7 +59,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, $table, $minutes, Container $container = null)
+    public function __construct(ConnectionInterface $connection, $table, $minutes, ?Container $container = null)
     {
         $this->table = $table;
         $this->minutes = $minutes;

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -35,7 +35,7 @@ class StartSession
      * @param  callable|null  $cacheFactoryResolver
      * @return void
      */
-    public function __construct(SessionManager $manager, callable $cacheFactoryResolver = null)
+    public function __construct(SessionManager $manager, ?callable $cacheFactoryResolver = null)
     {
         $this->manager = $manager;
         $this->cacheFactoryResolver = $cacheFactoryResolver;
@@ -286,7 +286,7 @@ class StartSession
      * @param  array|null  $config
      * @return bool
      */
-    protected function sessionIsPersistent(array $config = null)
+    protected function sessionIsPersistent(?array $config = null)
     {
         $config = $config ?: $this->manager->getSessionConfig();
 

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -71,7 +71,7 @@ class SymfonySessionDecorator implements SessionInterface
     /**
      * {@inheritdoc}
      */
-    public function invalidate(int $lifetime = null): bool
+    public function invalidate(?int $lifetime = null): bool
     {
         $this->store->invalidate();
 
@@ -81,7 +81,7 @@ class SymfonySessionDecorator implements SessionInterface
     /**
      * {@inheritdoc}
      */
-    public function migrate(bool $destroy = false, int $lifetime = null): bool
+    public function migrate(bool $destroy = false, ?int $lifetime = null): bool
     {
         $this->store->migrate($destroy);
 

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -63,7 +63,7 @@ class Composer
      * @param  string|null  $composerBinary
      * @return bool
      */
-    public function requirePackages(array $packages, bool $dev = false, Closure|OutputInterface $output = null, $composerBinary = null)
+    public function requirePackages(array $packages, bool $dev = false, Closure|OutputInterface|null $output = null, $composerBinary = null)
     {
         $command = collect([
             ...$this->findComposer($composerBinary),
@@ -92,7 +92,7 @@ class Composer
      * @param  string|null  $composerBinary
      * @return bool
      */
-    public function removePackages(array $packages, bool $dev = false, Closure|OutputInterface $output = null, $composerBinary = null)
+    public function removePackages(array $packages, bool $dev = false, Closure|OutputInterface|null $output = null, $composerBinary = null)
     {
         $command = collect([
             ...$this->findComposer($composerBinary),

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -60,7 +60,7 @@ class Bus extends Facade
      * @param  \Illuminate\Bus\BatchRepository|null  $batchRepository
      * @return \Illuminate\Support\Testing\Fakes\BusFake
      */
-    public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)
+    public static function fake($jobsToFake = [], ?BatchRepository $batchRepository = null)
     {
         $actualDispatcher = static::isFake()
                 ? static::getFacadeRoot()->dispatcher

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -65,7 +65,7 @@ class Process extends Facade
      * @param  \Closure|array|null  $callback
      * @return \Illuminate\Process\Factory
      */
-    public static function fake(Closure|array $callback = null)
+    public static function fake(Closure|array|null $callback = null)
     {
         return tap(static::getFacadeRoot(), function ($fake) use ($callback) {
             static::swap($fake->fake($callback));

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -485,7 +485,7 @@ abstract class ServiceProvider
      * @param  string  $path
      * @return bool
      */
-    public static function addProviderToBootstrapFile(string $provider, string $path = null)
+    public static function addProviderToBootstrapFile(string $provider, ?string $path = null)
     {
         $path ??= app()->getBootstrapProvidersPath();
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -970,7 +970,7 @@ class Str
      * @param  callable|null  $factory
      * @return void
      */
-    public static function createRandomStringsUsing(callable $factory = null)
+    public static function createRandomStringsUsing(?callable $factory = null)
     {
         static::$randomStringFactory = $factory;
     }
@@ -1723,7 +1723,7 @@ class Str
      * @param  callable|null  $factory
      * @return void
      */
-    public static function createUuidsUsing(callable $factory = null)
+    public static function createUuidsUsing(?callable $factory = null)
     {
         static::$uuidFactory = $factory;
     }
@@ -1768,7 +1768,7 @@ class Str
      * @param  \Closure|null  $callback
      * @return \Ramsey\Uuid\UuidInterface
      */
-    public static function freezeUuids(Closure $callback = null)
+    public static function freezeUuids(?Closure $callback = null)
     {
         $uuid = Str::uuid();
 
@@ -1830,7 +1830,7 @@ class Str
      * @param  callable|null  $factory
      * @return void
      */
-    public static function createUlidsUsing(callable $factory = null)
+    public static function createUlidsUsing(?callable $factory = null)
     {
         static::$ulidFactory = $factory;
     }
@@ -1875,7 +1875,7 @@ class Str
      * @param  Closure|null  $callback
      * @return Ulid
      */
-    public static function freezeUlids(Closure $callback = null)
+    public static function freezeUlids(?Closure $callback = null)
     {
         $ulid = Str::ulid();
 

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -88,7 +88,7 @@ class BusFake implements Fake, QueueingDispatcher
      * @param  \Illuminate\Bus\BatchRepository|null  $batchRepository
      * @return void
      */
-    public function __construct(QueueingDispatcher $dispatcher, $jobsToFake = [], BatchRepository $batchRepository = null)
+    public function __construct(QueueingDispatcher $dispatcher, $jobsToFake = [], ?BatchRepository $batchRepository = null)
     {
         $this->dispatcher = $dispatcher;
         $this->jobsToFake = Arr::wrap($jobsToFake);

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -288,7 +288,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null)
+    public function sendNow($notifiables, $notification, ?array $channels = null)
     {
         if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
             $notifiables = [$notifiables];

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -239,7 +239,7 @@ if (! function_exists('optional')) {
      * @param  callable|null  $callback
      * @return mixed
      */
-    function optional($value = null, callable $callback = null)
+    function optional($value = null, ?callable $callback = null)
     {
         if (is_null($callback)) {
             return new Optional($value);
@@ -479,7 +479,7 @@ if (! function_exists('with')) {
      * @param  (callable(TValue): (TReturn))|null  $callback
      * @return ($callback is null ? TValue : TReturn)
      */
-    function with($value, callable $callback = null)
+    function with($value, ?callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
     }

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -267,7 +267,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertStructure(array $structure = null, $responseData = null)
+    public function assertStructure(?array $structure = null, $responseData = null)
     {
         if (is_null($structure)) {
             return $this->assertSimilar($this->decoded);

--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -42,7 +42,7 @@ class AssertableJson implements Arrayable
      * @param  string|null  $path
      * @return void
      */
-    protected function __construct(array $props, string $path = null)
+    protected function __construct(array $props, ?string $path = null)
     {
         $this->path = $path;
         $this->props = $props;
@@ -69,7 +69,7 @@ class AssertableJson implements Arrayable
      * @param  string|null  $key
      * @return mixed
      */
-    protected function prop(string $key = null)
+    protected function prop(?string $key = null)
     {
         return Arr::get($this->props, $key);
     }

--- a/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
@@ -14,7 +14,7 @@ trait Debugging
      * @param  string|null  $prop
      * @return $this
      */
-    public function dump(string $prop = null): self
+    public function dump(?string $prop = null): self
     {
         dump($this->prop($prop));
 
@@ -27,5 +27,5 @@ trait Debugging
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -15,7 +15,7 @@ trait Has
      * @param  int|null  $length
      * @return $this
      */
-    public function count($key, int $length = null): self
+    public function count($key, ?int $length = null): self
     {
         if (is_null($length)) {
             $path = $this->dotPath();
@@ -48,7 +48,7 @@ trait Has
      * @param  \Closure|null  $callback
      * @return $this
      */
-    public function has($key, $length = null, Closure $callback = null): self
+    public function has($key, $length = null, ?Closure $callback = null): self
     {
         $prop = $this->prop();
 
@@ -185,7 +185,7 @@ trait Has
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 
     /**
      * Instantiate a new "scope" at the path of the given key.

--- a/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
@@ -63,5 +63,5 @@ trait Interaction
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -224,7 +224,7 @@ trait Matching
      * @param  \Closure|null  $scope
      * @return $this
      */
-    abstract public function has(string $key, $value = null, Closure $scope = null);
+    abstract public function has(string $key, $value = null, ?Closure $scope = null);
 
     /**
      * Retrieve a prop within the current scope using "dot" notation.
@@ -232,5 +232,5 @@ trait Matching
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -810,7 +810,7 @@ class TestResponse implements ArrayAccess
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertJsonStructure(array $structure = null, $responseData = null)
+    public function assertJsonStructure(?array $structure = null, $responseData = null)
     {
         $this->decodeResponseJson()->assertStructure($structure, $responseData);
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -361,7 +361,7 @@ trait FormatsMessages
      * @param  \Closure|null  $modifier
      * @return string
      */
-    protected function replaceIndexOrPositionPlaceholder($message, $attribute, $placeholder, Closure $modifier = null)
+    protected function replaceIndexOrPositionPlaceholder($message, $attribute, $placeholder, ?Closure $modifier = null)
     {
         $segments = explode('.', $attribute);
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -87,7 +87,7 @@ class Factory implements FactoryContract
      * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Translator $translator, Container $container = null)
+    public function __construct(Translator $translator, ?Container $container = null)
     {
         $this->container = $container;
         $this->translator = $translator;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -561,7 +561,7 @@ class Validator implements ValidatorContract
      * @param  array|null  $keys
      * @return \Illuminate\Support\ValidatedInput|array
      */
-    public function safe(array $keys = null)
+    public function safe(?array $keys = null)
     {
         return is_array($keys)
                 ? (new ValidatedInput($this->validated()))->only($keys)
@@ -1432,7 +1432,7 @@ class Validator implements ValidatorContract
      * @param  callable|null  $formatter
      * @return $this
      */
-    public function setImplicitAttributesFormatter(callable $formatter = null)
+    public function setImplicitAttributesFormatter(?callable $formatter = null)
     {
         $this->implicitAttributesFormatter = $formatter;
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -808,7 +808,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  string|null  $prefix
      * @return void
      */
-    public function anonymousComponentPath(string $path, string $prefix = null)
+    public function anonymousComponentPath(string $path, ?string $prefix = null)
     {
         $prefixHash = md5($prefix ?: $path);
 
@@ -830,7 +830,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  string|null  $prefix
      * @return void
      */
-    public function anonymousComponentNamespace(string $directory, string $prefix = null)
+    public function anonymousComponentNamespace(string $directory, ?string $prefix = null)
     {
         $prefix ??= $directory;
 

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -40,7 +40,7 @@ class CompilerEngine extends PhpEngine
      * @param  \Illuminate\Filesystem\Filesystem|null  $files
      * @return void
      */
-    public function __construct(CompilerInterface $compiler, Filesystem $files = null)
+    public function __construct(CompilerInterface $compiler, ?Filesystem $files = null)
     {
         parent::__construct($files ?: new Filesystem);
 

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -50,7 +50,7 @@ class FileViewFinder implements ViewFinderInterface
      * @param  array|null  $extensions
      * @return void
      */
-    public function __construct(Filesystem $files, array $paths, array $extensions = null)
+    public function __construct(Filesystem $files, array $paths, ?array $extensions = null)
     {
         $this->files = $files;
         $this->paths = array_map([$this, 'resolvePath'], $paths);

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -154,7 +154,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
      *
      * @throws \Throwable
      */
-    public function render(callable $callback = null)
+    public function render(?callable $callback = null)
     {
         try {
             $contents = $this->renderContents();

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -785,7 +785,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAllowsIfCallbackAcceptsGuestsWhenAuthenticated()
     {
-        $response = $this->getBasicGate()->allowIf(function (stdClass $user = null) {
+        $response = $this->getBasicGate()->allowIf(function (?stdClass $user = null) {
             return $user !== null;
         });
 
@@ -796,7 +796,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate()->forUser(null);
 
-        $response = $gate->allowIf(function (stdClass $user = null) {
+        $response = $gate->allowIf(function (?stdClass $user = null) {
             return $user === null;
         });
 
@@ -923,7 +923,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testDenyIfCallbackAcceptsGuestsWhenAuthenticated()
     {
-        $response = $this->getBasicGate()->denyIf(function (stdClass $user = null) {
+        $response = $this->getBasicGate()->denyIf(function (?stdClass $user = null) {
             return $user === null;
         });
 
@@ -934,7 +934,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate()->forUser(null);
 
-        $response = $gate->denyIf(function (stdClass $user = null) {
+        $response = $gate->denyIf(function (?stdClass $user = null) {
             return $user !== null;
         });
 

--- a/tests/Container/ContainerResolveNonInstantiableTest.php
+++ b/tests/Container/ContainerResolveNonInstantiableTest.php
@@ -44,7 +44,7 @@ class ParentClass
      */
     public $i;
 
-    public function __construct(TestInterface $testObject = null, int $i = 0)
+    public function __construct(?TestInterface $testObject = null, int $i = 0)
     {
         $this->i = $i;
     }

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -579,7 +579,7 @@ class ContainerTestContextWithOptionalInnerDependency
 {
     public $inner;
 
-    public function __construct(ContainerTestContextInjectOne $inner = null)
+    public function __construct(?ContainerTestContextInjectOne $inner = null)
     {
         $this->inner = $inner;
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1874,7 +1874,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->get('foo/{bar?}', [
             'middleware' => SubstituteBindings::class,
-            'uses' => function (RoutingTestUserModel $bar = null) {
+            'uses' => function (?RoutingTestUserModel $bar = null) {
                 $this->assertInstanceOf(RoutingTestUserModel::class, $bar);
 
                 return $bar->value;
@@ -1888,7 +1888,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->get('foo/{bar}', [
             'middleware' => SubstituteBindings::class,
-            'uses' => function (RouteModelBindingNullStub $bar = null) {
+            'uses' => function (?RouteModelBindingNullStub $bar = null) {
                 $this->assertInstanceOf(RouteModelBindingNullStub::class, $bar);
 
                 return $bar->first();
@@ -1912,7 +1912,7 @@ class RoutingRouteTest extends TestCase
             ->group(function () use ($router) {
                 $router->get('foo/{bar}', [
                     'middleware' => SubstituteBindings::class,
-                    'uses' => function (RouteModelBindingNullStub $bar = null) {
+                    'uses' => function (?RouteModelBindingNullStub $bar = null) {
                         $this->assertInstanceOf(RouteModelBindingNullStub::class, $bar);
 
                         return $bar->first();
@@ -1932,7 +1932,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->get('foo/{bar?}', [
             'middleware' => SubstituteBindings::class,
-            'uses' => function (RoutingTestUserModel $bar = null) {
+            'uses' => function (?RoutingTestUserModel $bar = null) {
                 $this->assertNull($bar);
             },
         ]);
@@ -1960,7 +1960,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->get('foo/{bar?}', [
             'middleware' => SubstituteBindings::class,
-            'uses' => function (RoutingTestNonExistingUserModel $bar = null) {
+            'uses' => function (?RoutingTestNonExistingUserModel $bar = null) {
                 $this->fail('ModelNotFoundException was expected.');
             },
         ]);
@@ -2338,7 +2338,7 @@ class RouteTestAnotherControllerWithParameterStub extends Controller
         //
     }
 
-    public function withModels(Request $request, RoutingTestUserModel $user, $defaultNull = null, RoutingTestTeamModel $team = null)
+    public function withModels(Request $request, RoutingTestUserModel $user, $defaultNull = null, ?RoutingTestTeamModel $team = null)
     {
         //
     }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -41,7 +41,7 @@ class SupportCarbonTest extends TestCase
 
     public function testCarbonIsMacroableWhenNotCalledStatically()
     {
-        Carbon::macro('diffInDecades', function (Carbon $dt = null, $abs = true) {
+        Carbon::macro('diffInDecades', function (?Carbon $dt = null, $abs = true) {
             return (int) ($this->diffInYears($dt, $abs) / 10);
         });
 

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -23,7 +23,7 @@ class SupportReflectsClosuresTest extends TestCase
             //
         });
 
-        $this->assertParameterTypes([null, ExampleParameter::class], function ($one, ExampleParameter $two = null) {
+        $this->assertParameterTypes([null, ExampleParameter::class], function ($one, ?ExampleParameter $two = null) {
             //
         });
 


### PR DESCRIPTION
Resend of #50921 to the 11.x branch

@GrahamCampbell 
Should the rule [`nullable_type_declarations`](https://docs.styleci.io/fixers#nullable_type_declarations) be added to the styleci config? (would this also result in changes in the 10.x branch if committed to 11.x?). I would leave such a change to you if you want because you know how styleci evaluates the config best.

Seems similar to the rule I used with Pint / PHP-CS-Fixer [`nullable_type_declaration_for_default_null_value`](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html), except that the description is a little different.