### PR TITLE
[11.x] Model virtual columns

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/HasVirtualColumns.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/HasVirtualColumns.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface HasVirtualColumns
+{
+    //
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
+use Illuminate\Contracts\Database\Eloquent\HasVirtualColumns;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -1185,6 +1186,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         $this->syncOriginal();
+
+        // virtual columns have to be retrieved from the database,
+        // if model is marked as a virtual columns owner
+        if ($this instanceof HasVirtualColumns) {
+            $this->refresh();
+        }
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelHasVirtualColumnsTest.php
+++ b/tests/Integration/Database/EloquentModelHasVirtualColumnsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Contracts\Database\Eloquent\HasVirtualColumns;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentModelHasVirtualColumnsTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase(): void
+    {
+        Schema::create('virtual', static function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+        });
+
+        Schema::table('virtual', static fn (Blueprint $table) => $table
+            ->string('full_name')
+            ->after('id')
+            ->virtualAs("first_name || ' ' || last_name"),
+        );
+    }
+
+    public function testVirtualColumnIsRetrievedWhenInterfaceIsApplied(): void
+    {
+        $record = EloquentModelWithVirtualColumns::query()->create([
+            'first_name' => 'John',
+            'last_name'  => 'Smith',
+        ]);
+
+        $this->assertSame('John', $record->first_name);
+        $this->assertSame('Smith', $record->last_name);
+        $this->assertSame('John Smith', $record->full_name);
+    }
+
+    public function testVirtualColumnIsMissingWhenInterfaceIsMissing(): void
+    {
+        $record = EloquentModelMissedVirtualColumns::query()->create([
+            'first_name' => 'John',
+            'last_name'  => 'Smith',
+        ]);
+
+        $this->assertSame('John', $record->first_name);
+        $this->assertSame('Smith', $record->last_name);
+        $this->assertNull($record->full_name);
+    }
+}
+
+abstract class VirtualColumnsEloquentModel extends Model
+{
+    protected $table = 'virtual';
+
+    public $timestamps = false;
+
+    protected $fillable = ['id', 'first_name', 'last_name'];
+}
+
+class EloquentModelWithVirtualColumns extends VirtualColumnsEloquentModel implements HasVirtualColumns
+{
+    //
+}
+
+class EloquentModelMissedVirtualColumns extends VirtualColumnsEloquentModel
+{
+    //
+}


### PR DESCRIPTION
Relates to: #50946

Currently models have to be retrieved from database to include virtual columns as attributes. This is an issue when somebody is using virtual columns directly after model is created/updated, because these columns are generated on database side and model does not retrieve data after saving.
I have added new interface to tag all models which has virtual columns and refresh them attributes on save finish, what allows us to get database generated columns always there. 
Interface is needed to do not perform unnecessary queries for models which does not have virtual columns.

I think that change should be reflected in docs as it is worth to propagate that behavior.
