### PR TITLE
[11.x] Add `Number::mapRange()` method

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -233,6 +233,21 @@ class Number
     }
 
     /**
+     * Map the given number from one range to another.
+     *
+     * @param  int|float  $number
+     * @param  int|float  $inMin
+     * @param  int|float  $inMax
+     * @param  int|float  $outMin
+     * @param  int|float  $outMax
+     * @return int|float
+     */
+    public static function mapRange(int|float $number, int|float $inMin, int|float $inMax, int|float $outMin, int|float $outMax)
+    {
+        return ($number - $inMin) * ($outMax - $outMin) / ($inMax - $inMin) + $outMin;
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -181,7 +181,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame(50, Number::mapRange(5, 0, 10, 0, 100));
         $this->assertSame(100, Number::mapRange(10, 0, 10, 0, 100));
         $this->assertSame(1.5, Number::mapRange(0.5, 0, 1, 1, 2));
-        $this->assertSame(42.42, Number::mapRange(0.42, 0, 1, 42, 43));
+        $this->assertSame(4.727272727272727, Number::mapRange(42, 1, 100, 1, 10));
         $this->assertSame(1.1666666666666667, Number::mapRange(2, 1, 7, 1, 2));
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -175,6 +175,16 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1, Number::clamp(-10, 1, 5));
     }
 
+    public function testMapRange()
+    {
+        $this->assertSame(0, Number::mapRange(0, 0, 10, 0, 100));
+        $this->assertSame(50, Number::mapRange(5, 0, 10, 0, 100));
+        $this->assertSame(100, Number::mapRange(10, 0, 10, 0, 100));
+        $this->assertSame(1.5, Number::mapRange(0.5, 0, 1, 1, 2));
+        $this->assertSame(42.42, Number::mapRange(0.42, 0, 1, 42, 43));
+        $this->assertSame(1.1666666666666667, Number::mapRange(2, 1, 7, 1, 2));
+    }
+
     public function testToHuman()
     {
         $this->assertSame('1', Number::forHumans(1));


### PR DESCRIPTION
This PR adds a new method `Number::mapRange()` for mapping values within a specified input range to a corresponding output range.

The function linearly interpolates the input value within the input range to determine its corresponding position within the output range. This interpolation is calculated based on the proportion of the input value's distance between the input minimum and maximum values, this is useful for tasks such as normalization, scaling, or converting values between units.

Example usage:

```php
// Map a temperature value from Fahrenheit to Celsius
$fahrenheit = 68;
Number::mapRange($fahrenheit, 32, 212, 0, 100); // Temperature in Celsius: 20

// Map a value to a custom range
$value = 42;
$mappedValue = mapRange($value, 1, 100, 1, 10); // Mapped value: 4.727272...
```