### PR TITLE
[11.x] Allow for contextual bindings using attributes

### DIFF
--- a/src/Illuminate/Contracts/Container/ContextualAttribute.php
+++ b/src/Illuminate/Contracts/Container/ContextualAttribute.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Container;
+
+interface ContextualAttribute
+{
+}


### PR DESCRIPTION
> [!NOTE] 
> I will update this with tests and some default implementations before marking for review. I've created it as a draft PR in case anyone wishes to feedback.

This PR adds functionality to allow users to register PHP 8 attributes and associated handlers with the container to add in resolving dependencies. All attributes must implement the `Illuminate\Contracts\Container\ContextualAttribute` marker interface. The attributes should be added to parameters, and will trump normal resolution.

The primary use of this sort of functionality would be to have dependency injection work with auth guards, connections, and other things where multiple instances exist with no difference from the perspective of the container.

Let's say for example that you have a platform that uses two guards, and different classes depend on different ones. Currently, the only solution to this is to manually get the guard, or create a contextual binding for each class. Instead, you could achieve it like so.

First, you create the attribute.

```php
#[Attribute(Attribute::TARGET_PARAMETER)]
class AuthGuard implements ContextualAttribute
{
	public function __construct(
		public readonly string $name
	){}
}
```

Then you register it with the container.

```php
Container::getInstance()->whenHas(AuthGuard::class, function (AuthGuard $attribute) {
	return Auth::guard($attribute->name);
});
```

Once this is done, you can use the attribute with dependency injection.

```php
class MyService {
	private Guard $guard;
	
	public function __construct(#[AuthGuard('api')] Guard $guard) {
		$this->guard = $guard;
	}
}

$service = Container::getInstance()->make(MyService::class);
```