### PR TITLE
[10.x] Fix support for the LARAVEL_STORAGE_PATH env var (#51238)

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -531,6 +531,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
+        if (isset($_ENV['LARAVEL_STORAGE_PATH'])) {
+            return $this->joinPaths($this->storagePath ?: $_ENV['LARAVEL_STORAGE_PATH'], $path);
+        }
+
         if (isset($_SERVER['LARAVEL_STORAGE_PATH'])) {
             return $this->joinPaths($this->storagePath ?: $_SERVER['LARAVEL_STORAGE_PATH'], $path);
         }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -531,8 +531,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        if (isset($_ENV['LARAVEL_STORAGE_PATH'])) {
-            return $this->joinPaths($this->storagePath ?: $_ENV['LARAVEL_STORAGE_PATH'], $path);
+        if (isset($_SERVER['LARAVEL_STORAGE_PATH'])) {
+            return $this->joinPaths($this->storagePath ?: $_SERVER['LARAVEL_STORAGE_PATH'], $path);
         }
 
         return $this->joinPaths($this->storagePath ?: $this->basePath('storage'), $path);


### PR DESCRIPTION
https://github.com/laravel/framework/pull/48115 introduced a convenient environment variable to configure the storage path.

However, by default, PHP doesn't populate the `$_ENV` superglobal in `dev` and `production` mode: https://github.com/php/php-src/blob/ed916214c478da36d473d425ca30e2ce7c310e87/php.ini-production#L159-L160

On the other hand, environment variables are always populated in the `$_SERVER` superglobal (https://www.php.net/manual/en/ini.core.php#ini.variables-order).

For its part https://github.com/vlucas/phpdotenv populates both `$_SERVER` and `$_ENV`.

This patch switches from `$_ENV` to `$_SERVER`, which will help using Laravel in containerized environments, where `.env` files aren't used in production. 