### PR TITLE
Name of job set by displayName() must be honoured by Schedule

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -154,6 +154,14 @@ class Schedule
      */
     public function job($job, $queue = null, $connection = null)
     {
+        $jobName = $job;
+
+        if (! is_string($job)) {
+            $jobName = method_exists($job, 'displayName')
+                ? $job->displayName()
+                : $job::class;
+        }
+
         return $this->call(function () use ($job, $queue, $connection) {
             $job = is_string($job) ? Container::getInstance()->make($job) : $job;
 
@@ -162,7 +170,7 @@ class Schedule
             } else {
                 $this->dispatchNow($job);
             }
-        })->name(is_string($job) ? $job : get_class($job));
+        })->name($jobName);
     }
 
     /**

--- a/tests/Console/Fixtures/JobToTestWithSchedule.php
+++ b/tests/Console/Fixtures/JobToTestWithSchedule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+final class JobToTestWithSchedule implements ShouldQueue
+{
+}

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Tests\Console\Fixtures\JobToTestWithSchedule;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Schedule::class)]
+final class ScheduleTest extends TestCase
+{
+    private Container $container;
+    private EventMutex&MockInterface $eventMutex;
+    private SchedulingMutex&MockInterface $schedulingMutex;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container;
+        Container::setInstance($this->container);
+        $this->eventMutex = m::mock(EventMutex::class);
+        $this->container->instance(EventMutex::class, $this->eventMutex);
+        $this->schedulingMutex = m::mock(SchedulingMutex::class);
+        $this->container->instance(SchedulingMutex::class, $this->schedulingMutex);
+    }
+
+    #[DataProvider('jobHonoursDisplayNameIfMethodExistsProvider')]
+    public function testJobHonoursDisplayNameIfMethodExists(object $job, string $jobName): void
+    {
+        $schedule = new Schedule();
+        $scheduledJob = $schedule->job($job);
+        self::assertSame($jobName, $scheduledJob->description);
+        self::assertFalse($this->container->resolved(JobToTestWithSchedule::class));
+    }
+
+    public static function jobHonoursDisplayNameIfMethodExistsProvider(): array
+    {
+        $job = new class implements ShouldQueue
+        {
+            public function displayName(): string
+            {
+                return 'testJob-123';
+            }
+        };
+
+        return [
+            [new JobToTestWithSchedule, JobToTestWithSchedule::class],
+            [$job, 'testJob-123'],
+        ];
+    }
+
+    public function testJobIsNotInstantiatedIfSuppliedAsClassname(): void
+    {
+        $schedule = new Schedule();
+        $scheduledJob = $schedule->job(JobToTestWithSchedule::class);
+        self::assertSame(JobToTestWithSchedule::class, $scheduledJob->description);
+        self::assertFalse($this->container->resolved(JobToTestWithSchedule::class));
+    }
+}


### PR DESCRIPTION
Queue jobs could have displayName() method providing a better naming than just a plain classname. This name is currently honoured by a queue worker but a queue scheduler. This PR fixes this inconsistency