### PR TITLE
[11.x] Add `bug` Command

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -5,6 +5,7 @@ body:
     attributes:
       value: "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before submitting bug reports. If you notice improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem."
   - type: input
+    id: laravel_version
     attributes:
       label: Laravel Version
       description: Provide the Laravel version that you are using. [Please ensure it is still supported.](https://laravel.com/docs/releases#support-policy)
@@ -12,6 +13,7 @@ body:
     validations:
       required: true
   - type: input
+    id: php_version
     attributes:
       label: PHP Version
       description: Provide the PHP version that you are using.
@@ -19,6 +21,7 @@ body:
     validations:
       required: true
   - type: input
+    id: database_info
     attributes:
       label: Database Driver & Version
       description: If applicable, provide the database driver and version you are using.
@@ -26,6 +29,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Provide a detailed description of the issue you are facing.
@@ -37,4 +41,4 @@ body:
       description: Provide detailed steps to reproduce your issue. If necessary, please provide a GitHub repository to demonstrate your issue using `laravel new bug-report --github="--public"`.
     validations:
       required: true
-      
+

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -17,7 +17,7 @@ class BugCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'bug {--title= : The title of bug}';
+    protected $signature = 'bug';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -42,9 +42,11 @@ class BugCommand extends Command
     }
 
     /**
+     * Detect the OS name and get the current command.
+     *
      * @return string
      */
-    public function detectOsName(): string
+    protected function detectOsName()
     {
         return match (PHP_OS_FAMILY) {
             'Windows' => 'start',
@@ -53,9 +55,11 @@ class BugCommand extends Command
     }
 
     /**
+     * Get the full url.
+     *
      * @return string
      */
-    public function getUrl(): string
+    protected function getUrl()
     {
         $dbInfo = config('database.default') . "-" . DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'bug')]
+class BugCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'bug {--title= : The title of bug}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = ''; // TODO
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Support\Composer;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -32,7 +33,37 @@ class BugCommand extends Command
      */
     public function handle()
     {
+        $osCommand = $this->detectOsName();
+        $url = $this->getUrl();
+
+        exec("$osCommand $url");
 
         return 0;
+    }
+
+    /**
+     * @return string
+     */
+    public function detectOsName(): string
+    {
+        return match (PHP_OS_FAMILY) {
+            'Windows' => 'start',
+            'Linux', 'Darwin' => 'xdg-open',
+        };
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        $dbInfo = config('database.default') . "-" . (string)DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+
+        $url = "https://github.com/laravel/framework/issues/new?assignees=&labels=&projects=&template=Bug_report.yml";
+        $url .= "&laravel_version=" . $this->laravel->version();
+        $url .= "&php_version=" . phpversion();
+        $url .= "&database_info=" . $dbInfo;
+
+        return $url;
     }
 }

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -23,7 +23,7 @@ class BugCommand extends Command
      *
      * @var string
      */
-    protected $description = ''; // TODO
+    protected $description = 'Start to create a bug report';
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -2,11 +2,8 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Closure;
 use Illuminate\Console\Command;
-use Illuminate\Support\Composer;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'bug')]
@@ -68,7 +65,7 @@ class BugCommand extends Command
      */
     protected function getUrl()
     {
-        $dbInfo = config('database.default') . "-" . DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $dbInfo = config('database.default').'-'.DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
         return implode([$this->url, '?', http_build_query([
             'assignees' => null,
@@ -76,7 +73,7 @@ class BugCommand extends Command
             'template' => 'Bug_report.yml',
             'laravel_version=' => $this->laravel->version(),
             'php_version' => phpversion(),
-            'database_info' => $dbInfo
+            'database_info' => $dbInfo,
         ])]);
     }
 }

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -55,6 +55,7 @@ class BugCommand extends Command
         return match (PHP_OS_FAMILY) {
             'Windows' => 'start',
             'Linux', 'Darwin' => 'xdg-open',
+            'default' => '',
         };
     }
 

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -57,7 +57,7 @@ class BugCommand extends Command
      */
     public function getUrl(): string
     {
-        $dbInfo = config('database.default') . "-" . (string)DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        $dbInfo = config('database.default') . "-" . DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
         $url = "https://github.com/laravel/framework/issues/new?assignees=&labels=&projects=&template=Bug_report.yml";
         $url .= "&laravel_version=" . $this->laravel->version();

--- a/src/Illuminate/Foundation/Console/BugCommand.php
+++ b/src/Illuminate/Foundation/Console/BugCommand.php
@@ -27,6 +27,13 @@ class BugCommand extends Command
     protected $description = 'Start to create a bug report';
 
     /**
+     * The issue url.
+     *
+     * @var string
+     */
+    protected $url = 'https://github.com/laravel/framework/issues/new';
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -63,11 +70,13 @@ class BugCommand extends Command
     {
         $dbInfo = config('database.default') . "-" . DB::connection()->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
-        $url = "https://github.com/laravel/framework/issues/new?assignees=&labels=&projects=&template=Bug_report.yml";
-        $url .= "&laravel_version=" . $this->laravel->version();
-        $url .= "&php_version=" . phpversion();
-        $url .= "&database_info=" . $dbInfo;
-
-        return $url;
+        return implode([$this->url, '?', http_build_query([
+            'assignees' => null,
+            'labels' => null,
+            'template' => 'Bug_report.yml',
+            'laravel_version=' => $this->laravel->version(),
+            'php_version' => phpversion(),
+            'database_info' => $dbInfo
+        ])]);
     }
 }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -112,7 +112,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     /**
      * The commands to be registered.
      *
-     * @var array   
+     * @var array
      */
     protected $commands = [
         'About' => AboutCommand::class,

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
+use Illuminate\Foundation\Console\BugCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
@@ -111,10 +112,11 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     /**
      * The commands to be registered.
      *
-     * @var array
+     * @var array   
      */
     protected $commands = [
         'About' => AboutCommand::class,
+        'Bug' => BugCommand::class,
         'CacheClear' => CacheClearCommand::class,
         'CacheForget' => CacheForgetCommand::class,
         'ClearCompiled' => ClearCompiledCommand::class,


### PR DESCRIPTION
This PR adds a new command called `bug`. This command is about reporting a bug for the framework. In GoLang we have a command named `bug`, I think it's a good command for Laravel. 

## How is working

When running this command, this command automatically opens your browser and redirects to the [issue](https://github.com/laravel/framework/issues/new?assignees=&labels=&projects=&template=Bug_report.yml) page. But it's not enough, this command fills the Larave, PHP input, and DB info input from your project.

## Why

This command helps to just focus on your bug and you don't need to check the Laravel, PHP, ... version, because this command fills the inputs auto. This helps others avoid entering wrong information.
