### PR TITLE
[11.x] Add database connection parameter to events that implement MigrationsEvent

### DIFF
--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -19,8 +19,9 @@ abstract class MigrationsEvent implements MigrationEventContract
      * @param  string  $method
      * @return void
      */
-    public function __construct($method)
+    public function __construct($method, $connection)
     {
         $this->method = $method;
+        $this->connection = $connection;
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -168,7 +168,7 @@ class Migrator
 
         $step = $options['step'] ?? false;
 
-        $this->fireMigrationEvent(new MigrationsStarted('up'));
+        $this->fireMigrationEvent(new MigrationsStarted('up', $this->connection));
 
         $this->write(Info::class, 'Running migrations.');
 
@@ -183,7 +183,7 @@ class Migrator
             }
         }
 
-        $this->fireMigrationEvent(new MigrationsEnded('up'));
+        $this->fireMigrationEvent(new MigrationsEnded('up', $this->connection));
 
         if ($this->output) {
             $this->output->writeln('');
@@ -281,7 +281,7 @@ class Migrator
 
         $this->requireFiles($files = $this->getMigrationFiles($paths));
 
-        $this->fireMigrationEvent(new MigrationsStarted('down'));
+        $this->fireMigrationEvent(new MigrationsStarted('down', $this->connection));
 
         $this->write(Info::class, 'Rolling back migrations.');
 
@@ -305,7 +305,7 @@ class Migrator
             );
         }
 
-        $this->fireMigrationEvent(new MigrationsEnded('down'));
+        $this->fireMigrationEvent(new MigrationsEnded('down', $this->connection));
 
         return $rolledBack;
     }


### PR DESCRIPTION
This PR adds the database connection that was used to run a migration to the events that implement MigrationsEvent. This allows users to not only run their code per the migration method but also as per what connection the migration used.

Example:

```php
Event::listen(function (MigrationsEnded $event) {
    if ($event->connection === 'postgres') { // when the value is null, then that means that the default connection was used
        // Execute code
    }
});
```

This feature especially helps when running a multitenancy application where one wants to execute code after a migration on a particular connection is run.

Existing features are not expected to break (even on clients codebase) since this addition does not touch on them.
