### PR TITLE
[11.x] Add @throws to some doc blocks

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -34,6 +34,7 @@ if (! function_exists('abort')) {
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException
      */
     function abort($code, $message = '', array $headers = [])
     {

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -152,6 +152,8 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @param  string|null  $disposition
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     *
+     * @throws \Illuminate\Routing\Exceptions\StreamedResponseException
      */
     public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
     {


### PR DESCRIPTION
### change 1:
```php
/**
   * Throw an HttpException with the given data.
   *
   * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
   * @param  string  $message
   * @param  array  $headers
   * @return never
   *
   * @throws \Symfony\Component\HttpKernel\Exception\HttpException
   * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
   * @throws \Illuminate\Http\Exceptions\HttpResponseException
   */
function abort($code, $message = '', array $headers = [])
{
    if ($code instanceof Response) {
        throw new HttpResponseException($code);
    } elseif ($code instanceof Responsable) {
        throw new HttpResponseException($code->toResponse(request()));  // ==> add `@throw` to doc block
    }

    app()->abort($code, $message, $headers);
}
```

### change 2:
```php
/**
  * Create a new file download response.
  *
  * @param  \SplFileInfo|string  $file
  * @param  string|null  $name
  * @param  array  $headers
  * @param  string|null  $disposition
  * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
  */
public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
{
  $withWrappedException = function () use ($callback) {
      try {
          $callback();
      } catch (Throwable $e) {
          throw new StreamedResponseException($e);  // ==> add `@throw` to doc block
      }
  };

 ..................
```