### PR TITLE
[11.x] Add `@logger` blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -28,6 +28,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesJson,
         Concerns\CompilesJs,
         Concerns\CompilesLayouts,
+        Concerns\CompilesLogger,
         Concerns\CompilesLoops,
         Concerns\CompilesRawPhp,
         Concerns\CompilesSessions,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLogger.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLogger.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesLogger
+{
+    /**
+     * Compile the logger statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileLogger(string $expression)
+    {
+        return "<?php logger{$expression}; ?>";
+    }
+}

--- a/tests/View/Blade/BladeLoggerTest.php
+++ b/tests/View/Blade/BladeLoggerTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeLoggerTest extends AbstractBladeTestCase
+{
+    public function testLoggerAreCompiled()
+    {
+        $this->assertSame('<?php logger(\'User authenticated.\', [\'user_id\' => 1]); ?>', $this->compiler->compileString('@logger(\'User authenticated.\', [\'user_id\' => 1])'));
+        $this->assertSame('<?php logger(\'User authenticated.\'); ?>', $this->compiler->compileString('@logger(\'User authenticated.\')'));
+    }
+}


### PR DESCRIPTION
This PR adds a new Blade directive, `@logger`, which allows developers to easily log messages within their Blade templates. 

```blade
// Example without using @logger directive in Blade templates:

@php
   logger('User logged in');
@endphp

OR

@php(logger('User logged in'))

//after

@logger('User logged in')
@logger('User logged in', ['user_id' => 1])

