### PR TITLE
[11.x] Consider after_commit config in SyncQueue

### DIFF
--- a/src/Illuminate/Queue/Connectors/SyncConnector.php
+++ b/src/Illuminate/Queue/Connectors/SyncConnector.php
@@ -14,6 +14,6 @@ class SyncConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        return new SyncQueue;
+        return new SyncQueue($config['after_commit'] ?? null);
     }
 }

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -16,6 +16,7 @@ class SyncQueue extends Queue implements QueueContract
      * Create a new sync queue instance.
      *
      * @param  bool  $dispatchAfterCommit
+     * @return void
      */
     public function __construct($dispatchAfterCommit = false)
     {

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -13,6 +13,8 @@ use Throwable;
 class SyncQueue extends Queue implements QueueContract
 {
     /**
+     * Create a new sync queue instance.
+     *
      * @param  bool  $dispatchAfterCommit
      */
     public function __construct($dispatchAfterCommit = false)

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -13,6 +13,14 @@ use Throwable;
 class SyncQueue extends Queue implements QueueContract
 {
     /**
+     * @param  bool  $dispatchAfterCommit
+     */
+    public function __construct($dispatchAfterCommit = false)
+    {
+        $this->dispatchAfterCommit = $dispatchAfterCommit;
+    }
+
+    /**
      * Get the size of the queue.
      *
      * @param  string|null  $queue


### PR DESCRIPTION
AfterCommit support was added to the SyncQueue in https://github.com/laravel/framework/pull/48860. However, it only works if the job in question implements the ShouldQueueAfterCommit interface or sets the afterCommit property - it does not work if after_commit is set to true in the sync driver's configuration. This makes the behavior inconsistent, which is what this PR intends to solve.

I spent some time unsuccessfully trying to figure out how to write a test for this. If anyone has an idea, please let me know and I'll add a test.