### PR TITLE
[11.x] Add when/unless to $fail of (closure/class) validation rule

### DIFF
--- a/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
+++ b/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
@@ -43,7 +43,7 @@ trait CreatesPotentiallyTranslatedStrings
             protected $destructor;
 
             /**
-             * The callback to call when rule should fail.
+             * The callback to call when the rule should fail.
              *
              * @var \Closure
              */

--- a/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
+++ b/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
@@ -22,7 +22,7 @@ trait CreatesPotentiallyTranslatedStrings
         $onFailure = function ($potentiallyTranslatedString) {
             $this->failed = true;
 
-            // Unsetting this object here ensures the exception that is thrown in the destructor is caught.
+            // Unsetting this object ensures the exception thrown in the destructor is caught...
             unset($potentiallyTranslatedString);
         };
 

--- a/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
+++ b/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
@@ -99,7 +99,7 @@ trait CreatesPotentiallyTranslatedStrings
             }
 
             /**
-             * Stop if a failure happened
+             * Stop if a failure happened.
              *
              * @param  bool  $stopOnFailure
              * @return $this

--- a/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
+++ b/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Translation;
 
+use Illuminate\Validation\StopOnFailureException;
+
 trait CreatesPotentiallyTranslatedStrings
 {
     /**
@@ -17,8 +19,22 @@ trait CreatesPotentiallyTranslatedStrings
             ? fn ($message) => $this->messages[] = $message
             : fn ($message) => $this->messages[$attribute] = $message;
 
-        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor) extends PotentiallyTranslatedString
+        $onFailure = function ($potentiallyTranslatedString) {
+            $this->failed = true;
+
+            // Unsetting this object here ensures the exception that is thrown in the destructor is caught.
+            unset($potentiallyTranslatedString);
+        };
+
+        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor, $onFailure) extends PotentiallyTranslatedString
         {
+            /**
+             * Indicates if the validation callback failed.
+             *
+             * @var bool
+             */
+            public $failed = true;
+
             /**
              * The callback to call when the object destructs.
              *
@@ -27,17 +43,72 @@ trait CreatesPotentiallyTranslatedStrings
             protected $destructor;
 
             /**
+             * The callback to call when rule should fail.
+             *
+             * @var \Closure
+             */
+            protected $onFailure;
+
+            /**
+             * Indicates if the validation should stop if this check fails.
+             *
+             * @var bool
+             */
+            protected $stopOnFailure = false;
+
+            /**
              * Create a new pending potentially translated string.
              *
              * @param  string  $message
              * @param  \Illuminate\Contracts\Translation\Translator  $translator
              * @param  \Closure  $destructor
+             * @return void
              */
-            public function __construct($message, $translator, $destructor)
+            public function __construct($message, $translator, $destructor, $onFailure)
             {
                 parent::__construct($message, $translator);
 
                 $this->destructor = $destructor;
+                $this->onFailure = $onFailure;
+            }
+
+            /**
+             * Raise the error message if the given condition is true.
+             *
+             * @param  mixed  $failed
+             * @return $this
+             */
+            public function when($failed)
+            {
+                $this->failed = value($failed);
+
+                return $this;
+            }
+
+            /**
+             * Raise the error message unless the given condition is true.
+             *
+             * @param  mixed  $failed
+             * @return $this
+             */
+            public function unless($failed)
+            {
+                $this->failed = ! value($failed);
+
+                return $this;
+            }
+
+            /**
+             * Stop if a failure happened
+             *
+             * @param  bool  $stopOnFailure
+             * @return $this
+             */
+            public function stopOnFailure($stopOnFailure = true)
+            {
+                $this->stopOnFailure = $stopOnFailure;
+
+                return $this;
             }
 
             /**
@@ -47,7 +118,17 @@ trait CreatesPotentiallyTranslatedStrings
              */
             public function __destruct()
             {
+                if (! $this->failed) {
+                    return;
+                }
+
+                ($this->onFailure)($this);
+
                 ($this->destructor)($this->toString());
+
+                if ($this->stopOnFailure) {
+                    throw new StopOnFailureException();
+                }
             }
         };
     }

