### PR TITLE
[11.x] Add the ability to bind keys together in translation 🚀

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -164,6 +164,12 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 if (! is_null($line = $this->getLine(
                     $namespace, $group, $languageLineLocale, $item, $replace
                 ))) {
+                    if (is_array($line)) {
+                        return Arr::map($line, function ($line) use ($key, $replace, $locale, $fallback) {
+                            return $this->makeReplacementsLinked($key, $line, $replace, $locale, $fallback);
+                        });
+                    }
+
                     return $this->makeReplacementsLinked($key, $line, $replace, $locale, $fallback);
                 }
             }
@@ -284,7 +290,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  bool  $fallback
      * @return string
      */
-    protected function makeReplacementsLinked(string $parentKey, string $line, array $replace = [], $locale = null, $fallback = true): string
+    protected function makeReplacementsLinked($parentKey, $line, $replace = [], $locale = null, $fallback = true): string
     {
         preg_match_all('/@{(.*?)}/', $line, $matches);
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -292,16 +292,16 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         foreach (last($matches) as $placeholder) {
             if (str($placeholder)->contains('.')) {
-                $prefix = $placeholder;
+                $key = $placeholder;
             } else {
-                $prefix = str($parentKey)
+                $key = str($parentKey)
                     ->beforeLast('.')
                     ->append('.')
                     ->append($placeholder)
                     ->toString();
             }
 
-            $shouldReplace['@{'.$placeholder.'}'] = $this->get($prefix, $replace, $locale, $fallback);
+            $shouldReplace['@{'.$placeholder.'}'] = $this->get($key, $replace, $locale, $fallback);
         }
 
         return strtr($line, $shouldReplace);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -178,6 +178,37 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
     }
 
+    public function testReplacementsLinked()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([
+            'link_many' => 'This is a link to @{many} @{locale} @{messages}',
+            'many' => 'Many',
+            'locale' => 'Locale',
+            'messages' => 'Messages',
+        ]);
+        $this->assertSame('This is a link to Many Locale Messages', $t->get('foo.link_many'));
+    }
+
+    public function testNestedReplacementsLinked()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([
+            'link_many' => 'This is a nested link to @{foo.nested.bar} @{foo.nested.foo.many.text}',
+            'nested' => [
+                'bar' => 'Bar',
+                'foo' => [
+                    'many' => [
+                        'text' => 'Many'
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertSame('This is a nested link to Bar Many', $t->get('foo.link_many'));
+    }
+
     public function testGetJsonReplacesForAssociativeInput()
     {
         $t = new Translator($this->getLoader(), 'en');

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -201,7 +201,7 @@ class TranslationTranslatorTest extends TestCase
                 'bar' => 'Bar',
                 'foo' => [
                     'many' => [
-                        'text' => 'Many'
+                        'text' => 'Many',
                     ],
                 ],
             ],


### PR DESCRIPTION
This PR introduces a significant enhancement to Laravel's translation capabilities by facilitating the linking of keys within an array of language files. For instance, if you have multiple keys with the same text, this feature allows for concise representation.

Previously, you would handle such scenarios like this:

```php
// Resources/lang/en/messages.php

return [
    'example' => [
        'hello' => 'Hello',
        'world' => 'World!',

        // Or, with a duplicate text with the same meaning
        'hello_world' => 'Hello World!'
    ]
];

// Resources/views/example.blade.php

{{ trans('messages.example.hello').trans('messages.example.world') }}

// Or
{{ trans('messages.hello_world') }}
```

With this enhancement, the process becomes more streamlined:

```php
// Resources/lang/en/messages.php

return [
    'example' => [
        'hello' => 'Hello',
        'world' => 'World!',
        'hello_world' => '@{hello} @{world}'
    ]
];

// Resources/views/example.blade.php

{{ trans('example.hello_world') }}
```

This improvement not only simplifies the code but also enhances readability and maintainability.