### PR TITLE
[11.x] Add Prompts `textarea` fallback for tests and add assertion tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "fruitcake/php-cors": "^1.3",
         "guzzlehttp/guzzle": "^7.8",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.1.15",
+        "laravel/prompts": "^0.1.18",
         "laravel/serializable-closure": "^1.3",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -12,6 +12,7 @@ use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SearchPrompt;
 use Laravel\Prompts\SelectPrompt;
 use Laravel\Prompts\SuggestPrompt;
+use Laravel\Prompts\TextareaPrompt;
 use Laravel\Prompts\TextPrompt;
 use stdClass;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,6 +36,12 @@ trait ConfiguresPrompts
         Prompt::fallbackWhen(windows_os() || $this->laravel->runningUnitTests());
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',
+            $prompt->required,
+            $prompt->validate
+        ));
+
+        TextareaPrompt::fallbackUsing(fn (TextareaPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',
             $prompt->required,
             $prompt->validate

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -42,7 +42,7 @@ trait ConfiguresPrompts
         ));
 
         TextareaPrompt::fallbackUsing(fn (TextareaPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',
+            fn () => $this->components->ask($prompt->label, $prompt->default ?: null, multiline: true) ?? '',
             $prompt->required,
             $prompt->validate
         ));

--- a/src/Illuminate/Console/View/Components/Ask.php
+++ b/src/Illuminate/Console/View/Components/Ask.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console\View\Components;
 
+use Symfony\Component\Console\Question\Question;
+
 class Ask extends Component
 {
     /**
@@ -11,8 +13,13 @@ class Ask extends Component
      * @param  string  $default
      * @return mixed
      */
-    public function render($question, $default = null)
+    public function render($question, $default = null, $multiline = false)
     {
-        return $this->usingQuestionHelper(fn () => $this->output->ask($question, $default));
+        return $this->usingQuestionHelper(
+            fn () => $this->output->askQuestion(
+                (new Question($question, $default))
+                    ->setMultiline($multiline)
+            )
+        );
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -168,7 +168,7 @@ class DummyPromptsMultiSelectAssertionCommand extends Command
             required: $this->option('required')
         );
 
-        if (!empty($names)) {
+        if (! empty($names)) {
             $this->line(sprintf('You like %s.', implode(', ', $names)));
         } else {
             $this->line('You do not like any names.');

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -75,15 +75,15 @@ class PromptsAssertionTest extends TestCase
             ->expectsOutput('Your name is Jane.');
     }
 
-    public function testAssertionForMultiselectPrompt()
+    public function testAssertionForRequiredMultiselectPrompt()
     {
         $this
-            ->artisan(DummyPromptsMultiSelectAssertionCommand::class)
+            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
             ->expectsChoice('Which names do you like?', ['John'], ['John', 'Jane', 'Sally', 'Jack'])
             ->expectsOutput('You like John.');
 
         $this
-            ->artisan(DummyPromptsMultiSelectAssertionCommand::class)
+            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
             ->expectsChoice('Which names do you like?', ['John', 'Jack', 'Sally'], ['John', 'Jane', 'Sally', 'Jack'])
             ->expectsOutput('You like John, Jack, Sally.');
     }
@@ -158,16 +158,20 @@ class DummyPromptsSelectAssertionCommand extends Command
 
 class DummyPromptsMultiSelectAssertionCommand extends Command
 {
-    protected $signature = 'ask:names-from-list';
+    protected $signature = 'ask:names-from-list {--required}';
 
     public function handle()
     {
         $names = multiselect(
             label: 'Which names do you like?',
             options: ['John', 'Jane', 'Sally', 'Jack'],
-            required: true
+            required: $this->option('required')
         );
 
-        $this->line(sprintf('You like %s.', implode(', ', $names)));
+        if (!empty($names)) {
+            $this->line(sprintf('You like %s.', implode(', ', $names)));
+        } else {
+            $this->line('You do not like any names.');
+        }
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;
 use Orchestra\Testbench\TestCase;
 
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\textarea;
 
@@ -15,6 +17,8 @@ class PromptsAssertionTest extends TestCase
     {
         $app[Kernel::class]->registerCommand(new DummyPromptsTextareaAssertionCommand());
         $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsPasswordAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsConfirmAssertionCommand());
     }
 
     public function testAssertionForTextPrompt()
@@ -31,6 +35,27 @@ class PromptsAssertionTest extends TestCase
             ->artisan(DummyPromptsTextareaAssertionCommand::class)
             ->expectsQuestion('What is your name?', 'John')
             ->expectsOutput('John');
+    }
+
+    public function testAssertionForPasswordPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsPasswordAssertionCommand::class)
+            ->expectsQuestion('What is your password?', 'secret')
+            ->expectsOutput('secret');
+    }
+
+    public function testAssertionForConfirmPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsConfirmAssertionCommand::class)
+            ->expectsQuestion('Is your name John?', false)
+            ->expectsOutput('Your name is not John.');
+
+        $this
+            ->artisan(DummyPromptsConfirmAssertionCommand::class)
+            ->expectsQuestion('Is your name John?', true)
+            ->expectsOutput('Your name is John.');
     }
 }
 
