### PR TITLE
[11.x] github: mariadb database healthcheck+naming

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -103,14 +103,14 @@ jobs:
     runs-on: ubuntu-22.04
 
     services:
-      mysql:
+      mariadb:
         image: mariadb:10
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: laravel
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes
+          MARIADB_DATABASE: laravel
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
 
     strategy:
       fail-fast: true


### PR DESCRIPTION
MariaDB's container has a healthcheck.sh script that can be used. mysqladmin ping has flaw that it checks unix socket first which means it can return true while the database is been bootstrapped.

Also use the MariaDB names as we haven't been MySQL for a while.

I looked at a 10.x merge of this, but it uses a different database name ("forge") and would have been a merge conflict going up. Happy to do a 10.x fix if desired.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
