### PR TITLE
[11.x] Make possible to pass nested validation keys instead of dot notation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1217,9 +1217,9 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Transform nested validation keys to dot notation (single level array of validations)
+     * Transform nested validation keys to dot notation (single level array of validations).
      *
-     * @param array $rules
+     * @param  array  $rules
      * @return array
      */
     private function dotifyNestedRules(array $rules)
@@ -1228,14 +1228,14 @@ class Validator implements ValidatorContract
 
         $dotify = static function (array $rules, string $prefix = '') use (&$dotify, &$dotifiedRules) {
             foreach ($rules as $attribute => $rule) {
-                if (!is_string($attribute)) {
+                if (! is_string($attribute)) {
                     $dotifiedRules[$prefix][] = $rule;
                     continue;
                 }
 
-                $preparedPrefix = Str::ltrim($prefix . '.' . $attribute, '.');
+                $preparedPrefix = Str::ltrim($prefix.'.'.$attribute, '.');
 
-                if (!is_array($rule)) {
+                if (! is_array($rule)) {
                     $dotifiedRules[$preparedPrefix] = $rule;
                     continue;
                 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -9413,7 +9413,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['required', 'array'], $rules['data']);
         $this->assertSame(['required_array_keys:string_rules,object_rules,nested'], $rules['data.0']);
         $this->assertSame(['required', 'integer'], $rules['data.0.string_rules']);
-        $this->assertSame([(string)$objectRule], $rules['data.0.object_rules']);
+        $this->assertSame([(string) $objectRule], $rules['data.0.object_rules']);
         $this->assertSame(['array'], $rules['data.0.nested']);
         $this->assertSame(['string'], $rules['data.0.nested.nested_array']);
     }


### PR DESCRIPTION
### Problem
When either you expect a huge payload in request or just need to validate a large dataset, especially if it has many nested data, it gets pretty difficult to follow dot notation (personally for me at least)
### Solution
In my opinion, it would be nice to have a way not only to write validations using dot notation but also by nesting them.

Let`s take a look at the following payload:
```
'payload' => [
                [
                    'authorization_key' => 123,
                    'personal' => [
                        'first_name' => 'Some name,
                    ],
                ],
            ]
```
The way you would usually write validation for it is like this:
```
[
    'payload' => ['required', 'array',],
    'payload.*' => ['array', 'required_array_keys:authorization_key,personal'],
    'payload.*.authorization_key' => ['required', 'integer'],
    'payload.*.personal' => ['array', 'required_array_keys:first_name',],
    'payload.*.personal.first_name' => ['required', 'string'],
]
```
However, now you are able to do it this way:
```
[
    'payload' => [
                'required',
                'array',

                '*' => [
                    'required_array_keys:authorization_key,personal',

                    'authorization_key' => ['required', 'integer],
                    'personal' => [
                        'array',
                        'required_array_keys:first_name',

                        'first_name' => [
                            'required',
                            'string',
                        ],
                    ],
                ],
            ],
]
```

### Note
This feature **does not break** the "old" way of using dot notation for rules. You are still able to use dot notation, there is **no breaking change** introduced