### PR TITLE
[11.x] Add some tests to `ValidationValidatorTest.php`

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -285,7 +285,7 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => ''], ['x' => 'size:10|array|integer|min:5']);
         $this->assertTrue($v->passes());
-        
+
         $v = new Validator($trans, ['x' => ''], ['x' => 'array']);
         $this->assertTrue($v->passes());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -285,18 +285,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => ''], ['x' => 'size:10|array|integer|min:5']);
         $this->assertTrue($v->passes());
-
-        // Test validation with empty string for array
+        
         $v = new Validator($trans, ['x' => ''], ['x' => 'array']);
-        $this->assertTrue($v->passes(), 'Validation should pass for empty string with "array" rule.');
+        $this->assertTrue($v->passes());
 
-        // Test validation with empty string for integer
         $v = new Validator($trans, ['x' => ''], ['x' => 'integer']);
-        $this->assertTrue($v->passes(), 'Validation should pass for empty string with "integer" rule.');
+        $this->assertTrue($v->passes());
 
-        // Test validation with empty string for min
         $v = new Validator($trans, ['x' => ''], ['x' => 'min:5']);
-        $this->assertTrue($v->passes(), 'Validation should pass for empty string with "min" rule.');
+        $this->assertTrue($v->passes());
     }
 
     public function testEmptyExistingAttributesAreValidated()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -209,9 +209,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(['foo' => ['Same' => ['baz']]], $v->failed());
 
-        $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz', 'baz' => 'Required']);
-        $this->assertFalse($v->passes());
-        $this->assertEquals(['foo' => ['Same' => ['baz']], 'baz' => ['Required' => []]], $v->failed());
+        $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'bar'], ['foo' => 'Same:baz', 'baz' => 'Required']);
+        $this->assertTrue($v->passes());
+        $this->assertEmpty($v->failed());
     }
 
     public function testFailingOnce()


### PR DESCRIPTION
This PR, improved test coverage in the `ValidationValidatorTest.php` class.

**Changes:**
- Added tests to the `testValidatedDoesntThrowOnPass` method to cover scenarios with empty rules and multiple rules.
  ```php
  // Test with empty rules
  $v = new Validator($trans, [], []);
  $this->assertSame([], $v->validated());
  
  // Test with multiple rules
  $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'qux'], ['foo' => 'required', 'baz' => 'required']);
  $this->assertSame(['foo' => 'bar', 'baz' => 'qux'], $v->validated());
  ```

- Added tests to the `testHasFailedValidationRules()` method to cover scenarios with multiple rules.
  ```php
  // Test with multiple rules
  $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'bar'], ['foo' => 'Same:baz', 'baz' => 'Required']);
  $this->assertTrue($v->passes());
  $this->assertEmpty($v->failed());
  ```

- Added additional tests to the `testValidateEmptyStringsAlwaysPasses` method to cover various validation scenarios with empty strings.
  ```php
  // Test validation with empty string for array
  $v = new Validator($trans, ['x' => ''], ['x' => 'array']);
  $this->assertTrue($v->passes());

  // Test validation with empty string for integer
  $v = new Validator($trans, ['x' => ''], ['x' => 'integer']);
  $this->assertTrue($v->passes());

  // Test validation with empty string for min
  $v = new Validator($trans, ['x' => ''], ['x' => 'min:5']);
  $this->assertTrue($v->passes());
  ```

Thanks!