### PR TITLE
[11.x] fix: add conditional return type to logger helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -499,7 +499,7 @@ if (! function_exists('logger')) {
      *
      * @param  string|null  $message
      * @param  array  $context
-     * @return \Illuminate\Log\LogManager|null
+     * @return ($message is null ? \Illuminate\Log\LogManager : null)
      */
     function logger($message = null, array $context = [])
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

Please see the related issue: https://github.com/larastan/larastan/issues/1914

This PR adds a conditional return type to the logger function to keep PHPStorm from throwing an incorrect warning.

Thanks!