### PR TITLE
[11.x] Allow disabling listener on `Registered` event

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -33,6 +33,13 @@ class EventServiceProvider extends ServiceProvider
     protected $observers = [];
 
     /**
+     * Indicates if the email verification listener should be configured.
+     *
+     * @var bool
+     */
+    protected $shouldConfigureEmailVerificationListener = true;
+
+    /**
      * Indicates if events should be discovered.
      *
      * @var bool
@@ -72,7 +79,9 @@ class EventServiceProvider extends ServiceProvider
         });
 
         $this->booted(function () {
-            $this->configureEmailVerification();
+            if ($this->shouldConfigureEmailVerificationListener) {
+                $this->configureEmailVerification();
+            }
         });
     }
 


### PR DESCRIPTION
Should solve the issue https://github.com/laravel/framework/issues/50783#issuecomment-2072411615

On Laravel 11 a new method `EventServiceProvider@configureEmailVerification()` was introduced.

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php#L207-L213.

It works fine when having only a single event service provider, the event gets triggered and the listener works fine. But the problem is when the application has more than one event service provider the listener defined here gets executed multiple times - if the application is using 10 event service providers it will be executed 10 times. It is common to have multiple event providers, especially in DDD applications.

Unfortunately, that new method was implemented without considering applications with more than one default event service provider. It seems too late to change it without causing a breaking change.
Instead, this PR aims to allow developers to turn off the listener on custom event service providers.

An alternative to this would be overwriting `configureEmailVerification()` on the custom event service provider and leaving it empty, which seems not that nice to me.

```php
protected function configureEmailVerification() {}
```