### PR TITLE
Clarify that \Illuminate\Http\Request::replace replace all input values

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -368,7 +368,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Replace the input for the current request.
+     * Replace the input values for the current request.
      *
      * @param  array  $input
      * @return $this


### PR DESCRIPTION
By adding "values" it clarify that this method replaces the current input values by a new set.
Otherwise it can be understood as a way to replace one value on the request.

Here's `\Symfony\Component\HttpFoundation\InputBag::replace` description: 
> Replaces the current input values by a new set.
