### PR TITLE
[11.x] Allow parallel testing for multiple connections

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -27,13 +27,13 @@ trait TestDatabases
     protected function bootTestDatabase()
     {
         ParallelTesting::setUpProcess(function () {
-            $this->whenNotUsingInMemoryDatabase(function ($database) {
+            $this->whenNotUsingInMemoryDatabase(function ($database, $connection) {
                 if (ParallelTesting::option('recreate_databases')) {
-                    Schema::dropDatabaseIfExists(
+                    Schema::connection($connection)->dropDatabaseIfExists(
                         $this->testDatabase($database)
                     );
                 }
-            });
+            }, $this->getConnections());
         });
 
         ParallelTesting::setUpTestCase(function ($testCase) {
@@ -47,30 +47,40 @@ trait TestDatabases
             ];
 
             if (Arr::hasAny($uses, $databaseTraits) && ! ParallelTesting::option('without_databases')) {
-                $this->whenNotUsingInMemoryDatabase(function ($database) use ($uses) {
-                    [$testDatabase, $created] = $this->ensureTestDatabaseExists($database);
 
-                    $this->switchToDatabase($testDatabase);
+                $testDatabases = $this->whenNotUsingInMemoryDatabase(function ($database, $connection) {
+                    [$testDatabase, $created] = $this->ensureTestDatabaseExists($database, $connection);
 
+                    $this->switchToDatabase($testDatabase, $connection);
+
+                    return [$testDatabase, $created];
+                }, $this->getConnections());
+
+                if ($testDatabases->count()) {
                     if (isset($uses[Testing\DatabaseTransactions::class])) {
                         $this->ensureSchemaIsUpToDate();
                     }
+                }
+
+                $testDatabases->each(function($params) {
+                    [$testDatabase, $created] = $params;
 
                     if ($created) {
                         ParallelTesting::callSetUpTestDatabaseCallbacks($testDatabase);
                     }
+
                 });
             }
         });
 
         ParallelTesting::tearDownProcess(function () {
-            $this->whenNotUsingInMemoryDatabase(function ($database) {
+            $this->whenNotUsingInMemoryDatabase(function ($database, $connection) {
                 if (ParallelTesting::option('drop_databases')) {
-                    Schema::dropDatabaseIfExists(
+                    Schema::connection($connection)->dropDatabaseIfExists(
                         $this->testDatabase($database)
                     );
                 }
-            });
+            }, $this->getConnections());
         });
     }
 
@@ -80,18 +90,18 @@ trait TestDatabases
      * @param  string  $database
      * @return array
      */
-    protected function ensureTestDatabaseExists($database)
+    protected function ensureTestDatabaseExists($database, $connection)
     {
         $testDatabase = $this->testDatabase($database);
 
         try {
-            $this->usingDatabase($testDatabase, function () {
-                Schema::hasTable('dummy');
+            $this->usingDatabase($testDatabase, $connection, function () use ($connection) {
+                Schema::connection($connection)->hasTable('dummy');
             });
         } catch (QueryException) {
-            $this->usingDatabase($database, function () use ($testDatabase) {
-                Schema::dropDatabaseIfExists($testDatabase);
-                Schema::createDatabase($testDatabase);
+            $this->usingDatabase($database, $connection, function () use ($testDatabase, $connection) {
+                Schema::connection($connection)->dropDatabaseIfExists($testDatabase);
+                Schema::connection($connection)->createDatabase($testDatabase);
             });
 
             return [$testDatabase, true];
@@ -118,18 +128,19 @@ trait TestDatabases
      * Runs the given callable using the given database.
      *
      * @param  string  $database
+     * @param string $connection
      * @param  callable  $callable
      * @return void
      */
-    protected function usingDatabase($database, $callable)
+    protected function usingDatabase($database, $connection, $callable)
     {
-        $original = DB::getConfig('database');
+        $original = DB::connection($connection)->getConfig('database');
 
         try {
-            $this->switchToDatabase($database);
+            $this->switchToDatabase($database, $connection);
             $callable();
         } finally {
-            $this->switchToDatabase($original);
+            $this->switchToDatabase($original, $connection);
         }
     }
 
@@ -137,43 +148,47 @@ trait TestDatabases
      * Apply the given callback when tests are not using in memory database.
      *
      * @param  callable  $callback
-     * @return void
+     * @param array $connections
+     * @return Collection
      */
-    protected function whenNotUsingInMemoryDatabase($callback)
+    protected function whenNotUsingInMemoryDatabase($callback, $connections)
     {
         if (ParallelTesting::option('without_databases')) {
             return;
         }
 
-        $database = DB::getConfig('database');
+        return collect($connections)
+            ->map(function ($connection) use ($callback) {
+                $database = DB::connection($connection)->getConfig('database');
 
-        if ($database !== ':memory:') {
-            $callback($database);
-        }
+                if ($database !== ':memory:') {
+                    return $callback($database, $connection);
+                }
+            })
+            ->filter();
     }
 
     /**
      * Switch to the given database.
      *
      * @param  string  $database
+     * @param string $connection
      * @return void
      */
-    protected function switchToDatabase($database)
+    protected function switchToDatabase($database, $connection)
     {
-        DB::purge();
+        DB::purge($connection);
 
-        $default = config('database.default');
-
-        $url = config("database.connections.{$default}.url");
+        $url = config("database.connections.{$connection}.url");
 
         if ($url) {
             config()->set(
-                "database.connections.{$default}.url",
+                "database.connections.{$connection}.url",
                 preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url),
             );
         } else {
             config()->set(
-                "database.connections.{$default}.database",
+                "database.connections.{$connection}.database",
                 $database,
             );
         }
@@ -189,5 +204,15 @@ trait TestDatabases
         $token = ParallelTesting::token();
 
         return "{$database}_test_{$token}";
+    }
+
+    /**
+     * Returns the database connections to be used.
+     *
+     * @return array
+     */
+    protected function getConnections(): array
+    {
+        return ParallelTesting::option('connections') ?: [DB::getDefaultConnection()];
     }
 }

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -20,12 +20,7 @@ class TestDatabasesTest extends TestCase
         Container::setInstance($container = new Container);
 
         $container->singleton('config', function () {
-            return m::mock(Config::class)
-                ->shouldReceive('get')
-                ->once()
-                ->with('database.default', null)
-                ->andReturn('mysql')
-                ->getMock();
+            return m::mock(Config::class);
         });
 
         $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
@@ -33,7 +28,7 @@ class TestDatabasesTest extends TestCase
 
     public function testSwitchToDatabaseWithoutUrl()
     {
-        DB::shouldReceive('purge')->once();
+        DB::shouldReceive('purge')->with('mysql')->once();
 
         config()->shouldReceive('get')
             ->once()
@@ -44,13 +39,15 @@ class TestDatabasesTest extends TestCase
             ->once()
             ->with('database.connections.mysql.database', 'my_database_test_1');
 
-        $this->switchToDatabase('my_database_test_1');
+        $this->switchToDatabase('my_database_test_1', 'mysql');
     }
 
     #[DataProvider('databaseUrls')]
     public function testSwitchToDatabaseWithUrl($testDatabase, $url, $testUrl)
     {
-        DB::shouldReceive('purge')->once();
+        DB::shouldReceive('purge')
+            ->with('mysql')
+            ->once();
 
         config()->shouldReceive('get')
             ->once()
@@ -61,10 +58,10 @@ class TestDatabasesTest extends TestCase
             ->once()
             ->with('database.connections.mysql.url', $testUrl);
 
-        $this->switchToDatabase($testDatabase);
+        $this->switchToDatabase($testDatabase, 'mysql');
     }
 
-    public function switchToDatabase($database)
+    public function switchToDatabase($database, $connection)
     {
         $instance = new class
         {
@@ -72,7 +69,7 @@ class TestDatabasesTest extends TestCase
         };
 
         $method = new ReflectionMethod($instance, 'switchToDatabase');
-        $method->invoke($instance, $database);
+        $method->invoke($instance, $database, $connection);
     }
 
     public static function databaseUrls()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add support for parallel testing with multiple connections.

Framework users can override the options resolver to return the connections they intend to test on:

```php
ParallelTesting::resolveOptionsUsing(function ($option) {
    if ($option === 'connections') {
        return [ 'mysql', 'pgsql' ];
    }

    $option = 'LARAVEL_PARALLEL_TESTING_'.Str::upper($option);

    return $_SERVER[$option] ?? false;
});
```