### PR TITLE
[11.x] Add tests for `make:interface` & `make:trait` when the folders exists

### DIFF
--- a/tests/Integration/Generators/InterfaceMakeCommandTest.php
+++ b/tests/Integration/Generators/InterfaceMakeCommandTest.php
@@ -16,4 +16,24 @@ class InterfaceMakeCommandTest extends TestCase
             'interface Gateway',
         ], 'app/Gateway.php');
     }
+
+    public function testItCanGenerateInterfaceFileWhenContractsFolderExists()
+    {
+        $interfacesFolderPath = app_path('Contracts');
+
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($interfacesFolderPath);
+
+        $this->artisan('make:interface', ['name' => 'Gateway'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Contracts;',
+            'interface Gateway',
+        ], 'app/Contracts/Gateway.php');
+
+        $files->deleteDirectory($interfacesFolderPath);
+    }
 }

--- a/tests/Integration/Generators/InterfaceMakeCommandTest.php
+++ b/tests/Integration/Generators/InterfaceMakeCommandTest.php
@@ -6,6 +6,12 @@ use Illuminate\Tests\Integration\Generators\TestCase;
 
 class InterfaceMakeCommandTest extends TestCase
 {
+    protected $files = [
+        'app/Gateway.php',
+        'app/Contracts/Gateway.php',
+        'app/Interfaces/Gateway.php',
+    ];
+
     public function testItCanGenerateInterfaceFile()
     {
         $this->artisan('make:interface', ['name' => 'Gateway'])
@@ -33,6 +39,27 @@ class InterfaceMakeCommandTest extends TestCase
             'namespace App\Contracts;',
             'interface Gateway',
         ], 'app/Contracts/Gateway.php');
+
+        $files->deleteDirectory($interfacesFolderPath);
+    }
+
+
+    public function testItCanGenerateInterfaceFileWhenInterfacesFolderExists()
+    {
+        $interfacesFolderPath = app_path('Interfaces');
+
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($interfacesFolderPath);
+
+        $this->artisan('make:interface', ['name' => 'Gateway'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Interfaces;',
+            'interface Gateway',
+        ], 'app/Interfaces/Gateway.php');
 
         $files->deleteDirectory($interfacesFolderPath);
     }

--- a/tests/Integration/Generators/InterfaceMakeCommandTest.php
+++ b/tests/Integration/Generators/InterfaceMakeCommandTest.php
@@ -43,7 +43,6 @@ class InterfaceMakeCommandTest extends TestCase
         $files->deleteDirectory($interfacesFolderPath);
     }
 
-
     public function testItCanGenerateInterfaceFileWhenInterfacesFolderExists()
     {
         $interfacesFolderPath = app_path('Interfaces');

--- a/tests/Integration/Generators/TraitMakeCommandTest.php
+++ b/tests/Integration/Generators/TraitMakeCommandTest.php
@@ -36,4 +36,24 @@ class TraitMakeCommandTest extends TestCase
 
         $files->deleteDirectory($traitsFolderPath);
     }
+
+    public function testItCanGenerateTraitFileWhenConcernsFolderExists()
+    {
+        $traitsFolderPath = app_path('Concerns');
+
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($traitsFolderPath);
+
+        $this->artisan('make:trait', ['name' => 'FooTrait'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Concerns;',
+            'trait FooTrait',
+        ], 'app/Concerns/FooTrait.php');
+
+        $files->deleteDirectory($traitsFolderPath);
+    }
 }

--- a/tests/Integration/Generators/TraitMakeCommandTest.php
+++ b/tests/Integration/Generators/TraitMakeCommandTest.php
@@ -16,4 +16,24 @@ class TraitMakeCommandTest extends TestCase
             'trait FooTrait',
         ], 'app/FooTrait.php');
     }
+
+    public function testItCanGenerateTraitFileWhenTraitsFolderExists()
+    {
+        $traitsFolderPath = app_path('Traits');
+
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($traitsFolderPath);
+
+        $this->artisan('make:trait', ['name' => 'FooTrait'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Traits;',
+            'trait FooTrait',
+        ], 'app/Traits/FooTrait.php');
+
+        $files->deleteDirectory($traitsFolderPath);
+    }
 }


### PR DESCRIPTION
I've written tests for both commands.
I have written tests to check if the `Traits` or `Concerns` folder exists for creating traits.
I have written tests to check if the `Interfaces` or `Contracts` folder exists for creating interfaces.