### PR TITLE
[11.x] Report failed job timeout exceptions

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -228,6 +228,10 @@ class Worker
                 $this->events->dispatch(new JobTimedOut(
                     $job->getConnectionName(), $job
                 ));
+
+                if ($job->hasFailed()) {
+                    $this->exceptions->report($e);
+                }
             }
 
             $this->kill(static::EXIT_ERROR, $options);


### PR DESCRIPTION
Currently when a job fails after timing out, the exception is not reported. However in all other job failure cases the exception **is** reported.

To keep reporting consistent, we should also report the exception when a failed job times out.