### PR TITLE
[11.x] Dynamic component with class name support

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -90,9 +90,9 @@ class ImplicitRouteBinding
 
             $reflectionEnum = new ReflectionEnum($backedEnumClass);
 
-            match ($reflectionEnum->getBackingType()->getName()) {
-                'int' => $backedEnum = collect($backedEnumClass::cases())->first(fn ($case) => (string) $case->value === (string) $parameterValue),
-                'string' => $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue),
+            $backedEnum = match ($reflectionEnum->getBackingType()->getName()) {
+                'int' => collect($backedEnumClass::cases())->first(fn ($case) => (string) $case->value === (string) $parameterValue),
+                'string' => $backedEnumClass::tryFrom((string) $parameterValue),
             };
 
             if (is_null($backedEnum)) {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -401,6 +401,38 @@ class ComponentTagCompiler
     }
 
     /**
+     * Find the component for the given class using the registered namespaces and aliases.
+     *
+     * @param  string  $class
+     * @return string|null
+     */
+    public function findComponentByClassName(string $class)
+    {
+        $component = array_search($class, $this->aliases);
+
+        if ($component !== false) {
+            return $component;
+        }
+
+        [$componentClass, $componentNamespace] = collect($this->namespaces)
+            ->where(fn ($namespace) => Str::startsWith($class, $namespace))
+            ->map(fn ($class, $namespace) => [$class.'\\', $namespace.'::'])
+            ->first();
+
+        $componentClass = $componentClass ?? 'App\\View\\Components\\';
+        $componentNamespace = $componentNamespace ?? '';
+
+        return Str::of($componentNamespace)
+            ->append(
+                Str::of($class)
+                    ->remove($componentClass)
+                    ->explode('\\')
+                    ->map(fn ($path) => Str::kebab($path))
+                    ->implode('.')
+            )->toString();
+    }
+
+    /**
      * Guess the class name for the given component.
      *
      * @param  string  $component

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -37,7 +37,10 @@ class DynamicComponent extends Component
      */
     public function __construct(string $component)
     {
-        $this->component = $component;
+        $this->component = match (true) {
+            class_exists($component) => $this->compiler()->findComponentByClassName($component),
+            default => $component
+        };
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -357,6 +357,48 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         Container::setInstance(null);
     }
 
+    public function testComponentNamesCanBeFoundByClassNames()
+    {
+        $container = new Container;
+        $container->instance(Application::class, m::mock(Application::class));
+
+        Container::setInstance($container);
+
+        $result = $this->compiler()->findComponentByClassName('App\\View\\Components\\Alert');
+
+        $this->assertSame('alert', trim($result));
+
+        Container::setInstance(null);
+    }
+
+    public function testAliasedComponentNamesCanBeFoundByClassNames()
+    {
+        $container = new Container;
+        $container->instance(Application::class, m::mock(Application::class));
+
+        Container::setInstance($container);
+
+        $result = $this->compiler(['core' => 'App\\View\\Components\\Core'])->findComponentByClassName('App\\View\\Components\\Core');
+
+        $this->assertSame('core', trim($result));
+
+        Container::setInstance(null);
+    }
+
+    public function testNamespacedComponentNamesCanBeFoundByClassNames()
+    {
+        $container = new Container;
+        $container->instance(Application::class, m::mock(Application::class));
+
+        Container::setInstance($container);
+
+        $result = $this->compiler(namespaces: ['core' => 'App\\View\\Components'])->findComponentByClassName('App\\View\\Components\\Alert\\Test');
+
+        $this->assertSame('core::alert.test', trim($result));
+
+        Container::setInstance(null);
+    }
+
     public function testComponentsCanBeCompiledWithHyphenAttributes()
     {
         $this->mockViewFactory();


### PR DESCRIPTION
This PR allows us to render dynamic component by it's class name


```php

<x-dynamic-component :component="App\View\Components\Alert::class"></x-dynamic-component>

```

It also supports aliased components and component namespaces. 

```php

// In AppServiceProvider.php

public function register(): void
{
    Blade::componentNamespace('Form\\Components', 'form');
}


// In any view: 
<x-dynamic-component :component="Form\Components\Input::class"></x-dynamic-component>


//It will render the dynamic component below behind the scenes: 

<x-dynamic-component component="form::input"></x-dynamic-component>

```

In my use case: 

- No need to remember component aliases/names from 3rd party packages. IDE will autocomplete the class names of components (Larevel Idea can auto-complete the component by their names)
- Can easily keep the components in DB with morph:

| component_type  | component_id |
| ------------- | ------------- |
| Custom\\AlertComponent  | 1  |
| App\\View\\Components\\Input  | 2  |

and while rendering, I can just pass the class name to the dynamic component without any transformation. 
_Of course I can keep component names in db but this approach is much closer to Laravel convention than the other._

Best.