### PR TITLE
[11.x] improvement tests for Arr::prepend

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -772,7 +772,7 @@ class SupportArrTest extends TestCase
         $array = Arr::prepend(['one', 'two'], ['zero']);
         $this->assertEquals([['zero'], 'one', 'two'], $array);
 
-        $array = Arr::prepend(['one', 'two'], ['zero'],'key');
+        $array = Arr::prepend(['one', 'two'], ['zero'], 'key');
         $this->assertEquals(['key' => ['zero'], 'one', 'two'], $array);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use TypeError;
 
 class SupportArrTest extends TestCase
 {
@@ -758,6 +759,29 @@ class SupportArrTest extends TestCase
 
         $array = Arr::prepend(['one' => 1, 'two' => 2], 0, null);
         $this->assertEquals([null => 0, 'one' => 1, 'two' => 2], $array);
+
+        $array = Arr::prepend(['one', 'two'], null, '');
+        $this->assertEquals(['' => null, 'one', 'two'], $array);
+
+        $array = Arr::prepend([], 'zero');
+        $this->assertEquals(['zero'], $array);
+
+        $array = Arr::prepend([''], 'zero');
+        $this->assertEquals(['zero', ''], $array);
+
+        $array = Arr::prepend(['one', 'two'], ['zero']);
+        $this->assertEquals([['zero'], 'one', 'two'], $array);
+
+        $array = Arr::prepend(['one', 'two'], ['zero'],'key');
+        $this->assertEquals(['key' => ['zero'], 'one', 'two'], $array);
+    }
+
+    public function testPrependWhenKeyIsArray()
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('Illegal offset type');
+
+        Arr::prepend(['one' => 1, 'two' => 2], 'zero', [0]);
     }
 
     public function testPull()


### PR DESCRIPTION
This PR, improvement tests for `Arr::prepend` method.

- `$value` is null

```php
$array = Arr::prepend(['one', 'two'], null, '');
$this->assertEquals(['' => null, 'one', 'two'], $array);
```

- array is empty

```php
$array = Arr::prepend([], 'zero');
$this->assertEquals(['zero'], $array);
```

- key in array is empty string

```php
$array = Arr::prepend([''], 'zero');
$this->assertEquals(['zero', ''], $array);
```

- `$value` is array

```php
$array = Arr::prepend(['one', 'two'], ['zero']);
$this->assertEquals([['zero'], 'one', 'two'], $array);
```

- $value is array, and key has value

```php
$array = Arr::prepend(['one', 'two'], ['zero'],'key');
$this->assertEquals(['key' => ['zero'], 'one', 'two'], $array);
```

- If `$key` is an array and `$value` is not empty, an exception is encountered.

```php
public function testPrependWhenKeyIsArray()
{
  $this->expectException(TypeError::class);
  $this->expectExceptionMessage('Illegal offset type');

  Arr::prepend(['one' => 1, 'two' => 2], 'zero', [0]);
}
```