--- a/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
+++ b/src/Illuminate/Translation/CreatesPotentiallyTranslatedStrings.php
@@ -43,7 +43,7 @@ trait CreatesPotentiallyTranslatedStrings
             protected $destructor;
 
             /**
-             * The callback to call when the rule should fail.
+             * The callback to call when the rule fails.
              *
              * @var \Closure
              */

--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -60,11 +60,12 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
     {
         $this->failed = false;
 
-        $this->callback->__invoke($attribute, $value, function ($attribute, $message = null) {
-            $this->failed = true;
-
-            return $this->pendingPotentiallyTranslatedString($attribute, $message);
-        }, $this->validator);
+        try {
+            $this->callback->__invoke($attribute, $value, function ($attribute, $message = null) {
+                return $this->pendingPotentiallyTranslatedString($attribute, $message);
+            });
+        } catch (StopOnFailureException) {
+        }
 
         return ! $this->failed;
     }

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Translation\CreatesPotentiallyTranslatedStrings;
-use Illuminate\Validation\StopOnFailureException;
 
 class InvokableValidationRule implements Rule, ValidatorAwareRule
 {

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Translation\CreatesPotentiallyTranslatedStrings;
+use Illuminate\Validation\StopOnFailureException;
 
 class InvokableValidationRule implements Rule, ValidatorAwareRule
 {
@@ -98,12 +99,12 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
         $method = $this->invokable instanceof ValidationRule
                         ? 'validate'
                         : '__invoke';
-
-        $this->invokable->{$method}($attribute, $value, function ($attribute, $message = null) {
-            $this->failed = true;
-
-            return $this->pendingPotentiallyTranslatedString($attribute, $message);
-        });
+        try {
+            $this->invokable->{$method}($attribute, $value, function ($attribute, $message = null) {
+                return $this->pendingPotentiallyTranslatedString($attribute, $message);
+            });
+        } catch (StopOnFailureException) {
+        }
 
         return ! $this->failed;
     }

--- a/src/Illuminate/Validation/StopOnFailureException.php
+++ b/src/Illuminate/Validation/StopOnFailureException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Exception;
+
+class StopOnFailureException extends Exception
+{
+
+}

--- a/src/Illuminate/Validation/StopOnFailureException.php
+++ b/src/Illuminate/Validation/StopOnFailureException.php
@@ -6,5 +6,4 @@ use Exception;
 
 class StopOnFailureException extends Exception
 {
-
 }


### PR DESCRIPTION
An improved version of #46814. In that PR, some issues were raised that caused the PR to be rejected. Today, I suddenly discovered a solution to solve those issues. 😄 

---

When using a closure validation rule (or a [custom validation rule class](https://laravel.com/docs/10.x/validation#using-rule-objects)), you always have an if-statement:
```php
function ($attribute, $value, $fail) {
    if ($value !== 'foo') {
        return;
    }

    $fail('value should be foo');
}

// or

function ($attribute, $value, $fail) {
    if ($value === 'foo') {
        $fail('value should be foo');
    }   
}

// or

function ($attribute, $value, $fail) {
    $fails = // ... some very long line of code that checks the value ...

    if ($fails) {
        $fail('value should be foo');
    }   
}
```
That is a lot of lines of code for something that is essentially always a truth check. It is also annoying when the check in the if-statement is too long and does not fit on one line. You then have to assign the check to a variable outside the if-statement.

So I thought: why not add a when/unless-method to the $fail variable? This makes the code a lot cleaner in my opinion. It also reads naturally: "it fails when ..." or "it fails unless ...".
```php
function ($attribute, $value, $fail) {
    $fail('value should be foo')->when($value !== 'foo');
    // or
    $fail('value should be foo')->unless($value === 'foo');
    // or
    $fail('value should be foo')->unless(function () use ($value) {
        // some very long check that now can be more easily
        // split on multiple lines
    });
}
```

But what if you have multiple `$fail`'s in a single rule and you want to stop as soon as you have a failure? This was the reason why the previous PR was rejected. Well, that is fixed now by introducing the `stopOnFailure()` method:
```php
function ($attribute, $value, $fail) {
    $fail('error 1')->when(true)->stopOnFailure();

    // Code beyond this point will never be executed!

    $fail('error 2');
}
```
