### PR TITLE
[11.x] Added "snippet" blade feature with >13x speed improvement

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -31,6 +31,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesLoops,
         Concerns\CompilesRawPhp,
         Concerns\CompilesSessions,
+        Concerns\CompilesSnippets,
         Concerns\CompilesStacks,
         Concerns\CompilesStyles,
         Concerns\CompilesTranslations,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesSnippets.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesSnippets.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+use Illuminate\Support\Str;
+
+trait CompilesSnippets
+{
+    /**
+     * Compile the snippet statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSnippet($expression)
+    {
+        [$function, $args] = $this->extractSnippetParts($expression);
+
+        return implode("\n", [
+            "<?php if (! isset(\${$function})):",
+            '$'.$function.' = static function('.$args.') use($__env) {',
+            '?>',
+        ]);
+    }
+
+    /**
+     * Compile the endsnippet statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndSnippet($expression)
+    {
+        return implode("\n", [
+            '<?php } ?>',
+            '<?php endif; ?>',
+        ]);
+    }
+
+    /**
+     * Compile the renderSnippet statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileRenderSnippet($expression)
+    {
+        [$function, $args] = $this->extractSnippetParts($expression);
+
+        return '<?php echo $'.$function.'('.$args.'); ?>';
+    }
+
+    /**
+     * Analyse the snippet expression and extract the function and optional arguments.
+     *
+     * @param  string  $expression
+     * @return array
+     */
+    protected function extractSnippetParts($expression)
+    {
+        $functionParts = explode(',', $this->stripParentheses($expression));
+
+        $function = trim(array_shift($functionParts), "'\" ");
+
+        if (empty($function)) {
+            $function = 'function';
+        }
+
+        $function = '__snippet_'.Str::camel($function);
+
+        $args = trim(implode(',', $functionParts));
+
+        return [$function, $args];
+    }
+}

