### PR TITLE
[11.x] Add `diffAll` method to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -243,6 +243,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get all the items that are not present in the collection nor the given items.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @return static
+     */
+    public function diffAll($items)
+    {
+        $items = $this->getArrayableItems($items);
+
+        return new static(array_merge(array_diff($this->items, $items), array_diff($items, $this->items)));
+    }
+
+    /**
      * Get the items in the collection that are not present in the given items, using the callback.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -331,6 +331,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get all the items that are not present in the collection nor the given items.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @return static
+     */
+    public function diffAll($items)
+    {
+        return $this->passthru('diffAll', func_get_args());
+    }
+
+    /**
      * Get the items that are not present in the given items, using the callback.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -22,11 +22,11 @@ use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
 use WeakMap;
-use stdClass;
 
 include_once 'Enums.php';
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -22,11 +22,11 @@ use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
 use WeakMap;
+use stdClass;
 
 include_once 'Enums.php';
 
@@ -1326,6 +1326,13 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals(['id' => 1], $c->diff(new $collection(['first_word' => 'Hello', 'last_word' => 'World']))->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testDiffAllCollection($collection)
+    {
+        $c = new $collection(['blue', 'green', 'red']);
+        $this->assertEquals(['green', 'yellow'], $c->diffAll(new $collection(['blue', 'yellow', 'red']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
This PR adds a `diffAll` method to the `Collection` & `LazyCollection` classes. This method differs from the existing `diff` method in that it will return _all_ the items that are not present in either the collection nor the given items.

Example:
```php
$c1 = collect(['green', 'blue', 'red']);
$c2 = collect(['yellow', 'blue', 'red']);

echo $c1->diff($c2); // ['green']
echo $c2->diff($c1); // ['yellow']

echo $c1->diff($c2)->merge($c2->diff($c1)); // ['green', 'yellow']
echo $c1->diffAll($c2); // ['green', 'yellow']
```

As demonstrated above, the `diffAll` method is a convenient way to get all the differences between the collections, skipping the need to merge the opposite diff.

A real use-case that I've needed this for several times is checking whether submitted user data is different to the already stored array value — only if a change is actually made should further processing take place.

Example using `diff`:
```php
// Inside a controller
$items = $request->collect('items'); // collect(['one'])
$savedItems = $model->items; // ['one', 'two']

// Option 1
$diff1 = $items->diff($savedItems);
$diff2 = collect($savedItems)->diff($items);
$hasChanged = $diff1->isNotEmpty() || $diff2->isNotEmpty();

// Option 2
$hasChanged = $items->diff($savedItems)->merge(collect($savedItems)->diff($items))->isNotEmpty();
```

While not terrible, it feels like this could be cleaner and more Laravel-like.

Example using `diffAll`:
```php
// Inside a controller
$hasChanged = $request->collect('items')->diffAll($model->items)->isNotEmpty();
```

Let me know if anything is unclear or whether any changes to the code are required. Thanks!