### PR TITLE
[11.x] Fix prompt fallback return value when using numeric keys

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Concerns;
 
+use Illuminate\Console\PromptOption;
 use Illuminate\Console\PromptValidationException;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSearchPrompt;
@@ -52,28 +53,16 @@ trait ConfiguresPrompts
         ));
 
         SelectPrompt::fallbackUsing(fn (SelectPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->choice($prompt->label, $prompt->options, $prompt->default),
+            fn () => $this->selectFallback($prompt->label, $prompt->options, $prompt->default),
             false,
             $prompt->validate
         ));
 
-        MultiSelectPrompt::fallbackUsing(function (MultiSelectPrompt $prompt) {
-            if ($prompt->default !== []) {
-                return $this->promptUntilValid(
-                    fn () => $this->components->choice($prompt->label, $prompt->options, implode(',', $prompt->default), multiple: true),
-                    $prompt->required,
-                    $prompt->validate
-                );
-            }
-
-            return $this->promptUntilValid(
-                fn () => collect($this->components->choice($prompt->label, ['' => 'None', ...$prompt->options], 'None', multiple: true))
-                    ->reject('')
-                    ->all(),
-                $prompt->required,
-                $prompt->validate
-            );
-        });
+        MultiSelectPrompt::fallbackUsing(fn (MultiSelectPrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->multiselectFallback($prompt->label, $prompt->options, $prompt->default, $prompt->required),
+            $prompt->required,
+            $prompt->validate
+        ));
 
         SuggestPrompt::fallbackUsing(fn (SuggestPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->askWithCompletion($prompt->label, $prompt->options, $prompt->default ?: null) ?? '',
@@ -87,7 +76,7 @@ trait ConfiguresPrompts
 
                 $options = ($prompt->options)($query);
 
-                return $this->components->choice($prompt->label, $options);
+                return $this->selectFallback($prompt->label, $options);
             },
             false,
             $prompt->validate
@@ -99,21 +88,7 @@ trait ConfiguresPrompts
 
                 $options = ($prompt->options)($query);
 
-                if ($prompt->required === false) {
-                    if (array_is_list($options)) {
-                        return collect($this->components->choice($prompt->label, ['None', ...$options], 'None', multiple: true))
-                            ->reject('None')
-                            ->values()
-                            ->all();
-                    }
-
-                    return collect($this->components->choice($prompt->label, ['' => 'None', ...$options], '', multiple: true))
-                        ->reject('')
-                        ->values()
-                        ->all();
-                }
-
-                return $this->components->choice($prompt->label, $options, multiple: true);
+                return $this->multiselectFallback($prompt->label, $options, required: $prompt->required);
             },
             $prompt->required,
             $prompt->validate
@@ -237,5 +212,56 @@ trait ConfiguresPrompts
     protected function restorePrompts()
     {
         Prompt::setOutput($this->output);
+    }
+
+    /**
+     * Select fallback.
+     *
+     * @param  string  $label
+     * @param  array  $options
+     * @param  string|int|null  $default
+     * @return string|int
+     */
+    private function selectFallback($label, $options, $default = null)
+    {
+        if ($default !== null) {
+            $default = array_search($default, array_is_list($options) ? $options : array_keys($options));
+        }
+
+        return PromptOption::unwrap($this->components->choice($label, PromptOption::wrap($options), $default));
+    }
+
+    /**
+     * Multi-select fallback.
+     *
+     * @param  string  $label
+     * @param  array  $options
+     * @param  array  $default
+     * @param  bool|string  $required
+     * @return array
+     */
+    private function multiselectFallback($label, $options, $default = [], $required = false)
+    {
+        $options = PromptOption::wrap($options);
+
+        if ($required === false) {
+            $options = [new PromptOption(null, 'None'), ...$options];
+
+            if ($default === []) {
+                $default = [null];
+            }
+        }
+
+        $default = $default !== []
+            ? implode(',', array_keys(array_filter($options, fn ($option) => in_array($option->value, $default))))
+            : null;
+
+        $answers = PromptOption::unwrap($this->components->choice($label, $options, $default, multiple: true));
+
+        if ($required === false) {
+            return array_values(array_filter($answers, fn ($value) => $value !== null));
+        }
+
+        return $answers;
     }
 }

