### PR TITLE
[11.x] Name of job set by displayName() must be honoured by Schedule

### DIFF
--- a/tests/Console/Fixtures/JobToTestWithSchedule.php
+++ b/tests/Console/Fixtures/JobToTestWithSchedule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+final class JobToTestWithSchedule implements ShouldQueue
+{
+    public function __invoke(): void
+    {
+    }
+}

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Tests\Console\Fixtures\JobToTestWithSchedule;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Schedule::class)]
+final class ScheduleTest extends TestCase
+{
+    private Container $container;
+    private EventMutex&MockInterface $eventMutex;
+    private SchedulingMutex&MockInterface $schedulingMutex;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container;
+        Container::setInstance($this->container);
+        $this->eventMutex = m::mock(EventMutex::class);
+        $this->container->instance(EventMutex::class, $this->eventMutex);
+        $this->schedulingMutex = m::mock(SchedulingMutex::class);
+        $this->container->instance(SchedulingMutex::class, $this->schedulingMutex);
+    }
+
+    #[DataProvider('jobHonoursDisplayNameIfMethodExistsProvider')]
+    public function testJobHonoursDisplayNameIfMethodExists(string|object $job, string $jobName): void
+    {
+        $schedule = new Schedule();
+        $scheduledJob = $schedule->job($job);
+        self::assertSame($jobName, $scheduledJob->description);
+    }
+
+    public static function jobHonoursDisplayNameIfMethodExistsProvider(): array
+    {
+        $job = new class implements ShouldQueue
+        {
+            public function displayName(): string
+            {
+                return 'testJob-123';
+            }
+        };
+
+        return [
+            [JobToTestWithSchedule::class, JobToTestWithSchedule::class],
+            [new JobToTestWithSchedule, JobToTestWithSchedule::class],
+            [$job, 'testJob-123'],
+        ];
+    }
+}


### PR DESCRIPTION
Queue jobs could have `displayName()` method providing a better naming than just a plain classname. This name is currently honoured by a queue worker but a queue scheduler. This PR fixes this inconsistency
