### PR TITLE
 Added "name" & "email" to Authenticatable trait

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -9,14 +9,14 @@ trait Authenticatable
      *
      * @var string
      */
-    protected $authNameKey = 'name';
+    protected $authNameKey = 'Name';
 
     /**
      * The column name of the "email" field.
      *
      * @var string
      */
-    protected $authEmailName = 'email';
+    protected $authEmailName = 'Email';
     
     /**
      * The column name of the password field using during authentication.
@@ -62,7 +62,7 @@ trait Authenticatable
         return $this->getAuthIdentifier();
     }
 
-    /**
+        /**
      * Get the name of the "name" attribute for the user.
      *
      * @return string
@@ -83,7 +83,7 @@ trait Authenticatable
     }
 
     /**
-     * Get the name of the email attribute for the user.
+     * Get the name of the "email" attribute for the user.
      *
      * @return string
      */
@@ -101,7 +101,7 @@ trait Authenticatable
     {
         return $this->{$this->getAuthEmailName()};
     }
-
+    
     /**
      * Get the name of the password attribute for the user.
      *

--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -99,7 +99,7 @@ trait Authenticatable
      */
     public function getAuthEmail()
     {
-        return $this->{$this->getAuthEmail()};
+        return $this->{$this->getAuthEmailName()};
     }
 
     /**

--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -5,6 +5,20 @@ namespace Illuminate\Auth;
 trait Authenticatable
 {
     /**
+     * The column name of the "name" field.
+     *
+     * @var string
+     */
+    protected $authNameKey = 'name';
+
+    /**
+     * The column name of the "email" field.
+     *
+     * @var string
+     */
+    protected $authEmailName = 'email';
+    
+    /**
      * The column name of the password field using during authentication.
      *
      * @var string
@@ -46,6 +60,46 @@ trait Authenticatable
     public function getAuthIdentifierForBroadcasting()
     {
         return $this->getAuthIdentifier();
+    }
+
+    /**
+     * Get the name of the "name" attribute for the user.
+     *
+     * @return string
+     */
+    public function getAuthNameKey()
+    {
+        return $this->authNameKey;
+    }
+
+    /**
+     * Get the name for the user.
+     *
+     * @return string
+     */
+    public function getAuthName()
+    {
+        return $this->{$this->getAuthNameKey()};
+    }
+
+    /**
+     * Get the name of the email attribute for the user.
+     *
+     * @return string
+     */
+    public function getAuthEmailName()
+    {
+        return $this->authEmailName;
+    }
+
+    /**
+     * Get the email for the user.
+     *
+     * @return string
+     */
+    public function getAuthEmail()
+    {
+        return $this->{$this->getAuthEmail()};
     }
 
     /**


### PR DESCRIPTION
These properties & methods are used to reference the columns for User Name & Email in DB. I intend to use these in Telescope to show the name & email of authenticated user when default column names are not used.