### PR TITLE
blank and filled now support stringable

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
@@ -58,6 +59,10 @@ if (! function_exists('blank')) {
 
         if ($value instanceof Countable) {
             return count($value) === 0;
+        }
+
+        if ($value instanceof Stringable) {
+            return $value->trim()->toString() === '';
         }
 
         return empty($value);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -62,11 +62,14 @@ class SupportHelpersTest extends TestCase
         $this->assertTrue(blank(null));
         $this->assertTrue(blank(''));
         $this->assertTrue(blank('  '));
+        $this->assertTrue(blank(new Stringable('')));
+        $this->assertTrue(blank(new Stringable('  ')));
         $this->assertFalse(blank(10));
         $this->assertFalse(blank(true));
         $this->assertFalse(blank(false));
         $this->assertFalse(blank(0));
         $this->assertFalse(blank(0.0));
+        $this->assertFalse(blank(new Stringable(' FooBar ')));
 
         $object = new SupportTestCountable();
         $this->assertTrue(blank($object));
@@ -102,11 +105,14 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(filled(null));
         $this->assertFalse(filled(''));
         $this->assertFalse(filled('  '));
+        $this->assertFalse(filled(new Stringable('')));
+        $this->assertFalse(filled(new Stringable('  ')));
         $this->assertTrue(filled(10));
         $this->assertTrue(filled(true));
         $this->assertTrue(filled(false));
         $this->assertTrue(filled(0));
         $this->assertTrue(filled(0.0));
+        $this->assertTrue(filled(new Stringable(' FooBar ')));
 
         $object = new SupportTestCountable();
         $this->assertFalse(filled($object));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


`Stringable` is currently not supported in the helper functions `blank` and `filled` This PR establishes support with `Stringable`.

```php

//true
filled(str('FooBar '));

//true
blank(str('  '));
```