### PR TITLE
[RFC][11.x] New option - Shared dependencies by default

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -187,4 +187,5 @@ return [
         // 'Example' => App\Facades\Example::class,
     ])->toArray(),
 
+    'sharedDependenciesByDefault' => false,
 ];

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -158,6 +158,13 @@ class Container implements ArrayAccess, ContainerContract
     protected $afterResolvingCallbacks = [];
 
     /**
+     * The container's private instances.
+     *
+     * @var array
+     */
+    protected $privateInstances = [];
+
+    /**
      * Define a contextual binding.
      *
      * @param  array|string  $concrete
@@ -1194,6 +1201,20 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Register a private binding in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function private($abstract, $concrete = null)
+    {
+        $this->privateInstances[$abstract] = true;
+
+        $this->bind($abstract, $concrete, false);
+    }
+
+    /**
      * Fire all of the before resolving callbacks.
      *
      * @param  string  $abstract
@@ -1397,6 +1418,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->instances = [];
         $this->abstractAliases = [];
         $this->scopedInstances = [];
+        $this->privateInstances = [];
     }
 
     /**

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -216,4 +216,13 @@ interface Container extends ContainerInterface
      * @return void
      */
     public function afterResolving($abstract, ?Closure $callback = null);
+
+    /**
+     * Register a private binding in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function private($abstract, $concrete = null);
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -201,6 +201,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     protected $absoluteCachePathPrefixes = ['/', '\\'];
 
+    protected $sharedDependenciesByDefault = false;
+
     /**
      * Create a new Illuminate application instance.
      *
@@ -310,6 +312,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
             $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
         }
+
+        $this->sharedDependenciesByDefault = (bool) $this['config']->get('app.sharedDependenciesByDefault');
     }
 
     /**
@@ -1009,6 +1013,19 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->loadDeferredProviderIfNeeded($abstract = $this->getAlias($abstract));
 
         return parent::make($abstract, $parameters);
+    }
+
+    public function isShared($abstract)
+    {
+        if (isset($this->privateInstances[$abstract])) {
+            return false;
+        }
+
+        if ($this->sharedDependenciesByDefault) {
+            return true;
+        }
+
+        return parent::isShared($abstract);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -693,11 +693,6 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->isShared(IContainerContractStub::class));
     }
 
-    public function testPrivateDependency()
-    {
-
-    }
-
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -680,6 +680,24 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationStub::class, $result);
     }
 
+    public function testPrivateDependencyIsResolvableAndNotShared(): void
+    {
+        $container = new Container;
+
+        $container->private(IContainerContractStub::class, ContainerImplementationStub::class);
+
+        $instance1 = $container->make(IContainerContractStub::class);
+        $instance2 = $container->make(IContainerContractStub::class);
+
+        $this->assertNotSame($instance1, $instance2);
+        $this->assertFalse($container->isShared(IContainerContractStub::class));
+    }
+
+    public function testPrivateDependency()
+    {
+
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -578,6 +578,32 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame(['overwrite' => true], $config->get('queue.connections.database'));
         $this->assertSame(['merge' => true], $config->get('queue.connections.new'));
     }
+
+    public function testSharedAsDefault(): void
+    {
+        $app = new Application;
+        $app['config'] = new Repository(['app' => ['sharedDependenciesByDefault' => true]]);
+        $app->bootstrapWith([]);
+
+        $app->scoped(NonContractBackedClass::class);
+        $instance1 = $app->make(NonContractBackedClass::class);
+        $instance2 = $app->make(NonContractBackedClass::class);
+
+        $this->assertSame($instance1, $instance2);
+    }
+
+    public function testPrivateDependencyIsNotSharedEvenWhenOptionSharedDependenciesByDefaultIsEnabled(): void
+    {
+        $app = new Application;
+        $app['config'] = new Repository(['app' => ['sharedDependenciesByDefault' => true]]);
+        $app->bootstrapWith([]);
+
+        $app->private(NonContractBackedClass::class);
+        $instance1 = $app->make(NonContractBackedClass::class);
+        $instance2 = $app->make(NonContractBackedClass::class);
+
+        $this->assertNotSame($instance1, $instance2);
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider


### PR DESCRIPTION
**PR Title:**
"Add a new option to the config to change the default behavior of the container"

**Description**
Currently, there is no possibility to share resolved dependencies without binding (no interface, no need to bind that dependency). I want to introduce that possibility by adding a new option to the config that will allow when enabled:
- share all resolved dependencies by default
- and only keep private those directly bonded by using the private method in the Container

private - creating always a new instance

**Why:**
In large monoliths with a complex dependency tree, creating the same dependencies over and over again is not performant. Types are recognized by using reflection, and it is slow.  I described it here:
https://sarvendev.com/2023/04/uncovering-the-bottlenecks-an-investigation-into-the-poor-performance-of-laravels-container/

It's a screenshot from Blackfire, which shows the time spent in the container within the large monolith at the heavy endpoint. It's roughly half of the whole request, which is very long.
<img width="381" alt="blackfire" src="https://github.com/laravel/framework/assets/6762480/ad3120b6-2468-46fb-9443-3943af5690c6">

I've seen that some people try to hack this by using a patch: https://github.com/rectorphp/vendor-patches/blob/main/patches/illuminate-container-container-php.patch

IMHO it would be better to provide such a possibility and keep this by default disabled for backward compatibility. 

It's a PoC version, it's needed to update the documentation and add proper phpdoc to the code. Let me know what you think about that, and when we have some agreement that it would be useful I will prepare a final implementation. I can also prepare a performance test to prove that it will impact positively large applications. 