### PR TITLE
[11.x] APC Cache - Remove apc_* method calls

### DIFF
--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -5,23 +5,6 @@ namespace Illuminate\Cache;
 class ApcWrapper
 {
     /**
-     * Indicates if APCu is supported.
-     *
-     * @var bool
-     */
-    protected $apcu = false;
-
-    /**
-     * Create a new APC wrapper instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->apcu = function_exists('apcu_fetch');
-    }
-
-    /**
      * Get an item from the cache.
      *
      * @param  string  $key
@@ -29,7 +12,7 @@ class ApcWrapper
      */
     public function get($key)
     {
-        $fetchedValue = $this->apcu ? apcu_fetch($key, $success) : apc_fetch($key, $success);
+        $fetchedValue = apcu_fetch($key, $success);
 
         return $success ? $fetchedValue : null;
     }
@@ -44,7 +27,7 @@ class ApcWrapper
      */
     public function put($key, $value, $seconds)
     {
-        return $this->apcu ? apcu_store($key, $value, $seconds) : apc_store($key, $value, $seconds);
+        return apcu_store($key, $value, $seconds);
     }
 
     /**
@@ -56,7 +39,7 @@ class ApcWrapper
      */
     public function increment($key, $value)
     {
-        return $this->apcu ? apcu_inc($key, $value) : apc_inc($key, $value);
+        return apcu_inc($key, $value);
     }
 
     /**
@@ -68,7 +51,7 @@ class ApcWrapper
      */
     public function decrement($key, $value)
     {
-        return $this->apcu ? apcu_dec($key, $value) : apc_dec($key, $value);
+        return apcu_dec($key, $value);
     }
 
     /**
@@ -79,7 +62,7 @@ class ApcWrapper
      */
     public function delete($key)
     {
-        return $this->apcu ? apcu_delete($key) : apc_delete($key);
+        return apcu_delete($key);
     }
 
     /**
@@ -89,6 +72,6 @@ class ApcWrapper
      */
     public function flush()
     {
-        return $this->apcu ? apcu_clear_cache() : apc_clear_cache('user');
+        return apcu_clear_cache();
     }
 }


### PR DESCRIPTION
APC has been deprecated since PHP 7 with the introduction of opcache, and no longer even compiles for PHP 8.x.

Removes the usage of apc_* functions and the need to check which version of the functions to call in ApcWrapper.

This has a code maintenance benefit of clearing out code paths that are no longer relevant due to supported PHP versions.
This has a minor performance benefit as usage of Apcu cache no longer has an extra boolean check on every method call.


Note: An even better implementation would be to ditch the ApcWrapper altogether and move the simple implementation  of each cache method directly into ApcStore, but that requires more creative changes to the CacheApcStoreTest as it relied on mocking the ApcWrapper to validate the implementation.  Updating these tests to mocking the builtin apcu_* functions would be a chore. Or perhaps with the implementation being simply a wrapper around apcu_* calls anyway it would be safe to kill off the test entirely.  But that may also be viewed as a breaking change.