### PR TITLE
[11.x] improvement test for string title

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -41,6 +41,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::title(''));
         $this->assertSame('123 Laravel', Str::title('123 laravel'));
         $this->assertSame('❤Laravel', Str::title('❤laravel'));
+        $this->assertSame('Laravel ❤', Str::title('laravel ❤'));
         $this->assertSame('Laravel123', Str::title('laravel123'));
         $this->assertSame('Laravel123', Str::title('Laravel123'));
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -45,8 +45,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel123', Str::title('laravel123'));
         $this->assertSame('Laravel123', Str::title('Laravel123'));
 
-        $longString = 'lorem ipsum ' . str_repeat('dolor sit amet ', 1000);
-        $expectedResult = 'Lorem Ipsum Dolor Sit Amet ' . str_repeat('Dolor Sit Amet ', 999);
+        $longString = 'lorem ipsum '.str_repeat('dolor sit amet ', 1000);
+        $expectedResult = 'Lorem Ipsum Dolor Sit Amet '.str_repeat('Dolor Sit Amet ', 999);
         $this->assertSame($expectedResult, Str::title($longString));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -37,6 +37,16 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('Jefferson Costella', Str::title('jefferson costella'));
         $this->assertSame('Jefferson Costella', Str::title('jefFErson coSTella'));
+
+        $this->assertSame('', Str::title(''));
+        $this->assertSame('123 Laravel', Str::title('123 laravel'));
+        $this->assertSame('❤Laravel', Str::title('❤laravel'));
+        $this->assertSame('Laravel123', Str::title('laravel123'));
+        $this->assertSame('Laravel123', Str::title('Laravel123'));
+
+        $longString = 'lorem ipsum ' . str_repeat('dolor sit amet ', 1000);
+        $expectedResult = 'Lorem Ipsum Dolor Sit Amet ' . str_repeat('Dolor Sit Amet ', 999);
+        $this->assertSame($expectedResult, Str::title($longString));
     }
 
     public function testStringHeadline()


### PR DESCRIPTION
This PR, improvement test for Str::title


The added tests include:

- Testing an empty string to ensure that `Str::title('')` returns an empty string.
```php
$this->assertSame('', Str::title(''));
```

- Testing a string containing numbers to ensure that `Str::title('123 laravel')` correctly capitalizes the first letter of each word.
```php
$this->assertSame('123 Laravel', Str::title('123 laravel'));
```

- Testing a string containing a special character (heart emoji) to ensure that `Str::title('❤laravel')` capitalizes the first letter of each word correctly.

```php
$this->assertSame('❤Laravel', Str::title('❤laravel'));
$this->assertSame('Laravel ❤', Str::title('laravel ❤'));
```
- Testing a string containing both letters and numbers to ensure that `Str::title('laravel123')` correctly capitalizes the first letter of each word.

```php
$this->assertSame('Laravel123', Str::title('laravel123'));
```

- Testing a string starting with a capital letter and containing numbers to ensure that `Str::title('Laravel123')` does not modify the original capitalization.

```php
$this->assertSame('Laravel123', Str::title('Laravel123'));
```

- Testing a long string to ensure that `Str::title()` works efficiently and accurately for large inputs.
```php
$longString = 'lorem ipsum ' . str_repeat('dolor sit amet ', 1000);
$expectedResult = 'Lorem Ipsum Dolor Sit Amet ' . str_repeat('Dolor Sit Amet ', 999);
$this->assertSame($expectedResult, Str::title($longString));
```

Thanks!