### PR TITLE
[11.x] Fix: Apply database connection  before checking if the repository exist

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -62,6 +62,10 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
+        if(! is_null($database)) {
+            $this->migrator->setConnection($database);
+        }
+
         if ($this->migrator->repositoryExists()) {
             $this->newLine();
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -62,7 +62,7 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        if(! is_null($database)) {
+        if (! is_null($database)) {
             $this->migrator->setConnection($database);
         }
 


### PR DESCRIPTION
- Issue

There is an issue when running the command "php artisan migrate:fresh --database=someconnection". 

When the command is ran providing the connection the tables are never being dropped.

So investigating the issue, we notice that the given connection isn't considered in the `$this->migrator->repositoryExists()` method.

To fix it was added the setConnection method as below:
```PHP
if(! is_null($database)) {
    $this->migrator->setConnection($database);
}
```

OBS: The issue occurs when you specify a connection different than the default.

Thanks for [@GabsCoding](https://github.com/GabsCoding), that discovered this issue with me. 