### PR TITLE
[11.x] Ability to generate URL's with query params

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -231,25 +231,23 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Generate an absolute URL with query parameters to the given path.
+     * Generate an absolute URL with the given query parameters.
      *
      * @param  string  $path
-     * @param  array  $params
+     * @param  array  $query
      * @param  mixed  $extra
      * @param  bool|null  $secure
      * @return string
      */
-    public function query($path, $params = [], $extra = [], $secure = null)
+    public function query($path, $query = [], $extra = [], $secure = null)
     {
-        [$path, $query] = $this->extractQueryString($path);
+        [$path, $existingQueryString] = $this->extractQueryString($path);
 
-        parse_str(Str::after($query, '?'), $pairs);
+        parse_str(Str::after($existingQueryString, '?'), $existingQueryArray);
 
-        $query = Arr::query(
-            array_merge($pairs, $params)
-        );
-
-        return $this->to($path.'?'.$query, $extra, $secure);
+        return $this->to($path.'?'.Arr::query(
+            array_merge($existingQueryArray, $query)
+        ), $extra, $secure);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -231,6 +231,28 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Generate an absolute URL with query parameters to the given path.
+     *
+     * @param string $path
+     * @param array $params
+     * @param mixed $extra
+     * @param bool|null $secure
+     * @return string
+     */
+    public function query($path, $params = [], $extra = [], $secure = null)
+    {
+        [$path, $query] = $this->extractQueryString($path);
+
+        parse_str(Str::after($query, '?'), $pairs);
+
+        $query = Arr::query(
+            array_merge($pairs, $params)
+        );
+
+        return $this->to($path . '?' . $query, $extra, $secure);
+    }
+
+    /**
      * Generate a secure, absolute URL to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -233,10 +233,10 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Generate an absolute URL with query parameters to the given path.
      *
-     * @param string $path
-     * @param array $params
-     * @param mixed $extra
-     * @param bool|null $secure
+     * @param  string  $path
+     * @param  array  $params
+     * @param  mixed  $extra
+     * @param  bool|null  $secure
      * @return string
      */
     public function query($path, $params = [], $extra = [], $secure = null)
@@ -249,7 +249,7 @@ class UrlGenerator implements UrlGeneratorContract
             array_merge($pairs, $params)
         );
 
-        return $this->to($path . '?' . $query, $extra, $secure);
+        return $this->to($path.'?'.$query, $extra, $secure);
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -42,6 +42,21 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.foo.com/foo/bar', $url->to('foo/bar'));
     }
 
+    public function testQueryGeneration()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $this->assertSame('http://www.foo.com/foo/bar?', $url->query('foo/bar'));
+        $this->assertSame('http://www.foo.com/foo/bar?0=foo', $url->query('foo/bar', ['foo']));
+        $this->assertSame('http://www.foo.com/foo/bar?baz=boom', $url->query('foo/bar', ['baz' => 'boom']));
+        $this->assertSame('http://www.foo.com/foo/bar?baz=zee&zal=bee', $url->query('foo/bar?baz=boom&zal=bee', ['baz' => 'zee']));
+        $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar&zal=bee', $url->query('foo/bar?foo=bar', ['zal' => 'bee'], ['baz'], true));
+        $this->assertSame('http://www.foo.com/foo/bar?baz[0]=boom&baz[1]=bam&baz[2]=bim', urldecode($url->query('foo/bar', ['baz' => ['boom', 'bam', 'bim']])));
+    }
+
     public function testAssetGeneration()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
This PR adds the ability to generate URL's with query parameters via a new `query()` method on the `UrlGenerator`.

Currently, URLs cannot be generated with query parameters using the `UrlGenerator`.

Example:

```php
// http://localhost/products?sort=-name
url()->query('products', ['sort' => '-name']);

// http://localhost/products?columns[0]=name&columns[1]=price&columns[2]=quantity
url()->query('products', ['columns' => ['name', 'price', 'quantity']]);
```

Existing query parameters in the given path may also be overridden:

```php
// http://localhost/products?sort=-price
url()->query('products?sort=-name', ['sort' => '-price']);
```

They may also be appended onto:

```php
// http://localhost/products?sort=-name&search=samsung
url()->query('products?sort=-name', ['search' => 'samsung']);
```