### PR TITLE
Add support for short syntax

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -26,6 +26,11 @@ trait ConditionallyLoadsAttributes
                 continue;
             }
 
+            if(is_numeric($key) && is_string($value)){
+                $data[$value] = $this->resource->{$value};
+                unset($data[$key]);
+            }
+
             if (is_numeric($key) && $value instanceof MergeValue) {
                 return $this->mergeData(
                     $data, $index, $this->filter($value->data),


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adding short syntax support

Currently we have to write all attibutes one by one even when they match with keys
example.

```php

    /**
     * Transform the resource into an array.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
     */
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'title' => $this->title,
            'body' => $this->body,
            // and so on
        ];
    }

```

So with this PR we can write shortly

```php

    public function toArray($request)
    {
        return [
            'id',
            'title',
            'body',
            // and so on
        ];
    }




```






