### PR TITLE
[11.x] Fix context helper always requiring `$key` value

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -298,7 +298,7 @@ if (! function_exists('context')) {
      * @param  mixed  $default
      * @return mixed|\Illuminate\Log\Context\Repository
      */
-    function context($key, $default = null)
+    function context($key = null, $default = null)
     {
         return match (true) {
             is_null($key) => app(ContextRepository::class),


### PR DESCRIPTION
The `context()` helper added in #50878 accepts `null` as a value for `$key` to simply return the Context repository, but without also defaulting `$key` to `null` it means you'd have to always do `context(null)->add('name', 'test')` to use that form of syntax instead of `context(['name' => 'test'])`. This PR addresses that.