### PR TITLE
[11.x] Added --uuid option to the make:model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -178,6 +178,10 @@ class ModelMakeCommand extends GeneratorCommand
             return $this->resolveStubPath('/stubs/model.morph-pivot.stub');
         }
 
+        if ($this->option('uuid')) {
+            return $this->resolveStubPath('/stubs/model.uuid.stub');
+        }
+
         return $this->resolveStubPath('/stubs/model.stub');
     }
 
@@ -219,6 +223,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
             ['morph-pivot', null, InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom polymorphic intermediate table model'],
+            ['uuid', null, InputOption::VALUE_NONE, 'Indicates if the generated model should use UUID as a primary key'],
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],

--- a/src/Illuminate/Foundation/Console/stubs/model.uuid.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.uuid.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+class {{ class }} extends Model
+{
+    use HasFactory, HasUuids;
+}


### PR DESCRIPTION
This PR adds a --uuid option to the **make:model** command for ease of use for creating models with UUID as a primary key

```sh
php artisan make:model Product --uuid
```

If this idea is acceptable I will also add the same option for the **make:migration** command which will also work for the make:model command with the -m flag for migrations

