### PR TITLE
[11.x] Fixed typo in PHPDoc `@param`

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -360,7 +360,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Send a new message synchronously using a view.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $mailable
      * @param  array  $data
      * @param  \Closure|string|null  $callback
      * @return \Illuminate\Mail\SentMessage|null

--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -65,7 +65,7 @@ class FakeJob extends Job
     /**
      * Delete the job, call the "failed" method, and raise the failed job event.
      *
-     * @param  \Throwable|null  $e
+     * @param  \Throwable|null  $exception
      * @return void
      */
     public function fail($exception = null)


### PR DESCRIPTION
Fixed some typos

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
