### PR TITLE
Prevent use of the Laravel HTTP Client as PSR client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1199,7 +1199,7 @@ class PendingRequest
      *
      * @return \GuzzleHttp\Client
      */
-    public function buildClient()
+    protected function buildClient()
     {
         return $this->client ?? $this->createClient($this->buildHandlerStack());
     }
@@ -1230,7 +1230,7 @@ class PendingRequest
      * @param  \GuzzleHttp\HandlerStack  $handlerStack
      * @return \GuzzleHttp\Client
      */
-    public function createClient($handlerStack)
+    protected function createClient($handlerStack)
     {
         return new Client([
             'handler' => $handlerStack,


### PR DESCRIPTION
Based on this comment, I am creating this PR against Laravel 12: https://github.com/laravel/framework/pull/51311#issuecomment-2095546086

----

As per this comment https://github.com/laravel/framework/issues/41872#issuecomment-2095505159 `\Illuminate\Http\Client\PendingRequest::buildClient()` and `\Illuminate\Http\Client\PendingRequest::createClient()` are intended for internal use only. So they have no business being publicly available to the users of the framework. Sadly this also means that Laravel does not provide a way to obtain a PSR compliant HTTP client.

This **is** a breaking change, since the API changes its visibility.

Since these methods were never intended to be publicly used and do not seem to be documented anywhere, this **could** be considered a patch.

**Other possible solution:** Mark both methods `@internal` via PHPDoc, which would not enforce anything and can easily be ignored.

**Further notes:**
This PR assumes that Laravel has no intention of providing a PSR compliant HTTP client via its API.
If that assumption is wrong, this PR is not a fitting solution.

Since the intention is not clearly communicated, this is the only solution I can think of right now.

Open to discussions on the direction of this PR.