### PR TITLE
[11.x] Allow date and datetime casts to be encrypted

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -104,6 +104,8 @@ trait HasAttributes
         'encrypted',
         'encrypted:array',
         'encrypted:collection',
+        'encrypted:date',
+        'encrypted:datetime',
         'encrypted:json',
         'encrypted:object',
         'float',
@@ -1630,7 +1632,7 @@ trait HasAttributes
      */
     protected function isDateCastable($key)
     {
-        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime']);
+        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime', 'encrypted:date', 'encrypted:datetime']);
     }
 
     /**
@@ -1663,7 +1665,7 @@ trait HasAttributes
      */
     protected function isEncryptedCastable($key)
     {
-        return $this->hasCast($key, ['encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
+        return $this->hasCast($key, ['encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:date', 'encrypted:datetime', 'encrypted:json', 'encrypted:object']);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -186,13 +186,18 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 
     public function testDateIsCastable()
     {
+        // SQL server serializes Carbon objects with milliseconds
+        $databaseValue = $this->driver !== 'sqlsrv'
+            ? '2024-04-01 00:00:00'
+            : '2024-04-01 00:00:00.000';
+
         $this->encrypter->expects('encrypt')
-            ->with('2024-04-01 00:00:00', false)
+            ->with($databaseValue, false)
             ->andReturn('encrypted-secret-date-string');
         $this->encrypter->expects('decrypt')
             ->twice()
             ->with('encrypted-secret-date-string', false)
-            ->andReturn('2024-04-01 00:00:00');
+            ->andReturn($databaseValue);
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
         $subject = EncryptedCast::create([
@@ -200,7 +205,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertInstanceOf(Carbon::class, $subject->secret_date);
-        $this->assertTrue($subject->secret_date->isSameAs('Y-m-d H:i:s', Carbon::parse('2024-04-01')));
+        $this->assertTrue($subject->secret_date->isSameAs('Y-m-d H:i:s.u', Carbon::parse('2024-04-01')));
         $this->assertDatabaseHas('encrypted_casts', [
             'id' => $subject->id,
             'secret_date' => 'encrypted-secret-date-string',
@@ -209,13 +214,19 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 
     public function testDateTimeIsCastable()
     {
+        // SQL server serializes Carbon objects with milliseconds
+        $databaseValue = $this->driver !== 'sqlsrv'
+            ? '2024-04-01 12:34:56'
+            : '2024-04-01 12:34:56.000';
+
         $this->encrypter->expects('encrypt')
-            ->with('2024-04-01 12:34:56', false)
+            ->with($databaseValue, false)
             ->andReturn('encrypted-secret-datetime-string');
         $this->encrypter->expects('decrypt')
             ->twice()
             ->with('encrypted-secret-datetime-string', false)
-            ->andReturn('2024-04-01 12:34:56');
+            ->andReturn($databaseValue);
+
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
         $subject = EncryptedCast::create([
@@ -223,7 +234,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertInstanceOf(Carbon::class, $subject->secret_datetime);
-        $this->assertTrue($subject->secret_datetime->isSameAs('Y-m-d H:i:s', Carbon::parse('2024-04-01 12:34:56')));
+        $this->assertTrue($subject->secret_datetime->isSameAs('Y-m-d H:i:s.u', Carbon::parse('2024-04-01 12:34:56')));
         $this->assertDatabaseHas('encrypted_casts', [
             'id' => $subject->id,
             'secret_datetime' => 'encrypted-secret-datetime-string',

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -227,7 +227,6 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('encrypted-secret-datetime-string', false)
             ->andReturn($databaseValue);
 
-
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
         $subject = EncryptedCast::create([
             'secret_datetime' => Carbon::parse('2024-04-01 12:34:56'),


### PR DESCRIPTION
Encrypted database casts currently support the following types:
```
encrypted
encrypted:array
encrypted:collection
encrypted:json
encrypted:object
```

This PR adds support for `encrypted:date` and `encrypted:datetime`. This allows fields to be encrypted in the database, and be automatically cast to a Carbon (or whatever else you've configured for the date / datetime cast) object, and makes it possible to use the `encrypted` and `date` or `datetime` cast at the same time.

It does not break existing features because custom casts are objects, and this is added to the `$primitiveCastTypes` array.