--- a/src/Illuminate/Console/PromptOption.php
+++ b/src/Illuminate/Console/PromptOption.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Console;
+
+/**
+ * @internal
+ */
+class PromptOption
+{
+    /**
+     * Create a new prompt option.
+     *
+     * @param  string|int|null  $value
+     * @param  string  $label
+     */
+    public function __construct(public $value, public $label)
+    {
+        //
+    }
+
+    /**
+     * Return the string representation of the option.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->label;
+    }
+
+    /**
+     * Wrap the given options in PromptOption objects.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    public static function wrap($options)
+    {
+        return array_map(
+            fn ($label, $value) => new static(array_is_list($options) ? $label : $value, $label),
+            $options,
+            array_keys($options)
+        );
+    }
+
+    /**
+     * Unwrap the given option(s).
+     *
+     * @param  static|string|int|array  $option
+     * @return string|int|array
+     */
+    public static function unwrap($option)
+    {
+        if (is_array($option)) {
+            return array_map(static::unwrap(...), $option);
+        }
+
+        return $option instanceof static ? $option->value : $option;
+    }
+}

--- a/tests/Console/ConfiguresPromptsTest.php
+++ b/tests/Console/ConfiguresPromptsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Application;
+use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\select;
+
+class ConfiguresPromptsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    #[DataProvider('selectDataProvider')]
+    public function testSelectFallback($prompt, $expectedDefault, $selection, $expectedReturn)
+    {
+        $command = new class($prompt) extends Command
+        {
+            public $answer;
+
+            public function __construct(protected $prompt)
+            {
+                parent::__construct();
+            }
+
+            public function handle()
+            {
+                $this->answer = ($this->prompt)();
+            }
+        };
+
+        $this->runCommand($command, fn ($components) => $components
+            ->expects('choice')
+            ->withArgs(fn ($question, $options, $default) => $default === $expectedDefault)
+            ->andReturnUsing(fn ($question, $options, $default) => $options[$selection])
+        );
+
+        $this->assertSame($expectedReturn, $command->answer);
+    }
+
+    public static function selectDataProvider()
+    {
+        return [
+            'list with no default' => [fn () => select('foo', ['a', 'b', 'c']), null, 1, 'b'],
+            'numeric keys with no default' => [fn () => select('foo', [1 => 'a', 2 => 'b', 3 => 'c']), null, 1, 2],
+            'assoc with no default' => [fn () => select('foo', ['a' => 'A', 'b' => 'B', 'c' => 'C']), null, 1, 'b'],
+            'list with default' => [fn () => select('foo', ['a', 'b', 'c'], 'b'), 1, 1, 'b'],
+            'numeric keys with default' => [fn () => select('foo', [1 => 'a', 2 => 'b', 3 => 'c'], 2), 1, 1, 2],
+            'assoc with default' => [fn () => select('foo', ['a' => 'A', 'b' => 'B', 'c' => 'C'], 'b'), 1, 1, 'b'],
+        ];
+    }
+
+    #[DataProvider('multiselectDataProvider')]
+    public function testMultiselectFallback($prompt, $expectedDefault, $selection, $expectedReturn)
+    {
+        $command = new class($prompt) extends Command
+        {
+            public $answer;
+
+            public function __construct(protected $prompt)
+            {
+                parent::__construct();
+            }
+
+            public function handle()
+            {
+                $this->answer = ($this->prompt)();
+            }
+        };
+
+        $this->runCommand($command, fn ($components) => $components
+            ->expects('choice')
+            ->withArgs(fn ($question, $options, $default, $multiple) => $default === $expectedDefault && $multiple === true)
+            ->andReturnUsing(fn ($question, $options, $default, $multiple) => array_values(array_filter($options, fn ($index) => in_array($index, $selection), ARRAY_FILTER_USE_KEY)))
+        );
+
+        $this->assertSame($expectedReturn, $command->answer);
+    }
+
+    public static function multiselectDataProvider()
+    {
+        return [
+            'list with no default' => [fn () => multiselect('foo', ['a', 'b', 'c']), '0', [2, 3], ['b', 'c']],
+            'numeric keys with no default' => [fn () => multiselect('foo', [1 => 'a', 2 => 'b', 3 => 'c']), '0', [2, 3], [2, 3]],
+            'assoc with no default' => [fn () => multiselect('foo', ['a' => 'A', 'b' => 'B', 'c' => 'C']), '0', [2, 3], ['b', 'c']],
+            'list with default' => [fn () => multiselect('foo', ['a', 'b', 'c'], ['b', 'c']), '2,3', [2, 3], ['b', 'c']],
+            'numeric keys with default' => [fn () => multiselect('foo', [1 => 'a', 2 => 'b', 3 => 'c'], [2, 3]), '2,3', [2, 3], [2, 3]],
+            'assoc with default' => [fn () => multiselect('foo', ['a' => 'A', 'b' => 'B', 'c' => 'C'], ['b', 'c']), '2,3', [2, 3], ['b', 'c']],
+            'required list with no default' => [fn () => multiselect('foo', ['a', 'b', 'c'], required: true), null, [1, 2], ['b', 'c']],
+            'required numeric keys with no default' => [fn () => multiselect('foo', [1 => 'a', 2 => 'b', 3 => 'c'], required: true), null, [1, 2], [2, 3]],
+            'required assoc with no default' => [fn () => multiselect('foo', ['a' => 'A', 'b' => 'B', 'c' => 'C'], required: true), null, [1, 2], ['b', 'c']],
+            'required list with default' => [fn () => multiselect('foo', ['a', 'b', 'c'], ['b', 'c'], required: true), '1,2', [1, 2], ['b', 'c']],
+            'required numeric keys with default' => [fn () => multiselect('foo', [1 => 'a', 2 => 'b', 3 => 'c'], [2, 3], required: true), '1,2', [1, 2], [2, 3]],
+            'required assoc with default' => [fn () => multiselect('foo', ['a' => 'A', 'b' => 'B', 'c' => 'C'], ['b', 'c'], required: true), '1,2', [1, 2], ['b', 'c']],
+        ];
+    }
+
+    protected function runCommand($command, $expectations)
+    {
+        $command->setLaravel($application = m::mock(Application::class));
+
+        $application->shouldReceive('make')->withArgs(fn ($abstract) => $abstract === OutputStyle::class)->andReturn($outputStyle = m::mock(OutputStyle::class));
+        $application->shouldReceive('make')->withArgs(fn ($abstract) => $abstract === Factory::class)->andReturn($factory = m::mock(Factory::class));
+        $application->shouldReceive('runningUnitTests')->andReturn(true);
+        $application->shouldReceive('call')->with([$command, 'handle'])->andReturnUsing(fn ($callback) => call_user_func($callback));
+        $outputStyle->shouldReceive('newLinesWritten')->andReturn(1);
+
+        $expectations($factory);
+
+        $command->run(new ArrayInput([]), new NullOutput);
+    }
+}


