### PR TITLE
[11.x] Add findOrThrow methods to the query builder.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -525,6 +525,31 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Find a model by its primary key or throw a custom exception.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array|string  $columns
+     * @param  string|\Throwable  $exception
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
+     */
+    public function findOrThrow($id, $columns = ['*'], string|\Throwable $exception = RecordsNotFoundException::class)
+    {
+        if (is_string($columns) || is_object($columns)) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        return $this->findOr($id, $columns, function () use ($exception) {
+            if (is_string($exception) && class_exists($exception)) {
+                throw new $exception();
+            }
+
+            throw is_string($exception) ? new RecordsNotFoundException($exception) : $exception;
+        });
+    }
+
+    /**
      * Find a model by its primary key or call a callback.
      *
      * @param  mixed  $id

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -20,7 +20,6 @@ use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Validation\ValidationException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -129,7 +128,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
-        $builder->findOrThrow('bar');
+        $builder->findOrThrow('bar', ['column']);
     }
 
     public function testFindOrThrowMethodThrowsRecordsNotFoundExceptionWithMessage()
@@ -143,12 +142,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
-        $builder->findOrThrow('bar', 'Some error message');
+        $builder->findOrThrow('bar', ['column'], 'Some error message');
     }
 
     public function testFindOrThrowMethodThrowsCustomException()
     {
-        $this->expectException(ValidationException::class);
+        $this->expectException(\Exception::class);
 
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
@@ -156,7 +155,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
-        $builder->findOrThrow('bar', ValidationException::withMessages(['Some error message']));
+        $builder->findOrThrow('bar', ['column'], new \Exception('Some error message'));
     }
 
     public function testFindOrFailMethodThrowsModelNotFoundException()


### PR DESCRIPTION
Sometimes I need to find a model and throw a new exception with a customized message when the ID is not found. While the method findOrFail accomplishes this, it lacks flexibility in altering the exception message. For instance:

```
User::findOrFail(88888);
```

This throws a ModelNotFoundException with the message "No query results for model [App\Models\User] 88888". However, there are occasions when I require a custom message, such as "User with ID 88888 not found" or "Usuário com ID 88888 não encontrado."

This pull request introduces a new method named findOrThrow. With this addition, we can call the method and specify a custom message. For example:

```
User::findOrThrow(88888, new RecordsNotFoundException('User with ID 88888 not found'))
```

or 

```
User::findOrThrow(88888, ['my_column_id'], new RecordsNotFoundException('User with ID 88888 not found'))
```

or 

```
User::findOrThrow(88888, new RecordsNotFoundException('Usuário com ID 88888 não encontrado'))
```

or

```
User::findOrThrow(88888, new RecordsNotFoundException)
```

or  

```
User::findOrThrow(88888, 'Usuário com ID 88888 não encontrado')
```

or 

```
User::findOrThrow(88888)
```