@@ -55,5 +80,33 @@ class DummyPromptsTextareaAssertionCommand extends Command
         $name = textarea('What is your name?', 'John');
 
         $this->line($name);
+    }
+}
+
+class DummyPromptsPasswordAssertionCommand extends Command
+{
+    protected $signature = 'ask:password';
+
+    public function handle()
+    {
+        $name = password('What is your password?', 'secret');
+
+        $this->line($name);
+    }
+}
+
+class DummyPromptsConfirmAssertionCommand extends Command
+{
+    protected $signature = 'ask:confirm';
+
+    public function handle()
+    {
+        $confirmed = confirm('Is your name John?');
+
+        if ($confirmed) {
+            $this->line('Your name is John.');
+        } else {
+            $this->line('Your name is not John.');
+        }
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\textarea;
 
@@ -19,6 +20,7 @@ class PromptsAssertionTest extends TestCase
         $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
         $app[Kernel::class]->registerCommand(new DummyPromptsPasswordAssertionCommand());
         $app[Kernel::class]->registerCommand(new DummyPromptsConfirmAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsSelectAssertionCommand());
     }
 
     public function testAssertionForTextPrompt()
@@ -49,13 +51,26 @@ class PromptsAssertionTest extends TestCase
     {
         $this
             ->artisan(DummyPromptsConfirmAssertionCommand::class)
-            ->expectsQuestion('Is your name John?', false)
+            ->expectsConfirmation('Is your name John?', 'no')
             ->expectsOutput('Your name is not John.');
 
         $this
             ->artisan(DummyPromptsConfirmAssertionCommand::class)
-            ->expectsQuestion('Is your name John?', true)
+            ->expectsConfirmation('Is your name John?', 'yes')
             ->expectsOutput('Your name is John.');
+    }
+
+    public function testAssertionForSelectPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsSelectAssertionCommand::class)
+            ->expectsChoice('What is your name?', 'John', ['John', 'Jane'])
+            ->expectsOutput('Your name is John.');
+
+        $this
+            ->artisan(DummyPromptsSelectAssertionCommand::class)
+            ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
+            ->expectsOutput('Your name is Jane.');
     }
 }
 
@@ -108,5 +123,20 @@ class DummyPromptsConfirmAssertionCommand extends Command
         } else {
             $this->line('Your name is not John.');
         }
