### PR TITLE
[11.x] Exclude `laravel_through_key` when replicating model, fixes #51097

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1729,6 +1729,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
             ...$this->uniqueIds(),
+            'laravel_through_key'
         ]));
 
         $attributes = Arr::except(

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1729,7 +1729,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
             ...$this->uniqueIds(),
-            'laravel_through_key'
+            'laravel_through_key',
         ]));
 
         $attributes = Arr::except(

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -366,6 +366,21 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         // $jane should not be updated, because it belongs to a different user altogether.
         $this->assertSame('jane-slug', $jane->fresh()->slug);
     }
+
+    public function testCanReplicateModelLoadedThroughHasManyThrough()
+    {
+        $team = Team::create();
+        $user = User::create(['team_id' => $team->id, 'name' => 'John']);
+        Article::create(['user_id' => $user->id, 'title' => 'John\'s new has-many-through-article']);
+
+        $article = $team->articles()->first();
+
+        $this->assertInstanceOf(Article::class, $article);
+
+        $newArticle = $article->replicate();
+        $newArticle->title .= ' v2';
+        $newArticle->save();
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
Currently, when replicating a model that was loaded via a `HasManyThrough` relation, the `laravel_through_key` stays included in the attributes, meaning it can't be saved unless manually removed. See #51097 for details including a reproducing repository.

This patch fixes that by adding `laravel_through_key` to the columns that are not replicated. I also included a test for it that fails without my patch and passes with my patch. 