### PR TITLE
[11.x] New Eloquent Methods: `deleteWhere` and `forceDeleteWhere`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1340,6 +1340,34 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Combine where and delete method.
+     *
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return mixed
+     */
+    public function deleteWhere($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->where($column, $operator, $value, $boolean)->delete();
+    }
+
+    /**
+     * Combine where and force delete method.
+     *
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return mixed
+     */
+    public function forceDeleteWhere($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->where($column, $operator, $value, $boolean)->forceDelete();
+    }
+
+    /**
      * Determine if the given model has a scope.
      *
      * @param  string  $scope


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In a real case, based on one of my projects:

```php
Contract::where('status', '=', Contracts::Pending)->delete();
```

I noticed there are numerous times when we need to do a `where` with a `delete`. Sometimes simple, sometimes a little bit complex, but the usage is always the same: the combination of "where" with "delete".

Therefore, I decided to send this suggestion to Taylor for analysis. I believe it is a simple addition, but useful in everyday life, eliminating the need to create code like the example I mentioned above.

---

This PR adds a shortcut by combining the two methods: "where" and "delete", into `deleteWhere` and `forceDeleteWhere`

```php
// Contract::where('status', '=', Contracts::Pending)->delete();

Contract::deleteWhere('status', '=', Contracts::Pending);

Contract::forceDeleteWhere('status', '=', Contracts::Pending);
```
