### PR TITLE
[12.x] Fix the issue of `HasMiddleware` compatibility

### DIFF
--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -9,5 +9,5 @@ interface HasMiddleware
      *
      * @return \Illuminate\Routing\Controllers\Middleware[]
      */
-    public static function middleware();
+    public static function seedMiddleware();
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1118,7 +1118,7 @@ class Route
      */
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
     {
-        return collect($class::middleware())->map(function ($middleware) {
+        return collect($class::seedMiddleware())->map(function ($middleware) {
             return $middleware instanceof Middleware
                 ? $middleware
                 : new Middleware($middleware);

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -21,7 +21,7 @@ class HasMiddlewareTest extends TestCase
 
 class HasMiddlewareTestController implements HasMiddleware
 {
-    public static function middleware()
+    public static function seedMiddleware()
     {
         return [
             new Middleware('all'),


### PR DESCRIPTION
I found a Tip related to #44516 PR that introduced the `HasMiddleware` interface by @taylorotwell. I always prefer trying the code by myself and when I tried that interface I found no issue when we did not extend the `BaseController` but, if we do, we will hit a compatibility issue, therefore, both `BaseController` and `HasMiddleware` define the same `middleware` method name. 

**I love to use an expressive name, so I will suggest other names I think about too that may help `(glueMiddleware, and injectMiddleware)`**.

> [!IMPORTANT]
> The Laravel v.11 users will not feel that issue because every newly created controller does not extend the `BaseController` therefore, they will not hit that compatibility issue **(Unless they do)**.