### PR TITLE
[11.x] Add tests for handling non-baked enum and empty string requests

### DIFF
--- a/tests/Http/Enums.php
+++ b/tests/Http/Enums.php
@@ -2,7 +2,13 @@
 
 namespace Illuminate\Tests\Http;
 
-enum TestEnum: string
+enum TestEnumBacked: string
 {
     case test = 'test';
+    case test_empty = '';
+}
+
+enum TestEnum
+{
+    case test;
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -771,7 +771,7 @@ class HttpRequestTest extends TestCase
 
         $this->assertNull($request->enum('invalid_enum_value', TestEnumBacked::class));
         $this->assertNull($request->enum('empty_value_request', TestEnumBacked::class));
-        $this->assertNull($request->enum('test', TestEnum::class));
+        $this->assertNull($request->enum('valid_enum_value', TestEnum::class));
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -762,13 +762,16 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', [
             'valid_enum_value' => 'test',
             'invalid_enum_value' => 'invalid',
+            'empty_value_request' => '',
         ]);
 
-        $this->assertNull($request->enum('doesnt_exists', TestEnum::class));
+        $this->assertNull($request->enum('doesnt_exists', TestEnumBacked::class));
 
-        $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
+        $this->assertEquals(TestEnumBacked::test, $request->enum('valid_enum_value', TestEnumBacked::class));
 
-        $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
+        $this->assertNull($request->enum('invalid_enum_value', TestEnumBacked::class));
+        $this->assertNull($request->enum('empty_value_request', TestEnumBacked::class));
+        $this->assertNull($request->enum('test', TestEnum::class));
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
```PHP
        /** Added some tests */
        $request = Request::create('/', 'GET', [
            'empty_value_request' => '',
        ]);

        // Empty string case         
        $this->assertNull($request->enum('empty_value_request', TestEnumBacked::class)); //this should be null
        
        // Non baked enum case         
        $this->assertNull($request->enum('valid_enum_value', TestEnum::class)); //this should be null (no error thrown)       
```

So now PR test look like this 
```PHP
    public function testEnumMethod()
    {
        $request = Request::create('/', 'GET', [
            'valid_enum_value' => 'test',
            'invalid_enum_value' => 'invalid',
            'empty_value_request' => '',
        ]);

        $this->assertNull($request->enum('doesnt_exists', TestEnumBacked::class));

        $this->assertEquals(TestEnumBacked::test, $request->enum('valid_enum_value', TestEnumBacked::class));

        $this->assertNull($request->enum('invalid_enum_value', TestEnumBacked::class));
        $this->assertNull($request->enum('empty_value_request', TestEnumBacked::class));
        $this->assertNull($request->enum('valid_enum_value', TestEnum::class));
    }
```
