### PR TITLE
[11.x] Blade Component Loop Speed Improvement

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -323,7 +323,7 @@ class Factory implements FactoryContract
     public function getEngineFromPath($path)
     {
         if ($this->hasPathEngine($path)) {
-            return $this->pathEngines[$path];
+            return $this->getPathEngine($path);
         }
 
         if (! $extension = $this->getExtension($path)) {
@@ -334,7 +334,7 @@ class Factory implements FactoryContract
 
         $this->setPathEngine($path, $this->engines->resolve($engine));
 
-        return $this->pathEngines[$path];
+        return $this->getPathEngine($path);
     }
 
     /**
@@ -501,6 +501,11 @@ class Factory implements FactoryContract
     public function setPathEngine($path, $engine)
     {
         $this->pathEngines[$path] = $engine;
+    }
+
+    public function getPathEngine($path)
+    {
+        return $this->pathEngines[$path];
     }
 
     public function hasPathEngine($path)

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -842,7 +842,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn(m::mock(Engine::class));
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(Engine::class));
         $factory->getDispatcher()->shouldReceive('hasListeners')->andReturn(false);
         $factory->make('foo/bar');
         $factory->make('foo.bar');
@@ -852,7 +852,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('vendor/package::foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn(m::mock(Engine::class));
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(Engine::class));
         $factory->getDispatcher()->shouldReceive('hasListeners')->andReturn(false);
         $factory->make('vendor/package::foo/bar');
         $factory->make('vendor/package::foo.bar');

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -1072,6 +1072,18 @@ class ViewFactoryTest extends TestCase
         $this->assertNull($factory->getLoopStack()[0]['last']);
     }
 
+    public function testPathEngines()
+    {
+        $factory = $this->getFactory();
+
+        $this->assertFalse($factory->hasPathEngine('foo'));
+        $factory->setPathEngine('foo', 'bar');
+        $this->assertTrue($factory->hasPathEngine('foo'));
+        $this->assertSame('bar', $factory->getPathEngine('foo'));
+        $factory->resetPathEngines();
+        $this->assertFalse($factory->hasPathEngine('foo'));
+    }
+
     public function testMacro()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -1072,18 +1072,6 @@ class ViewFactoryTest extends TestCase
         $this->assertNull($factory->getLoopStack()[0]['last']);
     }
 
-    public function testPathEngines()
-    {
-        $factory = $this->getFactory();
-
-        $this->assertFalse($factory->hasPathEngine('foo'));
-        $factory->setPathEngine('foo', 'bar');
-        $this->assertTrue($factory->hasPathEngine('foo'));
-        $this->assertSame('bar', $factory->getPathEngine('foo'));
-        $factory->resetPathEngines();
-        $this->assertFalse($factory->hasPathEngine('foo'));
-    }
-
     public function testMacro()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -842,7 +842,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(Engine::class));
+        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn(m::mock(Engine::class));
         $factory->getDispatcher()->shouldReceive('hasListeners')->andReturn(false);
         $factory->make('foo/bar');
         $factory->make('foo.bar');
@@ -852,7 +852,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('vendor/package::foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(Engine::class));
+        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn(m::mock(Engine::class));
         $factory->getDispatcher()->shouldReceive('hasListeners')->andReturn(false);
         $factory->make('vendor/package::foo/bar');
         $factory->make('vendor/package::foo.bar');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Cache repeated processes that will not change creates a 7% performance improvement:

Before:
```
OPCache Enabled: Enabled
With caching: 206.043693
```

After:
```
OPCache Enabled: Enabled
With caching: 192.26193209091
```

Profiling methodology: https://github.com/laravel/framework/pull/51141#issuecomment-2067184531

`welcome.blade.php`

```php
@for($i = 0; $i < 1000; $i++)
    <x-avatar :name="'Taylor'" class="mt-4" />
@endfor
```

`avatar.blade.php`

```php
<div>
    Hi! My name is {{ $name }}
</div>
```

`routes/web.php`
```php
Route::get('/bench', function () {
    $a = array_map(
        fn () => Benchmark::measure(fn() => view('welcome')->render()),
        range(0, 10)
    );

    return 'OPCache Enabled: ' . (is_array(opcache_get_status()) ? 'Enabled' : 'Disabled') .
            '<br>With caching: ' . (array_sum($a) / count($a));
});
```