### PR TITLE
[12.x] remove undocumented behavior of validation rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1153,10 +1153,6 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return BigNumber::of($this->getSize($attribute, $value))->isGreaterThan($this->trim($parameters[0]));
-        }
-
         if (is_numeric($parameters[0])) {
             return false;
         }
@@ -1187,10 +1183,6 @@ trait ValidatesAttributes
         $comparedToValue = $this->getValue($parameters[0]);
 
         $this->shouldBeNumeric($attribute, 'Lt');
-
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return BigNumber::of($this->getSize($attribute, $value))->isLessThan($this->trim($parameters[0]));
-        }
 
         if (is_numeric($parameters[0])) {
             return false;
@@ -1223,10 +1215,6 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return BigNumber::of($this->getSize($attribute, $value))->isGreaterThanOrEqualTo($this->trim($parameters[0]));
-        }
-
         if (is_numeric($parameters[0])) {
             return false;
         }
@@ -1257,10 +1245,6 @@ trait ValidatesAttributes
         $comparedToValue = $this->getValue($parameters[0]);
 
         $this->shouldBeNumeric($attribute, 'Lte');
-
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return BigNumber::of($this->getSize($attribute, $value))->isLessThanOrEqualTo($this->trim($parameters[0]));
-        }
 
         if (is_numeric($parameters[0])) {
             return false;


### PR DESCRIPTION
according to the documentation, the validation for "gt", "gte", "lt", and "lte" are intended to be compared to another field:

- `gt:field`
- `gte:field`
- `lt:field`
- `lte:field`

if you would like to compare to a value, we have the "max" and "min" rules:

- `max:value`
- `min:value`

however, the current implementations of the "gt", "gte", "lt", and "lte" rules do a little hand holding, and actually will validate against a passed value. this change removes that code, and forces the developer to use the correct validation rule as documented.

I believe this is still technically a breaking change, even though the behavior was never documented. If it is decided to not do this, I'm thinking we should document the behavior.