### PR TITLE
Allow sorting of route:list by multiple column/factors using a comma

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -157,7 +157,7 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-	if (Str::contains($sort, ",")) {
+	    if (Str::contains($sort, ",")) {
             $sortArr = explode(",", $sort);
             return collect($routes)
                 ->sortBy($sortArr)

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -158,16 +158,12 @@ class RouteListCommand extends Command
     protected function sortRoutes($sort, array $routes)
     {
         if (Str::contains($sort, ",")) {
-            $sortArr = explode(",", $sort);
-
-            return collect($routes)
-                ->sortBy($sortArr)
-                ->toArray();
+            $sort = explode(",", $sort);
         }
 
-        return Arr::sort($routes, function ($route) use ($sort) {
-            return $route[$sort];
-        });
+        return collect($routes)
+            ->sortBy($sort)
+            ->toArray();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -157,6 +157,13 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
+	if (Str::contains($sort, ",")) {
+            $sortArr = explode(",", $sort);
+            return collect($routes)
+                ->sortBy($sortArr)
+                ->toArray();
+        }
+
         return Arr::sort($routes, function ($route) use ($sort) {
             return $route[$sort];
         });

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -157,8 +157,8 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-        if (Str::contains($sort, ",")) {
-            $sort = explode(",", $sort);
+        if (Str::contains($sort, ',')) {
+            $sort = explode(',', $sort);
         }
 
         return collect($routes)

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -159,6 +159,7 @@ class RouteListCommand extends Command
     {
         if (Str::contains($sort, ",")) {
             $sortArr = explode(",", $sort);
+
             return collect($routes)
                 ->sortBy($sortArr)
                 ->toArray();

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -157,7 +157,7 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-	    if (Str::contains($sort, ",")) {
+        if (Str::contains($sort, ",")) {
             $sortArr = explode(",", $sort);
             return collect($routes)
                 ->sortBy($sortArr)


### PR DESCRIPTION
Today I had need to run `artisan route:list --sort={SORT}` but wanted to not only sort by `domain` but then by a second factor. 

This PR allows users to use the syntax:
```
artisan route:list --sort=domain,uri
```
Which first sorts the list by `domain` column and then by the `uri` column. 