### PR TITLE
[11.x] Allow adding array or string for web and api routes in bootstrap/app.php

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -250,7 +250,7 @@ class ApplicationBuilder
             $middleware = (new Middleware)
                 ->redirectGuestsTo(fn () => route('login'));
 
-            if (!is_null($callback)) {
+            if (! is_null($callback)) {
                 $callback($middleware);
             }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -131,8 +131,8 @@ class ApplicationBuilder
      * Register the routing services for the application.
      *
      * @param  \Closure|null  $using
-     * @param  string|null  $web
-     * @param  string|null  $api
+     * @param  string|array|null  $web
+     * @param  string|array|null  $api
      * @param  string|null  $commands
      * @param  string|null  $channels
      * @param  string|null  $pages
@@ -143,7 +143,7 @@ class ApplicationBuilder
     public function withRouting(
         ?Closure $using = null,
         string|array $web = null,
-        ?string $api = null,
+        string|array $api = null,
         ?string $commands = null,
         ?string $channels = null,
         ?string $pages = null,
@@ -175,8 +175,8 @@ class ApplicationBuilder
     /**
      * Create the routing callback for the application.
      *
-     * @param  string|null  $web
-     * @param  string|null  $api
+     * @param  string|array|null  $web
+     * @param  string|array|null  $api
      * @param  string|null  $pages
      * @param  string|null  $health
      * @param  string  $apiPrefix
@@ -184,8 +184,8 @@ class ApplicationBuilder
      * @return \Closure
      */
     protected function buildRoutingCallback(
-        string|array $web,
-        string|array $api,
+        string|array $web = null,
+        string|array $api = null,
         ?string $pages,
         ?string $health,
         string $apiPrefix,

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -96,7 +96,7 @@ class ApplicationBuilder
             AppEventServiceProvider::disableEventDiscovery();
         }
 
-        if (!isset($this->pendingProviders[AppEventServiceProvider::class])) {
+        if (! isset($this->pendingProviders[AppEventServiceProvider::class])) {
             $this->app->booting(function () {
                 $this->app->register(AppEventServiceProvider::class);
             });
@@ -117,7 +117,7 @@ class ApplicationBuilder
     public function withBroadcasting(string $channels, array $attributes = [])
     {
         $this->app->booted(function () use ($channels, $attributes) {
-            Broadcast::routes(!empty($attributes) ? $attributes : null);
+            Broadcast::routes(! empty($attributes) ? $attributes : null);
 
             if (file_exists($channels)) {
                 require $channels;
@@ -208,7 +208,7 @@ class ApplicationBuilder
                 Route::middleware('web')->get($health, function () {
                     Event::dispatch(new DiagnosingHealth);
 
-                    return View::file(__DIR__ . '/../resources/health-up.blade.php');
+                    return View::file(__DIR__.'/../resources/health-up.blade.php');
                 });
             }
 


### PR DESCRIPTION

This pull request proposes an enhancement to Laravel's `bootstrap/app.php` file, enabling developers to add routes in array format or as strings for both web and api route groups.

### Motivation

The motivation behind this enhancement is to provide developers with greater flexibility and convenience when defining routes, particularly in scenarios where applications have different guards and need to create different routes for each guard rather than writing require/require_once in route file.


### Use Cases

In projects where route management becomes complex due to the proliferation of routes or diverse authentication scenarios, this will simplifies the process by enabling developers to organize routes into multiple route files effortlessly. By allowing routes to be defined in array format, developers can easily create separate route files corresponding to different functionalities, user roles, or authentication guards. This approach promotes code organization and maintainability, as each route file can focus on a specific aspect of the application, making it easier to understand and manage.

## Additional Context

I'm developing an ecommerce website with five different guards, and I want to include separate route files for each guard. Using `require` or `require_once` made my code look outdated, and I disliked it. Let's simplify by allowing arrays as well in the `$web` parameter of `withRouting()` method in `Illuminate\Foundation\Application`
