### PR TITLE
[11.x] Add `whereOrNull` method to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1307,7 +1307,7 @@ class Builder implements BuilderContract
         return $this->whereNull($columns, $boolean, true);
     }
     /**
-     * Add a "where null or" clause to the query.
+     * Add a "where or null" clause to the query.
      *
      * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @param  \Closure|string  $operator
@@ -1315,27 +1315,26 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNullOr($columns, $operator = null, $value = null, $boolean = 'and', $not = false)
+    public function whereOrNull($columns, $operator = null, $value = null, $boolean = 'and', $not = false)
     {
         if ($operator instanceof Closure) {
             if (!is_null($value)) {
                 throw new InvalidArgumentException("A value is prohibited when subquery is used.");
             }
             return $this->whereNested(function (self $query) use ($not, $operator, $columns) {
-                return $query->whereNull($columns, 'and', $not)
-                    ->orWhere($operator);
+                return $query->whereNested($operator)
+                    ->whereNull($columns, 'or', $not);
             }, $boolean);
         }
 
         foreach (Arr::wrap($columns) as $column) {
             $this->whereNested(function (self $query) use ($value, $columns, $not, $operator, $column) {
-                $query->whereNull($column, 'and', $not)
-                    ->orWhere($column, $operator, $value);
+                $query->where($column, $operator, $value)
+                    ->whereNull($column, 'or', $not);
             }, $boolean);
         }
         return $this;
     }
-
     /**
      * Add a where between statement to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1285,6 +1285,7 @@ class Builder implements BuilderContract
 
         return $this;
     }
+
     /**
      * Add an "or where null" clause to the query.
      *
@@ -1295,6 +1296,7 @@ class Builder implements BuilderContract
     {
         return $this->whereNull($column, 'or');
     }
+
     /**
      * Add a "where not null" clause to the query.
      *
@@ -1306,6 +1308,7 @@ class Builder implements BuilderContract
     {
         return $this->whereNull($columns, $boolean, true);
     }
+
     /**
      * Add a "where or null" clause to the query.
      *
@@ -1318,9 +1321,10 @@ class Builder implements BuilderContract
     public function whereOrNull($columns, $operator = null, $value = null, $boolean = 'and', $not = false)
     {
         if ($operator instanceof Closure) {
-            if (!is_null($value)) {
-                throw new InvalidArgumentException("A value is prohibited when subquery is used.");
+            if (! is_null($value)) {
+                throw new InvalidArgumentException('A value is prohibited when subquery is used.');
             }
+
             return $this->whereNested(function (self $query) use ($not, $operator, $columns) {
                 return $query->whereNested($operator)
                     ->whereNull($columns, 'or', $not);
@@ -1328,13 +1332,15 @@ class Builder implements BuilderContract
         }
 
         foreach (Arr::wrap($columns) as $column) {
-            $this->whereNested(function (self $query) use ($value, $columns, $not, $operator, $column) {
+            $this->whereNested(function (self $query) use ($value, $not, $operator, $column) {
                 $query->where($column, $operator, $value)
                     ->whereNull($column, 'or', $not);
             }, $boolean);
         }
+
         return $this;
     }
+
     /**
      * Add a where between statement to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1285,6 +1285,31 @@ class Builder implements BuilderContract
 
         return $this;
     }
+    /**
+     * Add a "where null or" clause to the query.
+     *
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $columns
+     * @param  \Closure|string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNullOr($columns, $operator = null, $value = null, $boolean = 'and', $not = false)
+    {
+        foreach (Arr::wrap($columns) as $column) {
+            $this->where(function (self $query) use ($value, $columns, $not, $operator, $column) {
+                $query->whereNull($column, 'and', $not);
+                if ($operator instanceof Closure) {
+                    if (!is_null($value)) {
+                        throw new InvalidArgumentException("A value is prohibited when subquery is used.");
+                    }
+                    return $query->orWhere($operator);
+                }
+                return $query->orWhere($column, $operator, $value);
+            }, null, null, $boolean);
+        }
+        return $this;
+    }
 
     /**
      * Add an "or where null" clause to the query.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1255,8 +1255,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr('name', 'test');
-        $expected = 'select * from "table" where ("name" is null or "name" = ?)';
+        $query = $builder->whereOrNull('name', 'test');
+        $expected = 'select * from "table" where ("name" = ? or "name" is null)';
         $this->assertEquals($expected, $query->toSql());
     }
 
@@ -1264,8 +1264,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr('name', 'like', '%test%');
-        $expected = 'select * from "table" where ("name" is null or "name" like ?)';
+        $query = $builder->whereOrNull('name', 'like', '%test%');
+        $expected = 'select * from "table" where ("name" like ? or "name" is null)';
         $this->assertEquals($expected, $query->toSql());
     }
 
@@ -1273,8 +1273,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr(['name', 'name2'], 'test');
-        $expected = 'select * from "table" where ("name" is null or "name" = ?) and ("name2" is null or "name2" = ?)';
+        $query = $builder->whereOrNull(['name', 'name2'], 'test');
+        $expected = 'select * from "table" where ("name" = ? or "name" is null) and ("name2" = ? or "name2" is null)';
         $this->assertEquals($expected, $query->toSql());
     }
 
@@ -1282,8 +1282,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr(['name', 'name2'], '>=', 'test');
-        $expected = 'select * from "table" where ("name" is null or "name" >= ?) and ("name2" is null or "name2" >= ?)';
+        $query = $builder->whereOrNull(['name', 'name2'], '>=', 'test');
+        $expected = 'select * from "table" where ("name" >= ? or "name" is null) and ("name2" >= ? or "name2" is null)';
         $this->assertEquals($expected, $query->toSql());
     }
 
@@ -1291,8 +1291,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr(new Expression('GREATEST(from, to)'), '>', 2);
-        $expected = 'select * from "table" where (GREATEST(from, to) is null or GREATEST(from, to) > ?)';
+        $query = $builder->whereOrNull(new Expression('GREATEST(from, to)'), '>', 2);
+        $expected = 'select * from "table" where (GREATEST(from, to) > ? or GREATEST(from, to) is null)';
         $this->assertEquals($expected, $query->toSql());
         $this->assertEquals([2], $query->getBindings());
     }
@@ -1301,10 +1301,10 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr('first_name', function ($query) {
+        $query = $builder->whereOrNull('first_name', function ($query) {
             $query->where('last_name', 'test');
         });
-        $expected = 'select * from "table" where ("first_name" is null or ("last_name" = ?))';
+        $expected = 'select * from "table" where (("last_name" = ?) or "first_name" is null)';
         $this->assertEquals($expected, $query->toSql());
         $this->assertEquals(['test'], $query->getBindings());
     }
@@ -1313,10 +1313,10 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr(['first_name','last_name'], function ($query) {
+        $query = $builder->whereOrNull(['first_name','last_name'], function ($query) {
             $query->where('name', 'test');
         });
-        $expected = 'select * from "table" where ("first_name" is null and "last_name" is null or ("name" = ?))';
+        $expected = 'select * from "table" where (("name" = ?) or "first_name" is null or "last_name" is null)';
         $this->assertEquals($expected, $query->toSql());
         $this->assertEquals(['test'], $query->getBindings());
     }
@@ -1328,7 +1328,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $builder->whereNullOr('first_name', function ($query) {
+        $builder->whereOrNull('first_name', function ($query) {
             $query->where('last_name', 'test');
         }, 'test');
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5,11 +5,11 @@ namespace Illuminate\Tests\Database;
 use BadMethodCallException;
 use Closure;
 use DateTime;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Contracts\Database\Query\ConditionExpression;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Grammars\MariaDbGrammar;
@@ -1313,7 +1313,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereOrNull(['first_name','last_name'], function ($query) {
+        $query = $builder->whereOrNull(['first_name', 'last_name'], function ($query) {
             $query->where('name', 'test');
         });
         $expected = 'select * from "table" where (("name" = ?) or "first_name" is null or "last_name" is null)';
@@ -1332,6 +1332,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $query->where('last_name', 'test');
         }, 'test');
     }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1291,8 +1291,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('table');
-        $query = $builder->whereNullOr(new Expression('price - discount'), '>', 2);
-        $expected = 'select * from "table" where (price - discount is null or price - discount > ?)';
+        $query = $builder->whereNullOr(new Expression('GREATEST(from, to)'), '>', 2);
+        $expected = 'select * from "table" where (GREATEST(from, to) is null or GREATEST(from, to) > ?)';
         $this->assertEquals($expected, $query->toSql());
         $this->assertEquals([2], $query->getBindings());
     }
@@ -1305,6 +1305,18 @@ class DatabaseQueryBuilderTest extends TestCase
             $query->where('last_name', 'test');
         });
         $expected = 'select * from "table" where ("first_name" is null or ("last_name" = ?))';
+        $this->assertEquals($expected, $query->toSql());
+        $this->assertEquals(['test'], $query->getBindings());
+    }
+
+    public function testWhereNullOrCallbackWithArray()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('table');
+        $query = $builder->whereNullOr(['first_name','last_name'], function ($query) {
+            $query->where('name', 'test');
+        });
+        $expected = 'select * from "table" where ("first_name" is null and "last_name" is null or ("name" = ?))';
         $this->assertEquals($expected, $query->toSql());
         $this->assertEquals(['test'], $query->getBindings());
     }


### PR DESCRIPTION
Handling null values in queries can often be annoying, especially when it involves nested orWhere clauses. 
This is a common scenario in databases where null has a specific meaning, such as an indefinite end date (end_at is null), an optional record completion status (status is null), or when dealing with newly added nullable columns that require the graceful handling of historical null values.

For instance, a typical query might look like this:
```php
$query->where(function($query){
    $query->where('end_at', '>=', now())
          ->orWhereNull('end_at');
});
```
This method allows a cleaner and more developer-friendly approach:
```php
$query->whereOrNull('end_at', '>=', now());
```
Furthermore, this method facilitates the use of arrow functions for straightforward `orWhere` queries, for instance:
```php
$query->whereOrNull('status', fn($builder) => $builder->whereIn('status', ['canceled', 'completed']));
```
I hope this contribution makes developers lives easier by simplifying how we handle the little things. I’m open to any suggestions. Thanks!