### PR TITLE
[10.x] Fix `data_set()` while $overwrite set to false

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -140,7 +140,7 @@ if (! function_exists('data_set')) {
 
             if ($segments) {
                 data_set($target[$segment], $segments, $value, $overwrite);
-            } elseif ($overwrite) {
+            } else {
                 $target[$segment] = $value;
             }
         }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -328,6 +328,40 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
+    public function testDataFillWhileNotArrayOrObject()
+    {
+        $data = null;
+
+        $this->assertEquals(
+            ['baz' => 'boom'],
+            data_fill($data, 'baz', 'boom')
+        );
+
+        $this->assertEquals(
+            ['baz' => 'boom'],
+            data_fill($data, 'baz', 'noop')
+        );
+
+        $this->assertEquals(
+            ['foo' => 'bar', 'baz' => 'boom'],
+            data_fill($data, 'foo', 'bar')
+        );
+
+        $this->assertEquals(
+            ['foo' => ['bar' => 'noop'], 'baz' => 'boom'],
+            data_fill($data, 'foo.bar', 'noop')
+        );
+
+        $data = null;
+
+        $this->assertEquals(['foo' => []], data_fill($data, 'foo.*', 'noop'));
+
+        $this->assertEquals(
+            ['foo' => ['bar' => 'kaboom']],
+            data_fill($data, 'foo.bar', 'kaboom')
+        );
+    }
+
     public function testDataSet()
     {
         $data = ['foo' => 'bar'];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

For fixing issue #51049 created by me.

Remove the if expression of _$overwrite_ in case of _$target_ does not belong to array, object, or something like that.

Please make sure that the result of _$data_ is expected while `data_set()` be called. Expecially, the fourth `assertEquals()` case of code changes in test cases, the old value which is not array or object will be overwrote.

The benifit is that end user can use it and get correctly result, if my expected result of cases is correct. Though, I think this may break laravel procjets of end users if they ever call `data_set()` or `data_fill()` like this, but laravel/framework itself will not break.