### PR TITLE
[11.x] fix: Factory::createMany creating n^2 records

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -240,9 +240,8 @@ abstract class Factory
      */
     public function createMany(int|iterable|null $records = null)
     {
-        if (is_null($records)) {
-            $records = $this->count ?? 1;
-        }
+        $records ??= $this->count ?? 1;
+        $this->count = null;
 
         if (is_numeric($records)) {
             $records = array_fill(0, $records, []);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -240,7 +240,8 @@ abstract class Factory
      */
     public function createMany(int|iterable|null $records = null)
     {
-        $records ??= $this->count ?? 1;
+        $records ??= ($this->count ?? 1);
+
         $this->count = null;
 
         if (is_numeric($records)) {

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -129,14 +129,30 @@ class DatabaseEloquentFactoryTest extends TestCase
         $users = FactoryTestUserFactory::new()->createMany(2);
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertCount(2, $users);
+        $this->assertInstanceOf(FactoryTestUser::class, $users->first());
 
         $users = FactoryTestUserFactory::times(2)->createMany();
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertCount(2, $users);
+        $this->assertInstanceOf(FactoryTestUser::class, $users->first());
+
+        $users = FactoryTestUserFactory::times(2)->createMany();
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(2, $users);
+        $this->assertInstanceOf(FactoryTestUser::class, $users->first());
+
+        $users = FactoryTestUserFactory::times(3)->createMany([
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Jeffrey Way'],
+        ]);
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(2, $users);
+        $this->assertInstanceOf(FactoryTestUser::class, $users->first());
 
         $users = FactoryTestUserFactory::new()->createMany();
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertCount(1, $users);
+        $this->assertInstanceOf(FactoryTestUser::class, $users->first());
 
         $users = FactoryTestUserFactory::times(10)->create();
         $this->assertCount(10, $users);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

Closes #51224 

This PR fixes the N^2 issue when using `EloquentFactory::createMany` with a count. I went with Option 1 given in the issue, so passing an argument to `createMany` will overwrite any previous count set on the model---leaving the arg `null` will use the count set on the model.

```php
User::factory()->count(2)->createMany(); // 2 records created
User::factory()->count(2)->createMany([['foo' => 1], ['foo' => 2], ['foo' => 3]]); // 3 records created
```

If you'd like me to change the behaviour for that one edge case, just let me know!

Thanks!
