### PR TITLE
[11.x] improvement tests for Str::kebab method

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -533,6 +533,9 @@ class SupportStrTest extends TestCase
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
+        $this->assertSame('laravel-php-framework', Str::kebab('Laravel Php Framework'));
+        $this->assertSame('laravel❤-php-framework', Str::kebab('Laravel ❤ Php Framework'));
+        $this->assertSame('', Str::kebab(''));
     }
 
     public function testLower()


### PR DESCRIPTION
This PR enhances the test coverage for the `Str::kebab` method.

using space in `$value` input:
```php
$this->assertSame('laravel-php-framework', Str::kebab('Laravel Php Framework'));
```

using special character(❤) in `$value` input:
```php
$this->assertSame('laravel❤-php-framework', Str::kebab('Laravel ❤ Php Framework'));
```

if `$value` is empty string
```php
$this->assertSame('', Str::kebab(''));
```

