### PR TITLE
[11.x] Make displayable attribute with or without underscore configurable

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -12,6 +12,8 @@ namespace Illuminate\Support\Facades;
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
  * @method static void resolver(\Closure $resolver)
+ * @method static void displayableAttributeWithUnderscore()
+ * @method static void displayableAttributeWithoutUnderscore()
  * @method static \Illuminate\Contracts\Translation\Translator getTranslator()
  * @method static \Illuminate\Validation\PresenceVerifierInterface getPresenceVerifier()
  * @method static void setPresenceVerifier(\Illuminate\Validation\PresenceVerifierInterface $presenceVerifier)

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -294,7 +294,12 @@ trait FormatsMessages
                             : $attribute;
         }
 
-        return str_replace('_', ' ', Str::snake($attribute));
+        // For better readability the attribute is snake cased. Depending on the
+        // developers preference, the dashes are replaced with spaces. This
+        // makes "user_id" to "user id", what can increase readability.
+        return $this->displayableAttributeWithoutUnderscore
+            ? str_replace('_', ' ', Str::snake($attribute))
+            : Str::snake($attribute);
     }
 
     /**

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -60,6 +60,13 @@ class Factory implements FactoryContract
     protected $replacers = [];
 
     /**
+     * Indicates if an attribute is replaced with or without underscore in the error message.
+     *
+     * @var bool
+     */
+    public $displayableAttributeWithoutUnderscore = true;
+
+    /**
      * All of the fallback messages for custom rules.
      *
      * @var array<string, string>
@@ -123,6 +130,8 @@ class Factory implements FactoryContract
         }
 
         $validator->excludeUnvalidatedArrayKeys = $this->excludeUnvalidatedArrayKeys;
+
+        $validator->displayableAttributeWithoutUnderscore = $this->displayableAttributeWithoutUnderscore;
 
         $this->addExtensions($validator);
 
@@ -246,6 +255,26 @@ class Factory implements FactoryContract
     public function replacer($rule, $replacer)
     {
         $this->replacers[$rule] = $replacer;
+    }
+
+    /**
+     * Indicate if the displayable attribute should be without underscore in the error message.
+     *
+     * @return void
+     */
+    public function displayableAttributeWithoutUnderscore()
+    {
+        $this->displayableAttributeWithoutUnderscore = true;
+    }
+
+    /**
+     * Indicate if the displayable attribute should be with underscore in the error message.
+     *
+     * @return void
+     */
+    public function displayableAttributeWithUnderscore()
+    {
+        $this->displayableAttributeWithoutUnderscore = false;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -180,6 +180,13 @@ class Validator implements ValidatorContract
     public $replacers = [];
 
     /**
+     * Indicates if the displayable attribute should be with or without underscore.
+     *
+     * @var bool
+     */
+    public $displayableAttributeWithoutUnderscore = true;
+
+    /**
      * The validation rules that may be applied to files.
      *
      * @var string[]

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -45,16 +45,19 @@ class ValidationFactoryTest extends TestCase
         $this->assertEquals(['foo' => $noop1, 'implicit' => $noop2, 'dependent' => $noop3], $validator->extensions);
         $this->assertEquals(['replacer' => $noop3], $validator->replacers);
         $this->assertEquals($presence, $validator->getPresenceVerifier());
+        $this->assertTrue($validator->displayableAttributeWithoutUnderscore);
 
         $presence = m::mock(PresenceVerifierInterface::class);
         $factory->extend('foo', $noop1, 'foo!');
         $factory->extendImplicit('implicit', $noop2, 'implicit!');
         $factory->extendImplicit('dependent', $noop3, 'dependent!');
         $factory->setPresenceVerifier($presence);
+        $factory->displayableAttributeWithUnderscore();
         $validator = $factory->make([], []);
         $this->assertEquals(['foo' => $noop1, 'implicit' => $noop2, 'dependent' => $noop3], $validator->extensions);
         $this->assertEquals(['foo' => 'foo!', 'implicit' => 'implicit!', 'dependent' => 'dependent!'], $validator->fallbackMessages);
         $this->assertEquals($presence, $validator->getPresenceVerifier());
+        $this->assertFalse($validator->displayableAttributeWithoutUnderscore);
     }
 
     public function testValidateCallsValidateOnTheValidator()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -705,6 +705,35 @@ class ValidationValidatorTest extends TestCase
         new Validator($trans, ['firstname' => 'Bob', 'lastname' => 'Smith'], ['lastname' => 'alliteration:firstname']);
     }
 
+    public function testDisplayableAttributesReplaceWithOrWithoutUnderscore()
+    {
+        // Default behavior: The underscore in the attribute name is replaced with a space
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => 'The :attribute field is required.'], 'en');
+        $v = new Validator($trans, ['bar' => ''], ['tax_rate' => 'Required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('The tax rate field is required.', $v->messages()->first('tax_rate'));
+
+        // Replace with underscore in the attribute's name in error message
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => 'The :attribute field is required.'], 'en');
+        $v = new Validator($trans, ['bar' => ''], ['tax_rate' => 'Required']);
+        $v->displayableAttributeWithoutUnderscore = false;
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('The tax_rate field is required.', $v->messages()->first('tax_rate'));
+
+        // Replace with underscore in the attribute's name in error message
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => 'The :attribute field is required.'], 'en');
+        $v = new Validator($trans, ['bar' => ''], ['tax_rate' => 'Required']);
+        $v->displayableAttributeWithoutUnderscore = true;
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('The tax rate field is required.', $v->messages()->first('tax_rate'));
+    }
+
     public function testIndexValuesAreReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
The Validation error messages contain the attribute field name. To make it more readable, underscores are replaced with a space. This results in an error message like `The user id field is required.`. This is most of the time very readable.

When it comes to longer attribute names and nested attributes, this can (other than desired) become unreadable and unclear. Here is a real-world example:

```
The attributes.line items.0.quantity field is required. | 
The attributes.line items.0.unit price net field is required. | 
The attributes.line items.0.tax rate field is required. | 
The attributes.line items.0.tax amount field is required. | 
The attributes.line items.0.total price net field is required. | 
The attributes.line items.0.total price gross field is required.
```

This PR adds the possibility to define whether the underscores should be removed or not. By default, the current behavior is used.

If the underscores should not be removed, the following line can be added, f.e. in a service provider:

```php
Illuminate\Support\Facades\Validator::displayableAttributeWithUnderscore();
```

There is an additional method that will change the behavior to remove the underscore (current behavior):
```php
Illuminate\Support\Facades\Validator::displayableAttributeWithoutUnderscore();
```

The variable was named `displayableAttributeWithoutUnderscore` to represent the current behavior. 

Developers can already overwrite the attribute name in the `Request`'s `attributes()` method, but that is very unhandy, if the rules are generated dynamically.

I appreciate any feedback or concerns.