### PR TITLE
[11.x] Add type-hint to MultipleInstanceManager class

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -3,16 +3,16 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
 use RuntimeException;
-use Illuminate\Contracts\Foundation\Application;
 
 abstract class MultipleInstanceManager
 {
     /**
      * The application instance.
      *
-     * @var Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -5,13 +5,14 @@ namespace Illuminate\Support;
 use Closure;
 use InvalidArgumentException;
 use RuntimeException;
+use Illuminate\Contracts\Foundation\Application;
 
 abstract class MultipleInstanceManager
 {
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var Application
      */
     protected $app;
 
@@ -35,7 +36,7 @@ abstract class MultipleInstanceManager
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
+    public function __construct(Application $app)
     {
         $this->app = $app;
     }


### PR DESCRIPTION
The `Illuminate\Contracts\Foundation\Application` was not type-hinted in constructor of `MultipleInstanceManager.php` so container was not able to resolve this dependancy if not passed explicitly. It was resulting in following error

```
Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Support\MultipleInstanceManager
```

This PR aims to fix that issue.