### PR TITLE
[11.x] Add type-hint to multiple instance manager

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -35,7 +36,7 @@ abstract class MultipleInstanceManager
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
+    public function __construct(Application $app)
     {
         $this->app = $app;
     }


### PR DESCRIPTION
Creating a PR again (#51149) along with re-creation instructions. Currently, MultipleInstanceManager is throwing error when trying to resolve out of service container (when app dependancy is not passed explicitly). Consider following piece of code.

```php
class FooManager extends MultipleInstanceManager
{
    public function createFooDriver(array $config)
    {
        return new FooDriver($config);
    }
    public function createBarDriver(array $config)
    {
        return new BarDriver($config);
    }
    public function getDefaultInstance()
    {
        // TODO: Implement getDefaultInstance() method.
    }
    public function setDefaultInstance($name)
    {
        // TODO: Implement setDefaultInstance() method.
    }
    public function getInstanceConfig($name)
    {
        // TODO: Implement getInstanceConfig() method.
    }
}
// A facade for accessing manager
class Foo extends Facade
{
    protected static function getFacadeAccessor(): string
    {
        return FooManager::class;
    }
}
```
If we now try to call ```Foo::instance('bar')->something()```, it would fail with the following error
```
Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Support\MultipleInstanceManager
```
This is because in the constructor of ```MultipleInstanceManager.php```, the ```$app``` is not type-hinted, so container is not able to resolve the dependancy.  This PR aims to fix the issue by type-hinting the Application dependancy.