### PR TITLE
[11.x] Add some tests in RepositoryTest.php

### DIFF
--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -221,8 +221,21 @@ class RepositoryTest extends TestCase
 
     public function testOffsetExists()
     {
+        $data = [
+            'foo' => 'bar',
+            'null_value' => null,
+            'empty_string' => '',
+            'numeric_value' => 123,
+        ];
+        $this->repository->set($data);
+
         $this->assertTrue(isset($this->repository['foo']));
         $this->assertFalse(isset($this->repository['not-exist']));
+        $this->assertTrue(isset($this->repository['null_value']));
+        $this->assertTrue(isset($this->repository['empty_string']));
+        $this->assertTrue(isset($this->repository['numeric_value']));
+        $this->assertFalse(isset($this->repository[-1]));
+        $this->assertFalse(isset($this->repository['non_numeric']));
     }
 
     public function testOffsetGet()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -292,7 +292,7 @@ class RepositoryTest extends TestCase
     public function testItGetsAsString(): void
     {
         $this->assertSame(
-            $this->repository->string('a.b'), 'c'
+            'c', $this->repository->string('a.b')
         );
     }
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -255,6 +255,18 @@ class RepositoryTest extends TestCase
         $this->repository['key'] = 'value';
 
         $this->assertSame('value', $this->repository['key']);
+
+        $this->repository['key'] = 'new_value';
+        $this->assertSame('new_value', $this->repository['key']);
+
+        $this->repository['new_key'] = null;
+        $this->assertNull($this->repository['new_key']);
+
+        $this->repository[''] = 'value';
+        $this->assertSame('value', $this->repository['']);
+
+        $this->repository[123] = '123';
+        $this->assertSame('123', $this->repository[123]);
     }
 
     public function testOffsetUnset()


### PR DESCRIPTION
This PR, improvement test coverage for Repository.

### 1.Added new tests to the `testOffsetExists` method.

New tests have been added to ensure the correctness of the `offsetExists` method. These tests include checking the presence and absence of various data types in the repository array, such as null values, empty strings, numeric values, and non-numeric inputs. This action increases code coverage and ensures the accuracy and stability of the `offsetExists` method.

```php
$data = [
    'foo' => 'bar',
    'null_value' => null,
    'empty_string' => '',
    'numeric_value' => 123,
];

$this->assertTrue(isset($this->repository['null_value']));
$this->assertTrue(isset($this->repository['empty_string']));
$this->assertTrue(isset($this->repository['numeric_value']));
$this->assertFalse(isset($this->repository[-1]));
$this->assertFalse(isset($this->repository['non_numeric']));
```

### 2. Added new tests to the `testOffsetGet` method.

New tests have been added to ensure the correctness of the `offsetGet` method. These tests include setting and retrieving values for different keys, including string keys ('key', 'new_key', ''), numeric keys (123), and handling null values. This pull request enhances the coverage and validation of the `offsetGet` method."

```php
// change old value ===> $this->repository['key'] = 'value'
$this->repository['key'] = 'new_value';
$this->assertSame('new_value', $this->repository['key']);

// add new key with null value
$this->repository['new_key'] = null;
$this->assertNull($this->repository['new_key']);

// key is empty string
$this->repository[''] = 'value';
$this->assertSame('value', $this->repository['']);

// key is numeric
$this->repository[123] = '123';
$this->assertSame('123', $this->repository[123]);
```

### 3. [Fix assertion order in `testItGetsAsString` method
The first parameter in the `assertSame` method should be the expected value, and the second parameter should be the actual value.

```php 

// before
$this->assertSame(
    $this->repository->string('a.b'), 'c'
);

// after
$this->assertSame(
    'c', $this->repository->string('a.b')
);

```
