### PR TITLE
[11.x] Add true and false as strings within the form request

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -483,7 +483,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'true', 'false'];
 
         return in_array($value, $acceptable, true);
     }


### PR DESCRIPTION
### Why make this change?

When using the following code within a FormRequest:

`return [ 'is_boolean' => 'required|boolean' ];`

When sending the 'is_boolean' parameter as a query parameter or in a multipart/form-data form, the validation doesn't accept TRUE and FALSE as strings.

Therefore, this change was necessary.