### PR TITLE
[11.x] Add some tests and improvement test coverage for `Str::camel`

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -936,7 +936,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('***************', Str::mask('maria@email.com', '*', 0));
     }
 
-    public function testMatch()
+    public function testMatch(): void
     {
         $this->assertSame('bar', Str::match('/bar/', 'foo bar'));
         $this->assertSame('bar', Str::match('/foo (.*)/', 'foo bar'));
@@ -946,9 +946,12 @@ class SupportStrTest extends TestCase
 
         $this->assertEquals(['un', 'ly'], Str::matchAll('/f(\w*)/', 'bar fun bar fly')->all());
         $this->assertEmpty(Str::matchAll('/nothing/', 'bar fun bar fly'));
+
+        $this->assertEmpty(Str::match('/pattern/', ''));
+        $this->assertEmpty(Str::matchAll('/pattern/', ''));
     }
 
-    public function testCamel()
+    public function testCamel(): void
     {
         $this->assertSame('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));
         $this->assertSame('laravelPhpFramework', Str::camel('Laravel_php_framework'));
@@ -960,6 +963,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('fooBar', Str::camel('foo_bar')); // test cache
         $this->assertSame('fooBarBaz', Str::camel('Foo-barBaz'));
         $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
+
+        $this->assertSame('', Str::camel(''));
+        $this->assertSame('lARAVELPHPFRAMEWORK', Str::camel('LARAVEL_PHP_FRAMEWORK'));
+        $this->assertSame('laravelPhpFramework', Str::camel('   laravel   php   framework   '));
+
+        $this->assertSame('foo1Bar', Str::camel('foo1_bar'));
+        $this->assertSame('1FooBar', Str::camel('1 foo bar'));
     }
 
     public function testCharAt()


### PR DESCRIPTION
This PR , adds some tests to enhance test coverage. 

- Check empty string

```php
 $this->assertSame('', Str::camel(''));
```

- When all characters are uppercase

```php
$this->assertSame('lARAVELPHPFRAMEWORK', Str::camel('LARAVEL_PHP_FRAMEWORK'));
```

- When there are leading and trailing spaces in a string.

```php
 $this->assertSame('laravelPhpFramework', Str::camel('   laravel   php   framework   '));
```

- When there is a numeric character in the middle or at the beginning of the string

```php
$this->assertSame('foo1Bar', Str::camel('foo1_bar'));
$this->assertSame('1FooBar', Str::camel('1 foo bar'));
```




