### PR TITLE
[11.x] improvement test for prepend method

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -139,6 +139,8 @@ trait BuildsQueries
      * @param  string|null  $alias
      * @param  bool  $descending
      * @return bool
+     *
+     * @throws \RuntimeException
      */
     public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false)
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -775,6 +775,27 @@ class SupportArrTest extends TestCase
 
         $array = Arr::prepend(['one' => 1, 'two' => 2], 0, null);
         $this->assertEquals([null => 0, 'one' => 1, 'two' => 2], $array);
+
+        $array = Arr::prepend(['one', 'two'], null, '');
+        $this->assertEquals(['' => null, 'one', 'two'], $array);
+
+        $array = Arr::prepend([], 'zero');
+        $this->assertEquals(['zero'], $array);
+
+        $array = Arr::prepend([''], 'zero');
+        $this->assertEquals(['zero', ''], $array);
+
+        $array = Arr::prepend(['one', 'two'], ['zero']);
+        $this->assertEquals([['zero'], 'one', 'two'], $array);
+
+        $array = Arr::prepend(['one', 'two'], ['zero'], 'key');
+        $this->assertEquals(['key' => ['zero'], 'one', 'two'], $array);
+    }
+
+    public function testPrependWhenKeyIsArray()
+    {
+        $this->expectException(TypeError::class);
+        Arr::prepend(['one' => 1, 'two' => 2], 'zero', [0]);
     }
 
     public function testPull()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -793,12 +793,6 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['key' => ['zero'], 'one', 'two'], $array);
     }
 
-    public function testPrependWhenKeyIsArray()
-    {
-        $this->expectException(TypeError::class);
-        Arr::prepend(['one' => 1, 'two' => 2], 'zero', [0]);
-    }
-
     public function testPull()
     {
         $array = ['name' => 'Desk', 'price' => 100];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use TypeError;
 
 class SupportArrTest extends TestCase
 {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use TypeError;
 
 class SupportArrTest extends TestCase
 {


### PR DESCRIPTION
This PR, improvement tests for prepend method.

in https://github.com/laravel/framework/pull/50949 , i remove `testPrependWhenKeyIsArray`

```php
public function testPrependWhenKeyIsArray()
{
  $this->expectException(TypeError::class);
  $this->expectExceptionMessage('Illegal offset type');

  Arr::prepend(['one' => 1, 'two' => 2], 'zero', [0]);
}
```