### PR TITLE
[11.x] Fix `once()` cache when used in extended static class

### DIFF
--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -65,11 +65,13 @@ class Onceable
             fn (mixed $argument) => is_object($argument) ? spl_object_hash($argument) : $argument,
             $callable instanceof Closure ? (new ReflectionClosure($callable))->getClosureUsedVariables() : [],
         );
+        $class = $callable instanceof Closure ? (new ReflectionClosure($callable))->getClosureCalledClass()?->getName() : null;
+        $class ??= isset($trace[1]['class']) ? $trace[1]['class'] : null;
 
         return md5(sprintf(
             '%s@%s%s:%s (%s)',
             $trace[0]['file'],
-            isset($trace[1]['class']) ? ($trace[1]['class'].'@') : '',
+            $class ? $class.'@' : '',
             $trace[1]['function'],
             $trace[0]['line'],
             serialize($uses),

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -343,6 +343,14 @@ class OnceTest extends TestCase
 
         $this->assertNotSame($first, $third);
     }
+
+    public function testExtendedStaticClassOnceCalls()
+    {
+        $first = MyClass::staticRand();
+        $second = MyExtendedClass::staticRand();
+
+        $this->assertNotSame($first, $second);
+    }
 }
 
 $letter = 'a';
@@ -371,4 +379,8 @@ class MyClass
     {
         return once(fn () => $this->rand());
     }
+}
+
+class MyExtendedClass extends MyClass
+{
 }


### PR DESCRIPTION
Using `once()` from an extending class in static context will return the same value of the extended class, or vice versa, depending on which class was called first.

This change pulls the closure context class using `ReflectionFunctionAbstract::getClosureCalledClass()` which is currently undocumented, though it was introduced in 8.1 (https://github.com/php/php-src/issues/8932).