### PR TITLE
[11.x] Fix PHP_MAXPATHLEN check for existing check of files for views

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -170,7 +170,7 @@ abstract class Component
             return static::$bladeViewCache[$key];
         }
 
-        if (strlen($contents) <= PHP_MAXPATHLEN && $this->factory()->exists($contents)) {
+        if ($this->factory()->exists($contents)) {
             return static::$bladeViewCache[$key] = $contents;
         }
 

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -129,6 +129,7 @@ class FileViewFinder implements ViewFinderInterface
         foreach ((array) $paths as $path) {
             foreach ($this->getPossibleViewFiles($name) as $file) {
                 $viewPath = $path.'/'.$file;
+
                 if (strlen($viewPath) <= PHP_MAXPATHLEN && $this->files->exists($viewPath)) {
                     return $viewPath;
                 }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -128,7 +128,8 @@ class FileViewFinder implements ViewFinderInterface
     {
         foreach ((array) $paths as $path) {
             foreach ($this->getPossibleViewFiles($name) as $file) {
-                if ($this->files->exists($viewPath = $path.'/'.$file)) {
+                $viewPath = $path.'/'.$file;
+                if (strlen($viewPath) <= PHP_MAXPATHLEN && $this->files->exists($viewPath)) {
                     return $viewPath;
                 }
             }


### PR DESCRIPTION
Laravel can throw an error `File name is longer than the maximum allowed path length on this platform`, If a string is passed to the function `Blade::render`, which is the same length or slightly shorter than `\PHP_MAXPATHLEN` [1]. This happens due to an invalid check for the filename, because the filename gets an prefix (full path) and suffix (e.g. `.blade.php`) before the existence is checked. This leads to a filename, which is greater than `\PHP_MAXPATHLEN` which results in a PHP warning. 

Thus PHP warning is only thrown, if `open_basedir` [2] is configured [3]. 

[1] https://www.php.net/manual/en/reserved.constants.php#constant.php-maxpathlen
[2] https://www.php.net/manual/en/ini.core.php#ini.open-basedir
[3] https://github.com/php/php-src/blob/7c860628cd2bf11ee867bfb41b3fd0314c5177c5/main/fopen_wrappers.c#L302