### PR TITLE
[11.x] Fix support for other hashing implementations when using `hashed` cast

### DIFF
--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -96,7 +96,7 @@ class HashManager extends Manager implements Hasher
      */
     public function isHashed($value)
     {
-        return password_get_info($value)['algo'] !== null;
+        return $this->driver()->info($value)['algo'] !== null;
     }
 
     /**


### PR DESCRIPTION
On the function `Hash::isHashed()` added on 10.x (#47197) the function `password_get_info()` is hardcoded on the `HashManager` instead of using the driver's `info()` function (which, in all the 1st party drivers is a call to `password_get_info()` on the `AbstractHasher`). This hardcoded method prevents 3rd party drivers to use the `hashed` cast, because the call to `isHashed` will always return `false` when using any algorithm not directly supported by `password_get_info()`.

This was actually commented by @nunomaduro [here](https://github.com/laravel/framework/pull/47029#discussion_r1191148014) but the implementation on #47197 only moved the function call to `password_get_info()` to the `HashManager` instead of leverage the `info()` function from the drivers.

This PR fixes that.

cc @valorin @gdebrauwer in case you have any opinion regarding this.