### PR TITLE
Add some tests on route:list sort command

### DIFF
--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -56,6 +56,11 @@ class RouteListCommandTest extends TestCase
             return 'Hello World';
         })->middleware('exampleMiddleware');
 
+        $router->get('/sub-example', function () {
+            return 'Hello World';
+        })->domain('sub')
+        ->middleware('exampleMiddleware');
+
         $router->get('/example-group', function () {
             return 'Hello Group';
         })->middleware(['web', 'auth']);
@@ -72,6 +77,26 @@ class RouteListCommandTest extends TestCase
         $output = $this->app->output();
 
         $this->assertStringNotContainsString('exampleMiddleware', $output);
+    }
+
+    public function testSortRouteListAsc()
+    {
+        $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri']);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+    }
+
+    public function testSortRouteListDesc()
+    {
+        $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri', '--reverse' => true]);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
 
     public function testMiddlewareGroupsAssignmentInCli()
@@ -143,7 +168,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-vv' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }


### PR DESCRIPTION
This PR adds some tests on the `route:list` sort with multiple columns ([recently added](https://github.com/laravel/framework/pull/50998)).