### PR TITLE
[11.x] - Allow Prompt's `multiselect` prompt to be tested using `expectsChoice`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "fruitcake/php-cors": "^1.3",
         "guzzlehttp/guzzle": "^7.8",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.1.15",
+        "laravel/prompts": "^0.1.18",
         "laravel/serializable-closure": "^1.3",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -12,6 +12,7 @@ use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SearchPrompt;
 use Laravel\Prompts\SelectPrompt;
 use Laravel\Prompts\SuggestPrompt;
+use Laravel\Prompts\TextareaPrompt;
 use Laravel\Prompts\TextPrompt;
 use stdClass;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,6 +36,12 @@ trait ConfiguresPrompts
         Prompt::fallbackWhen(windows_os() || $this->laravel->runningUnitTests());
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',
+            $prompt->required,
+            $prompt->validate
+        ));
+
+        TextareaPrompt::fallbackUsing(fn (TextareaPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',
             $prompt->required,
             $prompt->validate

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -249,10 +249,10 @@ trait ConfiguresPrompts
      */
     private function multiselectFallback($label, $options, $default = [], $required = false)
     {
-        $options = PromptOption::wrap($options);
+        $promptOptions = PromptOption::wrap($options);
 
         if ($required === false) {
-            $options = [new PromptOption(null, 'None'), ...$options];
+            $promptOptions = [new PromptOption(null, 'None'), ...$promptOptions];
 
             if ($default === []) {
                 $default = [null];
@@ -260,10 +260,10 @@ trait ConfiguresPrompts
         }
 
         $default = $default !== []
-            ? implode(',', array_keys(array_filter($options, fn ($option) => in_array($option->value, $default))))
+            ? implode(',', array_keys(array_filter($promptOptions, fn ($option) => in_array($option->value, $default))))
             : null;
 
-        $answers = PromptOption::unwrap($this->components->choice($label, $options, $default, multiple: true));
+        $answers = PromptOption::unwrap($this->components->choice($label, PromptOption::wrap($options), $default, multiple: true));
 
         if ($required === false) {
             return array_values(array_filter($answers, fn ($value) => $value !== null));

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -249,10 +249,10 @@ trait ConfiguresPrompts
      */
     private function multiselectFallback($label, $options, $default = [], $required = false)
     {
-        $promptOptions = PromptOption::wrap($options);
+        $options = PromptOption::wrap($options);
 
         if ($required === false) {
-            $promptOptions = [new PromptOption(null, 'None'), ...$promptOptions];
+            $options = [new PromptOption(null, 'None'), ...$options];
 
             if ($default === []) {
                 $default = [null];
@@ -260,10 +260,10 @@ trait ConfiguresPrompts
         }
 
         $default = $default !== []
-            ? implode(',', array_keys(array_filter($promptOptions, fn ($option) => in_array($option->value, $default))))
+            ? implode(',', array_keys(array_filter($options, fn ($option) => in_array($option->value, $default))))
             : null;
 
-        $answers = PromptOption::unwrap($this->components->choice($label, PromptOption::wrap($options), $default, multiple: true));
+        $answers = PromptOption::unwrap($this->components->choice($label, $options, $default, multiple: true));
 
         if ($required === false) {
             return array_values(array_filter($answers, fn ($value) => $value !== null));

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -353,6 +353,8 @@ class PendingCommand
             foreach ($this->test->expectedChoices as $question => $answers) {
                 $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
 
+                dump($answers['actual']);
+                dump($answers['expected']);
                 $this->test->{$assertion}(
                     $answers['expected'],
                     $answers['actual'],

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -353,8 +353,6 @@ class PendingCommand
             foreach ($this->test->expectedChoices as $question => $answers) {
                 $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
 
-                dump($answers['actual']);
-                dump($answers['expected']);
                 $this->test->{$assertion}(
                     $answers['expected'],
                     $answers['actual'],

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -168,7 +168,7 @@ class DummyPromptsMultiSelectAssertionCommand extends Command
             required: $this->option('required')
         );
 
-        if (!empty($names)) {
+        if (! empty($names)) {
             $this->line(sprintf('You like %s.', implode(', ', $names)));
         } else {
             $this->line('You do not like any names.');

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -75,15 +75,15 @@ class PromptsAssertionTest extends TestCase
             ->expectsOutput('Your name is Jane.');
     }
 
-    public function testAssertionForMultiselectPrompt()
+    public function testAssertionForRequiredMultiselectPrompt()
     {
         $this
-            ->artisan(DummyPromptsMultiSelectAssertionCommand::class)
+            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
             ->expectsChoice('Which names do you like?', ['John'], ['John', 'Jane', 'Sally', 'Jack'])
             ->expectsOutput('You like John.');
 
         $this
-            ->artisan(DummyPromptsMultiSelectAssertionCommand::class)
+            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
             ->expectsChoice('Which names do you like?', ['John', 'Jack', 'Sally'], ['John', 'Jane', 'Sally', 'Jack'])
             ->expectsOutput('You like John, Jack, Sally.');
     }
@@ -158,16 +158,20 @@ class DummyPromptsSelectAssertionCommand extends Command
 
 class DummyPromptsMultiSelectAssertionCommand extends Command
 {
-    protected $signature = 'ask:names-from-list';
+    protected $signature = 'ask:names-from-list {--required}';
 
     public function handle()
     {
         $names = multiselect(
             label: 'Which names do you like?',
             options: ['John', 'Jane', 'Sally', 'Jack'],
-            required: true
+            required: $this->option('required')
         );
 
-        $this->line(sprintf('You like %s.', implode(', ', $names)));
+        if (!empty($names)) {
+            $this->line(sprintf('You like %s.', implode(', ', $names)));
+        } else {
+            $this->line('You do not like any names.');
+        }
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -86,6 +86,18 @@ class PromptsAssertionTest extends TestCase
             ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
             ->expectsChoice('Which names do you like?', ['John', 'Jack', 'Sally'], ['John', 'Jane', 'Sally', 'Jack'])
             ->expectsOutput('You like John, Jack, Sally.');
+
+        $this
+            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => true])
+            ->expectsChoice('Which names do you like?', [], ['John', 'Jane', 'Sally', 'Jack']);
+    }
+
+    public function testAssertionForOptionalRequiredMultiselectPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsMultiSelectAssertionCommand::class, ['--required' => false])
+            ->expectsChoice('Which names do you like?', [], ['John', 'Jane', 'Sally', 'Jack'])
+            ->expectsOutput('You do not like any names.');
     }
 }
 

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;
 use Orchestra\Testbench\TestCase;
 
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\textarea;
 
@@ -15,6 +17,8 @@ class PromptsAssertionTest extends TestCase
     {
         $app[Kernel::class]->registerCommand(new DummyPromptsTextareaAssertionCommand());
         $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsPasswordAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsConfirmAssertionCommand());
     }
 
     public function testAssertionForTextPrompt()
@@ -31,6 +35,27 @@ class PromptsAssertionTest extends TestCase
             ->artisan(DummyPromptsTextareaAssertionCommand::class)
             ->expectsQuestion('What is your name?', 'John')
             ->expectsOutput('John');
+    }
+
+    public function testAssertionForPasswordPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsPasswordAssertionCommand::class)
+            ->expectsQuestion('What is your password?', 'secret')
+            ->expectsOutput('secret');
+    }
+
+    public function testAssertionForConfirmPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsConfirmAssertionCommand::class)
+            ->expectsQuestion('Is your name John?', false)
+            ->expectsOutput('Your name is not John.');
+
+        $this
+            ->artisan(DummyPromptsConfirmAssertionCommand::class)
+            ->expectsQuestion('Is your name John?', true)
+            ->expectsOutput('Your name is John.');
     }
 }
 
@@ -55,5 +80,33 @@ class DummyPromptsTextareaAssertionCommand extends Command
         $name = textarea('What is your name?', 'John');
 
         $this->line($name);
+    }
+}
+
+class DummyPromptsPasswordAssertionCommand extends Command
+{
+    protected $signature = 'ask:password';
+
+    public function handle()
+    {
+        $name = password('What is your password?', 'secret');
+
+        $this->line($name);
+    }
+}
+
+class DummyPromptsConfirmAssertionCommand extends Command
+{
+    protected $signature = 'ask:confirm';
+
+    public function handle()
+    {
+        $confirmed = confirm('Is your name John?');
+
+        if ($confirmed) {
+            $this->line('Your name is John.');
+        } else {
+            $this->line('Your name is not John.');
+        }
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\textarea;
 
@@ -19,6 +20,7 @@ class PromptsAssertionTest extends TestCase
         $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
         $app[Kernel::class]->registerCommand(new DummyPromptsPasswordAssertionCommand());
         $app[Kernel::class]->registerCommand(new DummyPromptsConfirmAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsSelectAssertionCommand());
     }
 
     public function testAssertionForTextPrompt()
@@ -49,13 +51,26 @@ class PromptsAssertionTest extends TestCase
     {
         $this
             ->artisan(DummyPromptsConfirmAssertionCommand::class)
-            ->expectsQuestion('Is your name John?', false)
+            ->expectsConfirmation('Is your name John?', 'no')
             ->expectsOutput('Your name is not John.');
 
         $this
             ->artisan(DummyPromptsConfirmAssertionCommand::class)
-            ->expectsQuestion('Is your name John?', true)
+            ->expectsConfirmation('Is your name John?', 'yes')
             ->expectsOutput('Your name is John.');
+    }
+
+    public function testAssertionForSelectPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsSelectAssertionCommand::class)
+            ->expectsChoice('What is your name?', 'John', ['John', 'Jane'])
+            ->expectsOutput('Your name is John.');
+
+        $this
+            ->artisan(DummyPromptsSelectAssertionCommand::class)
+            ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
+            ->expectsOutput('Your name is Jane.');
     }
 }
 
