### PR TITLE
[11.x] Fix db:show's --counts option

### DIFF
--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -78,7 +78,7 @@ class ShowCommand extends DatabaseInspectionCommand
             'table' => $table['name'],
             'schema' => $table['schema'],
             'size' => $table['size'],
-            'rows' => $this->option('counts') ? $connection->table($table->getName())->count() : null,
+            'rows' => $this->option('counts') ? $connection->table($table['name'])->count() : null,
             'engine' => $table['engine'],
             'collation' => $table['collation'],
             'comment' => $table['comment'],


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I found a bug of db:show's `--counts` option, I believe it occurs in any new laravel apps

```console
➜  laravel-cms git:(main) artisan db:show --counts

   Error

  Call to a member function getName() on array

  at vendor/laravel/framework/src/Illuminate/Database/Console/ShowCommand.php:82
     78▕             '_' => ray($table),
     79▕             'table' => $table['name'],
     80▕             'schema' => $table['schema'],
     81▕             'size' => $table['size'],
  ➜  82▕             'rows' => $this->option('counts') ? $connection->table($table->getName())->count() : null,
     83▕             'engine' => $table['engine'],
     84▕             'collation' => $table['collation'],
     85▕             'comment' => $table['comment'],
     86▕         ]);

  1   [internal]:0
      Illuminate\Database\Console\ShowCommand::Illuminate\Database\Console\{closure}()
      +17 vendor frames

  19  artisan:13
      Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))
```

with the fix, now the command works fine

```
➜  laravel-cms git:(main) artisan db:show --counts

  SQLite ............................................................................................... 3.43.2
  Database ........................................................................... database/database.sqlite
  Host ........................................................................................................
  Port ........................................................................................................
  Username ....................................................................................................
  URL .........................................................................................................
  Open Connections ............................................................................................
  Tables ................................................................................................... 19

  Table ........................................................................................... Size / Rows
  banner_categories ..................................................................................... — / 5
  banners .............................................................................................. — / 10
  cache ................................................................................................. — / 1
  cache_locks ........................................................................................... — / 0
  failed_jobs ........................................................................................... — / 0
  job_batches ........................................................................................... — / 0
  jobs .................................................................................................. — / 0
  menu_categories ....................................................................................... — / 3
  menus ................................................................................................ — / 15
  messages ............................................................................................. — / 50
  migrations ........................................................................................... — / 14
  pages ................................................................................................ — / 10
  password_reset_tokens ................................................................................. — / 0
  personal_access_tokens ................................................................................ — / 0
  product_categories ................................................................................... — / 10
  products ............................................................................................. — / 50
  sessions .............................................................................................. — / 1
  settings .............................................................................................. — / 1
  users ................................................................................................ — / 5
```
