### PR TITLE
[11.x] Add support for specifying an alternate console output instance

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -188,6 +188,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $isRunningInConsole;
 
     /**
+     * @var ConsoleOutput|null
+     */
+    protected $consoleOutput = null;
+
+    /**
      * The application namespace.
      *
      * @var string
@@ -1182,12 +1187,38 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         $status = $kernel->handle(
             $input,
-            new ConsoleOutput
+            $this->getConsoleOutput()
         );
 
         $kernel->terminate($input, $status);
 
         return $status;
+    }
+
+    /**
+     * Gets the console output to use when running console commands.
+     * If none has been set, a new ConsoleOutput will be created.
+     *
+     * @return ConsoleOutput
+     */
+    public function getConsoleOutput()
+    {
+        if (is_null($this->consoleOutput)) {
+            $this->consoleOutput = new ConsoleOutput;
+        }
+
+        return $this->consoleOutput;
+    }
+
+    /**
+     * Sets the console output to use when running console commands.
+     *
+     * @param ConsoleOutput $output
+     * @return void
+     */
+    public function setConsoleOutput(ConsoleOutput $output)
+    {
+        $this->consoleOutput = $output;
     }
 
     /**

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Laravel\Folio\Folio;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class ApplicationBuilder
 {
@@ -354,6 +355,19 @@ class ApplicationBuilder
                 }
             }
         });
+    }
+
+    /**
+     * Register the application's console output instance.
+     *
+     * @param ConsoleOutput $consoleOutput
+     * @return $this
+     */
+    public function withConsoleOutput(ConsoleOutput $consoleOutput)
+    {
+        $this->app->setConsoleOutput($consoleOutput);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The default console output for errors is borderline unreadable when dark mode is used in editors like PhpStorm (example below). This adds the ability to define a custom ConsoleOutput instance, which can be triggered during `bootstrap/app.php`. The custom output can define a formatter that simply uses red text, instead of white text on a red background, which results in much more readable text on dark mode systems.
<img width="159" alt="image" src="https://github.com/laravel/framework/assets/3287663/96b4d441-82b0-49b6-ba60-77cb1beed42f">
