### PR TITLE
[11.x] Add `abstract` option to `make:class` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -37,9 +37,14 @@ class ClassMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->option('invokable')
-            ? $this->resolveStubPath('/stubs/class.invokable.stub')
-            : $this->resolveStubPath('/stubs/class.stub');
+        if ($this->option('invokable')) {
+            return $this->resolveStubPath('/stubs/class.invokable.stub');
+        }
+        if ($this->option('abstract')) {
+            return $this->resolveStubPath('/stubs/class.abstract.stub');
+        }
+
+        return $this->resolveStubPath('/stubs/class.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -68,7 +68,7 @@ class ClassMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['abstract', 'a', InputOption::VALUE_NONE, 'Generate a abstract class'],
+            ['abstract', 'a', InputOption::VALUE_NONE, 'Generate an abstract class'],
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable class'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the class already exists'],
         ];

--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -63,6 +63,7 @@ class ClassMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
+            ['abstract', 'a', InputOption::VALUE_NONE, 'Generate a abstract class'],
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable class'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the class already exists'],
         ];

--- a/src/Illuminate/Foundation/Console/stubs/class.abstract.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.abstract.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+abstract class {{ class }}
+{
+    //
+}

--- a/tests/Integration/Generators/ClassMakeCommandTest.php
+++ b/tests/Integration/Generators/ClassMakeCommandTest.php
@@ -30,4 +30,15 @@ class ClassMakeCommandTest extends TestCase
             'public function __invoke()',
         ], 'app/Notification.php');
     }
+
+    public function testItCanGenerateAbstractClassFile()
+    {
+        $this->artisan('make:class', ['name' => 'Controller', '--abstract' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App;',
+            'abstract class Controller',
+        ], 'app/Controller.php');
+    }
 }


### PR DESCRIPTION
I added a new option to the `make:class` command called `abstract` or `a`.
This option generates an abstract class. Sometimes we need to create an abstract instead of a normal class and I think it's a good option to add to this class instead of creating a new command for this!

```shell
php artisan make:class Controller --abstract // -i
```

Result:

```php
<?php

namespace App;

abstract class Controller
{
   //
}
```