### PR TITLE
[11.x] Fix Call to undefined method Illuminate\Http\Client\ConnectionException::toException()

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1055,7 +1055,11 @@ class PendingRequest
         }
 
         if ($attempt < $this->tries && $shouldRetry) {
-            $options['delay'] = value($this->retryDelay, $attempt, $response->toException());
+            $options['delay'] = value(
+                $this->retryDelay,
+                $attempt,
+                $response instanceof Response ? $response->toException() : $response
+            );
 
             return $this->makePromise($method, $url, $options, $attempt + 1);
         }


### PR DESCRIPTION
This commit fixes this error:

```
Call to undefined method Illuminate\Http\Client\ConnectionException::toException()
```
