### PR TITLE
[11.x] PrimaryKey attribute for Eloquent Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/PrimaryKey.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/PrimaryKey.php
@@ -10,15 +10,15 @@ class PrimaryKey
     /**
      * Create a new attribute instance.
      *
-     * @param  string  $name
-     * @param  string  $type
-     * @param  bool  $incrementing
+     * @param  string|null  $name
+     * @param  string|null  $type
+     * @param  bool|null  $incrementing
      * @return void
      */
     public function __construct(
-        public string $name = 'id',
-        public string $type = 'int',
-        public bool $incrementing = true,
+        public ?string $name = null,
+        public ?string $type = null,
+        public ?bool $incrementing = null,
     ) {
     }
 }

--- a/src/Illuminate/Database/Eloquent/Attributes/PrimaryKey.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/PrimaryKey.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class PrimaryKey
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string  $name
+     * @param  string  $type
+     * @param  bool  $incrementing
+     * @return void
+     */
+    public function __construct(
+        public string $name = 'id',
+        public string $type = 'int',
+        public bool $incrementing = true,
+    ) {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
@@ -12,7 +12,7 @@ trait HasCustomizations
      *
      * @return void
      */
-    protected function applyCustomizations()
+    protected function initializeHasCustomizations()
     {
         $primaryKeyAttribute = $this->resolveCustomPrimaryKey();
         if (! $primaryKeyAttribute) {
@@ -32,10 +32,10 @@ trait HasCustomizations
     protected function resolveCustomPrimaryKey()
     {
         $reflectionClass = new ReflectionClass(static::class);
-        /** @var $primaryKeyAttribute \ReflectionAttribute|null */
-        $primaryKeyAttribute = collect($reflectionClass->getAttributes(PrimaryKey::class))
-            ->first();
+        $primaryKeyAttribute = $reflectionClass->getAttributes(PrimaryKey::class);
 
-        return $primaryKeyAttribute?->newInstance();
+        return $primaryKeyAttribute === []
+            ? null
+            : $primaryKeyAttribute[0]->newInstance();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
@@ -8,7 +8,7 @@ use ReflectionClass;
 trait HasCustomizations
 {
     /**
-     * Apply customizations from attributes
+     * Apply customizations from attributes.
      *
      * @return void
      */
@@ -32,7 +32,7 @@ trait HasCustomizations
     protected function resolveCustomPrimaryKey()
     {
         $reflectionClass = new ReflectionClass(static::class);
-        /** @var  $primaryKeyAttribute \ReflectionAttribute|null */
+        /** @var $primaryKeyAttribute \ReflectionAttribute|null */
         $primaryKeyAttribute = collect($reflectionClass->getAttributes(PrimaryKey::class))
             ->first();
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\Attributes\PrimaryKey;
+use ReflectionClass;
+
+trait HasCustomizations
+{
+    /**
+     * Apply customizations from attributes
+     *
+     * @return void
+     */
+    protected function applyCustomizations()
+    {
+        $primaryKeyAttribute = $this->resolveCustomPrimaryKey();
+        if (! $primaryKeyAttribute) {
+            return;
+        }
+
+        $this->setKeyName($primaryKeyAttribute->name);
+        $this->setKeyType($primaryKeyAttribute->type);
+        $this->setIncrementing($primaryKeyAttribute->incrementing);
+    }
+
+    /**
+     * Resolve the custom primary key from the attributes.
+     *
+     * @return PrimaryKey|null
+     */
+    protected function resolveCustomPrimaryKey()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+        /** @var  $primaryKeyAttribute \ReflectionAttribute|null */
+        $primaryKeyAttribute = collect($reflectionClass->getAttributes(PrimaryKey::class))
+            ->first();
+
+        return $primaryKeyAttribute?->newInstance();
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasCustomizations.php
@@ -19,9 +19,15 @@ trait HasCustomizations
             return;
         }
 
-        $this->setKeyName($primaryKeyAttribute->name);
-        $this->setKeyType($primaryKeyAttribute->type);
-        $this->setIncrementing($primaryKeyAttribute->incrementing);
+        if (! is_null($primaryKeyAttribute->name)) {
+            $this->setKeyName($primaryKeyAttribute->name);
+        }
+        if (! is_null($primaryKeyAttribute->type)) {
+            $this->setKeyType($primaryKeyAttribute->type);
+        }
+        if (! is_null($primaryKeyAttribute->incrementing)) {
+            $this->setIncrementing($primaryKeyAttribute->incrementing);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -34,6 +34,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasUniqueIds,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
+        Concerns\HasCustomizations,
         ForwardsCalls;
 
     /**
@@ -236,6 +237,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->bootIfNotBooted();
 
         $this->initializeTraits();
+
+        $this->applyCustomizations();
 
         $this->syncOriginal();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -238,8 +238,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->initializeTraits();
 
-        $this->applyCustomizations();
-
         $this->syncOriginal();
 
         $this->fill($attributes);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3604,13 +3604,11 @@ class EloquentModelWithUpdatedAtNull extends Model
 #[PrimaryKey(name: 'uuid', type: 'string', incrementing: false)]
 class EloquentModelWithCustomPrimaryKey extends Model
 {
-
 }
 
 #[PrimaryKey(name: 'custom_id')]
 class EloquentModelWithPartialCustomPrimaryKey extends Model
 {
-
 }
 
 class UnsavedModel extends Model

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\PrimaryKey;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -2854,6 +2855,24 @@ class DatabaseEloquentModelTest extends TestCase
         }
     }
 
+    public function testModelHasCustomPrimaryKeyWithAttribute()
+    {
+        $model = new EloquentModelWithCustomPrimaryKey();
+
+        $this->assertEquals('uuid', $model->getKeyName());
+        $this->assertEquals('string', $model->getKeyType());
+        $this->assertFalse($model->getIncrementing());
+    }
+
+    public function testModelHasPartialCustomPrimaryKeyWithAttribute()
+    {
+        $model = new EloquentModelWithPartialCustomPrimaryKey();
+
+        $this->assertEquals('custom_id', $model->getKeyName());
+        $this->assertEquals('int', $model->getKeyType());
+        $this->assertTrue($model->getIncrementing());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
@@ -3580,6 +3599,18 @@ class EloquentModelWithUpdatedAtNull extends Model
 {
     protected $table = 'stub';
     const UPDATED_AT = null;
+}
+
+#[PrimaryKey(name: 'uuid', type: 'string', incrementing: false)]
+class EloquentModelWithCustomPrimaryKey extends Model
+{
+
+}
+
+#[PrimaryKey(name: 'custom_id')]
+class EloquentModelWithPartialCustomPrimaryKey extends Model
+{
+
 }
 
 class UnsavedModel extends Model


### PR DESCRIPTION
## Changes

This PR adds a new attribute that can be used on Eloquent Models to allow defining the Primary Key for the Model in a really simple and intuitive way. This attribute is inspired by a package I created to play around with attributes and to know more about the Eloquent Models.

## Why

This makes it really easy and intuitive to customize the primary key for the models.

Instead of this:

```php
class MyModel extends Model
{
    public $incrementing = false;

    protected $primaryKey = 'uuid';

    protected $keyType = 'string';

    // Model code here
}
```

We can do this:

```php
#[PrimaryKey(name: 'uuid', type: 'string', incrementing: false)]
class MyModel extends Model
{
    // Model code here
}
```

If we need to just update the name for example we can do this:

```php
#[PrimaryKey(name: 'custom_id')]
class MyModel extends Model
{
    // Model code here
}
```

## Additional Info

The package I mentioned has some other things on it and if this PR is something that the core team think could be useful I'll be happy to bring more ideas that I implemented on the package to be discussed to be added to the framework.