### PR TITLE
[11.x] Add `throttle` method to `LazyCollection`

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1571,6 +1571,28 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Throttle the values, releasing them at most once per the given seconds.
+     *
+     * @return static<TKey, TValue>
+     */
+    public function throttle(float $seconds)
+    {
+        return new static(function () use ($seconds) {
+            $microseconds = $seconds * 1_000_000;
+
+            foreach ($this as $key => $value) {
+                $fetchedAt = $this->preciseNow();
+
+                yield $key => $value;
+
+                $sleep = $microseconds - ($this->preciseNow() - $fetchedAt);
+
+                $this->usleep((int) $sleep);
+            }
+        });
+    }
+
+    /**
      * Flatten a multi-dimensional associative array with dots.
      *
      * @return static
@@ -1780,5 +1802,33 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         return class_exists(Carbon::class)
             ? Carbon::now()->timestamp
             : time();
+    }
+
+    /**
+     * Get the precise current time.
+     *
+     * @return float
+     */
+    protected function preciseNow()
+    {
+        return class_exists(Carbon::class)
+            ? Carbon::now()->getPreciseTimestamp()
+            : microtime(true) * 1_000_000;
+    }
+
+    /**
+     * Sleep for the given amount of microseconds.
+     *
+     * @return void
+     */
+    protected function usleep(int $microseconds)
+    {
+        if ($microseconds <= 0) {
+            return;
+        }
+
+        class_exists(Sleep::class)
+            ? Sleep::usleep($microseconds)
+            : usleep($microseconds);
     }
 }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
+use Illuminate\Support\Sleep;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -1368,6 +1369,25 @@ class SupportLazyCollectionIsLazyTest extends TestCase
                 // Silence is golden!
             })->all();
         });
+    }
+
+    public function testThrottleIsLazy()
+    {
+        Sleep::fake();
+
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->throttle(10);
+        });
+
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->throttle(10)->take(5)->all();
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->throttle(10)->all();
+        });
+
+        Sleep::fake(false);
     }
 
     public function testTimesIsLazy()


### PR DESCRIPTION
Allows throttling the values retrieved from a lazy collection:

```php
LazyCollection::times(3)->throttle(seconds: 1)->each(function ($number) {
    dump($number); // Will dump each number, with a pause (sleep) of about a second in between each...
});
```

> **Note**: The sleep will _not_ be 1 second. That would be quite naïve. Instead, it includes the time it takes to process each retrieved value, and only sleeps for the remainder of the duration. 

---

Especially useful when interacting with external APIs, which may have some rate limits. Can be used both for pulling data as well as for pushing data.

**Pulling data example**:

```php
$userIds = collect([1, 2, 3])->lazy();

$users = $userIds
    ->throttle(1)
    ->map(fn ($userId) => API::fetchUser($id));
```

Or, if the external API supports fetching, say, 50 users at once:

```php
$userIds = collect([1, 2, 3, /* ... */])->lazy();

$users = $userIds
    ->chunk(50)
    ->throttle(1)
    ->map(fn ($userIds) => API::fetchUsers($userIds))
    ->flatten();
```

**Pushing data example**:

```php
$userIds = collect([1, 2, 3])->lazy();

$userIds
    ->throttle(1)
    ->each(fn ($userId) => API::deleteUser($id));
```

---

[Here's a real-world use case](https://christalks.dev/post/using-laravels-sleep-helper-to-save-time-4b88299e), which would be vastly simplified after this PR:

```php
DB::table('stock_sync')->cursor()->throttle(1)->map(function ($sync) {
    // Handle stock sync updates...
});
```