### PR TITLE
[11.x] Adds support for `int` backed enums to implicit `Enum` route binding

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
+use ReflectionEnum;
 
 class ImplicitRouteBinding
 {
@@ -74,6 +75,7 @@ class ImplicitRouteBinding
      * @return \Illuminate\Routing\Route
      *
      * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
+     * @throws \ReflectionException
      */
     protected static function resolveBackedEnumsForRoute($route, $parameters)
     {
@@ -86,7 +88,12 @@ class ImplicitRouteBinding
 
             $backedEnumClass = $parameter->getType()?->getName();
 
-            $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);
+            $reflectionEnum = new ReflectionEnum($backedEnumClass);
+
+            match ($reflectionEnum->getBackingType()->getName()) {
+                'int' => $backedEnum = collect($backedEnumClass::cases())->first(fn ($case) => (string) $case->value === (string) $parameterValue),
+                'string' => $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue),
+            };
 
             if (is_null($backedEnum)) {
                 throw new BackedEnumCaseNotFoundException($backedEnumClass, $parameterValue);

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -28,7 +28,7 @@ class RouteSignatureParameters
 
         return match (true) {
             ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
-            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithValidBackingType($p)),
             default => $parameters,
         };
     }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -141,12 +141,12 @@ class Reflector
     }
 
     /**
-     * Determine if the parameter's type is a Backed Enum with a string backing type.
+     * Determine if the parameter's type is a Backed Enum with a string or int backing type.
      *
      * @param  \ReflectionParameter  $parameter
      * @return bool
      */
-    public static function isParameterBackedEnumWithStringBackingType($parameter)
+    public static function isParameterBackedEnumWithValidBackingType($parameter)
     {
         if (! $parameter->getType() instanceof ReflectionNamedType) {
             return false;
@@ -162,7 +162,7 @@ class Reflector
             $reflectionBackedEnum = new ReflectionEnum($backedEnumClass);
 
             return $reflectionBackedEnum->isBacked()
-                && $reflectionBackedEnum->getBackingType()->getName() == 'string';
+                && in_array($reflectionBackedEnum->getBackingType()->getName(), ['int', 'string']);
         }
 
         return false;

--- a/tests/Routing/Enums.php
+++ b/tests/Routing/Enums.php
@@ -13,3 +13,9 @@ enum CategoryBackedEnum: string
     case People = 'people';
     case Fruits = 'fruits';
 }
+
+enum CategoryIntBackedEnum: int
+{
+    case People = 1;
+    case Fruits = 2;
+}

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -31,6 +31,24 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category')->value);
     }
 
+    public function test_it_can_resolve_the_implicit_int_backed_enum_route_bindings_for_the_given_route()
+    {
+        $action = ['uses' => function (CategoryIntBackedEnum $category) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => '1'];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertSame(1, $route->parameter('category')->value);
+    }
+
     public function test_it_can_resolve_the_implicit_backed_enum_route_bindings_for_the_given_route_with_optional_parameter()
     {
         $action = ['uses' => function (?CategoryBackedEnum $category = null) {
@@ -86,6 +104,29 @@ class ImplicitRouteBindingTest extends TestCase
             'Case [%s] not found on Backed Enum [%s].',
             'cars',
             CategoryBackedEnum::class,
+        ));
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+    }
+
+    public function test_implicit_int_backed_enum_internal_exception()
+    {
+        $action = ['uses' => function (CategoryIntBackedEnum $category) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => ' 00001.'];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        $this->expectException(BackedEnumCaseNotFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Case [%s] not found on Backed Enum [%s].',
+            ' 00001.',
+            CategoryIntBackedEnum::class,
         ));
 
         ImplicitRouteBinding::resolveForRoute($container, $route);


### PR DESCRIPTION
This pull request allows you to bind `int` backed enums to your routes. 

```php
// Assuming the following `Enum`
enum DocumentType: int
{
    case ANNUAL_WORK_PLAN = 1;
    case ANNUAL_TRAINING_PLAN = 2;
}

// And assuming the following route;
Route::get('/documents/{documentType}', function (DocumentType $documentType) {
    return $documentType->name;
});
```

now, if we try to bind int backed enum to route, we are getting the error below : 

```
Illuminate\Contracts\Container\BindingResolutionException

Target [App\Enums\DocumentType] is not instantiable.
```

With this PR we'll see:
```
// GET `/documents/1` returns `ANNUAL_WORK_PLAN`...
// GET `/documents/2` returns `ANNUAL_TRAINING_PLAN`...
// GET `/documents/3` returns `404 Not Found`...
// GET `/documents/test` returns `404 Not Found`... <- I'm not sure if we should give 404 here
```

There is a [comment](https://github.com/laravel/framework/pull/40281) about why we didn't do it in the first place but I don't see any reason to not to try that. 

We can skip checking the backed enum type in the [ReflectionEnum](https://github.com/laravel/framework/pull/51029/files#diff-614b34c8eaac77de1d4faf100a7133e526cfe1350ce4f02e9f60c24a88179c77R91) part and validate all values via `collect($backedEnum::cases)->first()` without a `match`

And also I've created [a PR](https://github.com/laravel/docs/pull/9574) for the docs


Best.
