### PR TITLE
[11.x] Introduce method `Http::createPendingRequest()`

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -414,6 +414,16 @@ class Factory
     }
 
     /**
+     * Return a new pending request instance for this factory.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function createPendingRequest()
+    {
+        return $this->newPendingRequest();
+    }
+
+    /**
      * Create a new pending request instance for this factory.
      *
      * @return \Illuminate\Http\Client\PendingRequest

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -414,7 +414,7 @@ class Factory
     }
 
     /**
-     * Return a new pending request instance for this factory.
+     * Create a new pending request instance for this factory.
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */
@@ -426,7 +426,7 @@ class Factory
     }
 
     /**
-     * Create a new pending request instance for this factory.
+     * Instantiate a new pending request instance for this factory.
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -420,7 +420,9 @@ class Factory
      */
     public function createPendingRequest()
     {
-        return $this->newPendingRequest();
+        return tap($this->newPendingRequest(), function ($request) {
+            $request->stub($this->stubCallbacks)->preventStrayRequests($this->preventStrayRequests);
+        });
     }
 
     /**
@@ -466,8 +468,6 @@ class Factory
             return $this->macroCall($method, $parameters);
         }
 
-        return tap($this->newPendingRequest(), function ($request) {
-            $request->stub($this->stubCallbacks)->preventStrayRequests($this->preventStrayRequests);
-        })->{$method}(...$parameters);
+        return $this->createPendingRequest()->{$method}(...$parameters);
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3025,6 +3025,13 @@ class HttpClientTest extends TestCase
         $this->assertSame(['false'], $headers['X-Foo']);
         $this->assertSame(['true'], $headers['X-Bar']);
     }
+
+    public function testItCanCreatePendingRequest()
+    {
+        $factory = new Factory();
+
+        $this->assertInstanceOf(PendingRequest::class, $factory->createPendingRequest());
+    }
 }
 
 class CustomFactory extends Factory


### PR DESCRIPTION
This PR introduces a new public method to the HTTP Factory.

Currently, the HTTP factory does not provide any method to return an instance of `PendingRequest` which would not have side-effects.

Imagine a scenario, where we'd like to encapsulate clients for multiple services, which require API calls. To do that, we'd like to use the `PendingRequest` and have each client configure the underlying `PendingRequest`, if it needs any special configuration.

The sample code might look as follows:
```php
<?php

declare(strict_types=1);

namespace App\Client;

use Illuminate\Http\Client\Factory;
use Illuminate\Http\Client\PendingRequest;
use Illuminate\Support\Traits\ForwardsCalls;

/**
 * @mixin PendingRequest
 */
abstract readonly class AbstractPendingRequestBackedClient
{
    use ForwardsCalls;

    public function __construct(private Factory $factory)
    {
    }

    public function __call(string $name, array $arguments): mixed
    {
        return $this->forwardCallTo(
            $this->newPendingRequest(),
            $name,
            $arguments,
        );
    }

    public function getPendingRequest(): PendingRequest
    {
        return $this->newPendingRequest();
    }

    private function newPendingRequest(): PendingRequest
    {
        return tap(
            $this->factory->throw(), // <<< the issue, there's no method without side-effects
            $this->configurePendingRequest(...),
        );
    }

    abstract protected function configurePendingRequest(PendingRequest $pendingRequest): void;
}

```

Currently, there is no way to instantiate a `PendingRequest` without calling a method from the underlying Factory. However, none of these methods return just a `PendingRequest` instance, all of them have a side-effect.
At the same time, we cannot simply use dependency injection or the container to instantiate a new `PendingRequest`, because we'd lose the global middleware, global options, stubs & preventing stray requests, which are provided by the underlying Factory through its `__call` & `newPendingRequest` methods.

Hence why I suggest to either add a new method to the factory, or make the `newPendingRequest` method public (which, however, would be a breaking change and likely not a viable solution, unless targeting 12.x).
