### PR TITLE
[12.x] Make `Str::is()` match multiline strings

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -350,7 +350,7 @@ class PendingProcess
     protected function fakeFor(string $command)
     {
         return collect($this->fakeHandlers)
-                ->first(fn ($handler, $pattern) => $pattern === '*' || Str::is($pattern, $command));
+                ->first(fn ($handler, $pattern) => Str::is($pattern, $command));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -432,7 +432,7 @@ class Str
             // If the given value is an exact match we can of course return true right
             // from the beginning. Otherwise, we will translate asterisks and do an
             // actual pattern match against the two strings to see if they match.
-            if ($pattern === $value) {
+            if ($pattern === '*' || $pattern === $value) {
                 return true;
             }
 
@@ -443,7 +443,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
+            if (preg_match('#^'.$pattern.'\z#su', $value) === 1) {
                 return true;
             }
         }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -156,7 +156,7 @@ class ProcessTest extends TestCase
         $factory->preventStrayProcesses();
 
         $factory->fake([
-            '*' => 'The output',
+            '*' => $expectedOutput = 'The output',
         ]);
 
         $result = $factory->run(<<<'COMMAND'
@@ -167,6 +167,29 @@ class ProcessTest extends TestCase
         COMMAND);
 
         $this->assertSame(0, $result->exitCode());
+        $this->assertSame("$expectedOutput\n", $result->output());
+    }
+
+    public function testProcessFakeWithMultiLineCommand()
+    {
+        $factory = new Factory;
+
+        $factory->preventStrayProcesses();
+
+        $factory->fake([
+            '*--branch main*' => 'not this one',
+            '*--branch develop*' => $expectedOutput = 'yes thank you',
+        ]);
+
+        $result = $factory->run(<<<'COMMAND'
+        git clone --depth 1 \
+              --single-branch \
+              --branch develop \
+              git://some-url .
+        COMMAND);
+
+        $this->assertSame(0, $result->exitCode());
+        $this->assertSame("$expectedOutput\n", $result->output());
     }
 
     public function testProcessFakeExitCodes()

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
+use Illuminate\Support\Str;
 use OutOfBoundsException;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
-use Illuminate\Support\Str;
 use OutOfBoundsException;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -487,6 +487,38 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is([null], null));
     }
 
