### PR TITLE
Fix locale load sequence issue

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -238,6 +238,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         foreach ($lines as $key => $value) {
             [$group, $item] = explode('.', $key, 2);
+            
+            if (!$this->isLoaded($namespace, $group, $locale)) {
+                $this->load($namespace, $group, $locale);
+            }
 
             Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
         }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -239,7 +239,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         foreach ($lines as $key => $value) {
             [$group, $item] = explode('.', $key, 2);
             
-            if (!$this->isLoaded($namespace, $group, $locale)) {
+            if (! $this->isLoaded($namespace, $group, $locale)) {
                 $this->load($namespace, $group, $locale);
             }
 


### PR DESCRIPTION
Here is the issue. Let's assume we have the following locale folder structure: `lang/hy/pages.php` where it contains the following data:
```
<?php

return [
    'foo' => [
        'bar' => 'Laravel',
        'hello' => 'world',
        'ac' => 'dc',
    ],
];
```
then you execute below command in the according order:
1. `app('translator')->addLines(['pages.foo.bar' => 'PHP'], 'hy'))`,
2. `app('translator')->get('pages.foo.hello')` then instead of expected value `world`, you'll get fallback value `pages.foo.hello`, which is the issue. 

However, if you try running the commands in the following order:
1. `app('translator')->get('pages.foo.ac')`,
2. `app('translator')->addLines(['pages.foo.bar' => 'PHP'], 'hy'))`,
3. `app('translator')->get('pages.foo.hello')` 

now you see it's working for some reason. It's happening due to `Translator::get` method is calling `Translator::getLine` method which is itself calling `Translator::isLoaded` which is checking if the locale list is defined in `$group` level. So considering that in the first example of sequence of the code we used `Translator::addLines` method before using `Translator::get`, where the actual load of locales is happening, this is causing a case, where `Translator::addLines` injects and creates a nested array:
```
'foo' => [
    'bar' => 'PHP',
],
```
and since the `$group` level locale data is already created and is "loaded", `Translator::getLines` method's call for `Translator::isLoaded` falsly assumes the data is loaded since `$group` level data for `pages` is already loaded.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
