### PR TITLE
[11.x] Add `deleteIf`, `forceDeleteIf` and `restoreIf` methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1430,6 +1430,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Delete the model from the database if given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return bool|null
+     */
+    public function deleteIf($boolean)
+    {
+        return value($boolean) ? $this->delete() : null;
+    }
+
+    /**
      * Delete the model from the database within a transaction.
      *
      * @return bool|null

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -71,6 +71,17 @@ trait SoftDeletes
     }
 
     /**
+     * Force a hard delete on a soft-deleted model instance if given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return bool|null
+     */
+    public function forceDeleteIf($boolean)
+    {
+        return value($boolean) ? $this->forceDelete() : null;
+    }
+
+    /**
      * Perform the actual delete query on this model instance.
      *
      * @return mixed
@@ -150,6 +161,17 @@ trait SoftDeletes
     public function restoreQuietly()
     {
         return static::withoutEvents(fn () => $this->restore());
+    }
+
+    /**
+     * Restore a soft-deleted model instance if given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return bool|null
+     */
+    public function restoreIf($boolean)
+    {
+        return value($boolean) ? $this->restore() : null;
     }
 
     /**


### PR DESCRIPTION
This PR introduces three new methods to the `Model` and `SoftDeletes`.

- `deleteIf`
- `forceDeleteIf`
- `restoreIf`

Oftentimes, I'll want to conditionally delete or restore a model and so this saves writing that additional wrapping condition (when will PHP get primitive `if` and `unless`?!).

Like all good Laravel methods, these methods use the `value` helper underneath, so you can pass a `bool` or `Closure`.