### PR TITLE
[11.x] Allow time to be faked in database lock

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -75,7 +75,7 @@ class DatabaseLock extends Lock
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {
-                    return $query->where('owner', $this->owner)->orWhere('expiration', '<=', time());
+                    return $query->where('owner', $this->owner)->orWhere('expiration', '<=', $this->currentTime());
                 })->update([
                     'owner' => $this->owner,
                     'expiration' => $this->expiresAt(),
@@ -85,7 +85,7 @@ class DatabaseLock extends Lock
         }
 
         if (random_int(1, $this->lottery[1]) <= $this->lottery[0]) {
-            $this->connection->table($this->table)->where('expiration', '<=', time())->delete();
+            $this->connection->table($this->table)->where('expiration', '<=', $this->currentTime())->delete();
         }
 
         return $acquired;
@@ -100,7 +100,7 @@ class DatabaseLock extends Lock
     {
         $lockTimeout = $this->seconds > 0 ? $this->seconds : $this->defaultTimeoutInSeconds;
 
-        return time() + $lockTimeout;
+        return $this->currentTime() + $lockTimeout;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This would make it possible to fake time in tests when using the database for locking. (`freezeSecond`/`Date::setTestNow()`)