### PR TITLE
[11.x] Fix the error with the prefix in non-cached routes

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -66,7 +66,9 @@ class RouteGroup
         $old = $old['prefix'] ?? '';
 
         if ($prependExistingPrefix) {
-            return isset($new['prefix']) ? ($old ? trim($old, '/') . '/' . trim($new['prefix'], '/') : trim($new['prefix'], '/')) : $old;
+            return isset($new['prefix']) 
+                ? ($old ? trim($old, '/').'/'.trim($new['prefix'], '/') : trim($new['prefix'], '/')) 
+                : $old;
         }
 
         return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -66,7 +66,7 @@ class RouteGroup
         $old = $old['prefix'] ?? '';
 
         if ($prependExistingPrefix) {
-            return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+            return isset($new['prefix']) ? ($old ? trim($old, '/') . '/' . trim($new['prefix'], '/') : trim($new['prefix'], '/')) : $old;
         }
 
         return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;


### PR DESCRIPTION
Fixes : #50239 

The getPrefix() method of the Illuminate\Routing\Route returns different values for non-cached and cached routes:

/{locale} - the return value of the getPrefix() method for a non-cached route
{locale} - the return value of the getPrefix() method for a cached route

This PR fixes this issue by modifying the formatPrefix function in the RouteGroup class when initializing the route model

![image](https://github.com/laravel/framework/assets/36625222/bfc02c2a-01d0-4fec-8952-7d9d8bc8eeff)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
