### PR TITLE
[11.x] Add replaceable tags to translations

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -264,10 +264,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         foreach ($replace as $key => $value) {
             if (is_callable($value)) {
                 $line = preg_replace_callback(
-                    '/<' . $key . '>(.*?)<\/' . $key . '>/',
+                    '/<'.$key.'>(.*?)<\/'.$key.'>/',
                     fn ($args) => $value($args[1]),
                     $line
                 );
+
                 continue;
             }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -262,6 +262,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $shouldReplace = [];
 
         foreach ($replace as $key => $value) {
+            if (is_callable($value)) {
+                $line = preg_replace_callback(
+                    '/<' . $key . '>(.*?)<\/' . $key . '>/',
+                    fn ($args) => $value($args[1]),
+                    $line
+                );
+                continue;
+            }
+
             if (is_object($value) && isset($this->stringableHandlers[get_class($value)])) {
                 $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
             }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -262,7 +262,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $shouldReplace = [];
 
         foreach ($replace as $key => $value) {
-            if (is_callable($value)) {
+            if ($value instanceof Closure) {
                 $line = preg_replace_callback(
                     '/<'.$key.'>(.*?)<\/'.$key.'>/',
                     fn ($args) => $value($args[1]),

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -257,6 +257,42 @@ class TranslationTranslatorTest extends TestCase
         );
     }
 
+    public function testTagReplacements()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'We have some nice <docs-link>documentation</docs-link>', '*')->andReturn([]);
+
+        $this->assertSame(
+            'We have some nice <a href="https://laravel.com/docs">documentation</a>',
+            $t->get(
+                'We have some nice <docs-link>documentation</docs-link>',
+                [
+                    "docs-link" => fn ($children) => "<a href=\"https://laravel.com/docs\">$children</a>"
+                ]
+            )
+        );
+    }
+
+    public function testTagReplacementsHandleMultipleOfSameTag()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '<bold-this>bold</bold-this> something else <bold-this>also bold</bold-this>', '*')->andReturn([]);
+
+        $this->assertSame(
+            '<b>bold</b> something else <b>also bold</b>',
+            $t->get(
+                '<bold-this>bold</bold-this> something else <bold-this>also bold</bold-this>',
+                [
+                    "bold-this" => fn ($children) => "<b>$children</b>"
+                ]
+            )
+        );
+    }
+
     public function testDetermineLocalesUsingMethod()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
Turned https://github.com/laravel/framework/discussions/51188 into a PR.

When writing translations there are times when you may want to inline some HTML, such as for bolding some text or placing a link in the middle of a sentence, currently, you can achieve this by doing something along the lines of:

```blade
{!! __('Something <b>bold</b>, and a <a href=":href">link</a>', ['href' => 'https://laravel.com']) !!}
```

But this isn't very nice or readable to a translator, [FormatJS already has a solution to this](https://formatjs.io/docs/core-concepts/icu-syntax/#rich-text-formatting) with Tag Replacements, these look like normal HTML tags but they don't support attributes, they can be added with callable:

```blade
{!! __(
    'Something <b>bold</b> and a <link>link</link>',
    [
        'link' => fn ($children) => "<a href=\"https://laravel.com\">$children</a>"
    ]
) !!}
```

This takes the complexity away from the translator (as in the person, not the class), and makes the code more maintainable if you want to modify that anchor tag with a class then you don't have to go through each translation to add it.

This still requires the usage of unescaped echos within blade, I'm happy to accept any ideas for making this into a `HTMLString` to avoid this but I didn't want to pile too much into this merge.

This change should be fully backwards compatible.