### PR TITLE
[10.x] Improve releases flow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,9 +7,18 @@ on:
         description: 'Version to release'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    name: Release ${{ inputs.version }}
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      notes: ${{ steps.cleaned-notes.outputs.release-notes }}
 
     steps:
       - name: Checkout repository
@@ -20,6 +29,35 @@ jobs:
         run: |
           VERSION=${{ inputs.version }}
           echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if branch and version match
+        id: guard
+        run: |
+          MAJOR_VERSION="${NUMERIC_VERSION%%.*}"
+          BRANCH_MAJOR_VERSION="${BRANCH%%.*}"
+
+          echo "MAJOR_VERSION=$(echo $MAJOR_VERSION)" >> $GITHUB_OUTPUT;
+          echo "BRANCH_MAJOR_VERSION=$(echo $BRANCH_MAJOR_VERSION)" >> $GITHUB_OUTPUT;
+
+          if [ "$MAJOR_VERSION" != "$BRANCH_MAJOR_VERSION" ]; then
+            echo "Mismatched versions! Aborting."
+            VERSION_MISMATCH='true';
+          else
+            echo "Versions match! Proceeding."
+            VERSION_MISMATCH='false';
+          fi
+
+          echo "VERSION_MISMATCH=$(echo $VERSION_MISMATCH)" >> $GITHUB_OUTPUT;
+        env:
+          BRANCH: ${{ github.ref_name }}
+          NUMERIC_VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Fail if branch and release tag do not match
+        if: ${{ steps.guard.outputs.VERSION_MISMATCH == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+              core.setFailed('Workflow failed. Release version does not match with selected target branch. Did you select the correct branch?')
 
       - name: Update Application.php version
         run: sed -i "s/const VERSION = '.*';/const VERSION = '${{ steps.version.outputs.version }}';/g" src/Illuminate/Foundation/Application.php
@@ -41,24 +79,40 @@ jobs:
             bash ./bin/release.sh v${{ steps.version.outputs.version }}
           script_stop: true
 
-      # - name: Generate release notes
-      #   id: notes
-      #   uses: RedCrafter07/release-notes-action@main
-      #   with:
-      #     tag-name: v${{ steps.version.outputs.version }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch: ${{ github.ref_name }}
+      - name: Generate release notes
+        id: generated-notes
+        uses: RedCrafter07/release-notes-action@main
+        with:
+          tag-name: v${{ steps.version.outputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
 
-      # - name: Cleanup release notes
-      #   run: |
-      #     sed -i '/## What/d' ${{ steps.notes.outputs.release-notes }}
-      #     sed -i '/## New Contributors/,$d' ${{ steps.notes.outputs.release-notes }}
+      - name: Cleanup release notes
+        id: cleaned-notes
+        run: |
+          NOTES="${{ steps.generated-notes.outputs.release-notes }}"
+          NOTES=$(echo $NOTES | sed '/## What/d')
+          NOTES=$(echo $NOTES | sed '/## New Contributors/,$d')
+          echo "release-notes=${NOTES}" >> "$GITHUB_OUTPUT"
 
-      # - name: Create release
-      #   uses:  softprops/action-gh-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: v${{ steps.version.outputs.version }}
-      #     name: v${{ steps.version.outputs.version }}
-      #     body: ${{ steps.notes.outputs.release-notes }}
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          body: ${{ steps.cleaned-notes.outputs.release-notes }}
+          target_commitish: ${{ github.ref_name }}
+          make_latest: 'legacy'
+
+  update-changelog:
+    needs: release
+
+    name: Update changelog
+
+    uses: laravel/.github/.github/workflows/update-changelog.yml@main
+    with:
+      branch: ${{ github.ref_name }}
+      version: "v${{ needs.release.outputs.version }}"
+      notes: ${{ needs.release.outputs.notes }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,9 +1,0 @@
-name: update changelog
-
-on:
-  release:
-    types: [released]
-
-jobs:
-  update:
-    uses: laravel/.github/.github/workflows/update-changelog.yml@main


### PR DESCRIPTION
I finally managed to crack the way to generate release notes and automatically clean them up. We can now release everything from a single starting point. Additionally, the changelog is updated as soon as a release is done. 

Unfortunately doing it all from the GitHub releases UI was a bit too much as deleting and regenerating the tag loses the connection between the release and the GitHub action. But with this action we still have a nice way to do releases.

Lastly, I added an additional safety check to make sure we don't accidentally tag the wrong branch.