### PR TITLE
[11.x] Add column name customisation options for Auth used with database provider

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -65,15 +65,15 @@ return [
             'model' => env('AUTH_MODEL', App\Models\User::class),
         ],
 
-//         'users' => [
-//             'driver' => 'database',
-//             'table' => 'users',
-//             'columns' => [
-//                  'primary_key' => 'id',
-//                  'password' => 'password',
-//                  'remember_token' => 'remember_token',
-//             ],
-//         ],
+        // 'users' => [
+        //     'driver' => 'database',
+        //     'table' => 'users',
+        //     'columns' => [
+        //         'primary_key' => 'id',
+        //         'password' => 'password',
+        //         'remember_token' => 'remember_token',
+        //     ],
+        // ],
     ],
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -68,6 +68,9 @@ return [
         // 'users' => [
         //     'driver' => 'database',
         //     'table' => 'users',
+        //     'id' => 'id',
+        //     'password' => 'password',
+        //     'remember_token' => 'remember_token',
         // ],
     ],
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -65,13 +65,15 @@ return [
             'model' => env('AUTH_MODEL', App\Models\User::class),
         ],
 
-        // 'users' => [
-        //     'driver' => 'database',
-        //     'table' => 'users',
-        //     'id' => 'id',
-        //     'password' => 'password',
-        //     'remember_token' => 'remember_token',
-        // ],
+//         'users' => [
+//             'driver' => 'database',
+//             'table' => 'users',
+//             'columns' => [
+//                  'primary_key' => 'id',
+//                  'password' => 'password',
+//                  'remember_token' => 'remember_token',
+//             ],
+//         ],
     ],
 
     /*

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -65,7 +65,14 @@ trait CreatesUserProviders
     {
         $connection = $this->app['db']->connection($config['connection'] ?? null);
 
-        return new DatabaseUserProvider($connection, $this->app['hash'], $config['table']);
+        $columns = $config['columns'] ?? null;
+
+        return new DatabaseUserProvider(
+            $connection,
+            $this->app['hash'],
+            $config['table'],
+            $columns,
+        );
     }
 
     /**

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -33,6 +33,13 @@ class DatabaseUserProvider implements UserProvider
     protected $table;
 
     /**
+     * The columns used for authentication.
+     *
+     * @var array
+     */
+    protected $columns;
+
+    /**
      * Create a new database user provider.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -40,11 +47,12 @@ class DatabaseUserProvider implements UserProvider
      * @param  string  $table
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, HasherContract $hasher, $table)
+    public function __construct(ConnectionInterface $connection, HasherContract $hasher, $table, $columns = null)
     {
         $this->connection = $connection;
-        $this->table = $table;
         $this->hasher = $hasher;
+        $this->table = $table;
+        $this->columns = $columns;
     }
 
     /**
@@ -141,7 +149,7 @@ class DatabaseUserProvider implements UserProvider
     protected function getGenericUser($user)
     {
         if (! is_null($user)) {
-            return new GenericUser((array) $user);
+            return new GenericUser((array) $user, $this->columns);
         }
     }
 

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -61,7 +61,7 @@ class GenericUser implements UserContract
      */
     public function getAuthPassword()
     {
-        return $this->attributes['password'];
+        return $this->attributes[$this->getAuthPasswordName()];
     }
 
     /**

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -31,7 +31,7 @@ class GenericUser implements UserContract
      */
     public function getAuthIdentifierName()
     {
-        return config('auth.providers.users.id', 'id') ;
+        return config('auth.providers.users.id', 'id');
     }
 
     /**
@@ -51,7 +51,7 @@ class GenericUser implements UserContract
      */
     public function getAuthPasswordName()
     {
-        return config('auth.providers.users.password', 'password') ;
+        return config('auth.providers.users.password', 'password');
     }
 
     /**
@@ -92,7 +92,7 @@ class GenericUser implements UserContract
      */
     public function getRememberTokenName()
     {
-        return config('auth.providers.users.remember_token', 'remember_token') ;
+        return config('auth.providers.users.remember_token', 'remember_token');
     }
 
     /**

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -14,7 +14,7 @@ class GenericUser implements UserContract
     protected $attributes;
 
     /**
-     * The columns used for authentication
+     * The columns used for authentication.
      *
      * @var array
      */
@@ -32,7 +32,7 @@ class GenericUser implements UserContract
         $this->columns = $columns ?? [
             'primary_key' => 'id',
             'password' => 'password',
-            'remember_token' => 'remember_token'
+            'remember_token' => 'remember_token',
         ];
     }
 

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -14,14 +14,26 @@ class GenericUser implements UserContract
     protected $attributes;
 
     /**
+     * The columns used for authentication
+     *
+     * @var array
+     */
+    protected $columns;
+
+    /**
      * Create a new generic User object.
      *
      * @param  array  $attributes
      * @return void
      */
-    public function __construct(array $attributes)
+    public function __construct(array $attributes, $columns = null)
     {
         $this->attributes = $attributes;
+        $this->columns = $columns ?? [
+            'primary_key' => 'id',
+            'password' => 'password',
+            'remember_token' => 'remember_token'
+        ];
     }
 
     /**
@@ -31,7 +43,7 @@ class GenericUser implements UserContract
      */
     public function getAuthIdentifierName()
     {
-        return config('auth.providers.users.id', 'id');
+        return $this->columns['primary_key'];
     }
 
     /**
@@ -51,7 +63,7 @@ class GenericUser implements UserContract
      */
     public function getAuthPasswordName()
     {
-        return config('auth.providers.users.password', 'password');
+        return $this->columns['password'];
     }
 
     /**
@@ -92,7 +104,7 @@ class GenericUser implements UserContract
      */
     public function getRememberTokenName()
     {
-        return config('auth.providers.users.remember_token', 'remember_token');
+        return $this->columns['remember_token'];
     }
 
     /**

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -31,7 +31,7 @@ class GenericUser implements UserContract
      */
     public function getAuthIdentifierName()
     {
-        return 'id';
+        return config('auth.providers.users.id', 'id') ;
     }
 
     /**
@@ -51,7 +51,7 @@ class GenericUser implements UserContract
      */
     public function getAuthPasswordName()
     {
-        return 'password';
+        return config('auth.providers.users.password', 'password') ;
     }
 
     /**
@@ -92,7 +92,7 @@ class GenericUser implements UserContract
      */
     public function getRememberTokenName()
     {
-        return 'remember_token';
+        return config('auth.providers.users.remember_token', 'remember_token') ;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### This pull request will add:
This pr will add the option to customise column names, in the users table when using the Auth login functions in combination with the database driver. Column name customisation is also possible when eloquent is used (by overriding the getter functions in the users model, but there is no way to do it when the database provider is used.

### How to use:
Users can customise the column names by editing the providers config. My first thought was to add a new 'database' key, that is commented out by default, but since 'table' is already located in providers, it seems best to place it there.

By default, the eloquent provider is used, but when the database provider is used, you can easily replace the column names in the config.

```php
    'providers' => [
        // 'users' => [
        //     'driver' => 'eloquent',
        //     'model' => env('AUTH_MODEL', App\Models\User::class),
        // ],

        'users' => [
            'driver' => 'database',
            'table' => 'users',
            // The columns config is optional, to be backwards compatible. 
            // When not set, default column names will be used.
            'columns' => [
                'primary_key' => 'id',
                'password' => 'password',
                'remember_token' => 'remember_token',
            ],
        ],
    ],
```

