### PR TITLE
[11.x] Add `whereEnum` to route constraints

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 
 trait CreatesRegularExpressionRouteConstraints
 {
@@ -71,6 +72,22 @@ trait CreatesRegularExpressionRouteConstraints
     public function whereIn($parameters, array $values)
     {
         return $this->assignExpressionToParameters($parameters, implode('|', $values));
+    }
+
+    /**
+     * Specify that the given route parameters must be one of the enum values.
+     *
+     * @param  array|string  $parameters
+     * @param  class-string<\BackedEnum>  $enum
+     * @return $this
+     */
+    public function whereEnum($parameters, string $enum)
+    {
+        if (! is_subclass_of($enum, \BackedEnum::class)) {
+            throw new InvalidArgumentException("[$enum] must be an instance of [\BackedEnum].");
+        }
+
+        return $this->whereIn($parameters, array_column($enum::cases(), 'value'));
     }
 
     /**


### PR DESCRIPTION
> Extending https://github.com/laravel/framework/pull/46703 with tests and explanation, as suggested in the comment.

Introducing `whereEnum` lets us limit the scope of a route parameter by providing an enum class, rather than listing out all of its values in `whereIn`. I'll give an example:

Before `whereEnum` one would have to do:
```php
Route::get('/posts/{type}')->whereIn('type', [PostType::TypeA->value, PostType::TypeB->value, PostType::TypeC->value]);
Route::get('/posts/{post}');
```

And now it's just:
```php
Route::get('/posts/{type}')->whereEnum('type', PostType::class);
Route::get('/posts/{post}');
```

> [!NOTE]  
> Both of these routes have to co-exist under the same `/posts/` path, thus the need for limiting/constraints.
>
> Btw, do not confuse route constraining with the ability to inject an enum-type parameter in a controller.