### PR TITLE
[11.x] Add support for previous apps keys in signed URL verification

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -79,7 +79,6 @@ class RoutingServiceProvider extends ServiceProvider
             $url->setKeyResolver(function () {
                 $config = $this->app->make('config');
 
-                // Return all accepted app keys, but ensure current key is first for performance.
                 return [$config->get('app.key'), ...($config->get('app.previous_keys') ?? [])];
             });
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -77,7 +77,10 @@ class RoutingServiceProvider extends ServiceProvider
             });
 
             $url->setKeyResolver(function () {
-                return $this->app->make('config')->get('app.key');
+                $config = $this->app->make('config');
+
+                // Return all accepted app keys, but ensure current key is first for performance.
+                return [$config->get('app.key'), ...($config->get('app.previous_keys') ?? [])];
             });
 
             // If the route collection is "rebound", for example, when the routes stay

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -368,9 +368,9 @@ class UrlGenerator implements UrlGeneratorContract
         ksort($parameters);
 
         $key = call_user_func($this->keyResolver);
-        if (is_array($key)) {
-            $key = $key[0];
-        }
+
+        // If previous app keys are added for key rotation, pick the first one which is the current app key
+        $key = is_array($key) ? $key[0] : $key;
 
         return $this->route($name, $parameters + [
             'signature' => hash_hmac('sha256', $this->route($name, $parameters, $absolute), $key),
@@ -458,10 +458,10 @@ class UrlGenerator implements UrlGeneratorContract
 
         $original = rtrim($url.'?'.$queryString, '?');
 
+        // For app key rotation, $keys may be an array of keys. Wrap a single key in an array 
+        // to simplify  logic and preserve backwards compatility with previous keyResolvers.
         $keys = call_user_func($this->keyResolver);
-        if (!is_array($keys)) {
-            $keys = [$keys];
-        }
+        $keys = is_array($keys) ? $keys : [$keys];
 
         foreach ($keys as $key) {
             $signature = hash_hmac('sha256', $original, $key);

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -459,7 +459,7 @@ class UrlGenerator implements UrlGeneratorContract
         $original = rtrim($url.'?'.$queryString, '?');
 
         // For app key rotation, $keys may be an array of keys. Wrap a single key in an array
-        // to simplify  logic and preserve backwards compatility with previous keyResolvers.
+        // to simplify logic and preserve backwards compatility with previous keyResolvers.
         $keys = call_user_func($this->keyResolver);
         $keys = is_array($keys) ? $keys : [$keys];
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -369,7 +369,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $key = call_user_func($this->keyResolver);
 
-        // If previous app keys are added for key rotation, pick the first one which is the current app key
+        // If previous app keys are added for key rotation, pick the first one which is the current app key.
         $key = is_array($key) ? $key[0] : $key;
 
         return $this->route($name, $parameters + [
@@ -458,7 +458,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $original = rtrim($url.'?'.$queryString, '?');
 
-        // For app key rotation, $keys may be an array of keys. Wrap a single key in an array 
+        // For app key rotation, $keys may be an array of keys. Wrap a single key in an array
         // to simplify  logic and preserve backwards compatility with previous keyResolvers.
         $keys = call_user_func($this->keyResolver);
         $keys = is_array($keys) ? $keys : [$keys];

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -894,7 +894,7 @@ class RoutingUrlGeneratorTest extends TestCase
             $request = Request::create('http://www.foo.com/')
         );
         $url->setKeyResolver(function () {
-            return 'secret';
+            return 'first-secret';
         });
 
         $route = new Route(['GET'], 'foo', ['as' => 'foo', function () {
@@ -902,24 +902,32 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $request = Request::create($url->signedRoute('foo'));
+        $firstRequest = Request::create($url->signedRoute('foo'));
 
-        $this->assertTrue($url->hasValidSignature($request));
+        $this->assertTrue($url->hasValidSignature($firstRequest));
 
         $request = Request::create($url->signedRoute('foo').'?tempered=true');
 
         $this->assertFalse($url->hasValidSignature($request));
 
         $url2 = $url->withKeyResolver(function () {
-            return 'other-secret';
+            return 'second-secret';
         });
 
-        $this->assertFalse($url2->hasValidSignature($request));
+        $this->assertFalse($url2->hasValidSignature($firstRequest));
 
-        $request = Request::create($url2->signedRoute('foo'));
+        $secondRequest = Request::create($url2->signedRoute('foo'));
 
-        $this->assertTrue($url2->hasValidSignature($request));
-        $this->assertFalse($url->hasValidSignature($request));
+        $this->assertTrue($url2->hasValidSignature($secondRequest));
+        $this->assertFalse($url->hasValidSignature($secondRequest));
+
+        // Key resolver also supports multiple keys, for app key rotation via the config "app.previous_keys"
+        $url3 = $url->withKeyResolver(function () {
+            return ['first-secret', 'second-secret'];
+        });
+
+        $this->assertTrue($url3->hasValidSignature($firstRequest));
+        $this->assertTrue($url3->hasValidSignature($secondRequest));
     }
 
     public function testMissingNamedRouteResolution()


### PR DESCRIPTION
### Description 
Laravel 11 introduced the ability to add `app.previous_keys` to migrate the app-key for encryption transparently, added in https://github.com/laravel/framework/pull/49962

This PR adds the same support for signed URLs, by allowing URLs generated under one of the previous keys (listed in `app.previous_keys`) to be considered as valid.

### Implementation
The implementation iterates over the acceptable app keys, with the current app key first, and returns as soon as a valid `hmac` is found. Of course, signing a new URL always uses the current app key.

To support this, I updated the default `$keyResolver` in `UrlGenerator` (set in `RoutingServiceProvider`) to return an array of keys. I can't see this return value being typed anywhere, and I kept support for single keys being returned, in case anyone injects their own key resolver.

### Inspiration
The idea for this PR comes from @valorin and the Securing Laravel newsletter, where the missing support for signed URLs was mentioned.