### PR TITLE
[11.x] Fix docblock for collection pluck methods

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -755,7 +755,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  string|int|array<array-key, string>  $value
+     * @param  string|int|array<array-key, string>|null  $value
      * @param  string|null  $key
      * @return static<array-key, mixed>
      */

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -631,7 +631,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get an array with the values of a given key.
      *
-     * @param  string|array<array-key, string>  $value
+     * @param  string|array<array-key, string>|null  $value
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */


### PR DESCRIPTION
`Arr::pluck()` allows passing `null` as the `$value`, however `src/Illuminate/Collections/Collection::pluck()` and `src/Illuminate/Database/Eloquent/Collection::pluck()` don't include `null` int he docblock for the `$value` param.

This causes static analysis to report that passing `null` as the value is not allowed, e.g.:
```
  304    Parameter #1 $value of method                                                          
         Illuminate\Database\Eloquent\Collection<int,Illuminate\Database\Eloquent\Model>::pluck()  
         expects array<string>|string, null given.
```


See https://github.com/laravel/framework/blob/11.x/src/Illuminate/Collections/Arr.php#L545 for the `Arr::pluck()` definition containing `null` 