### PR TITLE
[11.x] Change castAttribute visibility to public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -787,7 +787,7 @@ trait HasAttributes
      * @param  mixed  $value
      * @return mixed
      */
-    protected function castAttribute($key, $value)
+    public function castAttribute($key, $value)
     {
         $castType = $this->getCastType($key);
 


### PR DESCRIPTION
Hello!

I need to be able to cast a value for a model attribute without filling the model. To enable this I've created a public `castAttributeValue` method on the model that just delegates to `castAttribute`, but it would be nicer (and I don't see any downsides) if this method was just made public.

Thanks!