### PR TITLE
[10.x] Corrected return type of object() function to account for array of JSON objects

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -85,7 +85,7 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as an object.
      *
-     * @return object|null
+     * @return array|object|null
      */
     public function object()
     {


### PR DESCRIPTION
The `object` function in `Illuminate/Http/Client/Response.php` is type-hinted to return `object|null`.
But in the case when the response body contains a JSON array, the type returned by `$response->object()` is an array.

Ideally, users would use the ->object() function to convert an array of JSON objects into an array of PHP objects, but without this fix they'd have to override any code-analysis tools.