### PR TITLE
[11.x] Fix renaming columns with `NULL` as default on legacy MariaDB/MySQL

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -354,7 +354,7 @@ class MySqlGrammar extends Grammar
                 default => $column['type_name'],
             },
             'nullable' => $column['nullable'],
-            'default' => $column['default'] && str_starts_with(strtolower($column['default']), 'current_timestamp')
+            'default' => $column['default'] && (str_starts_with(strtolower($column['default']), 'current_timestamp') || $column['default'] === 'NULL')
                 ? new Expression($column['default'])
                 : $column['default'],
             'autoIncrement' => $column['auto_increment'],

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -215,6 +215,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             $table->renameColumn('name', 'title');
             $table->renameColumn('id', 'key');
             $table->renameColumn('generated', 'new_generated');
+            $table->renameColumn('foo', 'bar');
         });
 
         $connection = m::mock(Connection::class);
@@ -224,12 +225,14 @@ class DatabaseSchemaBlueprintTest extends TestCase
             ['name' => 'name', 'type' => 'varchar(255)', 'type_name' => 'varchar', 'nullable' => true, 'collation' => 'utf8mb4_unicode_ci', 'default' => 'foo', 'comment' => null, 'auto_increment' => false],
             ['name' => 'id', 'type' => 'bigint unsigned', 'type_name' => 'bigint', 'nullable' => false, 'collation' => null, 'default' => null, 'comment' => 'lorem ipsum', 'auto_increment' => true],
             ['name' => 'generated', 'type' => 'int', 'type_name' => 'int', 'nullable' => false, 'collation' => null, 'default' => null, 'comment' => null, 'auto_increment' => false, 'generation' => ['type' => 'stored', 'expression' => 'expression']],
+            ['name' => 'foo', 'type' => 'int', 'type_name' => 'int', 'nullable' => true, 'collation' => null, 'default' => 'NULL', 'comment' => null, 'auto_increment' => false, 'generation' => null],
         ]);
 
         $this->assertEquals([
             "alter table `users` change `name` `title` varchar(255) collate 'utf8mb4_unicode_ci' null default 'foo'",
             "alter table `users` change `id` `key` bigint unsigned not null auto_increment comment 'lorem ipsum'",
             'alter table `users` change `generated` `new_generated` int as (expression) stored not null',
+            'alter table `users` change `foo` `bar` int null default NULL',
         ], $blueprint->toSql($connection, new MariaDbGrammar));
     }
 


### PR DESCRIPTION
Fixes #51171

This PR fixes renaming columns with `default null` on legacy MariaDB/MySQL.