### PR TITLE
[11.x]  Add the --strict option to `make:class` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -98,7 +98,7 @@ class ClassMakeCommand extends GeneratorCommand
         return [
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable class'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the class already exists'],
-            ['strict', 's', InputOption::VALUE_NONE, 'Add strict mode to the class']
+            ['strict', 's', InputOption::VALUE_NONE, 'Add strict mode to the class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -56,6 +56,39 @@ class ClassMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        return $this->replaceStrict($stub, (bool) $this->option('strict'));
+    }
+
+    /**
+     * @param  string  $stub
+     * @param  bool  $isStrict
+     * @return string
+     */
+    protected function replaceStrict($stub, bool $isStrict)
+    {
+        $replace = $isStrict ? 'declare(strict_types=1);' : '';
+
+        $stub = str_replace(['{{ strict_types }}', '{{strict_types}}'], $replace, $stub);
+
+        if ($isStrict === false) {
+            $stub = str_replace("\n\n\n", "\n", $stub);
+        }
+
+        return $stub;
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array
@@ -65,6 +98,7 @@ class ClassMakeCommand extends GeneratorCommand
         return [
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable class'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the class already exists'],
+            ['strict', 's', InputOption::VALUE_NONE, 'Add strict mode to the class']
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/class.invokable.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.invokable.stub
@@ -1,5 +1,7 @@
 <?php
 
+{{ strict_types }}
+
 namespace {{ namespace }};
 
 class {{ class }}

--- a/src/Illuminate/Foundation/Console/stubs/class.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.stub
@@ -1,5 +1,7 @@
 <?php
 
+{{ strict_types }}
+
 namespace {{ namespace }};
 
 class {{ class }}

--- a/tests/Integration/Generators/ClassMakeCommandTest.php
+++ b/tests/Integration/Generators/ClassMakeCommandTest.php
@@ -6,7 +6,7 @@ class ClassMakeCommandTest extends TestCase
 {
     protected array $files = [
         'app/Reverb.php',
-        'app/Notification.php'
+        'app/Notification.php',
     ];
 
     public function testItCanGenerateClassFile(): void

--- a/tests/Integration/Generators/ClassMakeCommandTest.php
+++ b/tests/Integration/Generators/ClassMakeCommandTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Integration\Generators;
-
-use Illuminate\Tests\Integration\Generators\TestCase;
+namespace Illuminate\Tests\Integration\Generators;
 
 class ClassMakeCommandTest extends TestCase
 {

--- a/tests/Integration/Generators/ClassMakeCommandTest.php
+++ b/tests/Integration/Generators/ClassMakeCommandTest.php
@@ -4,7 +4,12 @@ namespace Illuminate\Tests\Integration\Generators;
 
 class ClassMakeCommandTest extends TestCase
 {
-    public function testItCanGenerateClassFile()
+    protected array $files = [
+        'app/Reverb.php',
+        'app/Notification.php'
+    ];
+
+    public function testItCanGenerateClassFile(): void
     {
         $this->artisan('make:class', ['name' => 'Reverb'])
             ->assertExitCode(0);
@@ -16,12 +21,39 @@ class ClassMakeCommandTest extends TestCase
         ], 'app/Reverb.php');
     }
 
-    public function testItCanGenerateInvokableClassFile()
+    public function testItCanGenerateStrictClassFile(): void
+    {
+        $this->artisan('make:class', ['name' => 'Reverb', '--strict' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'declare(strict_types=1)',
+            'namespace App;',
+            'class Reverb',
+            'public function __construct()',
+        ], 'app/Reverb.php');
+    }
+
+    public function testItCanGenerateInvokableClassFile(): void
     {
         $this->artisan('make:class', ['name' => 'Notification', '--invokable' => true])
             ->assertExitCode(0);
 
         $this->assertFileContains([
+            'namespace App;',
+            'class Notification',
+            'public function __construct()',
+            'public function __invoke()',
+        ], 'app/Notification.php');
+    }
+
+    public function testItCanGenerateStrictInvokableClassFile(): void
+    {
+        $this->artisan('make:class', ['name' => 'Notification', '--invokable' => true, '--strict' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'declare(strict_types=1)',
             'namespace App;',
             'class Notification',
             'public function __construct()',


### PR DESCRIPTION
This PR, aims to add the `--strict` option to the `make:class` command. this option **empowers** developers to craft Laravel classes with strict typing, thereby harnessing the full potential of PHP's additional features.

> The aim is to give developers the option to choose whether to be in strict mode or not?

### Example
```php
php artisan make:class MyClass --strict
php artisan make:class MyInokableClass --invokable --strict
```

The phrase ```declare(strict_types=1); ``` at the beginning of the generated classes signifies that strict typing mode is enabled.

### Tests
Adding tests related to the `--strict` option and applying strict typing to ensure the correctness of these changes.


Thanks!