### PR TITLE
[11.x] fix: eloquent collections containing non-model values

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -39,17 +39,16 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model2->shouldReceive('getCasts')->andReturn([]);
         $model2->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
 
-        $result1 = (object) [
-            'pivot' => (object) [
-                'foreign_key' => new class
+        $result1 = m::mock(Model::class);
+        $result1->shouldReceive('getAttribute')->with('pivot')->andReturn((object) [
+            'foreign_key' => new class
+            {
+                public function __toString()
                 {
-                    public function __toString()
-                    {
-                        return '1';
-                    }
-                },
-            ],
-        ];
+                    return '1';
+                }
+            },
+        ]);
 
         $models = $relation->match([$model1, $model2], Collection::wrap($result1), 'foo');
         $this->assertNull($models[1]->foo);

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -22,10 +22,10 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testLookupDictionaryIsProperlyConstructedForEnums()
     {
+        $modelOne = m::mock(Model::class)->makePartial();
+        $modelOne->forceFill(['morph_type' => 'morph_type_2', 'foreign_key' => TestEnum::test]);
         $relation = $this->getRelation();
-        $relation->addEagerConstraints([
-            $one = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => TestEnum::test],
-        ]);
+        $relation->addEagerConstraints([$modelOne]);
         $dictionary = $relation->getDictionary();
         $relation->getDictionary();
         $enumKey = TestEnum::test;
@@ -47,12 +47,21 @@ class DatabaseEloquentMorphToTest extends TestCase
             }
         };
 
+        $modelOne = m::mock(Model::class)->makePartial();
+        $modelOne->forceFill(['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1']);
+        $modelTwo = m::mock(Model::class)->makePartial();
+        $modelTwo->forceFill(['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1']);
+        $modelThree = m::mock(Model::class)->makePartial();
+        $modelThree->forceFill(['morph_type' => 'morph_type_2', 'foreign_key' => 'foreign_key_2']);
+        $modelFour = m::mock(Model::class)->makePartial();
+        $modelFour->forceFill(['morph_type' => 'morph_type_2', 'foreign_key' => $stringish]);
+
         $relation = $this->getRelation();
         $relation->addEagerConstraints([
-            $one = (object) ['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1'],
-            $two = (object) ['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1'],
-            $three = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => 'foreign_key_2'],
-            $four = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => $stringish],
+            $modelOne,
+            $modelTwo,
+            $modelThree,
+            $modelFour,
         ]);
 
         $dictionary = $relation->getDictionary();
@@ -60,14 +69,14 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertEquals([
             'morph_type_1' => [
                 'foreign_key_1' => [
-                    $one,
-                    $two,
+                    $modelOne,
+                    $modelTwo,
                 ],
             ],
             'morph_type_2' => [
                 'foreign_key_2' => [
-                    $three,
-                    $four,
+                    $modelThree,
+                    $modelFour,
                 ],
             ],
         ], $dictionary);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

I'm currently targeting 11.x, however, depending on the definition of a BC I can target 12.x if necessary.

# Eloquent Collections shouldn't contain non-Models values (NMVs)

## Motivation

An Eloquent Collection is defined as a collection that only contains Eloquent Models:
https://github.com/laravel/framework/blob/6d598f5fc6e304cefdabc7e90e90b899b203ad74/src/Illuminate/Database/Eloquent/Collection.php#L13-L19

There are special methods on the Eloquent Collection that assume / require all values to be Models---calling these methods if the collection contains a NMV **will result in a runtime error**. Typing a collection as an Eloquent Collection that throws a run time error when you actually try to use the available methods is not cool---therefore, any Eloquent Collection that contains NMVs should be downgraded to a Support Collection (or not be allowed to be populated with NMVs in the first place).

There appears to have been some efforts to prevent Eloquent Collections from being populated with NMVs as the `map`/`mapWithKeys` methods conditionally converts `toBase`:
https://github.com/laravel/framework/blob/6d598f5fc6e304cefdabc7e90e90b899b203ad74/src/Illuminate/Database/Eloquent/Collection.php#L334-L347

And several methods preemptively convert `toBase` when they result in NMVs: 
https://github.com/laravel/framework/blob/6d598f5fc6e304cefdabc7e90e90b899b203ad74/src/Illuminate/Database/Eloquent/Collection.php#L565-L574

However, there's many more methods that still could / do result in an Eloquent Collection with NMVs, for example:

```php
// before
User::all()->chunk(2); // Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, User>>
// now
User::all()->chunk(2); // Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Collection<int, User>>
```

## Changes
This PR updates the remainder of the methods which can / do result in NMVs to return Support Collections if they do (I believe I updated them all, if I missed any then please let me know).

To help cut down on the duplication, I also introduced a `toBaseUnlessOnlyModels` method which converts `toBase` if the collection contains NMVs (naming things is hard! if you'd rather a different name then just let me know).

## Considerations

### Changes in return type
This technically does change the class that the method returns which *could* be considered a BC, however, I would say that returning an eloquent collection with NMVs is actually a bug that needs to be fixed as it's a potential landmine. If this breaks a php type somewhere then that type really does need to be updated.

### Eloquent collection instantiation

It is still possible to instantiate an Eloquent Collection with a NMV:
```php
new EloquentCollection(['foo']);
```
Ideally, this should not be possible and an `InvalidArgumentException` should be thrown if that's the case. I can do this but opted not to for the time being as this could be considered more of a BC than desired for 11.x.
 
### Mutating Methods

Several methods (`prepend`, `put`, `push`, `transform`, etc.) actually mutate the collection instead of returning a new instance. I went ahead and and return the proper instance (so method chaining and variable assignment will work as expected), but this means that it is still possible to do the following:

```php
$collection = User::all(); // Eloquent Collection
$collection->push('foo'); // returns a Support Collection
$collection; // still an Eloquent Collection!
```

The only way to really prevent this from happening is to keep the Eloquent collection from being populated with a NMV in the first place:
- type the function parameter as a Model
- throw an `InvalidArgumentException` if an input value is a NMV
- throw a `LogicException` if `transform` results in a NMV
- etc

Again, I can do these things, but I opted not to for the time being as they could be considered more of a breaking change than desired for 11.x.

# Fixed `->flip()` bug
I also fixed an issue when calling `->flip()` on an EloquentCollection, the following warning was generated and an empty collection was returned:

> WARNING  array_flip(): Can only flip string and integer values, entry skipped in vendor/laravel/framework/src/Illuminate/Collections/Collection.php on line 425.

To fix I just convert all models to their key with `->getKey()` before flipping. Another option would be to cast the model to a string but that could yield large json strings which didn't seem desirable.

```php
// before
User::all()->flip(); // resulted in a warning and an empty support collection
// now
User::all()->flip(); // returns a support collection with [$user->getKey() => TKey]
```


Thanks!