### PR TITLE
[11.x] Add Databases nightly workflow

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -1,0 +1,53 @@
+name: databases-nightly
+
+on:
+  pull_request: # TODO: Remove before merge
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+
+ mariadb:
+    runs-on: ubuntu-22.04
+
+    services:
+      mariadb:
+        image: quay.io/mariadb-foundation/mariadb-devel:verylatest
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: yes
+          MARIADB_DATABASE: laravel
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: true
+
+    name: MariaDB Very Latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "11.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: mariadb

--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -9,6 +9,7 @@ jobs:
 
   mariadb:
     runs-on: ubuntu-22.04
+    continue-on-error: true
 
     services:
       mariadb:

--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
- mariadb:
+  mariadb:
     runs-on: ubuntu-22.04
 
     services:


### PR DESCRIPTION
Alternative to https://github.com/laravel/framework/pull/51193

This PR adds a database nightly workflow, which runs preview versions of databases (currently only MariaDB) to make sure upcoming versions are supported.

Note: The line were it runs on pull_requests needs to be removed before merge. It is there only too make sure the tests pass here.
