### PR TITLE
[11.x] Add ability to override the default loading cached Routes for application

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -219,6 +219,19 @@ class ApplicationBuilder
     }
 
     /**
+     * Register loading cached routes for the application.
+     *
+     * @param  \Closure  $using
+     * @return $this
+     */
+    public function loadCachedRoutesUsing(Closure $using)
+    {
+        AppRouteServiceProvider::loadCachedRoutesUsing($using);
+
+        return $this;
+    }
+
+    /**
      * Register the global middleware, middleware groups, and middleware aliases for the application.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -219,19 +219,6 @@ class ApplicationBuilder
     }
 
     /**
-     * Register loading cached routes for the application.
-     *
-     * @param  \Closure  $using
-     * @return $this
-     */
-    public function loadCachedRoutesUsing(Closure $using)
-    {
-        AppRouteServiceProvider::loadCachedRoutesUsing($using);
-
-        return $this;
-    }
-
-    /**
      * Register the global middleware, middleware groups, and middleware aliases for the application.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -41,7 +41,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var \Closure|null
      */
-    protected static $loadCachedRoutesUsing;
+    protected static $alwaysLoadCachedRoutesUsing;
 
     /**
      * Register any application services.
@@ -103,12 +103,12 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Register the callback that will be used to load the application's cached routes.
      *
-     * @param  \Closure|null  $loadCachedRoutesCallback
+     * @param  \Closure|null  $routesCallback
      * @return void
      */
-    public static function loadCachedRoutesUsing(?Closure $loadCachedRoutesCallback)
+    public static function loadCachedRoutesUsing(?Closure $routesCallback)
     {
-        self::$loadCachedRoutesUsing = $loadCachedRoutesCallback;
+        self::$alwaysLoadCachedRoutesUsing = $routesCallback;
     }
 
     /**
@@ -140,11 +140,12 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function loadCachedRoutes()
     {
-        if (! is_null(self::$loadCachedRoutesUsing)) {
-            $this->app->call(self::$loadCachedRoutesUsing);
+        if (! is_null(self::$alwaysLoadCachedRoutesUsing)) {
+            $this->app->call(self::$alwaysLoadCachedRoutesUsing);
 
             return;
         }
+
         $this->app->booted(function () {
             require $this->app->getCachedRoutesPath();
         });

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -37,6 +37,13 @@ class RouteServiceProvider extends ServiceProvider
     protected static $alwaysLoadRoutesUsing;
 
     /**
+     * The callback that should be used to load the application's cached routes.
+     *
+     * @var \Closure|null
+     */
+    protected static $loadCachedRoutesUsing;
+
+    /**
      * Register any application services.
      *
      * @return void
@@ -94,6 +101,17 @@ class RouteServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register the callback that will be used to load the application's cached routes.
+     *
+     * @param  \Closure|null  $loadCachedRoutesCallback
+     * @return void
+     */
+    public static function loadCachedRoutesUsing(?Closure $loadCachedRoutesCallback)
+    {
+        self::$loadCachedRoutesUsing = $loadCachedRoutesCallback;
+    }
+
+    /**
      * Set the root controller namespace for the application.
      *
      * @return void
@@ -122,6 +140,11 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function loadCachedRoutes()
     {
+        if (! is_null(self::$loadCachedRoutesUsing)) {
+            $this->app->call(self::$loadCachedRoutesUsing);
+
+            return;
+        }
         $this->app->booted(function () {
             require $this->app->getCachedRoutesPath();
         });


### PR DESCRIPTION
The PR adding the ability to override the default loading of cached routes in application 

based on the previous discussion on the #51249 


```
class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        ...
        RouteServiceProvider::loadCachedRoutesUsing(function(){
         
          //logic here 
        });

    }
```

