### PR TITLE
[11.x] Add assertQueuedOn for MailFake

### DIFF
--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -47,6 +47,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static void assertNothingOutgoing()
  * @method static void assertNothingSent()
  * @method static void assertQueued(string|\Closure $mailable, callable|int|null $callback = null)
+ * @method static void assertQueuedOn(string $mailable, string $queue)
  * @method static void assertNotQueued(string|\Closure $mailable, callable|null $callback = null)
  * @method static void assertNothingQueued()
  * @method static void assertSentCount(int $count)

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -179,9 +179,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     /**
      * Assert if a mailable was queued on desired queue based on truth-test callaback.
      *
-     * @param  string $mailable
-     * @param  string $queue
-     * @param callable|int|null $callback
+     * @param  string  $mailable
+     * @param  string  $queue
+     * @param  callable|int|null  $callback
      * @return void
      */
     public function assertQueuedOn($mailable, $queue, $callback = null)
@@ -189,7 +189,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
         $message = "The expected [{$mailable}] mailable was not queued on {$queue}";
 
         $message .= ($actualQueue = $this->queued($mailable, $callback)->first()?->queue) ?
-            " but actual queue was {$actualQueue}." : ".";
+            " but actual queue was {$actualQueue}." : '.';
 
         PHPUnit::assertTrue(
             $this->queuedOn($mailable, $queue)->count() > 0,
@@ -347,15 +347,15 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
-     * Determine if the given mailable has been queued on the given queue
+     * Determine if the given mailable has been queued on the given queue.
      *
-     * @param string $mailable
-     * @param string $queue
+     * @param  string  $mailable
+     * @param  string  $queue
      * @return \Illuminate\Support\Collection
      */
     public function queuedOn($mailable, $queue)
     {
-        return $this->queued($mailable)->filter(fn($mailable) => $mailable->queue == $queue);
+        return $this->queued($mailable)->filter(fn ($mailable) => $mailable->queue == $queue);
     }
 
     /**
@@ -526,7 +526,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     /**
      * Queue a new mail message for sending on the given queue.
      *
-     * @param string|null $queue
+     * @param  string  $queue
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @return mixed
      */
@@ -538,7 +538,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     /**
      * Queue a new mail message for sending on the given queue.
      *
-     * @param string|null $queue
+     * @param  string  $queue
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @return mixed
      */

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -167,14 +167,15 @@ class SupportTestingMailFakeTest extends TestCase
         $mailable = new QueueableMailableStub();
         try {
             $this->fake->to('taylor@laravel.com')->queue($mailable);
-            $this->fake->assertQueuedOn(QueueableMailableStub::class,'default');
+            $this->fake->assertQueuedOn(QueueableMailableStub::class, 'default');
+            $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The expected [Illuminate\Tests\Support\QueueableMailableStub] mailable was not queued on default.', $e->getMessage());
         }
 
         try {
             $this->fake->to('taylor@laravel.com')->queue($mailable->onQueue('foo'));
-            $this->fake->assertQueuedOn(QueueableMailableStub::class,'baa');
+            $this->fake->assertQueuedOn(QueueableMailableStub::class, 'baa');
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The expected [Illuminate\Tests\Support\QueueableMailableStub] mailable was not queued on baa but actual queue was foo.', $e->getMessage());
@@ -182,7 +183,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->onQueue('default', $mailable);
 
-        $this->fake->assertQueuedOn(QueueableMailableStub::class,'default');
+        $this->fake->assertQueuedOn(QueueableMailableStub::class, 'default');
     }
 
     public function testAssertQueuedTimes()
@@ -341,7 +342,7 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
     /**
      * Set the desired queue for the mail.
      *
-     * @param $queue
+     * @param  $queue
      * @return $this
      */
     public function onQueue($queue)


### PR DESCRIPTION
Added `assertQueuedOn` For MailFake class. Which will add the ability to test whether the mail is queued on **desired queue** or not.

So after this PR, can assert mail queued on the desired queue like that.
``` PHP
  public function mail_should_be_queued_on_foo() 
  {
    Mail::fake();

    Mail::onQueue('foo', new QueueMailable());

    Mail::assertQueuedOn(QueueMailable::class, 'foo'); //it should success

    Mail::assertQueuedOn(QueueMailable::class,, 'baa'); //it should fail
  }
``` 