### PR TITLE
Fix computed columns mapping to wrong tables

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -125,7 +125,7 @@ class SqlServerGrammar extends Grammar
             .'join sys.schemas as scm on obj.schema_id = scm.schema_id '
             .'left join sys.default_constraints def on col.default_object_id = def.object_id and col.object_id = def.parent_object_id '
             ."left join sys.extended_properties as prop on obj.object_id = prop.major_id and col.column_id = prop.minor_id and prop.name = 'MS_Description' "
-            .'left join sys.computed_columns as com on col.column_id = com.column_id '
+            .'left join sys.computed_columns as com on col.column_id = com.column_id and col.object_id = com.object_id '
             ."where obj.type in ('U', 'V') and obj.name = %s and scm.name = %s "
             .'order by col.column_id',
             $this->quoteString($table),

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -21,6 +21,7 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
     protected function destroyDatabaseMigrations()
     {
         Schema::drop('users');
+        Schema::dropIfExists('computed');
         DB::statement('drop view if exists users_view');
     }
 
@@ -63,5 +64,13 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
     public function testGetViewsWhenNoneExist()
     {
         $this->assertSame([], Schema::getViews());
+    }
+
+    public function testComputedColumnsListing()
+    {
+        DB::statement('create table dbo.computed (id int identity (1,1) not null, computed as id + 1)');
+
+        $userColumns = Schema::getColumns('users');
+        $this->assertNull($userColumns[1]['generation']);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If at least one table contains a computed column, `Schema::getColumns()` would show the computed column for other tables as well.

The query created by `\Illuminate\Database\Schema\Grammars\SqlServerGrammar::compileColumns` is missing a join predicate between `sys.columns` and `sys.computed_columns`:

```sql
select col.name, type.name as type_name, 
col.max_length as length, col.precision as precision, col.scale as places, 
col.is_nullable as nullable, def.definition as [default], 
col.is_identity as autoincrement, col.collation_name as collation, 
com.definition as [expression], is_persisted as [persisted], 
cast(prop.value as nvarchar(max)) as comment 
from sys.columns as col 
join sys.types as type on col.user_type_id = type.user_type_id 
join sys.objects as obj on col.object_id = obj.object_id 
join sys.schemas as scm on obj.schema_id = scm.schema_id 
left join sys.default_constraints def on col.default_object_id = def.object_id and col.object_id = def.parent_object_id 
left join sys.extended_properties as prop on obj.object_id = prop.major_id and col.column_id = prop.minor_id and prop.name = 'MS_Description' 
left join sys.computed_columns as com on col.column_id = com.column_id and col.object_id = com.object_id 
--                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
where obj.type in ('U', 'V') and obj.name = %s and scm.name = %s 
order by col.column_id'
```

This adds the predicate to ensure only computed columns that belong to the current table are returned.

Tested on SQL Server 2019.