### PR DESCRIPTION
This PR fixes an inconsistency issue with any Prompt fallbacks that rely on Symfony's choice component.

The inconsistency occurs when passing an array of options with numeric keys that are not sequential, starting from 0.

Prompts uses PHP's `array_is_list` function to determine whether the returned value should be the selected key or the selected value. Symfony's choice component differs by always returning the value for any array with all numeric keys, regardless of whether they are sequential from 0:

```php
// Prompts without fallback

select('Foo', [
    '9999' => 'High', // returns '9999'
    '1' => 'Low', // returns '1'
]);

// Prompts with Symfony fallback

select('Foo', [
    '9999' => 'High', // returns 'High'
    '1' => 'Low', // returns 'Low',
]);

select('Foo', [
    '9999' => 'High', // returns '9999'
    'medium' => 'Medium', // returns 'medium',
    '1' => 'Low', // returns '1'
]);
```

This is an issue because the return value is inconsistent depending on whether or not the fallback was activated.

This PR solves this by wrapping each option in a new `PromptOption` class and passing them to Symfony as a list. Symfony can render the string version of the `PromptOption` class, and because it's passed as a list, it will always return the selected `PromptOption` class, allowing us to extract the correct value.

A nice side effect of always passing a list is that Symfony will not display the underlying array keys to the user, which makes the fallback more consistent with Prompts. It also simplifies the approach we use to inject the "None" option for the `multiselect` fallback.