### PR TITLE
[11.x] Name of job set by displayName() must be honoured by Schedule

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -154,15 +154,16 @@ class Schedule
      */
     public function job($job, $queue = null, $connection = null)
     {
-        return $this->call(function () use ($job, $queue, $connection) {
-            $job = is_string($job) ? Container::getInstance()->make($job) : $job;
+        $jobObject = is_string($job) ? Container::getInstance()->make($job) : $job;
+        $jobName = method_exists($jobObject, 'displayName') ? $jobObject->displayName() : $jobObject::class;
 
-            if ($job instanceof ShouldQueue) {
-                $this->dispatchToQueue($job, $queue ?? $job->queue, $connection ?? $job->connection);
+        return $this->call(function () use ($jobObject, $queue, $connection) {
+            if ($jobObject instanceof ShouldQueue) {
+                $this->dispatchToQueue($jobObject, $queue ?? $jobObject->queue, $connection ?? $jobObject->connection);
             } else {
-                $this->dispatchNow($job);
+                $this->dispatchNow($jobObject);
             }
-        })->name(is_string($job) ? $job : get_class($job));
+        })->name($jobName);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -154,16 +154,19 @@ class Schedule
      */
     public function job($job, $queue = null, $connection = null)
     {
-        $jobObject = is_string($job) ? Container::getInstance()->make($job) : $job;
-        $jobName = method_exists($jobObject, 'displayName') ? $jobObject->displayName() : $jobObject::class;
+        $instance = is_string($job)
+            ? Container::getInstance()->make($job)
+            : $job;
 
-        return $this->call(function () use ($jobObject, $queue, $connection) {
-            if ($jobObject instanceof ShouldQueue) {
-                $this->dispatchToQueue($jobObject, $queue ?? $jobObject->queue, $connection ?? $jobObject->connection);
-            } else {
-                $this->dispatchNow($jobObject);
-            }
-        })->name($jobName);
+        $name = method_exists($instance, 'displayName')
+            ? $instance->displayName()
+            : $instance::class;
+
+        return $this->call(function () use ($instance, $queue, $connection) {
+            $instance instanceof ShouldQueue
+                ? $this->dispatchToQueue($instance, $queue ?? $instance->queue, $connection ?? $instance->connection)
+                : $this->dispatchNow($instance);
+        })->name($name);
     }
 
     /**

--- a/tests/Console/Fixtures/JobToTestWithSchedule.php
+++ b/tests/Console/Fixtures/JobToTestWithSchedule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+final class JobToTestWithSchedule implements ShouldQueue
+{
+    public function __invoke(): void
+    {
+    }
+}

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Tests\Console\Fixtures\JobToTestWithSchedule;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Schedule::class)]
+final class ScheduleTest extends TestCase
+{
+    private Container $container;
+    private EventMutex&MockInterface $eventMutex;
+    private SchedulingMutex&MockInterface $schedulingMutex;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container;
+        Container::setInstance($this->container);
+        $this->eventMutex = m::mock(EventMutex::class);
+        $this->container->instance(EventMutex::class, $this->eventMutex);
+        $this->schedulingMutex = m::mock(SchedulingMutex::class);
+        $this->container->instance(SchedulingMutex::class, $this->schedulingMutex);
+    }
+
+    #[DataProvider('jobHonoursDisplayNameIfMethodExistsProvider')]
+    public function testJobHonoursDisplayNameIfMethodExists(string|object $job, string $jobName): void
+    {
+        $schedule = new Schedule();
+        $scheduledJob = $schedule->job($job);
+        self::assertSame($jobName, $scheduledJob->description);
+    }
+
+    public static function jobHonoursDisplayNameIfMethodExistsProvider(): array
+    {
+        $job = new class implements ShouldQueue
+        {
+            public function displayName(): string
+            {
+                return 'testJob-123';
+            }
+        };
+
+        return [
+            [JobToTestWithSchedule::class, JobToTestWithSchedule::class],
+            [new JobToTestWithSchedule, JobToTestWithSchedule::class],
+            [$job, 'testJob-123'],
+        ];
+    }
+}


### PR DESCRIPTION
Queue jobs could have displayName() method providing a better naming than just a plain classname. This name is currently honoured by a queue worker but a queue scheduler. This PR fixes this inconsistency