### PR TITLE
[11.x] Add in-memory cache support to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -181,7 +181,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         if (! is_null($this->cachePath)) {
-            $contents = $this->compileString($this->files->get($this->getPath()));
+            $contents =  $this->wrapInCallback(
+                $this->compileString($this->files->get($this->getPath()))
+            );
 
             if (! empty($this->getPath())) {
                 $contents = $this->appendFilePath($contents);
@@ -193,6 +195,23 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
             $this->files->put($compiledPath, $contents);
         }
+    }
+
+    /**
+     * Wrap the compiled string by a function.
+     *
+     * @param  string  $contents
+     * @return string
+     */
+    protected function wrapInCallback($contents)
+    {
+        $tokens = $this->getOpenAndClosingPhpTokens($contents);
+
+        if ($tokens->isNotEmpty() && $tokens->last() !== T_CLOSE_TAG) {
+            $contents .= ' ?>';
+        }
+
+        return "<?php return function (\$__laravel_data) { extract(\$__laravel_data, EXTR_SKIP); ?>$contents<?php } ?>";
     }
 
     /**

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -55,7 +55,11 @@ class PhpEngine implements Engine
         // flush out any stray output that might get out before an error occurs or
         // an exception is thrown. This prevents any partial views from leaking.
         try {
-            $this->files->getRequire($path, $data);
+            $requiredView = $this->files->getRequire($path, $data, fn ($require) => is_callable($require));
+
+            if (is_callable($requiredView)) {
+                $requiredView($data);
+            }
         } catch (Throwable $e) {
             $this->handleViewException($e, $obLevel);
         }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -344,6 +344,17 @@ class FilesystemTest extends TestCase
         $files->getRequire(self::$tempDir.'/file.php');
     }
 
+    public function testGetRequireCachedReturnsProperly()
+    {
+        file_put_contents(self::$tempDir.'/file.php', '<?php return "Howdy?"; ?>');
+        $files = new Filesystem;
+        $files->getRequire(self::$tempDir.'/file.php', cache: true);
+        file_put_contents(self::$tempDir.'/file.php', '<?php return "Hey!"; ?>');
+
+        $this->assertSame('Hey!', $files->getRequire(self::$tempDir.'/file.php'));
+        $this->assertSame('Howdy?', $files->getRequire(self::$tempDir.'/file.php', cache: true));
+    }
+
     public function testJsonReturnsDecodedJsonData()
     {
         file_put_contents(self::$tempDir.'/file.json', '{"foo": "bar"}');

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -66,7 +66,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?><?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
     }
 
@@ -76,7 +76,7 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(false);
         $files->shouldReceive('makeDirectory')->once()->with(__DIR__, 0777, true, true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?><?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
     }
 
@@ -85,7 +85,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?><?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
         $this->assertSame('foo', $compiler->getPath());
     }
@@ -102,7 +102,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?><?php /**PATH foo ENDPATH**/ ?>');
         // set path before compilation
         $compiler->setPath('foo');
         // trigger compilation with $path
@@ -145,39 +145,39 @@ class ViewBladeCompilerTest extends TestCase
         return [
             'No PHP blocks' => [
                 'Hello World',
-                'Hello World<?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Single PHP block without closing ?>' => [
                 '<?php echo $path',
-                '<?php echo $path ?><?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?><?php echo $path ?><?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Ending PHP block.' => [
                 'Hello world<?php echo $path ?>',
-                'Hello world<?php echo $path ?><?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello world<?php echo $path ?><?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Ending PHP block without closing ?>' => [
                 'Hello world<?php echo $path',
-                'Hello world<?php echo $path ?><?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello world<?php echo $path ?><?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'PHP block between content.' => [
                 'Hello world<?php echo $path ?>Hi There',
-                'Hello world<?php echo $path ?>Hi There<?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello world<?php echo $path ?>Hi There<?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Multiple PHP blocks.' => [
                 'Hello world<?php echo $path ?>Hi There<?php echo $path ?>Hello Again',
-                'Hello world<?php echo $path ?>Hi There<?php echo $path ?>Hello Again<?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello world<?php echo $path ?>Hi There<?php echo $path ?>Hello Again<?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Multiple PHP blocks without closing ?>' => [
                 'Hello world<?php echo $path ?>Hi There<?php echo $path',
-                'Hello world<?php echo $path ?>Hi There<?php echo $path ?><?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello world<?php echo $path ?>Hi There<?php echo $path ?><?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Short open echo tag' => [
                 'Hello world<?= echo $path',
-                'Hello world<?= echo $path ?><?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello world<?= echo $path ?><?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
             'Echo XML declaration' => [
                 '<?php echo \'<?xml version="1.0" encoding="UTF-8"?>\';',
-                '<?php echo \'<?xml version="1.0" encoding="UTF-8"?>\'; ?><?php /**PATH foo ENDPATH**/ ?>',
+                '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?><?php echo \'<?xml version="1.0" encoding="UTF-8"?>\'; ?><?php } ?><?php /**PATH foo ENDPATH**/ ?>',
             ],
         ];
     }
@@ -187,7 +187,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?>');
         $compiler->setPath('');
         $compiler->compile();
     }
@@ -197,7 +197,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with(null)->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', '<?php return function ($__laravel_data) { extract($__laravel_data, EXTR_SKIP); ?>Hello World<?php } ?>');
         $compiler->setPath(null);
         $compiler->compile();
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -94,19 +94,19 @@ class ViewCompilerEngineTest extends TestCase
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andReturn('compiled-content');
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andThrow(new FileNotFoundException(
                 "File does not exist at path {$path}."
             ));
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andReturn('compiled-content');
 
         $engine->getCompiler()
@@ -139,19 +139,19 @@ class ViewCompilerEngineTest extends TestCase
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andReturn('compiled-content');
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andThrow(new ErrorException(
                 "require({$path}): Failed to open stream: No such file or directory",
             ));
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andReturn('compiled-content');
 
         $engine->getCompiler()
@@ -184,19 +184,19 @@ class ViewCompilerEngineTest extends TestCase
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andReturn('compiled-content');
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andThrow(new FileNotFoundException(
                 "File does not exist at path {$path}."
             ));
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andThrow(new FileNotFoundException(
                 "File does not exist at path {$path}."
             ));
@@ -234,7 +234,7 @@ class ViewCompilerEngineTest extends TestCase
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andThrow(new Exception(
                 'Just an regular error...'
             ));
@@ -269,7 +269,7 @@ class ViewCompilerEngineTest extends TestCase
 
         $files->shouldReceive('getRequire')
             ->once()
-            ->with($compiled, [])
+            ->with($compiled, [], m::on(fn ($c) => $c(1) == false && $c(fn() => 'test') == true))
             ->andThrow(new FileNotFoundException(
                 "File does not exist at path {$path}."
             ));


### PR DESCRIPTION
I working on a [Filament ](https://github.com/filamentphp/filament) based project and experiencing slow performance on pages including tables, and realized the issue is that Filament uses lots of components to render resources.
I have seen Taylor's recent tweet about the Blade component's performance and tried to optimize it by converting Blade compiled codes to returning functions and caching it inside memory instead of reading the component from disk on each render.

I tried to keep PHP engine working on non-callback returns to prevent any breaking changes while rendering old compiled views.

Performance results:
![image](https://github.com/laravel/framework/assets/16279288/940b42b7-d54d-4c6a-90eb-32842d79e70c)
![image](https://github.com/laravel/framework/assets/16279288/5c2ecfb8-983c-436b-8c91-954218ced846)
