### PR TITLE
Add Conditionable trait to Testing\PendingCommand.php

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -18,6 +19,8 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class PendingCommand
 {
+    use Conditionable;
+    
     /**
      * The test being run.
      *


### PR DESCRIPTION
When testing an Artisan command, the command it not actually run until the chain is destructed ([see this discussion](https://github.com/laravel/framework/discussions/45809#discussioncomment-6189769)) - meaning you cannot set the result to a variable to append additional assertions to depending on test dataset context. 
For example asserting the output based on different inputs.

```php
// terrible example
test('example', function (bool $value) {
    $result = $this->artisan('update-table-command', ['value' => $value]);

    if ($value == true) {
        $result->assertOutput('setting X turned on');
    }

    if ($value == false) {
        $result->assertOutput('setting X turned off');
    }
});
```

The simple solution for this use case is to add the `Conditionable` trait to `PendingCommand` - problem solved.
You can now easily add more assertions based on dataset criteria.

```php
// terrible example
test('example', function (bool $value) {
    $this->artisan('update-table-command', ['value' => $value])
        ->when(
            $value, 
            fn ($result) => $result->assertOutput('setting X turned on'),
            fn ($result) => $result->assertOutput('setting X turned off')
        );
});
```