+    }
+}
+
+class DummyPromptsSelectAssertionCommand extends Command
+{
+    protected $signature = 'ask:name-from-list';
+
+    public function handle()
+    {
+        $name = select(
+            label: 'What is your name?',
+            options: ['John', 'Jane']
+        );
+
+        $this->line("Your name is $name.");
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Orchestra\Testbench\TestCase;
+
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\textarea;
+
+class PromptsAssertionTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app[Kernel::class]->registerCommand(new DummyPromptsTextareaAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
+    }
+
+    public function testAssertionForTextPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsTextareaAssertionCommand::class)
+            ->expectsQuestion('What is your name?', 'John')
+            ->expectsOutput('John');
+    }
+
+    public function testAssertionForTextareaPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsTextareaAssertionCommand::class)
+            ->expectsQuestion('What is your name?', 'John')
+            ->expectsOutput('John');
+    }
+}
+
+class DummyPromptsTextAssertionCommand extends Command
+{
+    protected $signature = 'ask:text';
+
+    public function handle()
+    {
+        $name = text('What is your name?', 'John');
+
+        $this->line($name);
+    }
+}
+
+class DummyPromptsTextareaAssertionCommand extends Command
+{
+    protected $signature = 'ask:textarea';
+
+    public function handle()
+    {
+        $name = textarea('What is your name?', 'John');
+
+        $this->line($name);
+    }
+}

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -15,163 +15,151 @@ use function Laravel\Prompts\textarea;
 
 class PromptsAssertionTest extends TestCase
 {
-    protected function defineEnvironment($app)
-    {
-        $app[Kernel::class]->registerCommand(new DummyPromptsTextareaAssertionCommand());
-        $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
-        $app[Kernel::class]->registerCommand(new DummyPromptsPasswordAssertionCommand());
-        $app[Kernel::class]->registerCommand(new DummyPromptsConfirmAssertionCommand());
-        $app[Kernel::class]->registerCommand(new DummyPromptsSelectAssertionCommand());
-        $app[Kernel::class]->registerCommand(new DummyPromptsMultiSelectAssertionCommand());
-    }
-
     public function testAssertionForTextPrompt()
     {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:text';
+
+                public function handle()
+                {
+                    $name = text('What is your name?', 'John');
+
+                    $this->line($name);
+                }
+            }
+        );
+
         $this
-            ->artisan(DummyPromptsTextareaAssertionCommand::class)
-            ->expectsQuestion('What is your name?', 'John')
-            ->expectsOutput('John');
+            ->artisan('test:text')
+            ->expectsQuestion('What is your name?', 'Jane')
+            ->expectsOutput('Jane');
     }
 
     public function testAssertionForTextareaPrompt()
     {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:textarea';
+
+                public function handle()
+                {
+                    $name = textarea('What is your name?', 'John');
+
+                    $this->line($name);
+                }
+            }
+        );
+
         $this
-            ->artisan(DummyPromptsTextareaAssertionCommand::class)
-            ->expectsQuestion('What is your name?', 'John')
-            ->expectsOutput('John');
+            ->artisan('test:textarea')
+            ->expectsQuestion('What is your name?', 'Jane')
+            ->expectsOutput('Jane');
     }
 
     public function testAssertionForPasswordPrompt()
     {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:password';
+
+                public function handle()
+                {
+                    $name = password('What is your password?');
+
+                    $this->line($name);
+                }
+            }
+        );
+
         $this
-            ->artisan(DummyPromptsPasswordAssertionCommand::class)
+            ->artisan('test:password')
             ->expectsQuestion('What is your password?', 'secret')
             ->expectsOutput('secret');
     }
 
     public function testAssertionForConfirmPrompt()
     {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:confirm';
+
+                public function handle()
+                {
+                    $confirmed = confirm('Is your name John?');
+
+                    if ($confirmed) {
+                        $this->line('Your name is John.');
+                    } else {
+                        $this->line('Your name is not John.');
+                    }
+                }
+            }
+        );
+
         $this
-            ->artisan(DummyPromptsConfirmAssertionCommand::class)
+            ->artisan('test:confirm')
             ->expectsConfirmation('Is your name John?', 'no')
             ->expectsOutput('Your name is not John.');
 
         $this
-            ->artisan(DummyPromptsConfirmAssertionCommand::class)
+            ->artisan('test:confirm')
             ->expectsConfirmation('Is your name John?', 'yes')
             ->expectsOutput('Your name is John.');
     }
 
     public function testAssertionForSelectPrompt()
     {
-        $this
-            ->artisan(DummyPromptsSelectAssertionCommand::class)
-            ->expectsChoice('What is your name?', 'John', ['John', 'Jane'])
-            ->expectsOutput('Your name is John.');
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:select';
+
+                public function handle()
+                {
+                    $name = select(
+                        label: 'What is your name?',
+                        options: ['John', 'Jane']
+                    );
+
+                    $this->line("Your name is $name.");
+                }
+            }
+        );
 
         $this
