### PR TITLE
Update RuntimeException message when no data has been found

### DIFF
--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -70,6 +70,6 @@ class BroadcastChannel
             return $notification->toArray($notifiable);
         }
 
-        throw new RuntimeException('Notification is missing toArray method.');
+        throw new RuntimeException('Notification is missing toBroadcast / toArray method.');
     }
 }


### PR DESCRIPTION
I discovered an inconsistency in the `getData` method of the `Illuminate\Notifications\Channels\BroadcastChannel`. 
When both the `toBroadcast` and `toArray` doesn't exists it only shows the `Notification is missing toArray method.` while it shows `Notification is missing toDatabase / toArray method.` in the `getData` of the `Illuminate\Notifications\Channels\DatabaseChannel`. 

I've update this line to be more consistent in the exception message of both classes.