### PR TITLE
[11.x] Remove redundant method_exists() check, apply code formatting

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -403,13 +403,11 @@ trait InteractsWithInput
      */
     public function enum($key, $enumClass)
     {
-        if ($this->isNotFilled($key) ||
-            ! enum_exists($enumClass) ||
-            ! method_exists($enumClass, 'tryFrom')) {
-            return null;
+        if ($this->filled($key) && enum_exists($enumClass)) {
+            return $enumClass::tryFrom($this->input($key));
         }
 
-        return $enumClass::tryFrom($this->input($key));
+        return null;
     }
 
     /**

--- a/tests/Http/Enums.php
+++ b/tests/Http/Enums.php
@@ -5,4 +5,5 @@ namespace Illuminate\Tests\Http;
 enum TestEnum: string
 {
     case test = 'test';
+    case test_empty = '';
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -762,6 +762,7 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', [
             'valid_enum_value' => 'test',
             'invalid_enum_value' => 'invalid',
+            'enum_empty_string_value' => '',
         ]);
 
         $this->assertNull($request->enum('doesnt_exists', TestEnum::class));
@@ -769,6 +770,8 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
 
         $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
+
+        $this->assertNull($request->enum('enum_empty_string_value', TestEnum::class));
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
Removed redundant `! method_exists($enumClass, 'tryFrom')` check. Since `! enum_exists($enumClass)` already verifies if the class is an enum, it's implicit that 'tryFrom' method exists for enums. This change improves code readability and eliminates unnecessary redundancy.