### PR TITLE
[11.x] Adds id to inputs of the bug report page

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -29,6 +29,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Provide a detailed description of the issue you are facing.

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -5,6 +5,7 @@ body:
     attributes:
       value: "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before submitting bug reports. If you notice improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem."
   - type: input
+    id: laravel_version
     attributes:
       label: Laravel Version
       description: Provide the Laravel version that you are using. [Please ensure it is still supported.](https://laravel.com/docs/releases#support-policy)
@@ -12,6 +13,7 @@ body:
     validations:
       required: true
   - type: input
+    id: php_version
     attributes:
       label: PHP Version
       description: Provide the PHP version that you are using.
@@ -19,6 +21,7 @@ body:
     validations:
       required: true
   - type: input
+    id: database_info
     attributes:
       label: Database Driver & Version
       description: If applicable, provide the database driver and version you are using.

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -17,7 +17,7 @@ class AboutCommandTest extends TestCase
             Assert::assertArraySubset([
                 'application_name' => 'Laravel',
                 'php_version' => PHP_VERSION,
-                'environment' => 'workbench',
+                'environment' => 'testing',
                 'debug_mode' => true,
                 'url' => 'localhost',
                 'maintenance_mode' => false,

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -17,7 +17,7 @@ class AboutCommandTest extends TestCase
             Assert::assertArraySubset([
                 'application_name' => 'Laravel',
                 'php_version' => PHP_VERSION,
-                'environment' => 'testing',
+                'environment' => 'workbench',
                 'debug_mode' => true,
                 'url' => 'localhost',
                 'maintenance_mode' => false,


### PR DESCRIPTION
This pull request includes the addition of an ID attribute to the inputs of bug reports.

## Why

You can populate input values using a parameter string in the URL, for example: `&laravel_version=11.0.1`. This pull request depends on https://github.com/laravel/framework/pull/50952.