### PR TITLE
[11.x] Allow implicit binding to have optional backed enums

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -84,6 +84,10 @@ class ImplicitRouteBinding
 
             $parameterValue = $parameters[$parameterName];
 
+            if ($parameterValue === null) {
+                continue;
+            }
+
             $backedEnumClass = $parameter->getType()?->getName();
 
             $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -49,6 +49,24 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category')->value);
     }
 
+    public function test_it_handles_optional_implicit_backed_enum_route_bindings_for_the_given_route_with_optional_parameter()
+    {
+        $action = ['uses' => function (?CategoryBackedEnum $category = null) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => null];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertNull($route->parameter('category'));
+    }
+
     public function test_it_does_not_resolve_implicit_non_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryEnum $category) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -42,6 +42,8 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use UnexpectedValueException;
 
+include_once __DIR__.'/Enums.php';
+
 class RoutingRouteTest extends TestCase
 {
     public function testBasicDispatchingOfRoutes()
@@ -1881,6 +1883,21 @@ class RoutingRouteTest extends TestCase
             },
         ]);
         $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testOptionalBackedEnumsReturnNullWhenMissing()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar?}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (?CategoryBackedEnum $bar = null) {
+                $this->assertNull($bar);
+
+                return 'bar';
+            },
+        ]);
+
+        $router->dispatch(Request::create('foo', 'GET'))->getContent();
     }
 
     public function testImplicitBindingsWithMissingModelHandledByMissing()


### PR DESCRIPTION
I think this PR speaks for itself but this is an example of what wasn't possible before and now is:

```php
<?php

use Illuminate\Support\Facades\Route;

Route::get('/settings/{tab?}', fn (?Tab $tab) => response()->json([
    'tab' => $tab?->value,
]));

enum Tab: string
{
    case Advanced = 'advanced';
    case General = 'general';
}
```

This doesn't contain breaking changes unless you expect 404s 