### PR TITLE
Move whitespace in front of verbatim block in Blade templates

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -390,8 +390,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storeVerbatimBlocks($value)
     {
-        return preg_replace_callback('/(?<!@)@verbatim(.*?)@endverbatim/s', function ($matches) {
-            return $this->storeRawBlock($matches[1]);
+        return preg_replace_callback('/(?<!@)@verbatim(\s*)(.*?)@endverbatim/s', function ($matches) {
+            return $matches[1].$this->storeRawBlock($matches[2]);
         }, $value);
     }
 

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -86,4 +86,19 @@ class BladeVerbatimTest extends AbstractBladeTestCase
 
         $this->assertSame($expected, $this->compiler->compileString($string));
     }
+
+    public function testNewlinesAreInsertedCorrectlyAfterEcho()
+    {
+        $string = "test @verbatim\nhello world\n@endverbatim";
+        $expected = "test \nhello world\n";
+        $this->assertSame($expected, $this->compiler->compileString($string));
+
+        $string = "{{ 1 }}\nhello world\n";
+        $expected = "<?php echo e(1); ?>\n\nhello world\n";
+        $this->assertSame($expected, $this->compiler->compileString($string));
+
+        $string = "{{ 1 }}@verbatim\nhello world\n@endverbatim";
+        $expected = "<?php echo e(1); ?>\n\nhello world\n";
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
Closes #51146

If a PHP end tag `?>` is followed by a newline, that newline is not shown in the output. To counteract this, CompilesEchos detects whether an echo is followed by a newline and then doubles that newline. However, if the newline is part of a verbatim block, it is already replaced by a placeholder and CompilesEchos won't detect it correctly.

This change moves the whitespace in front of the verbatim block. The whitespace remains outside of the placeholder and CompilesEchos can correctly detect it.

This assumes that whitespace is not modified by Blade in a manner that it would be necessary to put whitespace in a verbatim block to change its meaning.

Only the final assertion in the testNewlinesAreInsertedCorrectlyAfterEcho test actually tests for what we want. The first two are more of an introduction for the reader, to show that what we test in the last assertion really makes sense. It first tests a verbatim block, then an echo statement, and then the combination of the two, what is what we are really interested in.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
