### PR TITLE
Introduce ability to override default error view paths

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -30,6 +30,17 @@ class Exceptions
     }
 
     /**
+     * Register error view paths callback.
+     *
+     * @param  callable  $using
+     * @return void
+     */
+    public function registerErrorViewPathsUsing(callable $using)
+    {
+        $this->handler->registerErrorViewPathsUsing($using);
+    }
+
+    /**
      * Register a reportable callback.
      *
      * @param  callable  $reportUsing

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -117,6 +117,13 @@ class Handler implements ExceptionHandlerContract
     protected $finalizeResponseCallback;
 
     /**
+     * The callback that should be used to register the application's error view paths.
+     *
+     * @var callable|null
+     */
+    protected $registerErrorViewPathsUsing;
+
+    /**
      * The registered exception mappings.
      *
      * @var array<string, \Closure>
@@ -231,6 +238,17 @@ class Handler implements ExceptionHandlerContract
         $this->renderCallbacks[] = $renderUsing;
 
         return $this;
+    }
+
+    /**
+     * Register error view paths callback.
+     *
+     * @param  callable  $using
+     * @return void
+     */
+    public function registerErrorViewPathsUsing(callable $using)
+    {
+        $this->registerErrorViewPathsUsing = $using;
     }
 
     /**
@@ -897,6 +915,11 @@ class Handler implements ExceptionHandlerContract
      */
     protected function registerErrorViewPaths()
     {
+        if (! is_null($this->registerErrorViewPathsUsing)) {
+            call_user_func($this->registerErrorViewPathsUsing);
+
+            return;
+        }
         (new RegisterErrorViewPaths)();
     }
 


### PR DESCRIPTION
This PR introduces the capability to override the default error view paths through the `withExceptions` callback:


  ```
->withExceptions(function (Exceptions $exceptions) {
        $exceptions->registerErrorViewPathsUsing(function () {
            View::replaceNamespace('errors', collect(config('view.error_view_path'))->all());
        });
    })
```

After Laravel 11 released , we can still override it using a `withSingletons` , by making a new handler class extend the framework one then override `registerErrorViewPaths`
```
->withSingletons([
        \Illuminate\Contracts\Debug\ExceptionHandler::class => \App\Exceptions\Handler::class,
    ])
```

IMO ,This method of overriding follows the new approach of error handling.



