### PR TITLE
[11.x] Using the `??` Operator (Null Coalescing Operator) 

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -418,9 +418,7 @@ class Middleware
         ]));
 
         $middleware = array_map(function ($middleware) {
-            return isset($this->replacements[$middleware])
-                ? $this->replacements[$middleware]
-                : $middleware;
+            return $this->replacements[$middleware] ?? $middleware;
         }, $middleware);
 
         return array_values(array_filter(

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -226,7 +226,7 @@ class FakeInvokedProcess implements InvokedProcessContract
             $this->nextOutputIndex = $i + 1;
         }
 
-        return isset($output) ? $output : '';
+        return $output ?? '';
     }
 
     /**
@@ -249,7 +249,7 @@ class FakeInvokedProcess implements InvokedProcessContract
             $this->nextErrorOutputIndex = $i + 1;
         }
 
-        return isset($output) ? $output : '';
+        return $output ?? '';
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -360,11 +360,7 @@ abstract class Queue
             return $job->afterCommit;
         }
 
-        if (isset($this->dispatchAfterCommit)) {
-            return $this->dispatchAfterCommit;
-        }
-
-        return false;
+        return $this->dispatchAfterCommit ?? false;
     }
 
     /**

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -121,9 +121,7 @@ trait RunsInParallel
             });
         }
 
-        return $potentialExitCode === null
-            ? $this->getExitCode()
-            : $potentialExitCode;
+        return $potentialExitCode ?? $this->getExitCode();
     }
 
     /**


### PR DESCRIPTION
This PR, introduces the use of the Null Coalescing Operator (`??`) in the some cases. The Null Coalescing Operator is a concise and effective way to handle null values, providing a default value if the variable is null.


Laravel 11 supports PHP 8.2 and higher, and the `??` operator has been available since PHP 7 and above. Therefore, we have no issues in terms of compatibility with the changes. **The goal of these changes is to simplify the code and utilize the powerful features of PHP.**

### example:
```php
// before
if (isset($this->dispatchAfterCommit)) {
    return $this->dispatchAfterCommit;
}

return false;
```

```php
// after
return $this->dispatchAfterCommit ?? false;
```