### PR TITLE
[11.x] Adding PasswordResetLinkSent event

### DIFF
--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetLinkSent
+{
+    use SerializesModels;
+
+    /**
+     * The user.
+     *
+     * @var \Illuminate\Contracts\Auth\CanResetPassword
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -9,7 +9,7 @@ class PasswordResetLinkSent
     use SerializesModels;
 
     /**
-     * The user.
+     * The user instance.
      *
      * @var \Illuminate\Contracts\Auth\CanResetPassword
      */

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -82,6 +82,10 @@ class PasswordBroker implements PasswordBrokerContract
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification($token);
 
+        if ($this->events) {
+            $this->events->dispatch(new PasswordResetLinkSent($user));
+        }
+
         $this->firePasswordResetSentEvent($user);
 
         return static::RESET_LINK_SENT;
@@ -199,18 +203,5 @@ class PasswordBroker implements PasswordBrokerContract
     public function getRepository()
     {
         return $this->tokens;
-    }
-
-    /**
-     * Fire the login event if the dispatcher is set.
-     *
-     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
-     * @return void
-     */
-    protected function firePasswordResetSentEvent($user)
-    {
-        if ($this->events) {
-            $this->events->dispatch(new PasswordResetLinkSent($user));
-        }
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Auth\Passwords;
 
 use Closure;
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use UnexpectedValueException;
 
@@ -26,16 +28,25 @@ class PasswordBroker implements PasswordBrokerContract
     protected $users;
 
     /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $events;
+
+    /**
      * Create a new password broker instance.
      *
      * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
      * @param  \Illuminate\Contracts\Auth\UserProvider  $users
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $users
      * @return void
      */
-    public function __construct(TokenRepositoryInterface $tokens, UserProvider $users)
+    public function __construct(TokenRepositoryInterface $tokens, UserProvider $users, ?Dispatcher $dispatcher = null)
     {
         $this->users = $users;
         $this->tokens = $tokens;
+        $this->events = $dispatcher;
     }
 
     /**
@@ -70,6 +81,8 @@ class PasswordBroker implements PasswordBrokerContract
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification($token);
+
+        $this->firePasswordResetSentEvent($user);
 
         return static::RESET_LINK_SENT;
     }
@@ -186,5 +199,18 @@ class PasswordBroker implements PasswordBrokerContract
     public function getRepository()
     {
         return $this->tokens;
+    }
+
+    /**
+     * Fire the login event if the dispatcher is set.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    protected function firePasswordResetSentEvent($user)
+    {
+        if ($this->events) {
+            $this->events->dispatch(new PasswordResetLinkSent($user));
+        }
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -86,8 +86,6 @@ class PasswordBroker implements PasswordBrokerContract
             $this->events->dispatch(new PasswordResetLinkSent($user));
         }
 
-        $this->firePasswordResetSentEvent($user);
-
         return static::RESET_LINK_SENT;
     }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -69,7 +69,8 @@ class PasswordBrokerManager implements FactoryContract
         // aggregate service of sorts providing a convenient interface for resets.
         return new PasswordBroker(
             $this->createTokenRepository($config),
-            $this->app['auth']->createUserProvider($config['provider'] ?? null)
+            $this->app['auth']->createUserProvider($config['provider'] ?? null),
+            $this->app['events'] ?? null,
         );
     }
 

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
@@ -64,6 +66,25 @@ class ForgotPasswordTest extends TestCase
                     && $message->actionUrl === route('password.reset', ['token' => $notification->token, 'email' => $user->email]);
             }
         );
+    }
+
+    public function testItCanTriggerPasswordResetSentEvent()
+    {
+        Event::fake([PasswordResetLinkSent::class]);
+
+        UserFactory::new()->create();
+
+        $user = AuthenticationTestUser::first();
+
+        Password::broker()->sendResetLink([
+            'email' => $user->email,
+        ]);
+
+        Event::assertDispatched(PasswordResetLinkSent::class, function ($event) {
+            $this->assertEquals(1, $event->user->id);
+
+            return true;
+        });
     }
 
     public function testItCanSendForgotPasswordEmailViaCreateUrlUsing()


### PR DESCRIPTION
As per https://github.com/laravel/framework/pull/51223, I have updated this PR to remove the use of the global `event()` helper.

---

This PR adds are new event called `PasswordResetLinkSent`, which is triggered by the `PasswordBroker` directly after the Notification is queued.

We had a need for this ourselves, and this seemed to be the only missing event in the auth / reset chain, and seems like something that may be useful for others.

Note that it's possible to trigger your own event within the application layer at least a couple of different ways, using middleware or within a Notification event listener, but those solutions seem messy comparatively.

When looking at the other [Auth related events already supported](https://github.com/laravel/framework/tree/11.x/src/Illuminate/Auth/Events) I think doing this natively makes sense.

Note: I decided not to trigger the event if $callback is passed in, since we will not know how this is handled within the callback.