### PR TITLE
[11.x] Typeables

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -5,12 +5,13 @@ namespace Illuminate\Config;
 use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
-use Illuminate\Support\StrongTypeable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\StrongTypeable;
 
 class Repository implements ArrayAccess, ConfigContract
 {
-    use Macroable;
+    use Macroable,
+        StrongTypeable;
 
     /**
      * All of the configuration items.
@@ -18,13 +19,6 @@ class Repository implements ArrayAccess, ConfigContract
      * @var array
      */
     protected $items = [];
-
-    /**
-     * The strong typeable instance for retrieving configuration values.
-     *
-     * @var StrongTypeable
-     */
-    protected StrongTypeable $typeable;
 
     /**
      * Create a new configuration repository.
@@ -35,8 +29,6 @@ class Repository implements ArrayAccess, ConfigContract
     public function __construct(array $items = [])
     {
         $this->items = $items;
-
-        $this->typeable = new StrongTypeable($this, 'get');
     }
 
     /**
@@ -96,7 +88,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function string(string $key, $default = null): string
     {
-        return $this->typeable->string($key, $default);
+        return $this->typed()->get->string($key, $default);
     }
 
     /**
@@ -108,7 +100,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function integer(string $key, $default = null): int
     {
-        return $this->typeable->integer($key, $default);
+        return $this->typed()->get->integer($key, $default);
     }
 
     /**
@@ -120,7 +112,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function float(string $key, $default = null): float
     {
-        return $this->typeable->float($key, $default);
+        return $this->typed()->get->float($key, $default);
     }
 
     /**
@@ -132,7 +124,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function boolean(string $key, $default = null): bool
     {
-        return $this->typeable->boolean($key, $default);
+        return $this->typed()->get->boolean($key, $default);
     }
 
     /**
@@ -144,7 +136,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function array(string $key, $default = null): array
     {
-        return $this->typeable->array($key, $default);
+        return $this->typed()->get->array($key, $default);
     }
 
     /**

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -5,8 +5,8 @@ namespace Illuminate\Config;
 use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\StrongTypeable;
 use Illuminate\Support\Traits\Macroable;
-use InvalidArgumentException;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -20,6 +20,13 @@ class Repository implements ArrayAccess, ConfigContract
     protected $items = [];
 
     /**
+     * The strong typeable instance for retrieving configuration values.
+     *
+     * @var StrongTypeable
+     */
+    protected StrongTypeable $typeable;
+
+    /**
      * Create a new configuration repository.
      *
      * @param  array  $items
@@ -28,6 +35,8 @@ class Repository implements ArrayAccess, ConfigContract
     public function __construct(array $items = [])
     {
         $this->items = $items;
+
+        $this->typeable = new StrongTypeable($this, 'get');
     }
 
     /**
@@ -87,15 +96,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function string(string $key, $default = null): string
     {
-        $value = $this->get($key, $default);
-
-        if (! is_string($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a string, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
+        return $this->typeable->string($key, $default);
     }
 
     /**
@@ -107,15 +108,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function integer(string $key, $default = null): int
     {
-        $value = $this->get($key, $default);
-
-        if (! is_int($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an integer, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
+        return $this->typeable->integer($key, $default);
     }
 
     /**
@@ -127,15 +120,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function float(string $key, $default = null): float
     {
-        $value = $this->get($key, $default);
-
-        if (! is_float($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a float, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
+        return $this->typeable->float($key, $default);
     }
 
     /**
@@ -147,15 +132,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function boolean(string $key, $default = null): bool
     {
-        $value = $this->get($key, $default);
-
-        if (! is_bool($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a boolean, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
+        return $this->typeable->boolean($key, $default);
     }
 
     /**
@@ -167,15 +144,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function array(string $key, $default = null): array
     {
-        $value = $this->get($key, $default);
-
-        if (! is_array($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an array, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
+        return $this->typeable->array($key, $default);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Typeable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -84,6 +85,20 @@ class Command extends SymfonyCommand
     protected $aliases;
 
     /**
+     * The typeable instance for retrieving command arguments.
+     *
+     * @var Typeable<Command>
+     */
+    public Typeable $argument;
+
+    /**
+     * The typeable instance for retrieving command options.
+     *
+     * @var Typeable<Command>
+     */
+    public Typeable $option;
+
+    /**
      * Create a new console command instance.
      *
      * @return void
@@ -123,6 +138,9 @@ class Command extends SymfonyCommand
         if ($this instanceof Isolatable) {
             $this->configureIsolation();
         }
+
+        $this->argument = new Typeable($this, 'argument');
+        $this->option = new Typeable($this, 'option');
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -5,7 +5,7 @@ namespace Illuminate\Console;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Support\Typeable;
+use Illuminate\Support\Traits\Typeable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,7 +19,8 @@ class Command extends SymfonyCommand
         Concerns\InteractsWithIO,
         Concerns\InteractsWithSignals,
         Concerns\PromptsForMissingInput,
-        Macroable;
+        Macroable,
+        Typeable;
 
     /**
      * The Laravel application instance.
@@ -85,20 +86,6 @@ class Command extends SymfonyCommand
     protected $aliases;
 
     /**
-     * The typeable instance for retrieving command arguments.
-     *
-     * @var Typeable<Command>
-     */
-    public Typeable $argument;
-
-    /**
-     * The typeable instance for retrieving command options.
-     *
-     * @var Typeable<Command>
-     */
-    public Typeable $option;
-
-    /**
      * Create a new console command instance.
      *
      * @return void
@@ -138,9 +125,6 @@ class Command extends SymfonyCommand
         if ($this instanceof Isolatable) {
             $this->configureIsolation();
         }
-
-        $this->argument = new Typeable($this, 'argument');
-        $this->option = new Typeable($this, 'option');
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -328,7 +328,7 @@ trait InteractsWithInput
      */
     public function string($key, $default = null)
     {
-        return $this->typeable->string($key, $default);
+        return $this->typed()->input->string($key, $default);
     }
 
     /**
@@ -342,7 +342,7 @@ trait InteractsWithInput
      */
     public function boolean($key = null, $default = false)
     {
-        return $this->typeable->boolean($key, $default);
+        return $this->typed()->input->boolean($key, $default);
     }
 
     /**
@@ -354,7 +354,7 @@ trait InteractsWithInput
      */
     public function integer($key, $default = 0)
     {
-        return $this->typeable->integer($key, $default);
+        return $this->typed()->input->integer($key, $default);
     }
 
     /**
@@ -366,7 +366,7 @@ trait InteractsWithInput
      */
     public function float($key, $default = 0.0)
     {
-        return $this->typeable->float($key, $default);
+        return $this->typed()->input->float($key, $default);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -328,7 +328,7 @@ trait InteractsWithInput
      */
     public function string($key, $default = null)
     {
-        return str($this->input($key, $default));
+        return $this->typeable->string($key, $default);
     }
 
     /**
@@ -342,7 +342,7 @@ trait InteractsWithInput
      */
     public function boolean($key = null, $default = false)
     {
-        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
+        return $this->typeable->boolean($key, $default);
     }
 
     /**
@@ -354,7 +354,7 @@ trait InteractsWithInput
      */
     public function integer($key, $default = 0)
     {
-        return intval($this->input($key, $default));
+        return $this->typeable->integer($key, $default);
     }
 
     /**
@@ -366,7 +366,7 @@ trait InteractsWithInput
      */
     public function float($key, $default = 0.0)
     {
-        return floatval($this->input($key, $default));
+        return $this->typeable->float($key, $default);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Session\SymfonySessionDecorator;
+use Illuminate\Support;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -27,12 +28,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         Concerns\InteractsWithContentTypes,
         Concerns\InteractsWithFlashData,
         Concerns\InteractsWithInput,
+        Support\Traits\Typeable,
         Macroable;
-
-    /**
-     * @var Typeable<Request>
-     */
-    public Typeable $typeable;
 
     /**
      * The decoded JSON content for the request.
@@ -61,13 +58,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @var \Closure
      */
     protected $routeResolver;
-
-    public function __construct(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null)
-    {
-        parent::__construct($query, $request, $attributes, $cookies, $files, $server, $content);
-
-        $this->typeable = $this->typeable();
-    }
 
     /**
      * Create a new Illuminate HTTP request from server variables.

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -9,6 +9,7 @@ use Illuminate\Session\SymfonySessionDecorator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Typeable;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\InputBag;
@@ -27,6 +28,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         Concerns\InteractsWithFlashData,
         Concerns\InteractsWithInput,
         Macroable;
+
+    /**
+     * @var Typeable<Request>
+     */
+    public Typeable $typeable;
 
     /**
      * The decoded JSON content for the request.
@@ -55,6 +61,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @var \Closure
      */
     protected $routeResolver;
+
+    public function __construct(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null)
+    {
+        parent::__construct($query, $request, $attributes, $cookies, $files, $server, $content);
+
+        $this->typeable = $this->typeable();
+    }
 
     /**
      * Create a new Illuminate HTTP request from server variables.
@@ -772,6 +785,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get the typeable proxy instance.
+     *
+     * @return Typeable<$this>
+     */
+    protected function typeable(string $method = 'input'): Typeable
+    {
+        return new Typeable($this, $method);
+    }
+
+    /**
      * Check if an input element is set on the request.
      *
      * @param  string  $key
@@ -787,6 +810,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string  $key
      * @return mixed
+     *
+     * @deprecated Use the "all" or "route" method instead.
      */
     public function __get($key)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -800,8 +800,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string  $key
      * @return mixed
-     *
-     * @deprecated Use the "all" or "route" method instead.
      */
     public function __get($key)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -17,14 +17,18 @@ use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Support\Typeable;
+use Illuminate\Support\Traits\Typeable;
 use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
 {
-    use CreatesRegularExpressionRouteConstraints, FiltersControllerMiddleware, Macroable, ResolvesRouteDependencies;
+    use CreatesRegularExpressionRouteConstraints,
+        FiltersControllerMiddleware,
+        Macroable,
+        ResolvesRouteDependencies,
+        Typeable;
 
     /**
      * The URI pattern the route responds to.
@@ -131,8 +135,6 @@ class Route
      */
     public $compiled;
 
-    public Typeable $typeable;
-
     /**
      * The router instance used by the route.
      *
@@ -174,7 +176,6 @@ class Route
         $this->uri = $uri;
         $this->methods = (array) $methods;
         $this->action = Arr::except($this->parseAction($action), ['prefix']);
-        $this->typeable = new Typeable($this, 'parameter');
 
         if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods)) {
             $this->methods[] = 'HEAD';

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1375,8 +1375,6 @@ class Route
      *
      * @param  string  $key
      * @return mixed
-     *
-     * @deprecated Use the "parameter" method instead.
      */
     public function __get($key)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -17,6 +17,7 @@ use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Typeable;
 use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use Symfony\Component\Routing\Route as SymfonyRoute;
@@ -130,6 +131,8 @@ class Route
      */
     public $compiled;
 
+    public Typeable $typeable;
+
     /**
      * The router instance used by the route.
      *
@@ -171,6 +174,7 @@ class Route
         $this->uri = $uri;
         $this->methods = (array) $methods;
         $this->action = Arr::except($this->parseAction($action), ['prefix']);
+        $this->typeable = new Typeable($this, 'parameter');
 
         if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods)) {
             $this->methods[] = 'HEAD';
@@ -1370,6 +1374,8 @@ class Route
      *
      * @param  string  $key
      * @return mixed
+     *
+     * @deprecated Use the "parameter" method instead.
      */
     public function __get($key)
     {

--- a/src/Illuminate/Support/HigherOrderStrongTypeableProxy.php
+++ b/src/Illuminate/Support/HigherOrderStrongTypeableProxy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Support;
+
+class HigherOrderStrongTypeableProxy
+{
+    /**
+     * Create a new strong-typeable proxy instance.
+     *
+     * @param  mixed  $target
+     * @return void
+     */
+    public function __construct(protected mixed $target)
+    {
+        //
+    }
+
+    /**
+     * Dynamically access properties from the target.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Support\StrongTypeable
+     */
+    public function __get(string $key): StrongTypeable
+    {
+        return new StrongTypeable($this->target, $key);
+    }
+}

--- a/src/Illuminate/Support/HigherOrderTypeableProxy.php
+++ b/src/Illuminate/Support/HigherOrderTypeableProxy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Support;
+
+class HigherOrderTypeableProxy
+{
+    /**
+     * Create a new typeable proxy instance.
+     *
+     * @param  mixed  $target
+     * @return void
+     */
+    public function __construct(protected mixed $target)
+    {
+        //
+    }
+
+    /**
+     * Dynamically access properties from the target.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Support\Typeable
+     */
+    public function __get(string $key): Typeable
+    {
+        return new Typeable($this->target, $key);
+    }
+}

--- a/src/Illuminate/Support/StrongTypeable.php
+++ b/src/Illuminate/Support/StrongTypeable.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Closure;
+use InvalidArgumentException;
+
+/**
+ * @template TTarget
+ */
+class StrongTypeable
+{
+    /**
+     * Create a new strong typeable instance.
+     *
+     * @param  TTarget  $target
+     * @param  string  $typeable
+     * @return void
+     */
+    public function __construct(protected mixed $target, protected string $typeable)
+    {
+        //
+    }
+
+    /**
+     * Retrieve the value for the given strong typeable.
+     *
+     * @param  mixed  ...$args
+     * @return mixed
+     */
+    protected function value(mixed ...$args): mixed
+    {
+        return $this->target->{$this->typeable}(...$args);
+    }
+
+    /**
+     * Retrieve the value as a string.
+     *
+     * @param  mixed  ...$args
+     * @return string
+     */
+    public function string(mixed ...$args): string
+    {
+        if (! is_string($value = $this->value(...$args))) {
+            throw new InvalidArgumentException(
+                sprintf('Typed property [%s] must be a string, %s given.', $args[0], gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Retrieve the value as a boolean.
+     *
+     * @param  mixed  ...$args
+     * @return bool
+     */
+    public function boolean(mixed ...$args): bool
+    {
+        if (! is_bool($value = $this->value(...$args))) {
+            throw new InvalidArgumentException(
+                sprintf('Typed property [%s] must be a boolean, %s given.', $args[0], gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Retrieve the value as an integer.
+     *
+     * @param  mixed  ...$args
+     * @return int
+     */
+    public function integer(mixed ...$args): int
+    {
+        if (! is_int($value = $this->value(...$args))) {
+            throw new InvalidArgumentException(
+                sprintf('Typed property [%s] must be an integer, %s given.', $args[0], gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Retrieve the value as a float.
+     *
+     * @param  mixed  ...$args
+     * @return float
+     */
+    public function float(mixed ...$args): float
+    {
+        if (! is_float($value = $this->value(...$args))) {
+            throw new InvalidArgumentException(
+                sprintf('Typed property [%s] must be a float, %s given.', $args[0], gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Retrieve the value as an array.
+     *
+     * @param  mixed  ...$args
+     * @return array
+     */
+    public function array(mixed ...$args): array
+    {
+        if (! is_array($value = $this->value(...$args))) {
+            throw new InvalidArgumentException(
+                sprintf('Typed property [%s] must be an array, %s given.', $args[0], gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Retrieve the value as an object.
+     *
+     * @param  mixed  ...$args
+     * @return object
+     */
+    public function object(mixed ...$args): object
+    {
+        if (!is_object($value = $this->value(...$args))) {
+            throw new InvalidArgumentException(
+                sprintf('Typed property [%s] must be an object, %s given.', $args[0], gettype($value))
+            );
+        }
+
+        return $value;
+    }
+}

--- a/src/Illuminate/Support/StrongTypeable.php
+++ b/src/Illuminate/Support/StrongTypeable.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support;
 
-use Closure;
 use InvalidArgumentException;
 
 /**
@@ -126,7 +125,7 @@ class StrongTypeable
      */
     public function object(mixed ...$args): object
     {
-        if (!is_object($value = $this->value(...$args))) {
+        if (! is_object($value = $this->value(...$args))) {
             throw new InvalidArgumentException(
                 sprintf('Typed property [%s] must be an object, %s given.', $args[0], gettype($value))
             );

--- a/src/Illuminate/Support/Traits/StrongTypeable.php
+++ b/src/Illuminate/Support/Traits/StrongTypeable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Illuminate\Support\HigherOrderStrongTypeableProxy;
+
+trait StrongTypeable
+{
+    /**
+     * Retrieve a higher order strong-typeable proxy.
+     *
+     * @return HigherOrderStrongTypeableProxy
+     */
+    public function typed(): HigherOrderStrongTypeableProxy
+    {
+        return new HigherOrderStrongTypeableProxy($this);
+    }
+}

--- a/src/Illuminate/Support/Traits/Typeable.php
+++ b/src/Illuminate/Support/Traits/Typeable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Illuminate\Support\HigherOrderTypeableProxy;
+
+trait Typeable
+{
+    /**
+     * Retrieve a higher order typeable proxy.
+     *
+     * @return HigherOrderTypeableProxy
+     */
+    public function typed(): HigherOrderTypeableProxy
+    {
+        return new HigherOrderTypeableProxy($this);
+    }
+}

--- a/src/Illuminate/Support/Typeable.php
+++ b/src/Illuminate/Support/Typeable.php
@@ -15,7 +15,7 @@ class Typeable
      * @return void
      */
     public function __construct(
-        protected mixed           $target,
+        protected mixed $target,
         protected string $typeable)
     {
         //
@@ -24,7 +24,7 @@ class Typeable
     /**
      * Retrieve the value for the given typeable.
      *
-     * @param mixed ...$args
+     * @param  mixed  ...$args
      * @return mixed
      */
     protected function value(mixed ...$args): mixed
@@ -62,7 +62,7 @@ class Typeable
      */
     public function integer(mixed ...$args): int
     {
-        return (int)$this->value(...$args);
+        return (int) $this->value(...$args);
     }
 
     /**
@@ -73,7 +73,7 @@ class Typeable
      */
     public function float(mixed ...$args): float
     {
-        return (float)$this->value(...$args);
+        return (float) $this->value(...$args);
     }
 
     /**
@@ -84,7 +84,7 @@ class Typeable
      */
     public function array(mixed ...$args): array
     {
-        return (array)$this->value(...$args);
+        return (array) $this->value(...$args);
     }
 
     /**
@@ -95,6 +95,6 @@ class Typeable
      */
     public function object(mixed ...$args): object
     {
-        return (object)$this->value(...$args);
+        return (object) $this->value(...$args);
     }
 }

--- a/src/Illuminate/Support/Typeable.php
+++ b/src/Illuminate/Support/Typeable.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * @template TTarget
+ */
+class Typeable
+{
+    /**
+     * Create a new typeable instance.
+     *
+     * @param  TTarget  $target
+     * @param  string  $typeable
+     * @return void
+     */
+    public function __construct(
+        protected mixed           $target,
+        protected string $typeable)
+    {
+        //
+    }
+
+    /**
+     * Retrieve the value for the given typeable.
+     *
+     * @param mixed ...$args
+     * @return mixed
+     */
+    protected function value(mixed ...$args): mixed
+    {
+        return $this->target->{$this->typeable}(...$args);
+    }
+
+    /**
+     * Retrieve the value as a string.
+     *
+     * @param  mixed  ...$args
+     * @return Stringable|mixed
+     */
+    public function string(mixed ...$args): mixed
+    {
+        return str($this->value(...$args));
+    }
+
+    /**
+     * Retrieve the value as a boolean.
+     *
+     * @param  mixed  ...$args
+     * @return bool
+     */
+    public function boolean(mixed ...$args): bool
+    {
+        return filter_var($this->value(...$args), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Retrieve the value as an integer.
+     *
+     * @param  mixed  ...$args
+     * @return int
+     */
+    public function integer(mixed ...$args): int
+    {
+        return (int)$this->value(...$args);
+    }
+
+    /**
+     * Retrieve the value as a float.
+     *
+     * @param  mixed  ...$args
+     * @return float
+     */
+    public function float(mixed ...$args): float
+    {
+        return (float)$this->value(...$args);
+    }
+
+    /**
+     * Retrieve the value as an array.
+     *
+     * @param  mixed  ...$args
+     * @return array
+     */
+    public function array(mixed ...$args): array
+    {
+        return (array)$this->value(...$args);
+    }
+
+    /**
+     * Retrieve the value as an object.
+     *
+     * @param  mixed  ...$args
+     * @return object
+     */
+    public function object(mixed ...$args): object
+    {
+        return (object)$this->value(...$args);
+    }
+}

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -299,7 +299,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonStringValueAsString(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Configuration value for key \[a\] must be a string, (.*) given.#');
+        $this->expectExceptionMessageMatches('#Typed property \[a\] must be a string, (.*) given.#');
 
         $this->repository->string('a');
     }
@@ -314,7 +314,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonArrayValueAsArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an array, (.*) given.#');
+        $this->expectExceptionMessageMatches('#Typed property \[a.b\] must be an array, (.*) given.#');
 
         $this->repository->array('a.b');
     }
@@ -329,7 +329,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonBooleanValueAsBoolean(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be a boolean, (.*) given.#');
+        $this->expectExceptionMessageMatches('#Typed property \[a.b\] must be a boolean, (.*) given.#');
 
         $this->repository->boolean('a.b');
     }
@@ -344,7 +344,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonIntegerValueAsInteger(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an integer, (.*) given.#');
+        $this->expectExceptionMessageMatches('#Typed property \[a.b\] must be an integer, (.*) given.#');
 
         $this->repository->integer('a.b');
     }
@@ -359,7 +359,7 @@ class RepositoryTest extends TestCase
     public function testItThrowsAnExceptionWhenTryingToGetNonFloatValueAsFloat(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Configuration value for key \[a.b\] must be a float, (.*) given.#');
+        $this->expectExceptionMessageMatches('#Typed property \[a.b\] must be a float, (.*) given.#');
 
         $this->repository->float('a.b');
     }

--- a/tests/Support/SupportTypeableTest.php
+++ b/tests/Support/SupportTypeableTest.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Stringable;
-use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 

--- a/tests/Support/SupportTypeableTest.php
+++ b/tests/Support/SupportTypeableTest.php
@@ -2,10 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Config\Repository as Config;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -45,16 +43,16 @@ class SupportTypeableTest extends TestCase
 
         $route->bind($request);
 
-        $this->assertInstanceOf(Stringable::class, $route->typeable->string('userid'));
-        $this->assertEquals('1234', $route->typeable->string('userid'));
+        $this->assertInstanceOf(Stringable::class, $route->typed()->parameter->string('userid'));
+        $this->assertEquals('1234', $route->typed()->parameter->string('userid'));
 
-        $this->assertIsBool($boolean = $route->typeable->boolean('unexisting'));
+        $this->assertIsBool($boolean = $route->typed()->parameter->boolean('unexisting'));
         $this->assertFalse($boolean);
 
-        $this->assertIsInt($integer = $route->typeable->integer('userid'));
+        $this->assertIsInt($integer = $route->typed()->parameter->integer('userid'));
         $this->assertEquals(1234, $integer);
 
-        $this->assertIsFloat($float = $route->typeable->float('userid'));
+        $this->assertIsFloat($float = $route->typed()->parameter->float('userid'));
         $this->assertEquals(1234.0, $float);
     }
 
@@ -75,19 +73,19 @@ class SupportTypeableTest extends TestCase
 
         $command->run($input, $output);
 
-        $this->assertInstanceOf(Stringable::class, $string = $command->option->string('userid'));
+        $this->assertInstanceOf(Stringable::class, $string = $command->typed()->option->string('userid'));
         $this->assertEquals('4', $string);
 
-        $this->assertIsBool($boolean = $command->option->boolean('all'));
+        $this->assertIsBool($boolean = $command->typed()->option->boolean('all'));
         $this->assertTrue($boolean);
 
-        $this->assertIsInt($integer = $command->option->integer('userid'));
+        $this->assertIsInt($integer = $command->typed()->option->integer('userid'));
         $this->assertEquals(4, $integer);
 
-        $this->assertIsFloat($float = $command->option->float('userid'));
+        $this->assertIsFloat($float = $command->typed()->option->float('userid'));
         $this->assertEquals(4.0, $float);
 
-        $this->assertIsArray($array = $command->argument->array('theargument'));
+        $this->assertIsArray($array = $command->typed()->argument->array('theargument'));
         $this->assertSame(['first', 'second'], $array);
     }
 }

--- a/tests/Support/SupportTypeableTest.php
+++ b/tests/Support/SupportTypeableTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Config\Repository as Config;
+use Illuminate\Console\Application;
+use Illuminate\Console\Command;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Stringable;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class SupportTypeableTest extends TestCase
+{
+    public function testTypeableRequest(): void
+    {
+        $request = Request::create('/', 'GET', ['foo' => 'bar', 'empty' => '', 'checked' => 'on', 'strval' => '1234']);
+
+        $this->assertInstanceOf(Stringable::class, $request->string('strval'));
+        $this->assertEquals('1234', $request->string('strval'));
+
+        $this->assertIsBool($request->boolean('checked'));
+        $this->assertTrue($request->boolean('checked'));
+
+        $this->assertIsInt($request->integer('strval'));
+        $this->assertIsInt($request->integer('strval'));
+        $this->assertEquals(1234, $request->integer('strval'));
+
+        $this->assertIsFloat($request->float('strval'));
+        $this->assertEquals(1234.0, $request->float('strval'));
+    }
+
+    public function testTypeableRoute(): void
+    {
+        $request = Request::create('/users/1234', 'GET');
+
+        $route = new Route('GET', '/users/{userid}', function () {
+            return 'Hello World';
+        });
+
+        $route->bind($request);
+
+        $this->assertInstanceOf(Stringable::class, $route->typeable->string('userid'));
+        $this->assertEquals('1234', $route->typeable->string('userid'));
+
+        $this->assertIsBool($boolean = $route->typeable->boolean('unexisting'));
+        $this->assertFalse($boolean);
+
+        $this->assertIsInt($integer = $route->typeable->integer('userid'));
+        $this->assertEquals(1234, $integer);
+
+        $this->assertIsFloat($float = $route->typeable->float('userid'));
+        $this->assertEquals(1234.0, $float);
+    }
+
+    public function testTypeableCommand(): void
+    {
+        $app = new Application(
+            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $app->addCommands([$command = new FooCommand()]);
+
+        $command->setLaravel($laravel);
+
+        $input = new StringInput('foo:command first second --userid=4 --all');
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $this->assertInstanceOf(Stringable::class, $string = $command->option->string('userid'));
+        $this->assertEquals('4', $string);
+
+        $this->assertIsBool($boolean = $command->option->boolean('all'));
+        $this->assertTrue($boolean);
+
+        $this->assertIsInt($integer = $command->option->integer('userid'));
+        $this->assertEquals(4, $integer);
+
+        $this->assertIsFloat($float = $command->option->float('userid'));
+        $this->assertEquals(4.0, $float);
+
+        $this->assertIsArray($array = $command->argument->array('theargument'));
+        $this->assertSame(['first', 'second'], $array);
+    }
+}
+
+class FooCommand extends Command
+{
+    protected $signature = 'foo:command {theargument*} {--userid=} {--all}';
+
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
# Typeables
There currently are two classes in the framework which offer the ability to retrieve a mixed value by a specific type, which are:

```php
// Request objects (\Illuminate\Http\Request):
request()->string('userid'); // '1'
request()->boolean('is_admin'); // true
request()->integer('userid'); // 1
request()->float('price'); // 1.05

// Configuration objects (\Illuminate\Config\Repository):
config()->string('somekey.name'); // 'myname'
config()->boolean('somekey.enabled'); // false
config()->integer('somekey.port'); // 3010
config()->float('somekey.percentage') // 0.5
config()->array('somekey.percentage') // [0.5]
```

This PR proposes a new `Typeable` class (which casts types) and `StrongTypeable` class (which checks types and throws exceptions if it doesnt match) which serves as a centralized API through which developers can retrieve typed values for the following objects:

| Code | Value | Type | Is New |
| - | - | - | - |
| **`\Illuminate\Http\Request`** | | | |
| `request()->string('userid');` | `'1'` | Typeable | |
| `request()->boolean('is_admin');` | `true` | Typeable | |
| `request()->integer('userid');` | `1` | Typeable | |
| `request()->float('price');` | `1.05` | Typeable | |
| `request()->array('userid');` | `['1']` | Typeable | ✔️ |
| `request()->date('mydate');` | `Carbon` | custom | |
| `request()->enum('myenum');` | `Enum` | custom | |
| `request()->collect('myarray');` | `Collection` | custom | |
| **`\Illuminate\Config\Repository`** | | | |
| `config()->string('somekey.name');` | `'myname'` | StrongTypeable | |
| `config()->boolean('somekey.enabled');` | `false` | StrongTypeable | |
| `config()->integer('somekey.port');` | `3010` | StrongTypeable | |
| `config()->float('somekey.percentage');` | `0.5` | StrongTypeable | |
| `config()->array('somekey.percentage');` | `[0.5]` | StrongTypeable | |
| **`\Illuminate\Routing\Route`** | | | |
| `request()->route()->typed()->parameter->string('userid');` | `'1'` | Typeable | ✔️ |
| `request()->route()->typed()->parameter->boolean('userid');` | `true` | Typeable | ✔️ |
| `request()->route()->typed()->parameter->integer('userid');` | `1` | Typeable | ✔️ |
| `request()->route()->typed()->parameter->float('userid');` | `1.0` | Typeable | ✔️ |
| `request()->route()->typed()->parameter->array('userid');` | `['1']` | Typeable | ✔️ |
| **`\Illuminate\Console\Command`** | | | |
| `$command->typed()->argument->string('myargument');` | `'1'` | Typeable | ✔️ |
| `$command->typed()->argument->boolean('myargument');` | `true` | Typeable | ✔️ |
| `$command->typed()->argument->integer('myargument');` | `1` | Typeable | ✔️ |
| `$command->typed()->argument->float('myargument');` | `1.05` | Typeable | ✔️ |
| `$command->typed()->argument->array('myargument');` | `['1']` | Typeable | ✔️ |
| `$command->typed()->option->string('myoption');` | `'1'` | Typeable | ✔️ |
| `$command->typed()->option->boolean('myoption');` | `true` | Typeable | ✔️ |
| `$command->typed()->option->integer('myoption');` | `1` | Typeable | ✔️ |
| `$command->typed()->option->float('myoption');` | `1.05` | Typeable | ✔️ |
| `$command->typed()->option->array('myoption');` | `['1']` | Typeable | ✔️ |

The existing type helpers for `request()` and `config()` have not changed but instead refactored to use the `Typeable`/`StrongTypeable` code.