### PR TITLE
Add isProduction() and isLocal() methods to application contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -86,6 +86,20 @@ interface Application extends Container
     public function environment(...$environments);
 
     /**
+     * Determine if the application is in the local environment.
+     *
+     * @return bool
+     */
+    public function isLocal();
+
+    /**
+     * Determine if the application is in the production environment.
+     *
+     * @return bool
+     */
+    public function isProduction();
+
+    /**
      * Determine if the application is running in the console.
      *
      * @return bool


### PR DESCRIPTION
In the documentation is the following code snippet shown.

```php
use Illuminate\Database\Eloquent\Model;
 
/**
 * Bootstrap any application services.
 */
public function boot(): void
{
    Model::preventLazyLoading(! $this->app->isProduction());
}
```
(source: https://laravel.com/docs/11.x/eloquent#configuring-eloquent-strictness)

However, when doing so, you will get an error that the isProduction method does not exist.
The app property in the service provider is typed as ```\Illuminate\Contracts\Foundation\Application```.
The method does exist on the ```\Illuminate\Foundation\Application``` class but not in the contract.

This PR fixes the issue by adding the ```isProduction()``` and, for convenience, the ```isLocal()``` method to the contract