### PR TITLE
[11.x] Trim trailing `?` from generated URL without query params

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -245,9 +245,9 @@ class UrlGenerator implements UrlGeneratorContract
 
         parse_str(Str::after($existingQueryString, '?'), $existingQueryArray);
 
-        return $this->to($path.'?'.Arr::query(
+        return rtrim($this->to($path.'?'.Arr::query(
             array_merge($existingQueryArray, $query)
-        ), $extra, $secure);
+        ), $extra, $secure), '?');
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -49,10 +49,13 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/')
         );
 
-        $this->assertSame('http://www.foo.com/foo/bar?', $url->query('foo/bar'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar'));
         $this->assertSame('http://www.foo.com/foo/bar?0=foo', $url->query('foo/bar', ['foo']));
         $this->assertSame('http://www.foo.com/foo/bar?baz=boom', $url->query('foo/bar', ['baz' => 'boom']));
         $this->assertSame('http://www.foo.com/foo/bar?baz=zee&zal=bee', $url->query('foo/bar?baz=boom&zal=bee', ['baz' => 'zee']));
+        $this->assertSame('http://www.foo.com/foo/bar?zal=bee', $url->query('foo/bar?baz=boom&zal=bee', ['baz' => null]));
+        $this->assertSame('http://www.foo.com/foo/bar?baz=boom', $url->query('foo/bar?baz=boom', ['nonexist' => null]));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar?baz=boom', ['baz' => null]));
         $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar&zal=bee', $url->query('foo/bar?foo=bar', ['zal' => 'bee'], ['baz'], true));
         $this->assertSame('http://www.foo.com/foo/bar?baz[0]=boom&baz[1]=bam&baz[2]=bim', urldecode($url->query('foo/bar', ['baz' => ['boom', 'bam', 'bim']])));
     }


### PR DESCRIPTION
This is a follow-up for @stevebauman's PR #51075 👏. I would expect a generated URL without query params never ending with a sole `?`. The `url()->query()` helper also supports removing existing query params by setting them to `null`. If the final query param is removed, the URL should not end with a `?`.

This can be considered as a breaking change. But as this feature was just introduced in the newly released Laravel v11.5.0 and the behavior of this PR is probably the one you would expect, I would rather consider it as a tiny little improvement/fix over #51075. I've also added more assertions to test for query param removal.

Cheers, Pipo