### PR TITLE
[10.x] Added eachById and chunkByIdDesc to BelongsToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -997,19 +997,66 @@ class BelongsToMany extends Relation
      */
     public function chunkById($count, callable $callback, $column = null, $alias = null)
     {
-        $this->prepareQueryBuilder();
+        return $this->orderedChunkById($count, $callback, $column, $alias);
+    }
 
+    /**
+     * Chunk the results of a query by comparing IDs in descending order.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null)
+    {
+        return $this->orderedChunkById($count, $callback, $column, $alias, descending: true);
+    }
+
+    /**
+     * Execute a callback over each item while chunking by ID.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
+    {
+        return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
+            foreach ($results as $key => $value) {
+                if ($callback($value, (($page - 1) * $count) + $key) === false) {
+                    return false;
+                }
+            }
+        }, $column, $alias);
+    }
+
+    /**
+     * Chunk the results of a query by comparing IDs in a given order.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @param  bool  $descending
+     * @return bool
+     */
+    public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false)
+    {
         $column ??= $this->getRelated()->qualifyColumn(
             $this->getRelatedKeyName()
         );
 
         $alias ??= $this->getRelatedKeyName();
 
-        return $this->query->chunkById($count, function ($results) use ($callback) {
+        return $this->prepareQueryBuilder()->orderedChunkById($count, function ($results, $page) use ($callback) {
             $this->hydratePivotRelation($results->all());
 
-            return $callback($results);
-        }, $column, $alias);
+            return $callback($results, $page);
+        }, $column, $alias, $descending);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyEachByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyEachByIdTest.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
 
-class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
+class DatabaseEloquentBelongsToManyEachByIdTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -50,31 +50,16 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
         });
     }
 
-    public function testBelongsToChunkById()
+    public function testBelongsToEachById()
     {
         $this->seedData();
 
-        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+        $user = BelongsToManyEachByIdTestTestUser::query()->first();
         $i = 0;
 
-        $user->articles()->chunkById(1, function (Collection $collection) use (&$i) {
+        $user->articles()->eachById(function (BelongsToManyEachByIdTestTestArticle $model) use (&$i) {
             $i++;
-            $this->assertEquals($i, $collection->first()->id);
-        });
-
-        $this->assertSame(3, $i);
-    }
-
-    public function testBelongsToChunkByIdDesc()
-    {
-        $this->seedData();
-
-        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
-        $i = 0;
-
-        $user->articles()->chunkByIdDesc(1, function (Collection $collection) use (&$i) {
-            $this->assertEquals(3 - $i, $collection->first()->id);
-            $i++;
+            $this->assertEquals($i, $model->id);
         });
 
         $this->assertSame(3, $i);
@@ -97,8 +82,8 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
      */
     protected function seedData()
     {
-        $user = BelongsToManyChunkByIdTestTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
-        BelongsToManyChunkByIdTestTestArticle::query()->insert([
+        $user = BelongsToManyEachByIdTestTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        BelongsToManyEachByIdTestTestArticle::query()->insert([
             ['id' => 1, 'title' => 'Another title'],
             ['id' => 2, 'title' => 'Another title'],
             ['id' => 3, 'title' => 'Another title'],
@@ -128,7 +113,7 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
     }
 }
 
-class BelongsToManyChunkByIdTestTestUser extends Eloquent
+class BelongsToManyEachByIdTestTestUser extends Eloquent
 {
     protected $table = 'users';
     protected $fillable = ['id', 'email'];
@@ -136,11 +121,11 @@ class BelongsToManyChunkByIdTestTestUser extends Eloquent
 
     public function articles()
     {
-        return $this->belongsToMany(BelongsToManyChunkByIdTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+        return $this->belongsToMany(BelongsToManyEachByIdTestTestArticle::class, 'article_user', 'user_id', 'article_id');
     }
 }
 
-class BelongsToManyChunkByIdTestTestArticle extends Eloquent
+class BelongsToManyEachByIdTestTestArticle extends Eloquent
 {
     protected $table = 'articles';
     protected $keyType = 'string';

--- a/tests/Database/DatabaseEloquentBelongsToManyEachByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyEachByIdTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -100,7 +100,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
             });
 
             $this->schema($connection)->create('friends', function ($table) {
-                $table->increments('id');
                 $table->integer('user_id');
                 $table->integer('friend_id');
                 $table->integer('friend_level_id')->nullable();
@@ -701,21 +700,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $users[] = [$user->name, $i];
             }, 2, 'name');
         $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
-    }
-
-    public function testEachByIdOnPivotWithIncrementId()
-    {
-        $user = EloquentTestUser::create(['id' => 2, 'email' => 'taylorotwel@gmail.com']);
-        $user2 = EloquentTestUser::create(['id' => 3, 'email' => 'abigailotwel@gmail.com']);;
-        $user->friends()->attach($user2);
-
-        $user->friends()->eachById(
-            function (EloquentTestUser $model) use (&$models) {
-                $models[] = $model;
-            }
-        );
-
-        $this->assertSame($user2->id, $models[0]->id);
     }
 
     public function testPluck()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -100,6 +100,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             });
 
             $this->schema($connection)->create('friends', function ($table) {
+                $table->increments('id');
                 $table->integer('user_id');
                 $table->integer('friend_id');
                 $table->integer('friend_level_id')->nullable();
@@ -700,6 +701,21 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $users[] = [$user->name, $i];
             }, 2, 'name');
         $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
+    }
+
+    public function testEachByIdOnPivotWithIncrementId()
+    {
+        $user = EloquentTestUser::create(['id' => 2, 'email' => 'taylorotwel@gmail.com']);
+        $user2 = EloquentTestUser::create(['id' => 3, 'email' => 'abigailotwel@gmail.com']);;
+        $user->friends()->attach($user2);
+
+        $user->friends()->eachById(
+            function (EloquentTestUser $model) use (&$models) {
+                $models[] = $model;
+            }
+        );
+
+        $this->assertSame($user2->id, $models[0]->id);
     }
 
     public function testPluck()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If you have a BelongsToMany pivot with a incrementing key then you can get the wrong `id` hydrated in the model and further operations would be on the wrong model.

Similar to #47479, but I think the incrementing key needs to be emphasized. People could be selecting in the current release and getting the wrong ID.

People are adding methods to BuildsQuery and not following through with maintaining BelongsToMany or HasManyThrough. Example: chunkByIdDesc was added a few months ago and nobody even thought about BelongsToMany https://github.com/laravel/framework/pull/48666.

I'd ask internals to consider a larger rewrite as this doesn't appear to be well managed. I could keep writing failing tests (e.g. `lazyByIdDesc` or `orderedLazyById`), but I don't have time tonight. Additionally I'm guessing HasManyThrough (or anything else with a pivot) will have similar issues.