### PR TITLE
[11.x] Trigger event on password reset link send

### DIFF
--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetLinkSent
+{
+    use SerializesModels;
+
+    /**
+     * The user.
+     *
+     * @var \Illuminate\Contracts\Auth\CanResetPassword
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -72,7 +72,7 @@ class PasswordBroker implements PasswordBrokerContract
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification($token);
 
-        event(new PasswordResetLinkSent($user));
+        $this->firePasswordResetSentEvent($user);
 
         return static::RESET_LINK_SENT;
     }
@@ -189,5 +189,16 @@ class PasswordBroker implements PasswordBrokerContract
     public function getRepository()
     {
         return $this->tokens;
+    }
+
+    /**
+     * Fire the login event if the dispatcher is set.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    protected function firePasswordResetSentEvent($user)
+    {
+        event(new PasswordResetLinkSent($user));
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth\Passwords;
 
 use Closure;
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
@@ -70,6 +71,8 @@ class PasswordBroker implements PasswordBrokerContract
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification($token);
+
+        event(new PasswordResetLinkSent($user));
 
         return static::RESET_LINK_SENT;
     }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -74,7 +74,7 @@ class AuthPasswordBrokerTest extends TestCase
 
     public function testBrokerTriggersPasswordResetLinkEvent()
     {
-        Event::mock();
+        Event::fake();
 
         $mocks = $this->getMocks();
         $broker = m::mock(PasswordBroker::class, array_values($mocks))->makePartial();

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -7,6 +7,9 @@ use Illuminate\Auth\Passwords\TokenRepositoryInterface;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +17,19 @@ use UnexpectedValueException;
 
 class AuthPasswordBrokerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Application::setInstance($container = new Application);
+
+        $container->singleton(DispatcherContract::class, function () {
+            return new Dispatcher();
+        });
+
+        $container->alias(DispatcherContract::class, 'events');
+    }
+
     protected function tearDown(): void
     {
         m::close();

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -2,14 +2,12 @@
 
 namespace Illuminate\Tests\Auth;
 
-use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Auth\Passwords\TokenRepositoryInterface;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
@@ -70,26 +68,6 @@ class AuthPasswordBrokerTest extends TestCase
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
         $this->assertSame(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo']));
-    }
-
-    public function testBrokerTriggersPasswordResetLinkEvent()
-    {
-        Event::fake();
-
-        $mocks = $this->getMocks();
-        $broker = m::mock(PasswordBroker::class, array_values($mocks))->makePartial();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
-        $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(false);
-        $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
-        $user->shouldReceive('sendPasswordResetNotification')->with('token');
-
-        $broker->sendResetLink(['foo']);
-
-        Event::assertDispatched(PasswordResetLinkSent::class, function ($event) {
-            $this->assertEquals(1, $event->user->id);
-
-            return true;
-        });
     }
 
     public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Auth\Passwords\TokenRepositoryInterface;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
@@ -68,6 +70,26 @@ class AuthPasswordBrokerTest extends TestCase
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
         $this->assertSame(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo']));
+    }
+
+    public function testBrokerTriggersPasswordResetLinkEvent()
+    {
+        Event::mock();
+
+        $mocks = $this->getMocks();
+        $broker = m::mock(PasswordBroker::class, array_values($mocks))->makePartial();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
+        $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(false);
+        $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
+        $user->shouldReceive('sendPasswordResetNotification')->with('token');
+
+        $broker->sendResetLink(['foo']);
+
+        Event::assertDispatched(PasswordResetLinkSent::class, function ($event) {
+            $this->assertEquals(1, $event->user->id);
+
+            return true;
+        });
     }
 
     public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
@@ -64,6 +66,25 @@ class ForgotPasswordTest extends TestCase
                     && $message->actionUrl === route('password.reset', ['token' => $notification->token, 'email' => $user->email]);
             }
         );
+    }
+
+    public function testItCanTriggerPasswordResetSentEvent()
+    {
+        Event::fake();
+
+        UserFactory::new()->create();
+
+        $user = AuthenticationTestUser::first();
+
+        Password::broker()->sendResetLink([
+            'email' => $user->email,
+        ]);
+
+        Event::assertDispatched(PasswordResetLinkSent::class, function ($event) {
+            $this->assertEquals(1, $event->user->id);
+
+            return true;
+        });
     }
 
     public function testItCanSendForgotPasswordEmailViaCreateUrlUsing()

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -70,7 +70,7 @@ class ForgotPasswordTest extends TestCase
 
     public function testItCanTriggerPasswordResetSentEvent()
     {
-        Event::fake();
+        Event::fake([PasswordResetLinkSent::class]);
 
         UserFactory::new()->create();
 


### PR DESCRIPTION
This PR adds are new event called `PasswordResetLinkSent`, which is triggered by the PasswordBroker directly after the Notification is queued.

We had a need for this ourselves, and this seemed to be the only missing event in the auth / reset chain, and seems like something that may be useful for others.

Note that it's possible to trigger your own event within the application layer at least a couple of different ways, using middleware or within a `Notification` event listener, but those solutions seem messy comparatively.

When looking at the other [Auth related events already supported](https://github.com/laravel/framework/tree/11.x/src/Illuminate/Auth/Events) I think doing this natively makes sense.

Note: I decided not to trigger the event if `$callback` is passed in, since we will not know how this is handled within the callback.