### PR TITLE
[11.x] Add Benchmark Helper Functions

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -527,4 +527,5 @@ if (! function_exists('benchmark_value')) {
     {
         return Benchmark::value($callback);
     }
+    
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -527,5 +527,4 @@ if (! function_exists('benchmark_value')) {
     {
         return Benchmark::value($callback);
     }
-    
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -486,7 +486,7 @@ if (! function_exists('with')) {
     }
 }
 
-if (!function_exists('benchmark_measure')) {
+if (! function_exists('benchmark_measure')) {
     /**
      * Measure a callable or array of callables over the given number of iterations.
      *
@@ -500,7 +500,7 @@ if (!function_exists('benchmark_measure')) {
     }
 }
 
-if (!function_exists('benchmark_dd')) {
+if (! function_exists('benchmark_dd')) {
     /**
      * Measure a callable or array of callables over the given number of iterations, then dump and die.
      *
@@ -514,7 +514,7 @@ if (!function_exists('benchmark_dd')) {
     }
 }
 
-if (!function_exists('benchmark_value')) {
+if (! function_exists('benchmark_value')) {
     /**
      * Measure a callable once and return the duration and result.
      *

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -3,6 +3,7 @@
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Benchmark;
 use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\HigherOrderTapProxy;
@@ -482,5 +483,48 @@ if (! function_exists('with')) {
     function with($value, ?callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
+    }
+}
+
+if (!function_exists('benchmark_measure')) {
+    /**
+     * Measure a callable or array of callables over the given number of iterations.
+     *
+     * @param  \Closure|array  $benchmarkables
+     * @param  int  $iterations
+     * @return array|float
+     */
+    function benchmark_measure(Closure|array $benchmarkables, int $iterations = 1)
+    {
+        return Benchmark::measure($benchmarkables, $iterations);
+    }
+}
+
+if (!function_exists('benchmark_dd')) {
+    /**
+     * Measure a callable or array of callables over the given number of iterations, then dump and die.
+     *
+     * @param  \Closure|array  $benchmarkables
+     * @param  int  $iterations
+     * @return never
+     */
+    function benchmark_dd(Closure|array $benchmarkables, int $iterations = 1)
+    {
+        return Benchmark::dd($benchmarkables, $iterations);
+    }
+}
+
+if (!function_exists('benchmark_value')) {
+    /**
+     * Measure a callable once and return the duration and result.
+     *
+     * @template TReturn of mixed
+     *
+     * @param  (callable(): TReturn)  $callback
+     * @return array{0: TReturn, 1: float}
+     */
+    function benchmark_value(callable $callback)
+    {
+        return Benchmark::value($callback);
     }
 }


### PR DESCRIPTION
**PR Title:** 
"Add Benchmark Helper Functions to Illuminate\Support Namespace"

**Description:**
This PR introduces three new helper functions, `benchmark_measure`, `benchmark_dd`, and `benchmark_value` to the `helpers.php` file in the `Illuminate\Support` namespace.   These functions provide convenient wrappers for the corresponding methods in the Benchmark class, enhancing the usability and accessibility of the Benchmark class functionality within Laravel applications, which aligns with Laravel's commitment to providing developer-friendly features and tools.


**Documentation Updates:**

In the event of acceptance and merging of this PR, I commit to updating the Laravel documentation to include information about these new helper functions. Specifically, I will:
- Add entries for  `benchmark_measure`, `benchmark_dd`, and `benchmark_value` to the helpers section of the Laravel documentation, including descriptions and usage examples.
- Ensure that relevant sections of the documentation, such as the Benchmarking and Helpers sections, reflect the addition of these helper functions and provide clear guidance on their usage.

I understand the importance of keeping the Laravel documentation up-to-date to assist developers in utilizing the framework effectively, and I am committed to fulfilling this responsibility upon acceptance of this PR.

No hard feelings on closure. Thanks so much for your time! 🙏