### PR TITLE
fixing return type of CreateMembersTable migration

### DIFF
--- a/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
+++ b/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
@@ -11,7 +11,7 @@ class CreateMembersTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('members', function (Blueprint $table) {
             $table->increments('id');
@@ -28,7 +28,7 @@ class CreateMembersTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::drop('members');
     }


### PR DESCRIPTION
fixing return type of CreateMembersTable migration