### PR TITLE
[11.x] Allow sorting of route:list by multiple columns, ASC and DESC

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -160,6 +160,14 @@ class RouteListCommand extends Command
         if (Str::contains($sort, ',')) {
             $sort = explode(',', $sort);
         }
+        $sort = collect($sort)
+        ->map(function ($item) {
+            if (Str::endsWith($item, ':DESC')) {
+                return explode(':', $item);
+            }
+
+            return $item;
+        })->toArray();
 
         return collect($routes)
             ->sortBy($sort)

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -99,6 +99,16 @@ class RouteListCommandTest extends TestCase
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
 
+    public function testSortRouteListAscAndDesc()
+    {
+        $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri:DESC']);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+    }
+
     public function testMiddlewareGroupsAssignmentInCli()
     {
         $this->app->call('route:list', ['-v' => true]);


### PR DESCRIPTION
This PR improves [the new route:list multiple columns sort](https://github.com/laravel/framework/pull/50998), by allowing ASC or DESC for each factor.

For example, we can do this now :
```php
artisan route:list --sort=domain,uri:DESC
```
Which first sorts the list by domain column ASC (default value) and then by the uri column DESC.