### PR TITLE
[11.x] Configuration to disable events on Cache Repository

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -289,7 +289,7 @@ class CacheManager implements FactoryContract
     public function repository(Store $store, array $config = [])
     {
         return tap(new Repository($store, Arr::only($config, ['store'])), function ($repository) use ($config) {
-            if ($config['with_events'] ?? true) {
+            if ($config['events'] ?? true) {
                 $this->setEventDispatcher($repository);
             }
         });

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -288,8 +288,10 @@ class CacheManager implements FactoryContract
      */
     public function repository(Store $store, array $config = [])
     {
-        return tap(new Repository($store, Arr::only($config, ['store'])), function ($repository) {
-            $this->setEventDispatcher($repository);
+        return tap(new Repository($store, Arr::only($config, ['store'])), function ($repository) use ($config) {
+            if ($config['with_events'] ?? true) {
+                $this->setEventDispatcher($repository);
+            }
         });
     }
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -287,7 +287,7 @@ class CacheManagerTest extends TestCase
                     ],
                     'my_store_without_events' => [
                         'driver' => 'array',
-                        'with_events' => false,
+                        'events' => false,
                     ],
                 ],
             ],

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -277,6 +277,36 @@ class CacheManagerTest extends TestCase
         $cacheManager->store('alien_store');
     }
 
+    public function testMakesRepositoryWithoutDispatcherWhenEventsDisabled()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'my_store' => [
+                        'driver' => 'array',
+                    ],
+                    'my_store_without_events' => [
+                        'driver' => 'array',
+                        'with_events' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $app->bind(Dispatcher::class, fn () => new Event);
+
+        $cacheManager = new CacheManager($app);
+
+        // The repository will have an event dispatcher
+        $repo = $cacheManager->store('my_store');
+        $this->assertNotNull($repo->getEventDispatcher());
+
+        // This repository will not have an event dispatcher as 'with_events' is false
+        $repoWithoutEvents = $cacheManager->store('my_store_without_events');
+        $this->assertNull($repoWithoutEvents->getEventDispatcher());
+    }
+
     protected function getApp(array $userConfig)
     {
         $app = new Container;


### PR DESCRIPTION
This change allows caches to be defined without auto-registering events dispatcher.

On in-memory caches like array or apc, the overhead of triggering events results in an 80%+ overhead for basic cache operations.  This change allows a config value on any cache definition to disable events for that particular Repository.

Benefit:
In some circumstances it is helpful to use an in-memory cache like array or apc, however in operations that use a lot of cache calls the overhead starts to dramatically impact performance.  Being able to define a cache without events allows for the conveniences of the caching API while minimizing the overhead to the API implementation and not the events side-effects.


Usage:
Adding `'with_events' => false` to any cache stores configuration will prevent the automatic registration of the events dispatcher.  For example, the following changes the 'array' store to not register events:
```php
[
    ...
    'stores' => [
        'array' => [
            'driver' => 'array',
            'serialize' => false,
            'with_events' => false,
        ],
   ]
]
```

Backwards Compatibility Concerns:
I've implemented this new setting to default to true when the setting isn't defined on the config, so it has no backwards compatibility concerns.

Tests:
Added test for CacheManager to handle this new setting and test the previous functionality where no setting is provided.
