### PR TITLE
[11.x] Fix json columntype for posgres in notifications

### DIFF
--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->text('data');
+            $table->json('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
When creating the migration for notifications via artisan make, the data-column has a default type of text. The models typecasting however, leads to queries that potentially include json-specific operators in databases that support them. This leads to errors when using the text-column with postgres.

This seemed to be an old one. I found at least this post, stumbling across the same thing as I did: https://laracasts.com/discuss/channels/laravel/undefined-function-7-error-operator-does-not-exist-text-unknown

The particular query, in my case, resulted from the stock filament control panel.