### PR TITLE
[11.x] Reset connection after migrate for FreshCommand

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -62,20 +62,18 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        if (! is_null($database)) {
-            $this->migrator->setConnection($database);
-        }
+        $this->migrator->usingConnection($database, function () {
+            if ($this->migrator->repositoryExists()) {
+                $this->newLine();
 
-        if ($this->migrator->repositoryExists()) {
-            $this->newLine();
-
-            $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
-                '--database' => $database,
-                '--drop-views' => $this->option('drop-views'),
-                '--drop-types' => $this->option('drop-types'),
-                '--force' => true,
-            ])) == 0);
-        }
+                $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
+                    '--database' => $database,
+                    '--drop-views' => $this->option('drop-views'),
+                    '--drop-types' => $this->option('drop-types'),
+                    '--force' => true,
+                ])) == 0);
+            }
+        });
 
         $this->newLine();
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -62,7 +62,7 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        $this->migrator->usingConnection($database, function () {
+        $this->migrator->usingConnection($database, function () use ($database) {
             if ($this->migrator->repositoryExists()) {
                 $this->newLine();
 


### PR DESCRIPTION
This properly resets the database connection back to the default after dropping the tables for the fresh command. 

Fixes https://github.com/laravel/framework/issues/51163