### PR TITLE
[11.x] Introduce method `Rule::array()`

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
@@ -197,5 +198,16 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
+    }
+
+    /**
+     * Get an array constraint builder instance
+     *
+     * @param  array|null  $parameters
+     * @return \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string|null
+     */
+    public static function array($keys = null)
+    {
+        return new ArrayRule(...func_get_args());
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -61,6 +61,17 @@ class Rule
     }
 
     /**
+     * Get an array rule builder instance.
+     *
+     * @param  array|null  $keys
+     * @return \Illuminate\Validation\ArrayRule
+     */
+    public static function array($keys = null)
+    {
+        return new ArrayRule(...func_get_args());
+    }
+
+    /**
      * Create a new nested rule set.
      *
      * @param  callable  $callback
@@ -96,7 +107,7 @@ class Rule
     }
 
     /**
-     * Get an in constraint builder instance.
+     * Get an in rule builder instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\In
@@ -111,7 +122,7 @@ class Rule
     }
 
     /**
-     * Get a not_in constraint builder instance.
+     * Get a not_in rule builder instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\NotIn
@@ -126,7 +137,7 @@ class Rule
     }
 
     /**
-     * Get a required_if constraint builder instance.
+     * Get a required_if rule builder instance.
      *
      * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\RequiredIf
@@ -137,7 +148,7 @@ class Rule
     }
 
     /**
-     * Get a exclude_if constraint builder instance.
+     * Get a exclude_if rule builder instance.
      *
      * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\ExcludeIf
@@ -148,7 +159,7 @@ class Rule
     }
 
     /**
-     * Get a prohibited_if constraint builder instance.
+     * Get a prohibited_if rule builder instance.
      *
      * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\ProhibitedIf
@@ -159,7 +170,7 @@ class Rule
     }
 
     /**
-     * Get an enum constraint builder instance.
+     * Get an enum rule builder instance.
      *
      * @param  class-string  $type
      * @return \Illuminate\Validation\Rules\Enum
@@ -170,7 +181,7 @@ class Rule
     }
 
     /**
-     * Get a file constraint builder instance.
+     * Get a file rule builder instance.
      *
      * @return \Illuminate\Validation\Rules\File
      */
@@ -180,7 +191,7 @@ class Rule
     }
 
     /**
-     * Get an image file constraint builder instance.
+     * Get an image file rule builder instance.
      *
      * @return \Illuminate\Validation\Rules\ImageFile
      */
@@ -190,7 +201,7 @@ class Rule
     }
 
     /**
-     * Get a dimensions constraint builder instance.
+     * Get a dimensions rule builder instance.
      *
      * @param  array  $constraints
      * @return \Illuminate\Validation\Rules\Dimensions
@@ -198,16 +209,5 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
-    }
-
-    /**
-     * Get an array constraint builder instance.
-     *
-     * @param  array|null  $parameters
-     * @return \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string|null
-     */
-    public static function array($keys = null)
-    {
-        return new ArrayRule(...func_get_args());
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -201,7 +201,7 @@ class Rule
     }
 
     /**
-     * Get an array constraint builder instance
+     * Get an array constraint builder instance.
      *
      * @param  array|null  $parameters
      * @return \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string|null

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Validation\Rules;
 
 use BackedEnum;
@@ -19,9 +17,9 @@ class ArrayRule implements Stringable
     protected $keys;
 
     /**
-     * Create a new in rule instance.
+     * Create a new array rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string|null  $values
+     * @param  array|null  $keys
      * @return void
      */
     public function __construct($keys = null)
@@ -40,7 +38,7 @@ class ArrayRule implements Stringable
      */
     public function __toString()
     {
-        if (! $this->keys) {
+        if (empty($this->keys)) {
             return 'array';
         }
 

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -53,6 +53,6 @@ class ArrayRule implements Stringable
             $this->keys,
         );
 
-        return 'array:' . implode(',', $keys);
+        return 'array:'.implode(',', $keys);
     }
 }

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Validation\Rules;
+
+use BackedEnum;
+use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
+use UnitEnum;
+
+class ArrayRule implements Stringable
+{
+    /**
+     * The accepted keys.
+     *
+     * @var array
+     */
+    protected $keys;
+
+    /**
+     * Create a new in rule instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string|null  $values
+     * @return void
+     */
+    public function __construct($keys = null)
+    {
+        if ($keys instanceof Arrayable) {
+            $keys = $keys->toArray();
+        }
+
+        $this->keys = is_array($keys) ? $keys : func_get_args();
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (! $this->keys) {
+            return 'array';
+        }
+
+        $keys = array_map(
+            static fn ($key) => match (true) {
+                $key instanceof BackedEnum => $key->value,
+                $key instanceof UnitEnum => $key->name,
+                default => $key,
+            },
+            $this->keys,
+        );
+
+        return 'array:' . implode(',', $keys);
+    }
+}

--- a/tests/Validation/Enums.php
+++ b/tests/Validation/Enums.php
@@ -19,3 +19,17 @@ enum PureEnum
     case one;
     case two;
 }
+
+enum ArrayKeys
+{
+    case key_1;
+    case key_2;
+    case key_3;
+}
+
+enum ArrayKeysBacked: string
+{
+    case key_1 = 'key_1';
+    case key_2 = 'key_2';
+    case key_3 = 'key_3';
+}

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -15,6 +15,10 @@ class ValidationArrayRuleTest extends TestCase
 
         $this->assertSame('array', (string) $rule);
 
+        $rule = Rule::array('key_1', 'key_2', 'key_3');
+
+        $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+
         $rule = Rule::array(['key_1', 'key_2', 'key_3']);
 
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
+
+include_once 'Enums.php';
+
+class ValidationArrayRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = Rule::array();
+
+        $this->assertSame('array', (string) $rule);
+
+        $rule = Rule::array(['key_1', 'key_2', 'key_3']);
+
+        $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::array(collect(['key_1', 'key_2', 'key_3']));
+
+        $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::array([ArrayKeys::key_1, ArrayKeys::key_2, ArrayKeys::key_3]);
+
+        $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::array([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2, ArrayKeysBacked::key_3]);
+
+        $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+    }
+}


### PR DESCRIPTION
This PR introduces a new `array` method to `\Illuminate\Validation\Rule`.

Currently, it is often cumbersome to validate multiple array keys through the `array` rule. At the same time, if intending to using constants, or enums, we may end up in defining our rule such as:
```php
['array:' . MyBackedEnum::VALUE->value . ',' . MyBackedEnum::VALUE_2->value]
```

The goal of this change is to improve code readability and prevent uncaught typos when validating array keys, but to also improve the existing functionalities by introducing support for `Arrayable` & lists of enums.

The newly introduced `ArrayRule` works very similar to the already existing `In` rule, by stringifying to the original `array` string rule, introducing no breaking changes.

In summary, the following is now possible:

```php
Rule::array();

Rule::array('key_1', 'key_2', 'key_3');

Rule::array(['key_1', 'key_2', 'key_3']);

Rule::array(collect(['key_1', 'key_2', 'key_3']));

Rule::array([UnitEnum::key_1, UnitEnum::key_2, UnitEnum::key_3]);

Rule::array([BackedEnum::key_1, BackedEnum::key_2, BackedEnum::key_3]);
```