### PR TITLE
[11.x] Events Dispatcher performance improvements

### DIFF
--- a/tests/Events/BroadcastedEventsTest.php
+++ b/tests/Events/BroadcastedEventsTest.php
@@ -24,11 +24,11 @@ class BroadcastedEventsTest extends TestCase
 
         $event = new BroadcastEvent;
 
-        $this->assertTrue($d->shouldBroadcast([$event]));
+        $this->assertTrue($d->shouldBroadcast($event));
 
         $event = new AlwaysBroadcastEvent;
 
-        $this->assertTrue($d->shouldBroadcast([$event]));
+        $this->assertTrue($d->shouldBroadcast($event));
     }
 
     public function testShouldBroadcastAsQueuedAndCallNormalListeners()
@@ -56,11 +56,11 @@ class BroadcastedEventsTest extends TestCase
 
         $event = new BroadcastFalseCondition;
 
-        $this->assertFalse($d->shouldBroadcast([$event]));
+        $this->assertFalse($d->shouldBroadcast($event));
 
         $event = new ExampleEvent;
 
-        $this->assertFalse($d->shouldBroadcast([$event]));
+        $this->assertFalse($d->shouldBroadcast($event));
     }
 }
 


### PR DESCRIPTION
While digging through people's attempts to speed up Views, I noted that the event calls related to view creation and rendering contributed to a notable percentage of rendering time.  After my recent PR for allowing disabling events on cache stores I opted to dig into why the overhead on events can be so costly.  After some analysis and tinkering, I think I've come up with a more performant means of event handling.  While this doesn't move the needly immensely on the the faster view rendering challenge, it does make a dent to events.


### What was changed:
The event dispatching pipeline can be broken down into two implementation paths: Event as string and event as object.

Refactored dispatching to account for optimizations that can be made for string-based events and avoid running code when no listeners are registered.

For events that are registered, created a listeners cache to reduce repeated calls to makeListener() when the same event is called more than once.

Lastly, modified the shouldBroadcast calls to take the event object rather than the payload as that implementation seemed to be based on the presumed parsing of the object-based event calls.  Tests updated accordingly.

### Impact
String-based events should see an improvement to run-time as they will no longer be subject to the same event-based checks and in the event that no listeners are defined for the event, they will run faster as the dispatch() method returns early if no listeners have been defined.  
For all event types (string and object) where listeners are defined, the inclusion of the listenersCache will speed up repetitive calls to the same event as the existing calls to makeListener() now only incur the first time the event is ran.  In real-world scenarios this impact may vary, but I found ~4% improvement when querying hundreds of models during bulk model processing via Scout.


### Backwards Compatibility Concerns
This does unfortunately remove some protected methods and redefines the call signature of some other protected methods as part of the implementation.  Should any app create its own Dispatcher implementation overriding these methods, it will have some issues.  I still believe there's a means to preserve the existing method signatures at the expense of a additional clock cycles if it is deemed the methods signature changes are too risky. 

