### PR TITLE
[11.x] Make negative values possible for perPage in cursorPaginate

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -525,7 +525,7 @@ trait BuildsQueries
      * Create a new cursor paginator instance.
      *
      * @param  \Illuminate\Support\Collection  $items
-     * @param  int  $perPage
+     * @param  int|null  $perPage
      * @param  \Illuminate\Pagination\Cursor  $cursor
      * @param  array  $options
      * @return \Illuminate\Pagination\CursorPaginator

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -451,7 +451,7 @@ trait BuildsQueries
             $addCursorConditions($this, null, null, 0);
         }
 
-        $this->limit($perPage + 1);
+        $this->limit($perPage < 0 ? null : $perPage + 1);
 
         return $this->cursorPaginator($this->get($columns), $perPage, $cursor, [
             'path' => Paginator::resolveCurrentPath(),

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2564,7 +2564,7 @@ class Builder implements BuilderContract
     /**
      * Set the "limit" value of the query.
      *
-     * @param  int  $value
+     * @param  int|null  $value
      * @return $this
      */
     public function limit($value)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2571,7 +2571,7 @@ class Builder implements BuilderContract
     {
         $property = $this->unions ? 'unionLimit' : 'limit';
 
-        if ($value >= 0) {
+        if ((int) $value >= 0) {
             $this->$property = ! is_null($value) ? (int) $value : null;
         }
 

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -34,7 +34,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * The number of items to be shown per page.
      *
-     * @var int
+     * @var int|null
      */
     protected $perPage;
 
@@ -411,7 +411,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Get the number of items shown per page.
      *
-     * @return int
+     * @return ?int
      */
     public function perPage()
     {

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -24,7 +24,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
      * Create a new paginator instance.
      *
      * @param  mixed  $items
-     * @param  int  $perPage
+     * @param  int|null  $perPage
      * @param  \Illuminate\Pagination\Cursor|null  $cursor
      * @param  array  $options  (path, query, fragment, pageName)
      * @return void
@@ -37,7 +37,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
             $this->{$key} = $value;
         }
 
-        $this->perPage = (int) $perPage;
+        $this->perPage = $perPage;
         $this->cursor = $cursor;
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
 
@@ -54,7 +54,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     {
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
 
-        $this->hasMore = $this->items->count() > $this->perPage;
+        $this->hasMore = $this->items->count() > (int) $this->perPage;
 
         $this->items = $this->items->slice(0, $this->perPage);
 


### PR DESCRIPTION
Its not ideal to set limit to `null` in Paginators. Yet in some cases, we need to retrieve all results and also we want to keep the pagination response structure. That's why we use negative values ( `-1` ) as `limit` to retrieve all results in once.

The first problem occurs by calling `limit` method in `BuildsQueries` trait. `-1` value as `perPage` is being set to `0` as `limit` and this causes an empty result set

![image](https://github.com/laravel/framework/assets/10243325/88191168-8237-447f-889a-0d549189a0b2)

Since its possible to check if `$value` parameter is `null` and also possible to set `limit` or `unionLimit` properties to `null`

![image](https://github.com/laravel/framework/assets/10243325/b23ae82e-7138-4200-bd9f-d00c6fbdf08d)

The line where `limit` is set, can be updated as the following

![image](https://github.com/laravel/framework/assets/10243325/aa3f0249-331b-476b-9393-ef4969f8c2c5)

The second problem occurs in `CursorPaginator` with this change because of a `null` value of `perPage`

The `null` value for `perPage` is force casted into integer and sets its value to `0`

![image](https://github.com/laravel/framework/assets/10243325/7f88a110-a33f-4789-93fd-c01fbcf1568e)

Which makes the result set to be empty because of the second argument of `slicer` method being `0`

![image](https://github.com/laravel/framework/assets/10243325/f225d31c-029f-4072-bd63-9e34e09168e6)
