### PR TITLE
[12.x] Route aliases

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -179,7 +179,9 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             ];
         }
 
-        return compact('compiled', 'attributes');
+        $aliases = $this->routesAliasesList;
+
+        return compact('compiled', 'attributes', 'aliases');
     }
 
     /**

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -29,7 +29,14 @@ class CompiledRouteCollection extends AbstractRouteCollection
     protected $attributes = [];
 
     /**
-     * The dynamically added routes that were added after loading the cached, compiled routes.
+     * An array of the route aliases.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
+     * The dynamic  ly added routes that were added after loading the cached, compiled routes.
      *
      * @var \Illuminate\Routing\RouteCollection|null
      */
@@ -56,10 +63,11 @@ class CompiledRouteCollection extends AbstractRouteCollection
      * @param  array  $attributes
      * @return void
      */
-    public function __construct(array $compiled, array $attributes)
+    public function __construct(array $compiled, array $attributes, array $aliases = [])
     {
         $this->compiled = $compiled;
         $this->attributes = $attributes;
+        $this->aliases = $aliases;
         $this->routes = new RouteCollection;
     }
 
@@ -193,6 +201,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getByName($name)
     {
+        if (isset($this->aliases[$name])) {
+            $name = $this->aliases[$name];
+        }
+
         if (isset($this->attributes[$name])) {
             return $this->newRoute($this->attributes[$name]);
         }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -37,6 +37,13 @@ class RouteCollection extends AbstractRouteCollection
     protected $actionList = [];
 
     /**
+     * A look-up table to aliases and it's corresponding named routes.
+     *
+     * @var array
+     */
+    protected $routesAliasesList = [];
+
+    /**
      * Add a Route instance to the collection.
      *
      * @param  \Illuminate\Routing\Route  $route
@@ -124,6 +131,19 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Push a new alias to the aliases map to map it with it's corresponding route name.
+     *
+     * @param  string  $alias
+     * @param  string  $name
+     *
+     * @return void
+     */
+    public function setRouteAlias($alias, $name)
+    {
+        $this->routesAliasesList[$alias] = $name;
+    }
+
+    /**
      * Refresh the action look-up table.
      *
      * This is done in case any actions are overwritten with new controllers.
@@ -192,7 +212,22 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function getByName($name)
     {
-        return $this->nameList[$name] ?? null;
+        return $this->nameList[
+            $this->checkAliasedRoute($name)
+        ] ?? null;
+    }
+
+    /**
+     * Check if a given alias is already exists and return it's resolved route name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @return void
+     */
+    public function checkAliasedRoute($name)
+    {
+        return $this->routesAliasesList[$name] ?? $name;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use UnexpectedValueException;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -124,23 +125,18 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
+
+            if (isset($this->routesAliasesList[$route->getName()])) {
+                throw new UnexpectedValueException(sprintf(
+                    'The alias %s is already defined as a route and can not be defined as an alias.',
+                    $route->getName()
+                ));
+            }
+
             if ($route->getName()) {
                 $this->nameList[$route->getName()] = $route;
             }
         }
-    }
-
-    /**
-     * Push a new alias to the aliases map to map it with it's corresponding route name.
-     *
-     * @param  string  $alias
-     * @param  string  $name
-     *
-     * @return void
-     */
-    public function setRouteAlias($alias, $name)
-    {
-        $this->routesAliasesList[$alias] = $name;
     }
 
     /**
@@ -159,6 +155,19 @@ class RouteCollection extends AbstractRouteCollection
                 $this->addToActionList($route->getAction(), $route);
             }
         }
+    }
+
+    /**
+     * Push a new alias to the aliases map to map it with it's corresponding route name.
+     *
+     * @param  string  $alias
+     * @param  string  $name
+     *
+     * @return void
+     */
+    public function setRouteAlias($alias, $name)
+    {
+        $this->routesAliasesList[$alias] = $name;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Routing;
 
-use UnexpectedValueException;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use UnexpectedValueException;
 
 class RouteCollection extends AbstractRouteCollection
 {
@@ -125,7 +125,6 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
-
             if (isset($this->routesAliasesList[$route->getName()])) {
                 throw new UnexpectedValueException(sprintf(
                     'The alias %s is already defined as a route and can not be defined as an alias.',
@@ -162,7 +161,6 @@ class RouteCollection extends AbstractRouteCollection
      *
      * @param  string  $alias
      * @param  string  $name
-     *
      * @return void
      */
     public function setRouteAlias($alias, $name)
@@ -231,7 +229,6 @@ class RouteCollection extends AbstractRouteCollection
      *
      * @param  string  $name
      * @return string
-     *
      * @return void
      */
     public function checkAliasedRoute($name)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -232,6 +232,19 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a new alias.
+     *
+     * @param  string  $alias
+     * @param  string  $name
+     *
+     * @return void
+     */
+    public function alias($alias, $name)
+    {
+        $this->routes->setRouteAlias($alias, $name);
+    }
+
+    /**
      * Register a new fallback route with the router.
      *
      * @param  array|string|callable|null  $action

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1448,7 +1448,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function setCompiledRoutes(array $routes)
     {
-        $this->routes = (new CompiledRouteCollection($routes['compiled'], $routes['attributes']))
+        $this->routes = (new CompiledRouteCollection($routes['compiled'], $routes['attributes'], $routes['aliases'] ?? []))
             ->setRouter($this)
             ->setContainer($this->container);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -236,7 +236,6 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @param  string  $alias
      * @param  string  $name
-     *
      * @return void
      */
     public function alias($alias, $name)


### PR DESCRIPTION
Adding the ability to alias a named route by another name/alias.

### Motivation
Considering the following scenario, we have a package that implements some UI features with a basic routes, and another package that implementing some functionalities that needed to be used within the first package, if the first package does not allow configuring it's used routes, there will be no direct way to integrate the two packages.
Although, the previous scenario is considered as an edge-case due to the bad design that had been followed in the first package, yet, aliasing routes remain a good features that may be added value if it had been implemented in Laravel.

### Usage
```php

Route::get('some-path/', 'Controller@method')->name('base-name');

Route::alias('alias-route-name', 'base-name');

// .... now we can use the defined alias as a route name when we try to retrieve the route info, for example
return redirect('alias-route-name');
```

reference discussion #51306 