### PR TITLE
[11.x] Adds `intended_to_route` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -911,6 +911,22 @@ if (! function_exists('to_route')) {
     }
 }
 
+if (! function_exists('intended_to_route')) {
+    /**
+     * Create a new intended redirect response to a named route.
+     *
+     * @param  string  $route
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    function intended_to_route($route, $parameters = [], $status = 302, $headers = [], $secure = null)
+    {
+        return redirect()->intended(route($route, $parameters), $status, $headers, $secure);
+    }
+}
+
 if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -919,11 +919,13 @@ if (! function_exists('intended_to_route')) {
      * @param  mixed  $parameters
      * @param  int  $status
      * @param  array  $headers
+     * @param  bool|null  $secure
+     * @param  bool|null  $absolute
      * @return \Illuminate\Http\RedirectResponse
      */
-    function intended_to_route($route, $parameters = [], $status = 302, $headers = [], $secure = null)
+    function intended_to_route($route, $parameters = [], $status = 302, $headers = [], $secure = null, $absolute = true)
     {
-        return redirect()->intended(route($route, $parameters), $status, $headers, $secure);
+        return redirect()->intended(route($route, $parameters, $absolute), $status, $headers, $secure);
     }
 }
 


### PR DESCRIPTION
Introducing `intended_to_route` highly inspired from 'to_route`.

```php
// return redirect()->intended(route('users.show', ['user' => $user]));
return intended_to_route('users.show', ['user' => $user]);
```