### PR TITLE
[11.x] Pass decay seconds or minutes like hour and day

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -51,22 +51,24 @@ class Limit
      * Create a new rate limit.
      *
      * @param  int  $maxAttempts
+     * @param  int  $decaySeconds
      * @return static
      */
-    public static function perSecond($maxAttempts)
+    public static function perSecond($maxAttempts, $decaySeconds = 1)
     {
-        return new static('', $maxAttempts, 1);
+        return new static('', $maxAttempts, $decaySeconds);
     }
 
     /**
      * Create a new rate limit.
      *
      * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
      * @return static
      */
-    public static function perMinute($maxAttempts)
+    public static function perMinute($maxAttempts, $decayMinutes = 1)
     {
-        return new static('', $maxAttempts, 60);
+        return new static('', $maxAttempts, 60 * $decayMinutes);
     }
 
     /**

--- a/tests/Cache/LimitTest.php
+++ b/tests/Cache/LimitTest.php
@@ -18,8 +18,16 @@ class LimitTest extends TestCase
         $this->assertSame(1, $limit->decaySeconds);
         $this->assertSame(3, $limit->maxAttempts);
 
+        $limit = Limit::perSecond(3, 5);
+        $this->assertSame(5, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
         $limit = Limit::perMinute(3);
         $this->assertSame(60, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perMinute(3, 4);
+        $this->assertSame(240, $limit->decaySeconds);
         $this->assertSame(3, $limit->maxAttempts);
 
         $limit = Limit::perMinutes(2, 3);
@@ -30,8 +38,16 @@ class LimitTest extends TestCase
         $this->assertSame(3600, $limit->decaySeconds);
         $this->assertSame(3, $limit->maxAttempts);
 
+        $limit = Limit::perHour(3, 2);
+        $this->assertSame(7200, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
         $limit = Limit::perDay(3);
         $this->assertSame(86400, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perDay(3, 5);
+        $this->assertSame(432000, $limit->decaySeconds);
         $this->assertSame(3, $limit->maxAttempts);
 
         $limit = new GlobalLimit(3);


### PR DESCRIPTION
The existing `perHour` & `perDay` methods allow passing in an optional `decayHours`/`decayDays`, but `perSecond` & `perMinute` do not follow the same pattern. I know that there is the perMinutes, but it flips decay & max.

This is just a quick PR to make the API consistent.

NOTE: I am re-opening #51053 from my personal account to allow maintainer edits since the first PR was from our company account.