### PR TITLE
[11.x] Allowing Usage of Livewire Wire Boolean Style Directives

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -502,8 +502,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
             }
 
             if ($value === true) {
-                // Exception for Alpine...
-                $value = $key === 'x-data' ? '' : $key;
+                $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
             $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -113,6 +113,17 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('required="required" x-data=""', (string) $bag);
     }
 
+    public function testItMakesAnExceptionForLivewireWireAttributes()
+    {
+        $bag = new ComponentAttributeBag([
+            'wire:loading' => true,
+            'wire:loading.remove' => true,
+            'wire:poll' => true,
+        ]);
+
+        $this->assertSame('wire:loading="" wire:loading.remove="" wire:poll=""', (string) $bag);
+    }
+
     public function testAttributeExistence()
     {
         $bag = new ComponentAttributeBag(['name' => 'test']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Relates

Relates to #50994

## Explanation

As we know, Livewire allows us to use some Boolean-style directives, that is, without any defined value, which is the case with directives such as: `wire:poll`, `wire:loading`, `wire:loading.remove`, etc. This PR aims to ensure that the use of these directives does not define their value as the name of the directive itself.

Before:

```blade
{{-- Using like this --}}

<x-fetch wire:poll />

{{-- Generates this HTML --}}

<div ... wire:poll="wire:poll" />
```

After this PR:

```blade
<x-fetch wire:poll />

<div ... wire:poll />
```

---

Although there are ways to deal with this - as mentioned by @driesvints in the issue, the work becomes overwhelming when we need to use directives like `wire:poll` **(without specific value)** several times.