### PR TITLE
Fix return types of `firstWhere` and `first` of `BelongsToMany` and `HasManyThrough`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -784,7 +784,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -795,7 +795,7 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result.
      *
      * @param  array  $columns
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function first($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -320,7 +320,7 @@ class HasManyThrough extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -331,7 +331,7 @@ class HasManyThrough extends Relation
      * Execute the query and get the first related model.
      *
      * @param  array  $columns
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function first($columns = ['*'])
     {


### PR DESCRIPTION
The current return types of `firstWhere` does not include `null`, while it ends up calling `->first()` which can return `null` (when there's no results).

This change improves the IDE intellisense and fixes false positives static analyser errors, for example this Larastan error:

```
Using nullsafe property access on non-nullable type                                                                               
         Illuminate\Database\Eloquent\Model|Illuminate\Database\Eloquent\Relations\BelongsToMany<Illuminate\Database\Eloquent\Model>.  
         Use -> instead.   
```
