### PR TITLE
[11.x] Improvement Test for repository class

### DIFF
--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -186,8 +186,8 @@ class RepositoryTest extends TestCase
         $this->assertSame('xxx', $this->repository->get('array.0'));
         $this->assertSame('aaa', $this->repository->get('array.1'));
         $this->assertSame('zzz', $this->repository->get('array.2'));
-        $this->assertNull($this->repository->get('array.3'), 'There should be no item after the third item');
-        $this->assertCount(3, $this->repository->get('array'), 'The count of array should be 3 after prepending');
+        $this->assertNull($this->repository->get('array.3'));
+        $this->assertCount(3, $this->repository->get('array'));
     }
 
     public function testPush()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -178,10 +178,13 @@ class RepositoryTest extends TestCase
     {
         $this->assertSame('aaa', $this->repository->get('array.0'));
         $this->assertSame('zzz', $this->repository->get('array.1'));
+
         $this->repository->prepend('array', 'xxx');
         $this->assertSame('xxx', $this->repository->get('array.0'));
         $this->assertSame('aaa', $this->repository->get('array.1'));
         $this->assertSame('zzz', $this->repository->get('array.2'));
+        $this->assertNull($this->repository->get('array.3'), 'There should be no item after the third item');
+        $this->assertCount(3, $this->repository->get('array'), 'The count of array should be 3 after prepending');
     }
 
     public function testPush()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -198,6 +198,8 @@ class RepositoryTest extends TestCase
         $this->assertSame('aaa', $this->repository->get('array.0'));
         $this->assertSame('zzz', $this->repository->get('array.1'));
         $this->assertSame('xxx', $this->repository->get('array.2'));
+
+        $this->assertCount(3, $this->repository->get('array'));
     }
 
     public function testPrependWithNewKey()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -56,6 +56,9 @@ class RepositoryTest extends TestCase
         $this->assertNull(
             $this->repository->get('a.b.c')
         );
+
+        $this->assertNull($this->repository->get('x.y.z'));
+        $this->assertNull($this->repository->get('.'));
     }
 
     public function testGetBooleanValue()


### PR DESCRIPTION
This PR, improvement some tests in `RepositoryTest.php`

in SetUp method: 
```php
$this->repository = new Repository($this->config = [
  'foo' => 'bar',
  'bar' => 'baz',
  'baz' => 'bat',
  'null' => null,
  'boolean' => true,
  'integer' => 1,
  'float' => 1.1,
  'associate' => [
      'x' => 'xxx',
      'y' => 'yyy',
  ],
  'array' => [
      'aaa',
      'zzz',
  ],
  'x' => [
      'z' => 'zoo',
  ],
  'a.b' => 'c',
  'a' => [
      'b.c' => 'd',
  ],
]);
```

### 1. improvement tests  in `testGetValueWhenKeyContainDot`
If the key does not exist in any way,
```php
$this->assertNull($this->repository->get('x.y.z')); 

```
If the input is only a dot, `null` should be returned.
```php
$this->assertNull($this->repository->get('.')); 
```

### 2. improvement tests in `Prepend` method
When adding a new item, we ensure that the number of items has increased by one compared to before. Additionally, attempting to access more items than are currently available should return null.

```php
$this->assertNull($this->repository->get('array.3'));
$this->assertCount(3, $this->repository->get('array'));
```

### 3. improvement tests when push new item
We need to ensure that after pushing a new item, the count of items is correct and not less or more than expected.

```php
$this->assertCount(3, $this->repository->get('array'));
```