### PR TITLE
[11.x] Add ability to override RouteServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -157,7 +157,7 @@ class ApplicationBuilder
 
         $provider::loadRoutesUsing($using);
 
-        $this->app->booting(function ()use($provider) {
+        $this->app->booting(function () use ($provider) {
             $this->app->register($provider, force: true);
         });
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -148,16 +148,17 @@ class ApplicationBuilder
         ?string $pages = null,
         ?string $health = null,
         string $apiPrefix = 'api',
+        string $provider = AppRouteServiceProvider::class,
         ?callable $then = null)
     {
         if (is_null($using) && (is_string($web) || is_string($api) || is_string($pages) || is_string($health)) || is_callable($then)) {
             $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $then);
         }
 
-        AppRouteServiceProvider::loadRoutesUsing($using);
+        $provider::loadRoutesUsing($using);
 
-        $this->app->booting(function () {
-            $this->app->register(AppRouteServiceProvider::class, force: true);
+        $this->app->booting(function ()use($provider) {
+            $this->app->register($provider, force: true);
         });
 
         if (is_string($commands) && realpath($commands) !== false) {


### PR DESCRIPTION
I need to override `loadCacheRoutes` method inside `RouteServiceProvider` **as we did before laravel 11** but when i extend the framework RouteServiceProvider and add it inside the `bootstrap/providers.php` 
the framework RouteServiceProvider **always run last** 
i think we are forcing it here https://github.com/laravel/framework/pull/49732