### PR TITLE
[11.x] Auth User Impersonation

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -230,6 +230,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         $this->session->put($this->getImpersonationName(), $authenticated->getAuthIdentifier());
 
+        $this->session->regenerate();
+
         $this->login($user);
     }
 
@@ -246,6 +248,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         if ($user = $this->provider->retrieveById($id)) {
             $this->login($user);
+
+            $this->session->regenerate();
 
             return;
         }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -240,9 +240,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function unpersonate()
     {
-        $id = $this->session->pull($this->getImpersonationName());
-
-        if (is_null($id)) {
+        if (! $id = $this->session->pull($this->getImpersonationName())) {
             return;
         }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -220,6 +220,10 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function impersonate(AuthenticatableContract $user)
     {
+        if ($this->impersonating()) {
+            throw new AuthenticationException('Cannot impersonate while already impersonating.');
+        }
+
         if (! $authenticated = $this->user()) {
             throw new AuthenticationException('Cannot impersonate without a currently authenticated user.');
         }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -244,7 +244,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         if ($user = $this->provider->retrieveById($id)) {
             $this->login($user);
+
+            return;
         }
+
+        $this->logout();
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -661,6 +661,7 @@ class AuthGuardTest extends TestCase
         $impersonated = m::mock(Authenticatable::class);
         $impersonated->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
 
+        $mock->getSession()->shouldReceive('has')->with($mock->getImpersonationName())->once()->andReturn(false);
         $mock->getSession()->shouldReceive('get')->with($mock->getName())->once()->andReturn('foo');
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with('foo')->andReturn($impersonator);
         $mock->getSession()->shouldReceive('put')->with($mock->getImpersonationName(), 'foo')->once();
@@ -670,6 +671,18 @@ class AuthGuardTest extends TestCase
         $mock->impersonate($impersonated);
     }
 
+    public function testImpersonateThrowsWhenAlreadyImpersonating()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Cannot impersonate while already impersonating.');
+
+        $mock = $this->getGuard();
+
+        $mock->getSession()->shouldReceive('has')->with($mock->getImpersonationName())->once()->andReturn(true);
+
+        $mock->impersonate(m::mock(Authenticatable::class));
+    }
+
     public function testImpersonateThrowsWhenUserIsNotAuthenticated()
     {
         $this->expectException(AuthenticationException::class);
@@ -677,6 +690,7 @@ class AuthGuardTest extends TestCase
 
         $mock = $this->getGuard();
 
+        $mock->getSession()->shouldReceive('has')->with($mock->getImpersonationName())->once()->andReturn(false);
         $mock->getSession()->shouldReceive('get')->with($mock->getName())->once()->andReturn(null);
 
         $mock->impersonate(m::mock(Authenticatable::class));

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -666,6 +666,7 @@ class AuthGuardTest extends TestCase
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with('foo')->andReturn($impersonator);
         $mock->getSession()->shouldReceive('put')->with($mock->getImpersonationName(), 'foo')->once();
         $mock->getSession()->shouldReceive('put')->with($mock->getName(), 'bar')->once();
+        $mock->getSession()->shouldReceive('regenerate')->once();
         $mock->getSession()->shouldReceive('migrate')->once();
 
         $mock->impersonate($impersonated);
@@ -706,6 +707,7 @@ class AuthGuardTest extends TestCase
         $mock->getSession()->shouldReceive('pull')->with($mock->getImpersonationName())->once()->andReturn('foo');
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with('foo')->andReturn($impersonator);
         $mock->getSession()->shouldReceive('put')->with($mock->getName(), 'foo')->once();
+        $mock->getSession()->shouldReceive('regenerate')->once();
         $mock->getSession()->shouldReceive('migrate')->once();
 
         $mock->unpersonate();

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -651,6 +651,73 @@ class AuthGuardTest extends TestCase
         $this->assertNull($guard->getUser());
     }
 
+    public function testImpersonate()
+    {
+        $mock = $this->getGuard();
+
+        $impersonator = m::mock(Authenticatable::class);
+        $impersonator->shouldReceive('getAuthIdentifier')->once()->andReturn('foo');
+
+        $impersonated = m::mock(Authenticatable::class);
+        $impersonated->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
+
+        $mock->getSession()->shouldReceive('get')->with($mock->getName())->once()->andReturn('foo');
+        $mock->getProvider()->shouldReceive('retrieveById')->once()->with('foo')->andReturn($impersonator);
+        $mock->getSession()->shouldReceive('put')->with($mock->getImpersonationName(), 'foo')->once();
+        $mock->getSession()->shouldReceive('put')->with($mock->getName(), 'bar')->once();
+        $mock->getSession()->shouldReceive('migrate')->once();
+
+        $mock->impersonate($impersonated);
+    }
+
+    public function testImpersonateThrowsWhenUserIsNotAuthenticated()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Cannot impersonate without a currently authenticated user.');
+
+        $mock = $this->getGuard();
+
+        $mock->getSession()->shouldReceive('get')->with($mock->getName())->once()->andReturn(null);
+
+        $mock->impersonate(m::mock(Authenticatable::class));
+    }
+
+    public function testUnpersonate()
+    {
+        $mock = $this->getGuard();
+
+        $impersonator = m::mock(Authenticatable::class);
+        $impersonator->shouldReceive('getAuthIdentifier')->once()->andReturn('foo');
+
+        $mock->getSession()->shouldReceive('pull')->with($mock->getImpersonationName())->once()->andReturn('foo');
+        $mock->getProvider()->shouldReceive('retrieveById')->once()->with('foo')->andReturn($impersonator);
+        $mock->getSession()->shouldReceive('put')->with($mock->getName(), 'foo')->once();
+        $mock->getSession()->shouldReceive('migrate')->once();
+
+        $mock->unpersonate();
+    }
+
+    public function testImpersonator()
+    {
+        $mock = $this->getGuard();
+
+        $impersonator = m::mock(Authenticatable::class);
+
+        $mock->getSession()->shouldReceive('get')->with($mock->getImpersonationName())->once()->andReturn('foo');
+        $mock->getProvider()->shouldReceive('retrieveById')->once()->with('foo')->andReturn($impersonator);
+
+        $this->assertSame($impersonator, $mock->impersonator());
+    }
+
+    public function testImpersonating()
+    {
+        $mock = $this->getGuard();
+
+        $mock->getSession()->shouldReceive('has')->with($mock->getImpersonationName())->once()->andReturnTrue();
+
+        $this->assertTrue($mock->impersonating());
+    }
+
     protected function getGuard()
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();


### PR DESCRIPTION
This PR provides capability of first-party impersonation built into the default session guard, allowing developers to easily implement impersonating other users, while tracking the source user who initiated the impersonation:

**Impersonating:**

```php
// Initial impersonator session (an admin, for example)
Auth::login($impersonator);

// Impersonating another user
Auth::impersonate($user); // void

// Authenticated user is now the given user
Auth::user(); // $user

// Impersonator is the the initial session owner
Auth::impersonator(); // $impersonator
```

**Determining Impersonation State**:

```php
Auth::impersonating(); // bool
```

**Unpersonating:**

```php
Auth::unpersonate(); // void
```

Let me know your thoughts on this feature and if you'd like anything changed or adjusted.

No hard feelings on closure. Thanks so much for your time! 🙏 