@@ -108,5 +123,20 @@ class DummyPromptsConfirmAssertionCommand extends Command
         } else {
             $this->line('Your name is not John.');
         }
+    }
+}
+
+class DummyPromptsSelectAssertionCommand extends Command
+{
+    protected $signature = 'ask:name-from-list';
+
+    public function handle()
+    {
+        $name = select(
+            label: 'What is your name?',
+            options: ['John', 'Jane']
+        );
+
+        $this->line("Your name is $name.");
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Orchestra\Testbench\TestCase;
+
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\textarea;
+
+class PromptsAssertionTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app[Kernel::class]->registerCommand(new DummyPromptsTextareaAssertionCommand());
+        $app[Kernel::class]->registerCommand(new DummyPromptsTextAssertionCommand());
+    }
+
+    public function testAssertionForTextPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsTextareaAssertionCommand::class)
+            ->expectsQuestion('What is your name?', 'John')
+            ->expectsOutput('John');
+    }
+
+    public function testAssertionForTextareaPrompt()
+    {
+        $this
+            ->artisan(DummyPromptsTextareaAssertionCommand::class)
+            ->expectsQuestion('What is your name?', 'John')
+            ->expectsOutput('John');
+    }
+}
+
+class DummyPromptsTextAssertionCommand extends Command
+{
+    protected $signature = 'ask:text';
+
+    public function handle()
+    {
+        $name = text('What is your name?', 'John');
+
+        $this->line($name);
+    }
+}
+
+class DummyPromptsTextareaAssertionCommand extends Command
+{
+    protected $signature = 'ask:textarea';
+
+    public function handle()
+    {
+        $name = textarea('What is your name?', 'John');
+
+        $this->line($name);
+    }
+}


