### PR TITLE
[10.x] Add `serializeAndRestore()` to `NotificationFake`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Collection;
@@ -31,6 +32,13 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      * @var string|null
      */
     public $locale;
+
+    /**
+     * Indicates if notifications should be serialized and restored when pushed to the queue.
+     *
+     * @var bool
+     */
+    protected bool $serializeAndRestore = false;
 
     /**
      * Assert if a notification was sent on-demand based on a truth-test callback.
@@ -313,7 +321,9 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
             }
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
-                'notification' => $notification,
+                'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
+                    ? $this->serializeAndRestoreNotification($notification)
+                    : $notifiable,
                 'channels' => $notifiableChannels,
                 'notifiable' => $notifiable,
                 'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
@@ -347,6 +357,30 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         $this->locale = $locale;
 
         return $this;
+    }
+
+    /**
+     * Specify if notification should be serialized and restored when being "pushed" to the queue.
+     *
+     * @param  bool  $serializeAndRestore
+     * @return $this
+     */
+    public function serializeAndRestore(bool $serializeAndRestore = true)
+    {
+        $this->serializeAndRestore = $serializeAndRestore;
+
+        return $this;
+    }
+
+    /**
+     * Serialize and unserialize the notification to simulate the queueing process.
+     *
+     * @param  mixed  $notification
+     * @return mixed
+     */
+    protected function serializeAndRestoreNotification($notification)
+    {
+        return unserialize(serialize($notification));
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -323,7 +323,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
                 'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
                     ? $this->serializeAndRestoreNotification($notification)
-                    : $notifiable,
+                    : $notification,
                 'channels' => $notifiableChannels,
                 'notifiable' => $notifiable,
                 'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -38,7 +38,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      *
      * @var bool
      */
-    protected bool $serializeAndRestore = false;
+    protected $serializeAndRestore = false;
 
     /**
      * Assert if a notification was sent on-demand based on a truth-test callback.

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\AnonymousNotifiable;
@@ -221,6 +223,16 @@ class SupportTestingNotificationFakeTest extends TestCase
 
         $this->fake->assertNotSentTo($user, NotificationWithFalsyShouldSendStub::class);
     }
+
+    public function testAssertItCanSerializeAndRestoreNotifications()
+    {
+        $this->fake->serializeAndRestore();
+        $this->fake->send($this->user, new NotificationWithSerialization('hello'));
+
+        $this->fake->assertSentTo($this->user, NotificationWithSerialization::class, function ($notification) {
+            return $notification->value === 'hello-serialized-unserialized';
+        });
+    }
 }
 
 class NotificationStub extends Notification
@@ -254,5 +266,24 @@ class LocalizedUserStub extends User implements HasLocalePreference
     public function preferredLocale()
     {
         return 'au';
+    }
+}
+
+class NotificationWithSerialization extends NotificationStub implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public $value)
+    {
+    }
+
+    public function __serialize(): array
+    {
+        return ['value' => $this->value .'-serialized'];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->value = $data['value'] .'-unserialized';
     }
 }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -279,11 +279,11 @@ class NotificationWithSerialization extends NotificationStub implements ShouldQu
 
     public function __serialize(): array
     {
-        return ['value' => $this->value .'-serialized'];
+        return ['value' => $this->value.'-serialized'];
     }
 
     public function __unserialize(array $data): void
     {
-        $this->value = $data['value'] .'-unserialized';
+        $this->value = $data['value'].'-unserialized';
     }
 }


### PR DESCRIPTION
Similar to what was added at https://github.com/laravel/framework/pull/48131 , this PR introduces the same feature to `NotificationFake`...

Testing notification was sent is not enough if for some reason you're pushing it to the queue and it has problems serializing / unserializing... In my case, i was sending an Empty model...