### PR TITLE
[10.x] Address Null Parameter Deprecations in UrlGenerator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -567,7 +567,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function extractQueryString($path)
     {
-        if (($queryPosition = strpos($path ?? '', '?')) !== false) {
+        if (($queryPosition = strpos($path, '?')) !== false) {
             return [
                 substr($path, 0, $queryPosition),
                 substr($path, $queryPosition),
@@ -630,7 +630,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
-        if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path ?? '')) {
+        if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -567,7 +567,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function extractQueryString($path)
     {
-        if (($queryPosition = strpos($path, '?')) !== false) {
+        if (($queryPosition = strpos($path ?? '', '?')) !== false) {
             return [
                 substr($path, 0, $queryPosition),
                 substr($path, $queryPosition),
@@ -630,7 +630,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
-        if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
+        if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path ?? '')) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -310,7 +310,7 @@ class TestResponse implements ArrayAccess
     public function assertLocation($uri)
     {
         PHPUnit::assertEquals(
-            app('url')->to($uri), app('url')->to($this->headers->get('Location'))
+            app('url')->to($uri), app('url')->to($this->headers->get('Location', ''))
         );
 
         return $this;
@@ -324,7 +324,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertDownload($filename = null)
     {
-        $contentDisposition = explode(';', $this->headers->get('content-disposition'));
+        $contentDisposition = explode(';', $this->headers->get('content-disposition', ''));
 
         if (trim($contentDisposition[0]) !== 'attachment') {
             PHPUnit::fail(


### PR DESCRIPTION
UrlGenerator can currently receive a null value for `$path` in `isValidUrl` and `extractQueryString` which leads to null being passed to `preg_match` and `strpos` respectively which is deprecated.

Resolves #51147