+    public function testIsWithMultilineStrings()
+    {
+        $this->assertFalse(Str::is("/", "/\n"));
+        $this->assertTrue(Str::is("/*", "/\n"));
+        $this->assertTrue(Str::is("*/*", "/\n"));
+        $this->assertTrue(Str::is("*/*", "\n/\n"));
+
+        $this->assertTrue(Str::is("*", "\n"));
+        $this->assertTrue(Str::is("*", "\n\n"));
+        $this->assertFalse(Str::is("", "\n"));
+        $this->assertFalse(Str::is("", "\n\n"));
+
+        $multilineValue = <<<'VALUE'
+        <?php
+
+        namespace Illuminate\Tests\Support;
+
+        use Exception;
+        VALUE;
+
+        $this->assertTrue(Str::is($multilineValue, $multilineValue));
+        $this->assertTrue(Str::is("*", $multilineValue));
+        $this->assertTrue(Str::is("*namespace Illuminate\Tests\*", $multilineValue));
+        $this->assertFalse(Str::is("namespace Illuminate\Tests\*", $multilineValue));
+        $this->assertFalse(Str::is("*namespace Illuminate\Tests", $multilineValue));
+        $this->assertTrue(Str::is("<?php*", $multilineValue));
+        $this->assertTrue(Str::is("<?php*namespace Illuminate\Tests\*", $multilineValue));
+        $this->assertFalse(Str::is("use Exception;", $multilineValue));
+        $this->assertFalse(Str::is("use Exception;*", $multilineValue));
+        $this->assertTrue(Str::is("*use Exception;", $multilineValue));
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue(Str::isUrl('https://laravel.com'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -489,15 +489,15 @@ class SupportStrTest extends TestCase
 
     public function testIsWithMultilineStrings()
     {
-        $this->assertFalse(Str::is("/", "/\n"));
-        $this->assertTrue(Str::is("/*", "/\n"));
-        $this->assertTrue(Str::is("*/*", "/\n"));
-        $this->assertTrue(Str::is("*/*", "\n/\n"));
+        $this->assertFalse(Str::is('/', "/\n"));
+        $this->assertTrue(Str::is('/*', "/\n"));
+        $this->assertTrue(Str::is('*/*', "/\n"));
+        $this->assertTrue(Str::is('*/*', "\n/\n"));
 
-        $this->assertTrue(Str::is("*", "\n"));
-        $this->assertTrue(Str::is("*", "\n\n"));
-        $this->assertFalse(Str::is("", "\n"));
-        $this->assertFalse(Str::is("", "\n\n"));
+        $this->assertTrue(Str::is('*', "\n"));
+        $this->assertTrue(Str::is('*', "\n\n"));
+        $this->assertFalse(Str::is('', "\n"));
+        $this->assertFalse(Str::is('', "\n\n"));
 
         $multilineValue = <<<'VALUE'
         <?php
@@ -508,15 +508,15 @@ class SupportStrTest extends TestCase
         VALUE;
 
         $this->assertTrue(Str::is($multilineValue, $multilineValue));
-        $this->assertTrue(Str::is("*", $multilineValue));
+        $this->assertTrue(Str::is('*', $multilineValue));
         $this->assertTrue(Str::is("*namespace Illuminate\Tests\*", $multilineValue));
         $this->assertFalse(Str::is("namespace Illuminate\Tests\*", $multilineValue));
         $this->assertFalse(Str::is("*namespace Illuminate\Tests", $multilineValue));
-        $this->assertTrue(Str::is("<?php*", $multilineValue));
+        $this->assertTrue(Str::is('<?php*', $multilineValue));
         $this->assertTrue(Str::is("<?php*namespace Illuminate\Tests\*", $multilineValue));
-        $this->assertFalse(Str::is("use Exception;", $multilineValue));
-        $this->assertFalse(Str::is("use Exception;*", $multilineValue));
-        $this->assertTrue(Str::is("*use Exception;", $multilineValue));
+        $this->assertFalse(Str::is('use Exception;', $multilineValue));
+        $this->assertFalse(Str::is('use Exception;*', $multilineValue));
+        $this->assertTrue(Str::is('*use Exception;', $multilineValue));
 
         $this->assertTrue(Str::is("<?php\n\nnamespace Illuminate\Tests\*", $multilineValue));
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -517,6 +517,20 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::is("use Exception;", $multilineValue));
         $this->assertFalse(Str::is("use Exception;*", $multilineValue));
         $this->assertTrue(Str::is("*use Exception;", $multilineValue));
+
+        $this->assertTrue(Str::is("<?php\n\nnamespace Illuminate\Tests\*", $multilineValue));
+
+        $this->assertTrue(Str::is(<<<'PATTERN'
+        <?php
+        *
+        namespace Illuminate\Tests\*
+        PATTERN, $multilineValue));
+
+        $this->assertTrue(Str::is(<<<'PATTERN'
+        <?php
+
+        namespace Illuminate\Tests\*
+        PATTERN, $multilineValue));
     }
 
     public function testIsUrl()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -798,6 +799,38 @@ class SupportStringableTest extends TestCase
 
         // empty patterns
         $this->assertFalse($this->stringable('test')->is([]));
+    }
+
+    public function testIsWithMultilineStrings()
+    {
+        $this->assertFalse($this->stringable("/\n")->is("/"));
+        $this->assertTrue($this->stringable("/\n")->is("/*"));
+        $this->assertTrue($this->stringable("/\n")->is("*/*"));
+        $this->assertTrue($this->stringable("\n/\n")->is("*/*"));
+
+        $this->assertTrue($this->stringable("\n")->is("*"));
+        $this->assertTrue($this->stringable("\n\n")->is("*"));
+        $this->assertFalse($this->stringable("\n")->is(""));
+        $this->assertFalse($this->stringable("\n\n")->is(""));
+
+        $multilineValue = <<<'VALUE'
+        <?php
+
+        namespace Illuminate\Tests\Support;
+
+        use Exception;
+        VALUE;
+
+        $this->assertTrue($this->stringable($multilineValue)->is($multilineValue));
+        $this->assertTrue($this->stringable($multilineValue)->is("*"));
+        $this->assertTrue($this->stringable($multilineValue)->is("*namespace Illuminate\Tests\*"));
+        $this->assertFalse($this->stringable($multilineValue)->is("namespace Illuminate\Tests\*"));
+        $this->assertFalse($this->stringable($multilineValue)->is("*namespace Illuminate\Tests"));
+        $this->assertTrue($this->stringable($multilineValue)->is("<?php*"));
+        $this->assertTrue($this->stringable($multilineValue)->is("<?php*namespace Illuminate\Tests\*"));
+        $this->assertFalse($this->stringable($multilineValue)->is("use Exception;"));
+        $this->assertFalse($this->stringable($multilineValue)->is("use Exception;*"));
+        $this->assertTrue($this->stringable($multilineValue)->is("*use Exception;"));
     }
 
     public function testKebab()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -803,15 +802,15 @@ class SupportStringableTest extends TestCase
 
     public function testIsWithMultilineStrings()
     {
-        $this->assertFalse($this->stringable("/\n")->is("/"));
-        $this->assertTrue($this->stringable("/\n")->is("/*"));
-        $this->assertTrue($this->stringable("/\n")->is("*/*"));
-        $this->assertTrue($this->stringable("\n/\n")->is("*/*"));
+        $this->assertFalse($this->stringable("/\n")->is('/'));
+        $this->assertTrue($this->stringable("/\n")->is('/*'));
+        $this->assertTrue($this->stringable("/\n")->is('*/*'));
+        $this->assertTrue($this->stringable("\n/\n")->is('*/*'));
 
-        $this->assertTrue($this->stringable("\n")->is("*"));
-        $this->assertTrue($this->stringable("\n\n")->is("*"));
-        $this->assertFalse($this->stringable("\n")->is(""));
-        $this->assertFalse($this->stringable("\n\n")->is(""));
+        $this->assertTrue($this->stringable("\n")->is('*'));
+        $this->assertTrue($this->stringable("\n\n")->is('*'));
+        $this->assertFalse($this->stringable("\n")->is(''));
+        $this->assertFalse($this->stringable("\n\n")->is(''));
 
         $multilineValue = <<<'VALUE'
         <?php
@@ -822,15 +821,15 @@ class SupportStringableTest extends TestCase
         VALUE;
 
         $this->assertTrue($this->stringable($multilineValue)->is($multilineValue));
-        $this->assertTrue($this->stringable($multilineValue)->is("*"));
+        $this->assertTrue($this->stringable($multilineValue)->is('*'));
         $this->assertTrue($this->stringable($multilineValue)->is("*namespace Illuminate\Tests\*"));
         $this->assertFalse($this->stringable($multilineValue)->is("namespace Illuminate\Tests\*"));
         $this->assertFalse($this->stringable($multilineValue)->is("*namespace Illuminate\Tests"));
-        $this->assertTrue($this->stringable($multilineValue)->is("<?php*"));
+        $this->assertTrue($this->stringable($multilineValue)->is('<?php*'));
         $this->assertTrue($this->stringable($multilineValue)->is("<?php*namespace Illuminate\Tests\*"));
-        $this->assertFalse($this->stringable($multilineValue)->is("use Exception;"));
-        $this->assertFalse($this->stringable($multilineValue)->is("use Exception;*"));
-        $this->assertTrue($this->stringable($multilineValue)->is("*use Exception;"));
+        $this->assertFalse($this->stringable($multilineValue)->is('use Exception;'));
+        $this->assertFalse($this->stringable($multilineValue)->is('use Exception;*'));
+        $this->assertTrue($this->stringable($multilineValue)->is('*use Exception;'));
     }
 
     public function testKebab()


### PR DESCRIPTION
Currently `Str::is()` almost always returns false for strings containing a newline, for example:

```php
$multilineString = <<<'STRING'
first
second
third
STRING;

Str::is('*', $multilineString); // currently false
Str::is('first*', $multilineString); // currently false
Str::is("first\n*", $multilineString); // currently false
Str::is("first\nsecond\n*", $multilineString); // currently true but not very practical
```

This happens because the `*` wildcard gets changed to the regex pattern `.*`, but the `.` doesn't match newlines because [the `s` modifier](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php) isn't present.

`Str::is()` is used by the framework to match fake outputs for the `Process` facade. Currently you can't properly match a multiline command (as reported in https://github.com/laravel/framework/issues/50158 and fixed with a hack in https://github.com/laravel/framework/pull/50164). This PR fixes this problem properly. For example:

```php
$result = Process::run(<<<'COMMAND'
git clone --depth 1 \
      --single-branch \
      --branch main \
      git://some-url .
'COMMAND');

Process::preventStrayProcesses();

// Currently this pattern will never match and your test will always fail.
// After this PR the pattern works as you'd expect.
Process::fake(['git clone*' => 'faked output']);
```

After this PR the `*` pattern always matches everything, so I've added the `$pattern === '*'` check because it is a minor speed boost.

I've targeted 12.x because this PR is a breaking change. If you rely on `Str::is()` or `str()->is()` returning false on multiline strings then you'll have to update your code.



