### PR TITLE
[11.x] Add support for Random\Engine in random() at Arr Helper, Collection

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -711,7 +711,7 @@ class Arr
      * @param  array  $array
      * @param  int|null  $number
      * @param  bool  $preserveKeys
-     * @param  Engine|null $engine
+     * @param  Engine|null  $engine
      * @return mixed
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -6,6 +6,7 @@ use ArgumentCountError;
 use ArrayAccess;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use Random\Engine;
 use Random\Randomizer;
 
 class Arr
@@ -710,11 +711,12 @@ class Arr
      * @param  array  $array
      * @param  int|null  $number
      * @param  bool  $preserveKeys
+     * @param  Engine|null $engine
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public static function random($array, $number = null, $preserveKeys = false)
+    public static function random($array, $number = null, $preserveKeys = false, $engine = null)
     {
         $requested = is_null($number) ? 1 : $number;
 
@@ -730,7 +732,7 @@ class Arr
             return is_null($number) ? null : [];
         }
 
-        $keys = (new Randomizer)->pickArrayKeys($array, $requested);
+        $keys = (new Randomizer($engine))->pickArrayKeys($array, $requested);
 
         if (is_null($number)) {
             return $array[$keys[0]];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1049,7 +1049,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(self<TKey, TValue>): int)|int|null  $number
      * @param  bool  $preserveKeys
-     * @param  Engine|null $engine
+     * @param  Engine|null  $engine
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
+use Random\Engine;
 use stdClass;
 use Traversable;
 
@@ -1048,21 +1049,22 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(self<TKey, TValue>): int)|int|null  $number
      * @param  bool  $preserveKeys
+     * @param  Engine|null $engine
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
      */
-    public function random($number = null, $preserveKeys = false)
+    public function random($number = null, $preserveKeys = false, $engine = null)
     {
         if (is_null($number)) {
             return Arr::random($this->items);
         }
 
         if (is_callable($number)) {
-            return new static(Arr::random($this->items, $number($this), $preserveKeys));
+            return new static(Arr::random($this->items, $number($this), $preserveKeys, $engine));
         }
 
-        return new static(Arr::random($this->items, $number, $preserveKeys));
+        return new static(Arr::random($this->items, $number, $preserveKeys, $engine));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1010,8 +1010,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @param  bool $preserveKeys
-     * @param  Engine|null $engine
+     * @param  bool  $preserveKeys
+     * @param  Engine|null  $engine
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use IteratorAggregate;
+use Random\Engine;
 use stdClass;
 use Traversable;
 
@@ -1009,11 +1010,13 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
+     * @param  bool $preserveKeys
+     * @param  Engine|null $engine
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
      */
-    public function random($number = null)
+    public function random($number = null, $preserveKeys = false, $engine = null)
     {
         $result = $this->collect()->random(...func_get_args());
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -21,6 +21,9 @@ use JsonSerializable;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Random\Engine\Mt19937;
+use Random\Engine\PcgOneseq128XslRr64;
+use Random\Engine\Xoshiro256StarStar;
 use ReflectionClass;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -2325,6 +2328,24 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(5, $random);
         $this->assertCount(5, array_intersect_assoc($random->all(), $data->all()));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testRandomWithEngine($collection)
+    {
+        $engines = [
+            'null' => null, // Secure Engine will be used
+            'Mt19937' => new Mt19937(),
+            'PcgOneseq128XslRr64' => new PcgOneseq128XslRr64(),
+            'Xoshiro256StarStar' => new Xoshiro256StarStar(),
+        ];
+
+        $data = new $collection([1, 2, 3, 4, 5, 6]);
+        foreach ($engines as $name => $engine) {
+            $random = $data->random(2, engine: $engine);
+            $this->assertInstanceOf($collection, $random, "with $name Random Engine.");
+            $this->assertCount(2, $random, "with $name Random Engine.");
+        }
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
## Overview
This pull request aims to add support for the Random\Engine introduced in PHP 8.2 to the Arr::random(), Collection::random(), and LazyCollection::random() methods in Laravel.

## Changes Made
- Added support for the Random\Engine argument in the Arr::random() method.
- Added support for the Random\Engine argument in the Collection::random() method.
- Added support for the Random\Engine argument in the LazyCollection::random() method.

## Motivation
The Random\Engine introduced in PHP 8.2 provides a flexible way to control randomness. Integrating this feature into Laravel's collection methods allows developers to have finer control over randomness.

The reason for wanting to inject the Engine was the existence of a use case in my project where I needed to fix the seed value for random number generation during testing. By using Random\Engine, it becomes possible to set the seed value and achieve deterministic random number generation, improving the stability of tests.

Random\Engine allows specifying various random number generation algorithms and random seeds, enabling the realization of appropriate randomness for specific use cases. This makes it possible to achieve more secure random number generation, even for applications with high security requirements.

## Potential Future Work
Since the shuffle method in Arr and Collection also uses the Randomizer, if necessary, a separate pull request can be made to enable injecting the Engine into those methods as well.