### PR TITLE
[11.x] Redis Cluster Connection Error Fix

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -147,6 +147,8 @@ return [
             'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
         ],
 
+        'cluster_enabled' => env('REDIS_CLUSTER_ENABLED', false),
+
         'default' => [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -106,6 +106,14 @@ class RedisManager implements Factory
 
         $options = $this->config['options'] ?? [];
 
+        $cluster_enabled = $this->config['cluster_enabled'] ?? false;
+
+        if ($cluster_enabled) {
+            if (isset($this->config['clusters'][$name])) {
+                return $this->resolveCluster($name);
+            }
+        }
+
         if (isset($this->config[$name])) {
             return $this->connector()->connect(
                 $this->parseConnectionConfiguration($this->config[$name]),

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -129,6 +129,7 @@ class RedisManagerExtensionTest extends TestCase
             $mock = m::mock(Connector::class);
             $mock->shouldReceive('connect')->andReturn('single-connection');
             $mock->shouldReceive('connectToCluster')->andReturn('cluster-connection');
+
             return $mock;
         });
 
@@ -169,6 +170,7 @@ class RedisManagerExtensionTest extends TestCase
             $mock = m::mock(Connector::class);
             $mock->shouldReceive('connect')->andReturn('single-connection');
             $mock->shouldReceive('connectToCluster')->andReturn('cluster-connection');
+
             return $mock;
         });
 


### PR DESCRIPTION
There is a Connection Refused error that occurs when you configure a redis cluster but still maintain the default `config('database.redis')` config without modifying or deleting it. This PR is a fix for #51011

I have a basic demo app that works with a keydb cluster here that you can check out [https://github.com/anabeto93/laravel11-keydb-cluster](https://github.com/anabeto93/laravel11-keydb-cluster)

Laravel basically defaults to using the singular redis instance even when you setup a redis cluster correctly following the documentation here [https://laravel.com/docs/11.x/redis#clusters](https://laravel.com/docs/11.x/redis#clusters). But if you go ahead to provide valid credentials using the default singular redis instance, then your application would be using the singular instance instead of the cluster you've defined.

This PR is to ensure you have the option to toggle between using clusters and singular instances or even using the two together.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
