### PR TITLE
[11.x] github actions: test mariadb very latest

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -144,6 +144,51 @@ jobs:
         env:
           DB_CONNECTION: mariadb
 
+  mariadblatest:
+    runs-on: ubuntu-22.04
+
+    services:
+      mariadb:
+        image: quay.io/mariadb-foundation/mariadb-devel:verylatest
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes
+          MARIADB_DATABASE: laravel
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: true
+
+    name: MariaDB Very Latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "11.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: mariadb
+
   pgsql:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
MariaDB Foundation produce a quay.io image off the latest RC branch. This included only reviewed and tested changes that developers consider finished.

To maintain compatibility with important ecosystem projects like Laravel, its important that Laravel's test suite be applied to this testing too. MariaDB would like to find out about any accidental incompatibilities before release for our mutual users' benefit.

announce doc: https://mariadb.org/new-service-quay-io-mariadb-foundation-mariadb-devel/
(and yes images have got a bit behind recently due to accidential builder change, but will be back soon).

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
