### PR TITLE
[11.x] improvement tests for Arr::map

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -706,6 +706,23 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
 
+    public function testMapWithEmptyArray()
+    {
+        $mapped = Arr::map([], static function ($value, $key) {
+            return $key.'-'.$value;
+        });
+        $this->assertEquals([], $mapped);
+    }
+
+    public function testMapNullValues()
+    {
+        $data = ['first' => 'taylor', 'last' => null];
+        $mapped = Arr::map($data, static function ($value, $key) {
+            return $key.'-'.$value;
+        });
+        $this->assertEquals(['first' => 'first-taylor', 'last' => 'last-'], $mapped);
+    }
+
     public function testMapWithKeys()
     {
         $data = [


### PR DESCRIPTION
This PR, improvement tests for Arr::map method.

This pull request introduces two additional tests aimed at scrutinizing the behavior of the Arr::map function more thoroughly.

The `testMapWithEmptyArray` ensures proper functionality of the function when encountering an empty array.
The `testMapNullValues` validates the function's ability to handle NULL values within the input array accurately.


Thanks!