### PR TITLE
[11.x] Memoize requiring of view files to improve loop performance

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -18,6 +18,8 @@ class Filesystem
 {
     use Conditionable, Macroable;
 
+    private array $cachedCallables = [];
+
     /**
      * Determine if a file or directory exists.
      *
@@ -100,6 +102,31 @@ class Filesystem
         }
 
         return $contents;
+    }
+
+    /**
+     * Get the returned callable of a file.
+     *
+     * @param  string  $path
+     * @param  array  $data
+     * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function getRequireCallable($path, array $data = [])
+    {
+        if ($this->isFile($path)) {
+            $__path = $path;
+            $__data = $data;
+
+            if (! isset($this->cachedCallables[$__path])) {
+                $this->cachedCallables[$__path] = require_once $__path;
+            }
+
+            return $this->cachedCallables[$__path]($__data);
+        }
+
+        throw new FileNotFoundException("File does not exist at path {$path}.");
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -120,7 +120,11 @@ class Filesystem
             $__data = $data;
 
             if (! isset($this->cachedCallables[$__path])) {
-                $this->cachedCallables[$__path] = require_once $__path;
+                $code = file_get_contents($__path);
+                $this->cachedCallables[$__path] = function ($data) use ($code) {
+                    extract($data, EXTR_SKIP);
+                    return eval("?>" . $code);
+                };
             }
 
             return $this->cachedCallables[$__path]($__data);

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -115,19 +115,18 @@ class Filesystem
      */
     public function getRequireCallable($path, array $data = [])
     {
+        if (isset($this->cachedCallables[$path])) {
+            return $this->cachedCallables[$path]($data);
+        }
+
         if ($this->isFile($path)) {
-            $__path = $path;
-            $__data = $data;
+            $code = file_get_contents($path);
+            $this->cachedCallables[$path] = function ($data) use ($code) {
+                extract($data, EXTR_SKIP);
+                return eval("?>" . $code);
+            };
 
-            if (! isset($this->cachedCallables[$__path])) {
-                $code = file_get_contents($__path);
-                $this->cachedCallables[$__path] = function ($data) use ($code) {
-                    extract($data, EXTR_SKIP);
-                    return eval("?>" . $code);
-                };
-            }
-
-            return $this->cachedCallables[$__path]($__data);
+            return $this->cachedCallables[$path]($data);
         }
 
         throw new FileNotFoundException("File does not exist at path {$path}.");

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -123,7 +123,8 @@ class Filesystem
             $code = file_get_contents($path);
             $this->cachedCallables[$path] = function ($data) use ($code) {
                 extract($data, EXTR_SKIP);
-                return eval("?>" . $code);
+
+                return eval('?>'.$code);
             };
 
             return $this->cachedCallables[$path]($data);

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -8,6 +8,7 @@ namespace Illuminate\Support\Facades;
  * @method static string get(string $path, bool $lock = false)
  * @method static array json(string $path, int $flags = 0, bool $lock = false)
  * @method static string sharedGet(string $path)
+ * @method static mixed getRequireCallable(string $path, array $data = [])
  * @method static mixed getRequire(string $path, array $data = [])
  * @method static mixed requireOnce(string $path, array $data = [])
  * @method static \Illuminate\Support\LazyCollection lines(string $path)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -183,6 +183,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
         if (! is_null($this->cachePath)) {
             $contents = $this->compileString($this->files->get($this->getPath()));
 
+            $contents = implode("\n", [
+                '<?php return function ($data) { extract($data, EXTR_SKIP); ?>',
+                $contents,
+                '<?php } ?>',
+            ]);
+
             if (! empty($this->getPath())) {
                 $contents = $this->appendFilePath($contents);
             }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -183,12 +183,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
         if (! is_null($this->cachePath)) {
             $contents = $this->compileString($this->files->get($this->getPath()));
 
-            $contents = implode("\n", [
-                '<?php return function ($data) { extract($data, EXTR_SKIP); ?>',
-                $contents,
-                '<?php } ?>',
-            ]);
-
             if (! empty($this->getPath())) {
                 $contents = $this->appendFilePath($contents);
             }

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -55,7 +55,7 @@ class PhpEngine implements Engine
         // flush out any stray output that might get out before an error occurs or
         // an exception is thrown. This prevents any partial views from leaking.
         try {
-            $this->files->getRequire($path, $data);
+            $this->files->getRequireCallable($path, $data);
         } catch (Throwable $e) {
             $this->handleViewException($e, $obLevel);
         }


### PR DESCRIPTION
Spent some time on this as a result of Taylor's tweet: https://twitter.com/taylorotwell/status/1781039378376146970

This reduces the main overhead of `require` calls when looping over 1000 components by storing the code, and running it through `eval`.

This seems to be something that Twig does as well when I was researching how *evil* calling eval in this case is https://github.com/twigphp/Twig/blob/12625c0c050db5a71d94ab8d599bf711673a41c3/src/Environment.php#L384 though I'm not that familiar with Twig.

This lowers the rendering in a testcase for me from 25ms to 11ms, though I'm not sure we'd want to use `eval`

Thanks to @mpociot mentioning it, it also skips an extra `file_exists` check.

