### PR TITLE
[11.x] Additonal Blade Loop Improvements

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -67,6 +67,13 @@ class Dispatcher implements DispatcherContract
     protected $transactionManagerResolver;
 
     /**
+     * The cache of events that have listeners.
+     *
+     * @var array
+     */
+    protected $listenerCache = [];
+
+    /**
      * Create a new event dispatcher instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
@@ -107,6 +114,8 @@ class Dispatcher implements DispatcherContract
                 $this->listeners[$event][] = $listener;
             }
         }
+
+        $this->listenerCache = [];
     }
 
     /**
@@ -131,9 +140,15 @@ class Dispatcher implements DispatcherContract
      */
     public function hasListeners($eventName)
     {
-        return isset($this->listeners[$eventName]) ||
+        if (isset($this->listenerCache[$eventName])) {
+            return $this->listenerCache[$eventName];
+        }
+
+        $this->listenerCache[$eventName] = isset($this->listeners[$eventName]) ||
                isset($this->wildcards[$eventName]) ||
                $this->hasWildcardListeners($eventName);
+
+        return $this->listenerCache[$eventName];
     }
 
     /**
@@ -703,6 +718,8 @@ class Dispatcher implements DispatcherContract
                 unset($this->wildcardsCache[$key]);
             }
         }
+
+        $this->listenerCache = [];
     }
 
     /**

--- a/src/Illuminate/View/AnonymousComponent.php
+++ b/src/Illuminate/View/AnonymousComponent.php
@@ -50,7 +50,7 @@ class AnonymousComponent extends Component
      */
     public static function resolve($data)
     {
-        return new static(...$data);
+        return new static($data['view'], $data['data'], $data['factory']);
     }
 
     /**

--- a/src/Illuminate/View/AnonymousComponent.php
+++ b/src/Illuminate/View/AnonymousComponent.php
@@ -25,10 +25,11 @@ class AnonymousComponent extends Component
      * @param  array  $data
      * @return void
      */
-    public function __construct($view, $data)
+    public function __construct($view, $data, Factory $factory)
     {
         $this->view = $view;
         $this->data = $data;
+        self::$factory = $factory;
     }
 
     /**
@@ -39,6 +40,29 @@ class AnonymousComponent extends Component
     public function render()
     {
         return $this->view;
+    }
+
+    /**
+     * Resolve the component instance with the given data.
+     *
+     * @param  array  $data
+     * @return static
+     */
+    public static function resolve($data)
+    {
+        return new static(...$data);
+    }
+
+    /**
+     * Resolve the Blade view or view file that should be used when rendering the component.
+     *
+     * @return string
+     */
+    public function resolveView()
+    {
+        $view = $this->render();
+
+        return $this->extractBladeViewFromString($view);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -45,6 +45,13 @@ abstract class Compiler
     protected $compiledExtension = 'php';
 
     /**
+     * The cache of compiled paths.
+     *
+     * @var array
+     */
+    protected $compiledPathCache = [];
+
+    /**
      * Create a new compiler instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -82,7 +89,7 @@ abstract class Compiler
      */
     public function getCompiledPath($path)
     {
-        return $this->cachePath.'/'.hash('xxh128', 'v2'.Str::after($path, $this->basePath)).'.'.$this->compiledExtension;
+        return $this->compiledPathCache[$path] ??= $this->cachePath.'/'.hash('xxh128', 'v2'.Str::after($path, $this->basePath)).'.'.$this->compiledExtension;
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -56,9 +56,11 @@ trait ManagesComponents
         if (ob_start()) {
             $this->componentStack[] = $view;
 
-            $this->componentData[$this->currentComponent()] = $data;
+            $currentComponent = $this->currentComponent();
 
-            $this->slots[$this->currentComponent()] = [];
+            $this->componentData[$currentComponent] = $data;
+
+            $this->slots[$currentComponent] = [];
         }
     }
 

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -215,7 +215,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
      */
     public function gatherData()
     {
-        $data = array_merge($this->factory->getShared(), $this->data);
+        $data = $this->data;
 
         foreach ($data as $key => $value) {
             if ($value instanceof Renderable) {
@@ -223,7 +223,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
             }
         }
 
-        return $data;
+        return array_merge($this->factory->getRenderableShared(), $data);
     }
 
     /**
@@ -305,7 +305,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
      */
     public function name()
     {
-        return $this->getName();
+        return $this->view;
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -474,7 +474,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo'],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>
@@ -493,7 +493,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component.index','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component.index','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo'],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>
@@ -512,7 +512,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler()->compileTags('<x-package::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'package::anonymous-component', ['view' => 'package::components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'package::anonymous-component', ['view' => 'package::components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo'],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>
@@ -546,7 +546,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $compiler->compileTags('<x-frontend::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'frontend::anonymous-component', ['view' => 'public.frontend.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'frontend::anonymous-component', ['view' => 'public.frontend.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo'],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>
@@ -580,7 +580,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $compiler->compileTags('<x-admin.auth::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'admin.auth::anonymous-component', ['view' => 'admin.auth.components.anonymous-component.index','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'admin.auth::anonymous-component', ['view' => 'admin.auth.components.anonymous-component.index','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo'],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>
@@ -613,7 +613,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $compiler->compileTags('<x-panel />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => '".md5('test-directory')."::panel.index','data' => []])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => '".md5('test-directory')."::panel.index','data' => [],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>
@@ -646,7 +646,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $compiler->compileTags('<x-panel />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => '".md5('test-directory')."::panel','data' => []])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => '".md5('test-directory')."::panel','data' => [],'factory' => \$__env])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
 <?php \$attributes = \$attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
 <?php endif; ?>


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Using same benchmarking as in #51158 

Before:

OPCache Enabled: Enabled
With caching: 164.14968581818

After:

OPCache Enabled: Enabled
With caching: 135.41356454545

Essentially the framework is suffering from a death by 1,000 cuts for anything in a loop. Anything that is repeatable (e.g. Compiler::getCompiledPath) or anything that includes unnecessary indirection (e.g. View::name) should be cleaned up.

Each one of these changes improved performance by ~1-3%. Combined it was ~15-20%.