### PR TITLE
[11.x] improvement test  for Arr::collapse method

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -38,11 +38,26 @@ class SupportArrTest extends TestCase
 
     public function testCollapse()
     {
+        // Normal case: a two-dimensional array with different elements
         $data = [['foo', 'bar'], ['baz']];
         $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
 
+        // Case including numeric and string elements
         $array = [[1], [2], [3], ['foo', 'bar'], collect(['baz', 'boom'])];
         $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($array));
+
+        // Case with empty two-dimensional arrays
+        $emptyArray = [[], [], []];
+        $this->assertEquals([], Arr::collapse($emptyArray));
+
+        // Case with both empty arrays and arrays with elements
+        $mixedArray = [[], [1, 2], [], ['foo', 'bar']];
+        $this->assertEquals([1, 2, 'foo', 'bar'], Arr::collapse($mixedArray));
+
+        // Case including collections and arrays
+        $collection = collect(['baz', 'boom']);
+        $mixedArray = [[1], [2], [3], ['foo', 'bar'], $collection];
+        $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($mixedArray));
     }
 
     public function testCrossJoin()


### PR DESCRIPTION
This PR, improvement tests  for `Arr::colapse` method:

- Case with empty two-dimensional arrays

```php
$emptyArray = [[], [], []];
$this->assertEquals([], Arr::collapse($emptyArray));
```

- Case with both empty arrays and arrays with elements

```php
$mixedArray = [[], [1, 2], [], ['foo', 'bar']];
$this->assertEquals([1, 2, 'foo', 'bar'], Arr::collapse($mixedArray));
```

- Case including collections and arrays

```php
$collection = collect(['baz', 'boom']);
$mixedArray = [[1], [2], [3], ['foo', 'bar'], $collection];
$this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($mixedArray));
```