### PR TITLE
[12.x] Adding PasswordResetLinkSent event

### DIFF
--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetLinkSent
+{
+    use SerializesModels;
+
+    /**
+     * The user.
+     *
+     * @var \Illuminate\Contracts\Auth\CanResetPassword
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Auth\Passwords;
 
 use Closure;
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use UnexpectedValueException;
 
@@ -26,16 +28,25 @@ class PasswordBroker implements PasswordBrokerContract
     protected $users;
 
     /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $events;
+
+    /**
      * Create a new password broker instance.
      *
      * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
      * @param  \Illuminate\Contracts\Auth\UserProvider  $users
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $users
      * @return void
      */
-    public function __construct(TokenRepositoryInterface $tokens, UserProvider $users)
+    public function __construct(TokenRepositoryInterface $tokens, UserProvider $users, ?Dispatcher $dispatcher = null)
     {
         $this->users = $users;
         $this->tokens = $tokens;
+        $this->events = $dispatcher;
     }
 
     /**
@@ -70,6 +81,8 @@ class PasswordBroker implements PasswordBrokerContract
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification($token);
+
+        $this->firePasswordResetSentEvent($user);
 
         return static::RESET_LINK_SENT;
     }
@@ -186,5 +199,18 @@ class PasswordBroker implements PasswordBrokerContract
     public function getRepository()
     {
         return $this->tokens;
+    }
+
+    /**
+     * Fire the login event if the dispatcher is set.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    protected function firePasswordResetSentEvent($user)
+    {
+        if ($this->events) {
+            $this->events->dispatch(new PasswordResetLinkSent($user));
+        }
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -69,7 +69,8 @@ class PasswordBrokerManager implements FactoryContract
         // aggregate service of sorts providing a convenient interface for resets.
         return new PasswordBroker(
             $this->createTokenRepository($config),
-            $this->app['auth']->createUserProvider($config['provider'] ?? null)
+            $this->app['auth']->createUserProvider($config['provider'] ?? null),
+            $this->app['events'] ?? null,
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -784,7 +784,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -795,7 +795,7 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result.
      *
      * @param  array  $columns
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function first($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -320,7 +320,7 @@ class HasManyThrough extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -331,7 +331,7 @@ class HasManyThrough extends Relation
      * Execute the query and get the first related model.
      *
      * @param  array  $columns
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function first($columns = ['*'])
     {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -262,6 +262,16 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $shouldReplace = [];
 
         foreach ($replace as $key => $value) {
+            if ($value instanceof Closure) {
+                $line = preg_replace_callback(
+                    '/<'.$key.'>(.*?)<\/'.$key.'>/',
+                    fn ($args) => $value($args[1]),
+                    $line
+                );
+
+                continue;
+            }
+
             if (is_object($value) && isset($this->stringableHandlers[get_class($value)])) {
                 $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
             }

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
@@ -64,6 +66,25 @@ class ForgotPasswordTest extends TestCase
                     && $message->actionUrl === route('password.reset', ['token' => $notification->token, 'email' => $user->email]);
             }
         );
+    }
+
+    public function testItCanTriggerPasswordResetSentEvent()
+    {
+        Event::fake([PasswordResetLinkSent::class]);
+
+        UserFactory::new()->create();
+
+        $user = AuthenticationTestUser::first();
+
+        Password::broker()->sendResetLink([
+            'email' => $user->email,
+        ]);
+
+        Event::assertDispatched(PasswordResetLinkSent::class, function ($event) {
+            $this->assertEquals(1, $event->user->id);
+
+            return true;
+        });
     }
 
     public function testItCanSendForgotPasswordEmailViaCreateUrlUsing()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -12,11 +12,13 @@ use ValueError;
 
 class SupportStrTest extends TestCase
 {
-    public function testStringCanBeLimitedByWords()
+    public function testStringCanBeLimitedByWords(): void
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));
         $this->assertSame('Taylor___', Str::words('Taylor Otwell', 1, '___'));
         $this->assertSame('Taylor Otwell', Str::words('Taylor Otwell', 3));
+        $this->assertSame('Taylor Otwell', Str::words('Taylor Otwell', -1, '...'));
+        $this->assertSame('', Str::words('', 3, '...'));
     }
 
     public function testStringCanBeLimitedByWordsNonAscii()
@@ -114,11 +116,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('   ', Str::apa('   '));
     }
 
-    public function testStringWithoutWordsDoesntProduceError()
+    public function testStringWithoutWordsDoesntProduceError(): void
     {
         $nbsp = chr(0xC2).chr(0xA0);
         $this->assertSame(' ', Str::words(' '));
         $this->assertEquals($nbsp, Str::words($nbsp));
+        $this->assertSame('   ', Str::words('   '));
+        $this->assertSame("\t\t\t", Str::words("\t\t\t"));
     }
 
     public function testStringAscii()
@@ -265,7 +269,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han2nah', 2));
     }
 
-    public function testStrBeforeLast()
+    public function testStrBeforeLast(): void
     {
         $this->assertSame('yve', Str::beforeLast('yvette', 'tte'));
         $this->assertSame('yvet', Str::beforeLast('yvette', 't'));
@@ -276,6 +280,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('yv0et', Str::beforeLast('yv0et0te', '0'));
         $this->assertSame('yv0et', Str::beforeLast('yv0et0te', 0));
         $this->assertSame('yv2et', Str::beforeLast('yv2et2te', 2));
+        $this->assertSame('', Str::beforeLast('', 'test'));
+        $this->assertSame('', Str::beforeLast('yvette', 'yvette'));
+        $this->assertSame('laravel', Str::beforeLast('laravel framework', ' '));
+        $this->assertSame('yvette', Str::beforeLast("yvette\tyv0et0te", "\t"));
     }
 
     public function testStrBetween()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -257,6 +257,42 @@ class TranslationTranslatorTest extends TestCase
         );
     }
 
+    public function testTagReplacements()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'We have some nice <docs-link>documentation</docs-link>', '*')->andReturn([]);
+
+        $this->assertSame(
+            'We have some nice <a href="https://laravel.com/docs">documentation</a>',
+            $t->get(
+                'We have some nice <docs-link>documentation</docs-link>',
+                [
+                    "docs-link" => fn ($children) => "<a href=\"https://laravel.com/docs\">$children</a>"
+                ]
+            )
+        );
+    }
+
+    public function testTagReplacementsHandleMultipleOfSameTag()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '<bold-this>bold</bold-this> something else <bold-this>also bold</bold-this>', '*')->andReturn([]);
+
+        $this->assertSame(
+            '<b>bold</b> something else <b>also bold</b>',
+            $t->get(
+                '<bold-this>bold</bold-this> something else <bold-this>also bold</bold-this>',
+                [
+                    "bold-this" => fn ($children) => "<b>$children</b>"
+                ]
+            )
+        );
+    }
+
     public function testDetermineLocalesUsingMethod()
     {
         $t = new Translator($this->getLoader(), 'en');

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -269,7 +269,7 @@ class TranslationTranslatorTest extends TestCase
             $t->get(
                 'We have some nice <docs-link>documentation</docs-link>',
                 [
-                    "docs-link" => fn ($children) => "<a href=\"https://laravel.com/docs\">$children</a>"
+                    'docs-link' => fn ($children) => "<a href=\"https://laravel.com/docs\">$children</a>",
                 ]
             )
         );
@@ -287,7 +287,7 @@ class TranslationTranslatorTest extends TestCase
             $t->get(
                 '<bold-this>bold</bold-this> something else <bold-this>also bold</bold-this>',
                 [
-                    "bold-this" => fn ($children) => "<b>$children</b>"
+                    'bold-this' => fn ($children) => "<b>$children</b>",
                 ]
             )
         );


### PR DESCRIPTION
As per https://github.com/laravel/framework/pull/51223, I have updated this PR to remove the use of the global `event()` helper.

Now targeting 12.x due to change in `PasswordBroker` constructor.

---

This PR adds are new event called `PasswordResetLinkSent`, which is triggered by the `PasswordBroker` directly after the Notification is queued.

We had a need for this ourselves, and this seemed to be the only missing event in the auth / reset chain, and seems like something that may be useful for others.

Note that it's possible to trigger your own event within the application layer at least a couple of different ways, using middleware or within a Notification event listener, but those solutions seem messy comparatively.

When looking at the other [Auth related events already supported](https://github.com/laravel/framework/tree/11.x/src/Illuminate/Auth/Events) I think doing this natively makes sense.

Note: I decided not to trigger the event if $callback is passed in, since we will not know how this is handled within the callback.