### PR TITLE
add data_first helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -107,13 +107,13 @@ if (! function_exists('data_first')) {
      */
     function data_first($target, $keys, $default = null)
     {
-        if (!is_array($keys)) {
+        if (! is_array($keys)) {
             return data_get($target, $keys, $default);
         }
 
         foreach ($keys as $key) {
             $result = data_get($target, $key);
-            if($result !== null){
+            if ($result !== null){
                 return $result;
             }
         }

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -96,6 +96,32 @@ if (! function_exists('data_get')) {
     }
 }
 
+if (! function_exists('data_first')) {
+    /**
+     * Get an item from an array or object using first match array of "dot" notation.
+     *
+     * @param  mixed  $target
+     * @param  string|array|int|null  $keys
+     * @param  mixed  $default
+     * @return mixed
+     */
+    function data_first($target, $keys, $default = null)
+    {
+        if (!is_array($keys)) {
+            return data_get($target, $keys, $default);
+        }
+
+        foreach ($keys as $key) {
+            $result = data_get($target, $key);
+            if($result !== null){
+                return $result;
+            }
+        }
+
+        return $default;
+    }
+}
+
 if (! function_exists('data_set')) {
     /**
      * Set an item on an array or object using dot notation.

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -113,7 +113,7 @@ if (! function_exists('data_first')) {
 
         foreach ($keys as $key) {
             $result = data_get($target, $key);
-            if ($result !== null){
+            if ($result !== null) {
                 return $result;
             }
         }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -194,8 +194,8 @@ class SupportHelpersTest extends TestCase
 
         $this->assertSame('Taylor', data_first($object, 'users.name.0'));
         $this->assertSame('Taylor', data_first($object, ['users.name.0']));
-        $this->assertSame('Taylor', data_first($object, ['book.name','users.name.0']));
-        $this->assertSame('Laravel', data_first($object, ['framework','users.name.0']));
+        $this->assertSame('Taylor', data_first($object, ['book.name', 'users.name.0']));
+        $this->assertSame('Laravel', data_first($object, ['framework', 'users.name.0']));
     }
 
     public function testDataGetWithNestedArrays()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -188,6 +188,16 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(data_get($arrayAccess, 'email', 'Not found'));
     }
 
+    public function testDataFirst()
+    {
+        $object = (object) ['users' => ['name' => ['Taylor', 'Otwell']], 'framework' => 'Laravel'];
+
+        $this->assertSame('Taylor', data_first($object, 'users.name.0'));
+        $this->assertSame('Taylor', data_first($object, ['users.name.0']));
+        $this->assertSame('Taylor', data_first($object, ['book.name','users.name.0']));
+        $this->assertSame('Laravel', data_first($object, ['framework','users.name.0']));
+    }
+
     public function testDataGetWithNestedArrays()
     {
         $array = [


### PR DESCRIPTION
data_first is like data_get but get array of keys and return the target that match to first key and not null

this may be useful when we have array and want to get the target but if target was null take another one for example 

``` php
$array = ['user' => [
    'name' => 'milad', 'username' => 'mnr73', 'phone' => '+98913xxxxxxx'],
];

$title = data_first($array, ['user.name', 'user.username', 'user.phone'], 'profile');
```
