### PR TITLE
Revert "[11.x] Adds support for `int` backed enums to implicit `Enum` route binding"

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
-use ReflectionEnum;
 
 class ImplicitRouteBinding
 {
@@ -75,7 +74,6 @@ class ImplicitRouteBinding
      * @return \Illuminate\Routing\Route
      *
      * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
-     * @throws \ReflectionException
      */
     protected static function resolveBackedEnumsForRoute($route, $parameters)
     {
@@ -88,12 +86,7 @@ class ImplicitRouteBinding
 
             $backedEnumClass = $parameter->getType()?->getName();
 
-            $reflectionEnum = new ReflectionEnum($backedEnumClass);
-
-            match ($reflectionEnum->getBackingType()->getName()) {
-                'int' => $backedEnum = collect($backedEnumClass::cases())->first(fn ($case) => (string) $case->value === (string) $parameterValue),
-                'string' => $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue),
-            };
+            $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);
 
             if (is_null($backedEnum)) {
                 throw new BackedEnumCaseNotFoundException($backedEnumClass, $parameterValue);

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -28,7 +28,7 @@ class RouteSignatureParameters
 
         return match (true) {
             ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
-            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithValidBackingType($p)),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
             default => $parameters,
         };
     }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -141,12 +141,12 @@ class Reflector
     }
 
     /**
-     * Determine if the parameter's type is a Backed Enum with a string or int backing type.
+     * Determine if the parameter's type is a Backed Enum with a string backing type.
      *
      * @param  \ReflectionParameter  $parameter
      * @return bool
      */
-    public static function isParameterBackedEnumWithValidBackingType($parameter)
+    public static function isParameterBackedEnumWithStringBackingType($parameter)
     {
         if (! $parameter->getType() instanceof ReflectionNamedType) {
             return false;
@@ -162,7 +162,7 @@ class Reflector
             $reflectionBackedEnum = new ReflectionEnum($backedEnumClass);
 
             return $reflectionBackedEnum->isBacked()
-                && in_array($reflectionBackedEnum->getBackingType()->getName(), ['int', 'string']);
+                && $reflectionBackedEnum->getBackingType()->getName() == 'string';
         }
 
         return false;

--- a/tests/Routing/Enums.php
+++ b/tests/Routing/Enums.php
@@ -13,9 +13,3 @@ enum CategoryBackedEnum: string
     case People = 'people';
     case Fruits = 'fruits';
 }
-
-enum CategoryIntBackedEnum: int
-{
-    case People = 1;
-    case Fruits = 2;
-}

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -31,24 +31,6 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category')->value);
     }
 
-    public function test_it_can_resolve_the_implicit_int_backed_enum_route_bindings_for_the_given_route()
-    {
-        $action = ['uses' => function (CategoryIntBackedEnum $category) {
-            return $category->value;
-        }];
-
-        $route = new Route('GET', '/test', $action);
-        $route->parameters = ['category' => '1'];
-
-        $route->prepareForSerialization();
-
-        $container = Container::getInstance();
-
-        ImplicitRouteBinding::resolveForRoute($container, $route);
-
-        $this->assertSame(1, $route->parameter('category')->value);
-    }
-
     public function test_it_can_resolve_the_implicit_backed_enum_route_bindings_for_the_given_route_with_optional_parameter()
     {
         $action = ['uses' => function (?CategoryBackedEnum $category = null) {
@@ -104,29 +86,6 @@ class ImplicitRouteBindingTest extends TestCase
             'Case [%s] not found on Backed Enum [%s].',
             'cars',
             CategoryBackedEnum::class,
-        ));
-
-        ImplicitRouteBinding::resolveForRoute($container, $route);
-    }
-
-    public function test_implicit_int_backed_enum_internal_exception()
-    {
-        $action = ['uses' => function (CategoryIntBackedEnum $category) {
-            return $category->value;
-        }];
-
-        $route = new Route('GET', '/test', $action);
-        $route->parameters = ['category' => ' 00001.'];
-
-        $route->prepareForSerialization();
-
-        $container = Container::getInstance();
-
-        $this->expectException(BackedEnumCaseNotFoundException::class);
-        $this->expectExceptionMessage(sprintf(
-            'Case [%s] not found on Backed Enum [%s].',
-            ' 00001.',
-            CategoryIntBackedEnum::class,
         ));
 
         ImplicitRouteBinding::resolveForRoute($container, $route);


### PR DESCRIPTION
Reverts laravel/framework#51029