### PR TITLE
[11.x] Add decrement method to the rate limiter class

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -144,6 +144,19 @@ class RateLimiter
     }
 
     /**
+     * Decrement the counter for a given key for a given decay time by a given amount.
+     *
+     * @param  string  $key
+     * @param  int  $decaySeconds
+     * @param  int  $amount
+     * @return int
+     */
+    public function decrement($key, $decaySeconds = 60, $amount = 1)
+    {
+        return $this->increment($key, $decaySeconds, $amount * -1);
+    }
+
+    /**
      * Get the number of attempts for the given key.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -9,6 +9,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool tooManyAttempts(string $key, int $maxAttempts)
  * @method static int hit(string $key, int $decaySeconds = 60)
  * @method static int increment(string $key, int $decaySeconds = 60, int $amount = 1)
+ * @method static int decrement(string $key, int $decaySeconds = 60, int $amount = 1)
  * @method static mixed attempts(string $key)
  * @method static mixed resetAttempts(string $key)
  * @method static int remaining(string $key, int $maxAttempts)

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -47,6 +47,17 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->increment('key', 1, 5);
     }
 
+    public function testDecrementProperlyDecrementsAttemptCount()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
+        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(true);
+        $cache->shouldReceive('increment')->once()->with('key', -5)->andReturn(-5);
+        $rateLimiter = new RateLimiter($cache);
+
+        $rateLimiter->decrement('key', 1, 5);
+    }
+
     public function testHitHasNoMemoryLeak()
     {
         $cache = m::mock(Cache::class);


### PR DESCRIPTION
I ran into a scenario with a third party API where I was calling their API on a rate limited job. The job was consumed and therefore reduced the rate limit, but I wanted to catch the exception and decrease the rate limit again. 

I could get around this by calling RateLimiter::increment(...) and passing it a negative value e.g. -1, but thought it would be a nicer DX to have a decrement method available like in other cache classes.

I have followed the approach for how other cache classes achieve this for consistency.

