### PR TITLE
Add collection function containsMultipleItems

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -699,6 +699,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection contains multiple items.
+     *
+     * @return bool
+     */
+    public function containsMultipleItems()
+    {
+        return $this->count() > 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -698,6 +698,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if the collection contains multiple items.
+     *
+     * @return bool
+     */
+    public function containsMultipleItems()
+    {
+        return $this->take(2)->count() > 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -796,6 +796,15 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse((new $collection([1, 2]))->containsOneItem());
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testContainsMultipleItems($collection)
+    {
+        $this->assertFalse((new $collection([]))->containsMultipleItems());
+        $this->assertFalse((new $collection([1]))->containsMultipleItems());
+        $this->assertTrue((new $collection([1, 2]))->containsMultipleItems());
+        $this->assertTrue((new $collection([1, 2, 3]))->containsMultipleItems());
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -574,6 +574,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testContainsMultipleItemsIsLazy()
+    {
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->containsMultipleItems();
+        });
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
`\Illuminate\Support\Collection` and `\Illuminate\Support\LazyCollection` already offer syntax sugar for determining the number of items like:

```php
$collection->isEmpty(); // count() === 0
$collection->isNotEmpty(); // count() !== 0
$collection->containsOneItem(); // count() === 1
```

This PR simply adds the last missing piece:

```php
$collection->containsMultipleItems(); // count() > 1
```
