### PR TITLE
[11.x] Str::firstAndLast method for extracting the first and last character from a string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -111,6 +111,26 @@ class Str
     }
 
     /**
+     * Extracts the first and last character from a string.
+     *
+     * This function handles multibyte characters and allows specifying
+     * the string encoding for better accuracy.
+     *
+     * @param string $string The input string.
+     * @param string $encoding
+     * @return string The first and last character of the string concatenated.
+     */
+    public static function firstAndLast(string $string, $encoding = 'UTF-8')
+    {
+
+        if (mb_strlen($string, $encoding) <= 2) {
+            return $string;
+        }
+
+        return mb_substr($string, 0, 1, $encoding) . mb_substr($string, -1, 1, $encoding);
+    }
+
+    /**
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -334,6 +334,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::afterLast('----foo', '---'));
     }
 
+    public function testStrFirstAndLast()
+    {
+        $this->assertSame('', Str::firstAndLast(''));
+        $this->assertSame('a', Str::firstAndLast('a'));
+        $this->assertSame('cy', Str::firstAndLast('city'));
+        $this->assertSame('€$', Str::firstAndLast('€uro$'));
+        $this->assertSame('!y', Str::firstAndLast('!1nfinity'));
+        $this->assertSame('x ', Str::firstAndLast('x0 . '));
+        $this->assertSame('fo', Str::firstAndLast('foo'));
+        $this->assertSame(' ', Str::firstAndLast(' '));
+    }
+
     #[DataProvider('strContainsProvider')]
     public function testStrContains($haystack, $needles, $expected, $ignoreCase = false)
     {


### PR DESCRIPTION
## PR: Introduce `Str::firstAndLast` for Extracting First and Last Character

This pull request introduces a new function `Str::firstAndLast` to the `Str` class. This function extracts and concatenates the first and last character of a given string.

**Function Description:**

* `Str::firstAndLast(string $string, string $stringEncoding = 'UTF-8')`
    * This function takes a string as input and an optional `$stringEncoding` parameter.
    * The default encoding is `UTF-8`.
    * It returns a string containing the first and last character of the input string concatenated.

**Benefits:**

* Provides a convenient way to extract the first and last character from a string within the `Str` class.
* Supports multi-byte characters through the use of `mb_strlen` and `mb_substr` for accurate handling of special characters.
* Improves code readability and maintainability by offering a dedicated function for this common task.

**Implementation:**

```php
public static function firstAndLast(string $string, $encoding = 'UTF-8')
{

    if (mb_strlen($string, $encoding) <= 2) {
        return $string;
    }

    return mb_substr($string, 0, 1, $encoding) . mb_substr($string, -1, 1, $encoding);
}
```

**Testing:**

* Unit tests have been added to ensure the function behaves correctly with various string lengths, including empty strings, single characters, and strings with special characters.

**Request for Feedback:**

* Please review the code and provide any suggestions for improvement.