### PR TITLE
[11.x] Ensure path is aligned with OS

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -644,7 +644,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function joinPaths($basePath, $path = '')
     {
-        return join_paths($basePath, $path);
+        return join_paths($basePath, str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path));
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?
It ensures that the path being passed into Laravel's `*_path` helper functions in aligned with the operating system's directory separators.

## Why do we need this?
### Before this PR
`app_path('Services/Example.php')`  would result in `'.../app/Services/Example.php'` which is what I would expect as a dev using a UNIX based OS. But another dev running the same code on a Windows machine would result in `'...\app\Services/Example.php'` which is not a valid windows path and would throw an error.

In most cases, I don't think the dev considers this could break on another OS, until it happens.

### With this PR
The `$path` provided into any of the `*_path` helper functions will be automatically parsed with the correct `DIRECTORY_SEPARATOR` syntax based on the current OS. So for using the same example above we can expect that the windows user gets  `'...\app\Services\Example.php'` which is a valid windows path.

## Other considerations
I would consider this PR a "nice to have" to improve the DX when using Laravels out of the box path helpers, and prevent a bug from happening when you begin onboarding cross-OS teams. But an alternative solution for the developer could be simply using the `join_paths` function like this: `app_path(join_paths('Services', 'Example.php'))`
