### PR TITLE
[11.x] Add  some tests in `SupportStrTest` class 

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -265,7 +265,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han2nah', 2));
     }
 
-    public function testStrBeforeLast()
+    public function testStrBeforeLast(): void
     {
         $this->assertSame('yve', Str::beforeLast('yvette', 'tte'));
         $this->assertSame('yvet', Str::beforeLast('yvette', 't'));
@@ -276,6 +276,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('yv0et', Str::beforeLast('yv0et0te', '0'));
         $this->assertSame('yv0et', Str::beforeLast('yv0et0te', 0));
         $this->assertSame('yv2et', Str::beforeLast('yv2et2te', 2));
+        $this->assertSame('', Str::beforeLast('', 'test'));
+        $this->assertSame('', Str::beforeLast('yvette', 'yvette'));
+        $this->assertSame('laravel', Str::beforeLast("laravel framework", ' '));
+        $this->assertSame('yvette', Str::beforeLast("yvette\t", "\t"));
     }
 
     public function testStrBetween()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -283,7 +283,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::beforeLast('', 'test'));
         $this->assertSame('', Str::beforeLast('yvette', 'yvette'));
         $this->assertSame('laravel', Str::beforeLast("laravel framework", ' '));
-        $this->assertSame('yvette', Str::beforeLast("yvette\t", "\t"));
+        $this->assertSame('yvette', Str::beforeLast("yvette\tyv0et0te", "\t"));
     }
 
     public function testStrBetween()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -282,7 +282,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('yv2et', Str::beforeLast('yv2et2te', 2));
         $this->assertSame('', Str::beforeLast('', 'test'));
         $this->assertSame('', Str::beforeLast('yvette', 'yvette'));
-        $this->assertSame('laravel', Str::beforeLast("laravel framework", ' '));
+        $this->assertSame('laravel', Str::beforeLast('laravel framework', ' '));
         $this->assertSame('yvette', Str::beforeLast("yvette\tyv0et0te", "\t"));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -12,11 +12,13 @@ use ValueError;
 
 class SupportStrTest extends TestCase
 {
-    public function testStringCanBeLimitedByWords()
+    public function testStringCanBeLimitedByWords(): void
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));
         $this->assertSame('Taylor___', Str::words('Taylor Otwell', 1, '___'));
         $this->assertSame('Taylor Otwell', Str::words('Taylor Otwell', 3));
+        $this->assertSame('Taylor Otwell', Str::words('Taylor Otwell', -1, '...'));
+        $this->assertSame('', Str::words('', 3, '...'));
     }
 
     public function testStringCanBeLimitedByWordsNonAscii()
@@ -114,11 +116,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('   ', Str::apa('   '));
     }
 
-    public function testStringWithoutWordsDoesntProduceError()
+    public function testStringWithoutWordsDoesntProduceError(): void
     {
         $nbsp = chr(0xC2).chr(0xA0);
         $this->assertSame(' ', Str::words(' '));
         $this->assertEquals($nbsp, Str::words($nbsp));
+        $this->assertSame('   ', Str::words('   '));
+        $this->assertSame("\t\t\t", Str::words("\t\t\t"));
     }
 
     public function testStringAscii()


### PR DESCRIPTION
This PR, enhances the test coverage for the `SupportStrTest` class by adding new tests.

### 1. testStringCanBeLimitedByWords()
Testing negative values for the word count and an empty string are important edge cases to cover. 

```php
$this->assertSame('Taylor Otwell', Str::words('Taylor Otwell', -1, '...'));
$this->assertSame('', Str::words('', 3, '...')); 
```

### 2. testStringWithoutWordsDoesntProduceError
Testing multiple space and tabs

```php
$this->assertSame('   ', Str::words('   '));
$this->assertSame("\t\t\t", Str::words("\t\t\t"));
```

### 3. testStrBeforeLast

```php
$this->assertSame('', Str::beforeLast('', 'test')); // empty string
$this->assertSame('', Str::beforeLast('yvette', 'yvette')); // search parater equal subject parameter
$this->assertSame('laravel', Str::beforeLast("laravel framework", ' ')); // check space
$this->assertSame('yvette', Str::beforeLast("yvette\tyv0et0te", "\t")); // check tab space
```