### PR TITLE
[11.x] Verified & Unverified, Blade Directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -73,6 +73,29 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the unverified statements into valid PHP.
+     *
+     * @param  string|null  $guard
+     * @return string
+     */
+    protected function compileUnverified($guard = null)
+    {
+        $guard = is_null($guard) ? '()' : $guard;
+
+        return "<?php if(!auth()->guard{$guard}->user()->hasVerifiedEmail()): ?>";
+    }
+
+    /**
+     * Compile the end-unverified statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndUnverified()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the env statements into valid PHP.
      *
      * @param  string  $environments

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -50,6 +50,29 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the verified statements into valid PHP.
+     *
+     * @param  string|null  $guard
+     * @return string
+     */
+    protected function compileVerified($guard = null)
+    {
+        $guard = is_null($guard) ? '()' : $guard;
+
+        return "<?php if(auth()->guard{$guard}->user()->hasVerifiedEmail()): ?>";
+    }
+
+    /**
+     * Compile the end-verified statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndVerified()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the env statements into valid PHP.
      *
      * @param  string  $environments

--- a/tests/View/Blade/BladeVerifiedStatementsTest.php
+++ b/tests/View/Blade/BladeVerifiedStatementsTest.php
@@ -16,4 +16,17 @@ class BladeVerifiedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testBladeUnverifiedAreCompiled()
+    {
+        $string = '@unverified
+        Foo bar baz
+@endunverified';
+
+        $expected = '<?php if(!auth()->guard()->user()->hasVerifiedEmail()): ?>
+        Foo bar baz
+<?php endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeVerifiedStatementsTest.php
+++ b/tests/View/Blade/BladeVerifiedStatementsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeVerifiedStatementsTest extends AbstractBladeTestCase
+{
+    public function testBladeVerifiedAreCompiled()
+    {
+        $string = '@verified
+        Foo bar baz
+@endverified';
+
+        $expected = '<?php if(auth()->guard()->user()->hasVerifiedEmail()): ?>
+        Foo bar baz
+<?php endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR introduces two new Blade directives that aim to check the email status of the authenticated user:

The `verified` directive:

```blade
@verified
    Your email address is already verified, thank you!
@endverified
```

The `unverified` directive:

```blade
@unverified
    Your email address is not verified. Click here to receive a new email to confirm your email address.
@endunverified
```

Both of them act related to `hasVerifiedEmail` method of the `MustVerifyEmail` interface.