### PR TITLE
[10.x] fix: calling flip on an eloquent collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -597,11 +597,11 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Flip the items in the collection.
      *
-     * @return \Illuminate\Support\Collection<TModel, TKey>
+     * @return \Illuminate\Support\Collection<array-key, TKey>
      */
     public function flip()
     {
-        return $this->toBase()->flip();
+        return $this->toBase()->map(fn ($v) => $v->getKey())->flip();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -491,14 +491,22 @@ class DatabaseEloquentCollectionTest extends TestCase
     public function testNonModelRelatedMethods()
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
-        $b = new Collection(['a', 'b', 'c']);
         $this->assertEquals(BaseCollection::class, get_class($a->pluck('foo')));
         $this->assertEquals(BaseCollection::class, get_class($a->keys()));
         $this->assertEquals(BaseCollection::class, get_class($a->collapse()));
         $this->assertEquals(BaseCollection::class, get_class($a->flatten()));
         $this->assertEquals(BaseCollection::class, get_class($a->zip(['a', 'b'], ['c', 'd'])));
         $this->assertEquals(BaseCollection::class, get_class($a->countBy('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($b->flip()));
+    }
+
+    public function testEloquentCollectionsCanBeFlipped()
+    {
+        $this->seedData();
+        $c = EloquentTestArticleModel::all()->flip();
+
+        $this->assertSame(BaseCollection::class, get_class($c));
+        $this->assertSame(3, $c->count());
+        $this->assertSame([1 => 0, 2 => 1, 3 => 2], $c->all());
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -171,7 +171,7 @@ assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse())
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten(4));
 
-assertType('Illuminate\Support\Collection<User, int>', $collection->flip());
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection->flip());
 
 assertType('Illuminate\Support\Collection<int, int|User>', $collection->pad(2, 0));
 assertType('Illuminate\Support\Collection<int, string|User>', $collection->pad(2, 'string'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR fixes a bug when calling `->flip()` on an EloquentCollection---the following warning was generated and an empty collection was returned:

> WARNING  array_flip(): Can only flip string and integer values, entry skipped in vendor/laravel/framework/src/Illuminate/Collections/Collection.php on line 425.

To fix I just convert all models to their key with `->getKey()` before flipping. Another option would be to cast the model to a string but that could yield large json strings which didn't seem desirable.

```php
// before
User::all()->flip(); // resulted in a warning and an empty support collection
// now
User::all()->flip(); // returns a support collection with [$user->getKey() => TKey]
```

Thanks!