--- a/tests/View/Blade/BladeSnippetStatementsTest.php
+++ b/tests/View/Blade/BladeSnippetStatementsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeSnippetStatementsTest extends AbstractBladeTestCase
+{
+    public function testSnippetStatementsAreCompiled()
+    {
+        $string = '@snippet
+default breeze
+@endsnippet
+
+@snippet ("bar")
+breeze with double quotes
+@endsnippet
+
+@snippet (\'foo\', $bar)
+breeze with single quotes {{ $bar }}
+@endsnippet
+
+@snippet (foobar, string $barfoo)
+breeze without quotes {{ $barfoo }}
+@endsnippet
+
+@snippet ("foo-bar", ?string $barfoo = null)
+breeze with slugged snippet name {{ $barfoo }}
+@endsnippet';
+        $expected = '<?php if (! isset($__snippet_function)):
+$__snippet_function = static function() use($__env) {
+?>
+default breeze
+<?php } ?>
+<?php endif; ?>
+
+<?php if (! isset($__snippet_bar)):
+$__snippet_bar = static function() use($__env) {
+?>
+breeze with double quotes
+<?php } ?>
+<?php endif; ?>
+
+<?php if (! isset($__snippet_foo)):
+$__snippet_foo = static function($bar) use($__env) {
+?>
+breeze with single quotes <?php echo e($bar); ?>
+
+<?php } ?>
+<?php endif; ?>
+
+<?php if (! isset($__snippet_foobar)):
+$__snippet_foobar = static function(string $barfoo) use($__env) {
+?>
+breeze without quotes <?php echo e($barfoo); ?>
+
+<?php } ?>
+<?php endif; ?>
+
+<?php if (! isset($__snippet_fooBar)):
+$__snippet_fooBar = static function(?string $barfoo = null) use($__env) {
+?>
+breeze with slugged snippet name <?php echo e($barfoo); ?>
+
+<?php } ?>
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testRenderSnippetStatementsAreCompiled()
+    {
+        $string = '@renderSnippet
+
+@renderSnippet ("bar")
+
+@renderSnippet (\'foo\', $bar)
+
+@renderSnippet (foobar, $barfoo)
+
+@renderSnippet ("foo-bar", $barfoo)';
+        $expected = '<?php echo $__snippet_function(); ?>
+
+<?php echo $__snippet_bar(); ?>
+
+<?php echo $__snippet_foo($bar); ?>
+
+<?php echo $__snippet_foobar($barfoo); ?>
+
+<?php echo $__snippet_fooBar($barfoo); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Svelte 5 has a neat new feature called "snippets". See https://svelte-5-preview.vercel.app/docs/snippets

Basically it allows you to extract parts of a template into a snippet, in the same file, and reuse that later in the file. That way you can avoid using another blade file, which in certain cases might be preferable.

To take those Svelte examples and translate them to blade:

This:
```blade
@foreach($images as $image)
  @if($image['href'])
    <a href="{{ $image['href'] }}">
      <figure>
        <img
          src="{{ $image['src'] }}"
          alt="{{ $image['caption'] }}"
          width="{{ $image['width'] }}"
          height="{{ $image['height'] }}"
        />
        <figcaption>{{ $image['caption'] }}</figcaption>
      </figure>
    </a>
  @else
    <figure>
      <img
        src="{{ $image['src'] }}"
        alt="{{ $image['caption'] }}"
        width="{{ $image['width'] }}"
        height="{{ $image['height'] }}"
      />
      <figcaption>{{ $image['caption'] }}</figcaption>
    </figure>
  @endif
@endforeach
```

Becomes this:
```blade
@snippet ('image', $img)
  <figure>
    <img
      src="{{ $img['src'] }}"
      alt="{{ $img['caption'] }}"
      width="{{ $img['width'] }}"
      height="{{ $img['height'] }}"
    />
    <figcaption>{{ $img['caption'] }}</figcaption>
  </figure>
@endsnippet

@foreach ($images as $image)
  @if ($image['href'])
    <a href="{{ $image['href'] }}">
      @renderSnippet ('image', $image)
    </a>
  @else
    @renderSnippet ('image', $image)
  @endif
@endforeach
```

Like function declarations, snippets can have an arbitrary number of parameters, which can have default values.

## Snippet scope

Snippets can be declared anywhere inside a blade file. But since they are functions they cannot reference variables outside themselves. Maybe one day PHP will have multiline arrow functions. Nuno tried that already (https://github.com/php/php-src/pull/6246).

Declared snippets are only usable in the same blade file with the exception of included bladed files using @include directive, which makes sense since you are literally including the content of another file.

## Snippet declaration

Snippets can be declared with or without a specific function name, and with or without parameters:
```blade
@snippet
will be declared as main snippet of this blade file
@endsnippet

@snippet ("foo")
will be declared as 'foo' snippet
@endsnippet

@snippet ('foo', $bar)
will be declared as 'foo' snippet with $bar as parameter
@endsnippet

@snippet (foobar, string $barfoo)
will be declared as 'foobar' snippet with an explicit string as $barfoo parameter
@endsnippet

@snippet ("foo-bar", string $barfoo)
will be declared as 'foo-bar' snippet with an explicit string as $barfoo parameter
@endsnippet
```

Snippet function name declaration could also be declared as `@snippet (foo)`. The implementation can handle this case too.

## Snippet rendering

Taking the previous examples, snippets can be rendered like this:
```blade
Render the default snippet of the current blade file
@renderSnippet

Render the "foo" snippet, with double quotes
@renderSnippet ("foo")

Render the "foo" snippet with single quotes and $bar as parameter
@renderSnippet ('foo', $bar)

Render the "foobar" snippet without quotes and $barfoo as parameter
@renderSnippet (foobar, $bar)

Render the sluggy "foo-bar" snippet without quotes and $barfoo as parameter
@renderSnippet ("foo-bar", $bar)
```

## Benchmarks

I've done some benchmarking, with PHP 8.3, on a Macbook Pro M2 Max, analog to this (https://github.com/laravel/framework/pull/51141#issuecomment-2067184531), with the following process:

```php
Route::get('/test', function () {
    $a = array_map(
        fn () => Benchmark::measure(fn() => view('simple-component-test')->render()),
        range(0, 10)
    );

    $b = array_map(
        fn () => Benchmark::measure(fn() => view('snippet-test')->render()),
        range(0, 10)
    );

    return 'OPCache Enabled: ' . (is_array(opcache_get_status()) ? 'Enabled' : 'Disabled') .
        '<br>With blade component call: ' . (array_sum($a) / count($a)) .
        '<br>With snippet call: ' . (array_sum($b) / count($b)) .
        '<br>Performance improvement: ' . ((array_sum($a) / count($a)) / (array_sum($b) / count($b)));
});
````

avatar.blade.php:
```blade
@props(['name'])
<div {{ $attributes }}>
    Name: {{ $name }}
</div>
```

simple-component-test.blade.php:
```blade
@foreach (range(1, 20000) as $id)
    <x-avatar :name="'Taylor'" class="mt-4" />
@endforeach
```

snippet-test.blade.php:
```blade
@snippet('avatar', string $name)
<div class="mt-4">
    Name: {{ $name }}
</div>
@endsnippet

@foreach (range(1, 20000) as $id)
    @renderSnippet('avatar', 'Taylor')
@endforeach
```

### Results

With opcache, cached views:
<img width="380" alt="Screenshot-2024-05-02-11 29 25" src="https://github.com/laravel/framework/assets/4375825/fb8eb988-4167-469c-8c0f-1c99ea3a95f6">

Without opcache, but cached views:
<img width="381" alt="Screenshot-2024-05-02-11 33 14" src="https://github.com/laravel/framework/assets/4375825/e6b7582a-0081-4938-9bc1-0e873645b6d5">


I know, the example falls a bit short, but it's still nice to see some numbers :-)

## Backport to older Laravel versions

In case someone wants to use this feature on older installations, this would be the code:

AppServiceProvider.php:
```php
\Blade::directive('snippet', static function ($expression) {
    $functionParts = explode(',', $expression);

    $function = trim(array_shift($functionParts), "'\" ");

    if (empty($function)) {
        $function = 'function';
    }

    $function = '__snippet_' . Str::camel($function);

    $args = trim(implode(',', $functionParts));

    return implode("\n", [
        "<?php if (! isset(\${$function})):",
        '$'.$function.' = static function('.$args.') use($__env) {',
        '?>',
    ]);
});

\Blade::directive('endsnippet', static function ($expression) {
    return implode("\n", [
        '<?php } ?>',
        '<?php endif; ?>',
    ]);
});

\Blade::directive('renderSnippet', static function ($expression) {
    $functionParts = explode(',', $expression);

    $function = trim(array_shift($functionParts), "'\" ");

    if (empty($function)) {
        $function = 'function';
    }

    $function = '__snippet_' . Str::camel($function);

    $args = trim(implode(',', $functionParts));

    return '<?php echo $'.$function.'('.$args.'); ?>';
});
```