### PR TITLE
[11.x] Prevent crash when handling ConnectionException in HttpClient retry logic

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1055,7 +1055,11 @@ class PendingRequest
         }
 
         if ($attempt < $this->tries && $shouldRetry) {
-            $options['delay'] = value($this->retryDelay, $attempt, $response->toException());
+            $options['delay'] = value(
+                $this->retryDelay,
+                $attempt,
+                $response instanceof Response ? $response->toException() : $response
+            );
 
             return $this->makePromise($method, $url, $options, $attempt + 1);
         }


### PR DESCRIPTION
Recently, I have been using `HttpClient` to crawl some websites in order to extract data for personal purposes. During the crawler monitoring process, I noticed that many errors like the following appear:

```
  Error 
  Call to undefined method Illuminate\Http\Client\ConnectionException::toException()

  at vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:1058
    1054▕             return $exception;
    1055▕         }
    1056▕ 
    1057▕         if ($attempt < $this->tries && $shouldRetry) {
  ➜ 1058▕             $options['delay'] = value($this->retryDelay, $attempt, $response->toException());
    1059▕ 
    1060▕             return $this->makePromise($method, $url, $options, $attempt + 1);
    1061▕         }
    1062▕ 

      +14 vendor frames 
```

After reading through the source code at the error location, I found that when the `$response` variable is of type `ConnectionException`, an error occurs at line 1058 because there is no `toException()` method defined in the `ConnectionException` class.

https://github.com/laravel/framework/blob/53a5aab7da8b0b56ac2ee07e02a77edb9595e9f4/src/Illuminate/Http/Client/PendingRequest.php#L1058

This pull request will add a condition to check the data type of the `$response` variable before passing it as a parameter to the `value()` function. This approach is similar to other locations within the same `handlePromiseResponse()` function where the value is being used, so I think it will not affect other functionalities.

I would appreciate if you could review and merge this patch.