### PR TITLE
[11.x] Add @throws ConnectionException tag on Http methods for IDE support

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -764,6 +764,8 @@ class PendingRequest
      * @param  string  $url
      * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
+     *
+     * @throws ConnectionException|\Throwable
      */
     public function get(string $url, $query = null)
     {
@@ -778,6 +780,8 @@ class PendingRequest
      * @param  string  $url
      * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
+     *
+     * @throws ConnectionException|\Throwable
      */
     public function head(string $url, $query = null)
     {
@@ -792,6 +796,8 @@ class PendingRequest
      * @param  string  $url
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
+     *
+     * @throws ConnectionException|\Throwable
      */
     public function post(string $url, $data = [])
     {
@@ -806,6 +812,8 @@ class PendingRequest
      * @param  string  $url
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
+     *
+     * @throws ConnectionException|\Throwable
      */
     public function patch(string $url, $data = [])
     {
@@ -820,6 +828,8 @@ class PendingRequest
      * @param  string  $url
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
+     *
+     * @throws ConnectionException|\Throwable
      */
     public function put(string $url, $data = [])
     {
@@ -834,6 +844,8 @@ class PendingRequest
      * @param  string  $url
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
+     *
+     * @throws ConnectionException|\Throwable
      */
     public function delete(string $url, $data = [])
     {
@@ -869,7 +881,7 @@ class PendingRequest
      * @param  array  $options
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws \Exception
+     * @throws ConnectionException|\Exception|\Throwable
      */
     public function send(string $method, string $url, array $options = [])
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -765,7 +765,7 @@ class PendingRequest
      * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Throwable
+     * @throws ConnectionException
      */
     public function get(string $url, $query = null)
     {
@@ -781,7 +781,7 @@ class PendingRequest
      * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Throwable
+     * @throws ConnectionException
      */
     public function head(string $url, $query = null)
     {
@@ -797,7 +797,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Throwable
+     * @throws ConnectionException
      */
     public function post(string $url, $data = [])
     {
@@ -813,7 +813,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Throwable
+     * @throws ConnectionException
      */
     public function patch(string $url, $data = [])
     {
@@ -829,7 +829,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Throwable
+     * @throws ConnectionException
      */
     public function put(string $url, $data = [])
     {
@@ -845,7 +845,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Throwable
+     * @throws ConnectionException
      */
     public function delete(string $url, $data = [])
     {
@@ -881,7 +881,8 @@ class PendingRequest
      * @param  array  $options
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException|\Exception|\Throwable
+     * @throws Exception
+     * @throws ConnectionException
      */
     public function send(string $method, string $url, array $options = [])
     {
@@ -1100,7 +1101,7 @@ class PendingRequest
      * @param  array  $options
      * @return \Psr\Http\Message\MessageInterface|\GuzzleHttp\Promise\PromiseInterface
      *
-     * @throws \Exception
+     * @throws Exception
      */
     protected function sendRequest(string $method, string $url, array $options = [])
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -765,7 +765,7 @@ class PendingRequest
      * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function get(string $url, $query = null)
     {
@@ -781,7 +781,7 @@ class PendingRequest
      * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function head(string $url, $query = null)
     {
@@ -797,7 +797,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function post(string $url, $data = [])
     {
@@ -813,7 +813,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function patch(string $url, $data = [])
     {
@@ -829,7 +829,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function put(string $url, $data = [])
     {
@@ -845,7 +845,7 @@ class PendingRequest
      * @param  array  $data
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws ConnectionException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function delete(string $url, $data = [])
     {
@@ -881,8 +881,8 @@ class PendingRequest
      * @param  array  $options
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws Exception
-     * @throws ConnectionException
+     * @throws \Exception
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function send(string $method, string $url, array $options = [])
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1101,7 +1101,7 @@ class PendingRequest
      * @param  array  $options
      * @return \Psr\Http\Message\MessageInterface|\GuzzleHttp\Promise\PromiseInterface
      *
-     * @throws Exception
+     * @throws \Exception
      */
     protected function sendRequest(string $method, string $url, array $options = [])
     {


### PR DESCRIPTION
This pull request just adds the @throws ConnectionException tag to the head, get, post, put, patch, and delete methods on the HTTP class for support IDE suggestion.

if only use this method after the facade i.e. ```Http::post()``` IDE can't suggest but if used after any other method such as ```asJson()``` IDE can suggest exceptions and developers notice that this method throws exceptions.

Some time ago in my company Due to not being aware of this exception, we encountered an error due to a connection error and there is no complete explanation about this exception in the Laravel documentation.
