### PR TITLE
[11.x] Add support for enums in `whereIn` route constraints

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -71,9 +71,11 @@ trait CreatesRegularExpressionRouteConstraints
      */
     public function whereIn($parameters, array $values)
     {
-        return $this->assignExpressionToParameters($parameters, collect($values)
-            ->map(fn ($value) => $value instanceof BackedEnum ? $value->value : $value)
-            ->implode('|')
+        return $this->assignExpressionToParameters(
+            $parameters, 
+            collect($values)
+                ->map(fn ($value) => $value instanceof BackedEnum ? $value->value : $value)
+                ->implode('|')
         );
     }
 

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -70,7 +70,10 @@ trait CreatesRegularExpressionRouteConstraints
      */
     public function whereIn($parameters, array $values)
     {
-        return $this->assignExpressionToParameters($parameters, implode('|', $values));
+        return $this->assignExpressionToParameters($parameters, collect($values)
+            ->map(fn ($value) => $value instanceof \BackedEnum ? $value->value : $value)
+            ->implode('|')
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use BackedEnum;
 use Illuminate\Support\Arr;
 
 trait CreatesRegularExpressionRouteConstraints
@@ -71,7 +72,7 @@ trait CreatesRegularExpressionRouteConstraints
     public function whereIn($parameters, array $values)
     {
         return $this->assignExpressionToParameters($parameters, collect($values)
-            ->map(fn ($value) => $value instanceof \BackedEnum ? $value->value : $value)
+            ->map(fn ($value) => $value instanceof BackedEnum ? $value->value : $value)
             ->implode('|')
         );
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -12,6 +12,8 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Stringable;
 
+include_once 'Enums.php';
+
 class RouteRegistrarTest extends TestCase
 {
     /**
@@ -939,6 +941,19 @@ class RouteRegistrarTest extends TestCase
         /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
             $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereInEnumRegistration()
+    {
+        $this->router->get('/posts/{category}')->whereIn('category', CategoryBackedEnum::cases());
+
+        $invalidRequest = Request::create('/posts/invalid-value', 'GET');
+        $this->assertFalse($this->getRoute()->matches($invalidRequest));
+
+        foreach (CategoryBackedEnum::cases() as $case) {
+            $request = Request::create('/posts/'.$case->value, 'GET');
+            $this->assertTrue($this->getRoute()->matches($request));
         }
     }
 


### PR DESCRIPTION
Currently, passing an array of enum cases results in an exception:

```php
Route::get('/posts/{type}')->whereIn('type', PostType::cases());

// Error: Object of class Illuminate\Tests\Routing\CategoryBackedEnum could not be converted to string
```

This change fixes it, allowing us to pass array of enums into `whereIn`.

Probably interchangeable with https://github.com/laravel/framework/pull/51104