-            ->artisan(DummyPromptsSelectAssertionCommand::class)
+            ->artisan('test:select')
             ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
             ->expectsOutput('Your name is Jane.');
     }
 
     public function testAssertionForRequiredMultiselectPrompt()
     {
-        $this
-            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
-            ->expectsChoice('Which names do you like?', ['John'], ['John', 'Jane', 'Sally', 'Jack'])
-            ->expectsOutput('You like John.');
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:multiselect';
 
-        $this
-            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
-            ->expectsChoice('Which names do you like?', ['John', 'Jack', 'Sally'], ['John', 'Jane', 'Sally', 'Jack'])
-            ->expectsOutput('You like John, Jack, Sally.');
-    }
-}
+                public function handle()
+                {
+                    $names = multiselect(
+                        label: 'Which names do you like?',
+                        options: ['John', 'Jane', 'Sally', 'Jack'],
+                        required: true
+                    );
 
-class DummyPromptsTextAssertionCommand extends Command
-{
-    protected $signature = 'ask:text';
-
-    public function handle()
-    {
-        $name = text('What is your name?', 'John');
-
-        $this->line($name);
-    }
-}
-
-class DummyPromptsTextareaAssertionCommand extends Command
-{
-    protected $signature = 'ask:textarea';
-
-    public function handle()
-    {
-        $name = textarea('What is your name?', 'John');
-
-        $this->line($name);
-    }
-}
-
-class DummyPromptsPasswordAssertionCommand extends Command
-{
-    protected $signature = 'ask:password';
-
-    public function handle()
-    {
-        $name = password('What is your password?', 'secret');
-
-        $this->line($name);
-    }
-}
-
-class DummyPromptsConfirmAssertionCommand extends Command
-{
-    protected $signature = 'ask:confirm';
-
-    public function handle()
-    {
-        $confirmed = confirm('Is your name John?');
-
-        if ($confirmed) {
-            $this->line('Your name is John.');
-        } else {
-            $this->line('Your name is not John.');
-        }
-    }
-}
-
-class DummyPromptsSelectAssertionCommand extends Command
-{
-    protected $signature = 'ask:name-from-list';
-
-    public function handle()
-    {
-        $name = select(
-            label: 'What is your name?',
-            options: ['John', 'Jane']
+                    $this->line(sprintf('You like %s.', implode(', ', $names)));
+                }
+            }
         );
 
-        $this->line("Your name is $name.");
-    }
-}
-
-class DummyPromptsMultiSelectAssertionCommand extends Command
-{
-    protected $signature = 'ask:names-from-list {--required}';
-
-    public function handle()
-    {
-        $names = multiselect(
-            label: 'Which names do you like?',
-            options: ['John', 'Jane', 'Sally', 'Jack'],
-            required: $this->option('required')
-        );
-
-        if (! empty($names)) {
-            $this->line(sprintf('You like %s.', implode(', ', $names)));
-        } else {
-            $this->line('You do not like any names.');
-        }
+        $this
+            ->artisan('test:multiselect')
+            ->expectsChoice('Which names do you like?', ['John', 'Jane'], ['John', 'Jane', 'Sally', 'Jack'])
+            ->expectsOutput('You like John, Jane.');
     }
 }


### PR DESCRIPTION
This PR adds a `fallback` for the new `textarea` component in Laravel Prompts, similar to other components. Without this, you can not use `expectsQuestion` when using the `textarea` prompt.

## Issue
I don't quite understand the underlying `fallbackUsing` behaviour but I do know that if it's missing, it causes the tests to hang.

## Fixes
- https://github.com/laravel/prompts/issues/131

## Tests
I'm not sure if the tests are the right way to go about this but it's the only way I could validate the fix in the framework. If you remove the new `Textarea::fallbackUsing(...)` and run the new tests, they will hang. I also found some other interesting behaviour when writing those tests but require these to be merged first before I can work on a fix.

## Additional PR
If this PR is merged, can https://github.com/laravel/framework/pull/51056 please be looked at as well?