### PR TITLE
[11.x] Add component view instance caching

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -125,7 +125,7 @@ trait ManagesComponents
                         $this->componentViews[$view][$componentViewDepth] = $this->make($view);
                     }
 
-                    return $this->componentViews[$view][$componentViewDepth]->with($data)->render();
+                    return (clone $this->componentViews[$view][$componentViewDepth])->with($data)->render();
                 } finally {
                     $this->componentViewsDepths[$view]--;
                 }

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -245,5 +245,7 @@ trait ManagesComponents
         $this->componentStack = [];
         $this->componentData = [];
         $this->currentComponentData = [];
+        $this->componentViews = [];
+        $this->componentViewsDepths = [];
     }
 }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -149,6 +149,43 @@ class BladeTest extends TestCase
 <div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
+    public function test_reuse_component_views_data()
+    {
+        $content = Blade::render('
+            <x-isset-check param1="1" />
+            <x-isset-check param1="2" param2="Hello" />
+            <x-isset-check param1="3" />
+        ');
+
+        View::composer('*', fn ($view) => $view->with('globalParam', 'Test'));
+
+        $contentWithGlobal = Blade::render('
+            <x-isset-check param1="1" />
+            <x-isset-check param1="2" param2="Hello" />
+            <x-isset-check param1="3" />
+        ');
+
+        $this->assertSame('<p>Global Param is not set</p>
+    <p>Param 1: 1</p>
+    <p>Param 2 is not set</p>
+            <p>Global Param is not set</p>
+    <p>Param 1: 2</p>
+    <p>Param 2: Hello</p>
+            <p>Global Param is not set</p>
+    <p>Param 1: 3</p>
+    <p>Param 2 is not set</p>', trim($content));
+
+        $this->assertSame('<p>Global Param: Test</p>
+    <p>Param 1: 1</p>
+    <p>Param 2 is not set</p>
+            <p>Global Param: Test</p>
+    <p>Param 1: 2</p>
+    <p>Param 2: Hello</p>
+            <p>Global Param: Test</p>
+    <p>Param 1: 3</p>
+    <p>Param 2 is not set</p>', trim($contentWithGlobal));
+    }
+
     public function test_rendering_a_nested_component()
     {
         $content = Blade::render('@foreach(range(1, 2) as $count) <x-nested :$count /> @endforeach');

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -149,6 +149,24 @@ class BladeTest extends TestCase
 <div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
+    public function test_rendering_a_nested_component()
+    {
+        $content = Blade::render('@foreach(range(1, 2) as $count) <x-nested :$count /> @endforeach');
+
+        $this->assertSame('<div>
+        1
+                    <small>1</small>
+                    <small>2</small>
+                    <small>3</small>
+            </div>
+  <div>
+        2
+                    <small>1</small>
+                    <small>2</small>
+                    <small>3</small>
+            </div>', trim($content));
+    }
+
     public function test_name_attribute_can_be_used_if_using_short_slot_names()
     {
         $content = Blade::render('<x-input-with-slot>

--- a/tests/Integration/View/templates/components/isset-check.blade.php
+++ b/tests/Integration/View/templates/components/isset-check.blade.php
@@ -1,0 +1,15 @@
+@if (isset($globalParam))
+    <p>Global Param: {{ $globalParam }}</p>
+@else
+    <p>Global Param is not set</p>
+@endif
+@if (isset($param1))
+    <p>Param 1: {{ $param1 }}</p>
+@else
+    <p>Param 1 is not set</p>
+@endif
+@if (isset($param2))
+    <p>Param 2: {{ $param2 }}</p>
+@else
+    <p>Param 2 is not set</p>
+@endif

--- a/tests/Integration/View/templates/components/nested.blade.php
+++ b/tests/Integration/View/templates/components/nested.blade.php
@@ -1,0 +1,10 @@
+@if (isset($nested) == true && $nested == true)
+    <small>{{ $count }}</small>
+@else
+    <div>
+        {{ $count }}
+        @foreach (range(1, 3) as $c)
+            <x-nested :count="$c" :nested="true" />
+        @endforeach
+    </div>
+@endif


### PR DESCRIPTION
This PR will add a view instance caching support to components and prevent creating new view instances on each render resulting in increasing +20% performance rendering components.

Benchmarks:
Before the view instance caching:
![image](https://github.com/laravel/framework/assets/16279288/ad1a4b5f-62c6-4494-8197-6bb8625f40b0)

After the view instance caching:
![image](https://github.com/laravel/framework/assets/16279288/f08b57b2-1e0c-48e3-b823-2e198a993523)
