### PR TITLE
[11.x] Fix typo in tests

### DIFF
--- a/tests/Integration/Generators/InterfaceMakeCommandTest.php
+++ b/tests/Integration/Generators/InterfaceMakeCommandTest.php
@@ -6,7 +6,7 @@ use Illuminate\Tests\Integration\Generators\TestCase;
 
 class InterfaceMakeCommandTest extends TestCase
 {
-    public function testItCanGenerateEnumFile()
+    public function testItCanGenerateInterfaceFile()
     {
         $this->artisan('make:interface', ['name' => 'Gateway'])
             ->assertExitCode(0);


### PR DESCRIPTION
Interface instead Enum