### PR TITLE
[11.x] Fix SesV2Transport to use correct `EmailTags` argument

### DIFF
--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -56,7 +56,7 @@ class SesV2Transport extends AbstractTransport implements Stringable
 
             foreach ($message->getOriginalMessage()->getHeaders()->all() as $header) {
                 if ($header instanceof MetadataHeader) {
-                    $options['Tags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
+                    $options['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
                 }
             }
         }

--- a/tests/Mail/MailSesV2TransportTest.php
+++ b/tests/Mail/MailSesV2TransportTest.php
@@ -75,7 +75,7 @@ class MailSesV2TransportTest extends TestCase
                 return $arg['Source'] === 'myself@example.com' &&
                     $arg['Destination']['ToAddresses'] === ['me@example.com', 'you@example.com'] &&
                     $arg['ListManagementOptions'] === ['ContactListName' => 'TestList', 'TopicName' => 'TestTopic'] &&
-                    $arg['Tags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
+                    $arg['EmailTags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
                     strpos($arg['Content']['Raw']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>') !== false;
             }))
             ->andReturn($sesResult);
@@ -113,7 +113,7 @@ class MailSesV2TransportTest extends TestCase
                             'region' => 'eu-west-1',
                             'options' => [
                                 'ConfigurationSetName' => 'Laravel',
-                                'Tags' => [
+                                'EmailTags' => [
                                     ['Name' => 'Laravel', 'Value' => 'Framework'],
                                 ],
                             ],
@@ -146,7 +146,7 @@ class MailSesV2TransportTest extends TestCase
 
         $this->assertSame([
             'ConfigurationSetName' => 'Laravel',
-            'Tags' => [
+            'EmailTags' => [
                 ['Name' => 'Laravel', 'Value' => 'Framework'],
             ],
         ], $transport->getOptions());


### PR DESCRIPTION
`Illuminate\Mail\Transport\SesV2Transport` calls SESv2's `SendEmail` API but passes v1's `Tags` argument. The call doesn't fail but the tags are not attached to the sent email.
(ConfigurationSet events don't include specified tags)

This PR fixes the parameter name to correct `EmailTags`.

Notes:
- Please don't confuse that `SesTransport` uses SES v1, which argument name is `Tags`.
- Laravel 10.x has same issue. Backport will be needed.

Reference:
- https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html#SES-SendEmail-request-EmailTags
- https://docs.aws.amazon.com/ja_jp/aws-sdk-php/v3/api/api-sesv2-2019-09-27.html#sendemail

Steps:
``` php
class TestMail extends Mailable
{
    public function envelope(): Envelope
    {
        return new Envelope(subject: 'blah blah blah', metadata: ['Foo' => 'Bar']);
    }
}
```

The ConfigurationSet event Before:
``` json5
{
    "eventType": "Delivery",
    "mail": {
        ...
        "tags": {
            "ses:operation": ["SendRawEmail"],
            ...
        }
    }, ...
}
```

After:
``` json5
{
    "eventType": "Delivery",
    "mail": {
        ...
        "tags": {
            "ses:operation": ["SendRawEmail"],
            ...
            "Foo": ["Bar"] // <- HERE
        }
    }, ...
}
```

Related PR: #42390