### PR DESCRIPTION
## Dependent on another PR
This PR depends on https://github.com/laravel/framework/pull/51055 and should not be merged until it is merged.

## Purpose
This PR will allow the `expectsChoice` method to be used when a Laravel Prompt `multiselect` is being used but when `required` is `false`.

## Failing Test
I'm not quire sure how to approach the fix here so I first created a failing test;
https://github.com/laravel/framework/pull/51056/files#diff-2cba8279071f67c5fee6df1c8f5112974a28f48ef91fe0e821193ed27c6d8e1cR95-R101

## Issue
The issue has to do with the fact that an additional option is being added when `required === false`;
https://github.com/laravel/framework/blob/48246da2320c95a17bfae922d36264105a917906/src/Illuminate/Console/Concerns/ConfiguresPrompts.php#L247-L253

Then, ALL options are being passed to the `choice` component;
https://github.com/laravel/framework/blob/48246da2320c95a17bfae922d36264105a917906/src/Illuminate/Console/Concerns/ConfiguresPrompts.php#L259

The `expectsChoice` assertion though does not cater for the additional choice that has been added. I assume this is because the `expectsChoice` method is interacting directly with the Symfony command that handles `required` internally on it's own.

## Proposed Solutions
I'm unsure how to best handle this because I'm not sure why `$options = [new PromptOption(null, 'None'), ...$options];` is required in the first place.

I was hoping @jessarcher could provide some insights as to how I could go about fixing this failing test.

### Adjusting the expectation
If we add `None` to the expection, this makes the test pass but won't work if the user has actually defined `None` as an option in their arg list as well;
```diff
- ->expectsChoice('Which names do you like?', [], ['John', 'Jane', 'Sally', 'Jack'])
+ ->expectsChoice('Which names do you like?', [], ['John', 'Jane', 'Sally', 'Jack', 'None'])
```

### Extract prompt options
This is what I initially tried in this PR but tests were then failing...
