### PR TITLE
Add Parameters to GET Request Method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -336,14 +336,15 @@ trait MakesHttpRequests
      *
      * @param  string  $uri
      * @param  array  $headers
+     * @param  array  $parameters
      * @return \Illuminate\Testing\TestResponse
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $headers = [], array $parameters = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], $cookies, [], $server);
+        return $this->call('GET', $uri, $parameters, $cookies, [], $server);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces an enhancement to the get method in the MakesHttpRequests.php file.

Previously, the ```get``` method only accepted ```$uri``` and ```$headers``` as parameters. This update adds ```$parameters``` array to the method, allowing users to pass query parameters when making a GET request.

This change improves the flexibility of the get method and aligns it with common use cases of GET requests, which often include query parameters.

Here's the updated method signature:
```
public function get($uri, array $headers = [], array $parameters = [])
```
This update should not break any existing functionality, as the $parameters argument is optional and defaults to an empty array.