### PR TITLE
[11.x] Allow to remove scopes from BelongsToMany relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1563,7 +1563,7 @@ class BelongsToMany extends Relation
      */
     public function qualifyPivotColumn($column)
     {
-        if ($this->getGrammar()->isExpression($column)) {
+        if ($this->query->getQuery()->getGrammar()->isExpression($column)) {
             return $column;
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyExpressionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Exception;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -50,6 +51,31 @@ class DatabaseEloquentBelongsToManyExpressionTest extends TestCase
 
         $this->assertCount(1, $tags);
         $this->assertEquals(3, $tags->first()->getKey());
+    }
+
+    public function testGlobalScopesAreAppliedToBelongsToManyRelation(): void
+    {
+        $this->seedData();
+        $post = DatabaseEloquentBelongsToManyExpressionTestTestPost::query()->firstOrFail();
+        DatabaseEloquentBelongsToManyExpressionTestTestTag::addGlobalScope(
+            'default',
+            static fn () => throw new Exception('Default global scope.')
+        );
+
+        $this->expectExceptionMessage('Default global scope.');
+        $post->tags()->get();
+    }
+
+    public function testGlobalScopesCanBeRemovedFromBelongsToManyRelation(): void
+    {
+        $this->seedData();
+        $post = DatabaseEloquentBelongsToManyExpressionTestTestPost::query()->firstOrFail();
+        DatabaseEloquentBelongsToManyExpressionTestTestTag::addGlobalScope(
+            'default',
+            static fn () => throw new Exception('Default global scope.')
+        );
+
+        $this->assertNotEmpty($post->tags()->withoutGlobalScopes()->get());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
 {
@@ -64,8 +65,8 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related);
         $related->shouldReceive('qualifyColumn');
         $builder->shouldReceive('join', 'where');
-        $builder->shouldReceive('getGrammar')->andReturn(
-            m::mock(Grammar::class, ['isExpression' => false])
+        $builder->shouldReceive('getQuery')->andReturn(
+            m::mock(stdClass::class, ['getGrammar' => m::mock(Grammar::class, ['isExpression' => false])])
         );
 
         return new BelongsToMany(

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -31,8 +31,7 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('club_user')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['club_id' => 1, 'user_id' => 1, 'is_admin' => 1]])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+        $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
 
         $relation->attach(1);
     }
@@ -56,7 +55,9 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $builder->shouldReceive('join')->once()->with('club_user', 'users.id', '=', 'club_user.user_id');
         $builder->shouldReceive('where')->once()->with('club_user.club_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('club_user.is_admin', '=', 1, 'and');
-        $builder->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class, ['isExpression' => false]));
+
+        $builder->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
+        $mockQueryBuilder->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class, ['isExpression' => false]));
 
         return [$builder, $parent, 'club_user', 'club_id', 'user_id', 'id', 'id', null, false];
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithoutTouchingTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithoutTouchingTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class DatabaseEloquentBelongsToManyWithoutTouchingTest extends TestCase
 {
@@ -32,7 +33,9 @@ class DatabaseEloquentBelongsToManyWithoutTouchingTest extends TestCase
             $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
             $builder->shouldReceive('getModel')->andReturn($related);
             $builder->shouldReceive('where');
-            $builder->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class, ['isExpression' => false]));
+            $builder->shouldReceive('getQuery')->andReturn(
+                m::mock(stdClass::class, ['getGrammar' => m::mock(Grammar::class, ['isExpression' => false])])
+            );
             $relation = new BelongsToMany($builder, $parent, 'article_users', 'user_id', 'article_id', 'id', 'id');
             $builder->shouldReceive('update')->never();
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -33,8 +33,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+        $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
         $relation->attach(2, ['foo' => 'bar']);
@@ -49,8 +48,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('taggables.tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+        $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
         $this->assertTrue($relation->detach([1, 2, 3]));
@@ -65,8 +63,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+        $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
         $this->assertTrue($relation->detach());
@@ -130,7 +127,9 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $grammar = m::mock(Grammar::class);
         $grammar->shouldReceive('isExpression')->with(m::type(Expression::class))->andReturnTrue();
         $grammar->shouldReceive('isExpression')->with(m::type('string'))->andReturnFalse();
-        $builder->shouldReceive('getGrammar')->andReturn($grammar);
+        $builder->shouldReceive('getQuery')->andReturn(
+            m::mock(stdClass::class, ['getGrammar' => $grammar])
+        );
 
         return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id', 'relation_name', false];
     }


### PR DESCRIPTION
As @ccharz [discovered here](https://github.com/laravel/framework/pull/50849#issuecomment-2036993416), after changes which came with #50849 relation is not able to remove global scopes when it should.

Fixes: #50945
@tpetry FYI

