### PR TITLE
[11.x] Add environmentSchedule method to the Scheduling Event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -704,6 +704,21 @@ class Event
     }
 
     /**
+     * Register a callback to further filter the schedule based on the environment
+     *
+     * @param  \Closure|bool  $callback
+     * @return $this
+     */
+    public function environmentSchedule($callback)
+    {
+        // Retrieve the current application environment
+        $environment = config('app.env');
+
+        // Execute the closure with the schedule instance and environment
+        return $callback($this, $environment);
+    }
+
+    /**
      * State that the command should run even in maintenance mode.
      *
      * @return $this


### PR DESCRIPTION
This PR introduces the ability to set different schedules for a job based on the environment.

Scenario:
You have a site in production and a dev site where you are making calls to a 3rd-party provider. This provider may have API quotas for how often it can be hit so you set different schedules for production and staging.

Current Solution:
Currently, you can use the `->environments()` method to specify which environment to run it in. This works great but also leads to duplicate code.

```php
$schedule->job(ProcessInvoices::class)
    ->name('process_invoices')
    ->onOneServer()
    ->runInBackground()
    ->environments(['production'])
    ->daily();

$schedule->job(ProcessInvoices::class)
    ->name('process_invoices')
    ->onOneServer()
    ->runInBackground()
    ->environments(['staging', 'development'])
    ->weekly();
```

The Solution:
I'd like to introduce the `environmentSchedule` method to simplify the scheduling

```php
$schedule->job(ProcessInvoices::class)
    ->name('process_invoices')
    ->onOneServer()
    ->runInBackground()
    ->environmentSchedule(function(Event $schedule, string $environment) {
        return match($environment) {
            'production' => $schedule->daily(),
            default => $schedule->weekly(),
        };
    });
```

This reduces code duplication by simply accounting for both schedules in the same definition. I am passing in the current environment to the callback but users could use whatever they like.
