### PR TITLE
[11.x] Provide context for NestedRules

### DIFF
--- a/src/Illuminate/Validation/NestedRules.php
+++ b/src/Illuminate/Validation/NestedRules.php
@@ -30,11 +30,12 @@ class NestedRules
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  mixed  $data
+     * @param  mixed  $context
      * @return \stdClass
      */
-    public function compile($attribute, $value, $data = null)
+    public function compile($attribute, $value, $data = null, $context = null)
     {
-        $rules = call_user_func($this->callback, $value, $attribute, $data);
+        $rules = call_user_func($this->callback, $value, $attribute, $data, $context);
 
         $parser = new ValidationRuleParser(
             Arr::undot(Arr::wrap($data))

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -127,7 +127,7 @@ class ValidationRuleParser
 
         if ($rule instanceof NestedRules) {
             return $rule->compile(
-                $attribute, $this->data[$attribute] ?? null, Arr::dot($this->data)
+                $attribute, $this->data[$attribute] ?? null, Arr::dot($this->data), $this->data
             )->rules[$attribute];
         }
 
@@ -152,7 +152,9 @@ class ValidationRuleParser
             if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $rule) {
                     if ($rule instanceof NestedRules) {
-                        $compiled = $rule->compile($key, $value, $data);
+                        $context = Arr::get($this->data, Str::beforeLast($key, '.'));
+
+                        $compiled = $rule->compile($key, $value, $data, $context);
 
                         $this->implicitAttributes = array_merge_recursive(
                             $compiled->implicitAttributes,

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -179,15 +179,16 @@ class ValidationRuleParserTest extends TestCase
     {
         $parser = (new ValidationRuleParser([
             'users' => [
-                ['name' => 'Taylor Otwell'],
+                ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'],
             ],
         ]));
 
         $results = $parser->explode([
-            'users.*.name' => Rule::forEach(function ($value, $attribute, $data) {
+            'users.*.name' => Rule::forEach(function ($value, $attribute, $data, $context) {
                 $this->assertSame('Taylor Otwell', $value);
                 $this->assertSame('users.0.name', $attribute);
                 $this->assertEquals($data['users.0.name'], 'Taylor Otwell');
+                $this->assertEquals(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'], $context);
 
                 return [Rule::requiredIf(true)];
             }),
@@ -201,13 +202,15 @@ class ValidationRuleParserTest extends TestCase
     {
         $parser = (new ValidationRuleParser([
             'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
         ]));
 
         $results = $parser->explode([
-            'name' => Rule::forEach(function ($value, $attribute, $data = null) {
+            'name' => Rule::forEach(function ($value, $attribute, $data = null, $context) {
                 $this->assertSame('Taylor Otwell', $value);
                 $this->assertSame('name', $attribute);
-                $this->assertEquals(['name' => 'Taylor Otwell'], $data);
+                $this->assertEquals(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'], $data);
+                $this->assertEquals(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'], $context);
 
                 return 'required';
             }),


### PR DESCRIPTION
In the `forEach` closure, `$data` containing all the validation data, while `$context` provides the specific data associated with the current iteration.
This helps to add validation rules based on the context of each field being validated.

```php
// Sample Code
$formData = [
    'users' => [
        ['id' => 1, 'name' => 'Foo', 'file' => ''],
        ['id' => 2, 'name' => 'Bar', 'file' => ''],
    ],
];

$validator = Validator::make($formData, [
    'users.*.file' => Rule::forEach(function ($value, $attribute, $data, $context) {
        dump($data);
        // Output:
        // [
        //   'users.0.id' => '1',
        //   'users.0.name' => 'Foo',
        //   'users.0.file' => '',
        //   'users.1.id' => '2',
        //   'users.1.name' => 'Bar',
        //   'users.1.file' => '',
        // ]

        dump($context);
        // Output:
        // [
        //   'id' => '1',
        //   'name' => 'Foo',
        //   'file' => '',
        // ]

        return [
            $this->userHasAvatar($context['id']) ? 'nullable' : 'required'
        ];
    }),
]);
```