### PR TITLE
[11.x] Add int|float support to e method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -110,7 +110,7 @@ if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.
      *
-     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|\BackedEnum|string|null  $value
+     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|\BackedEnum|string|int|float|null  $value
      * @param  bool  $doubleEncode
      * @return string
      */
@@ -126,6 +126,10 @@ if (! function_exists('e')) {
 
         if ($value instanceof BackedEnum) {
             $value = $value->value;
+        }
+        
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
         }
 
         return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', $doubleEncode);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -128,10 +128,6 @@ if (! function_exists('e')) {
             $value = $value->value;
         }
 
-        if (is_int($value) || is_float($value)) {
-            return (string) $value;
-        }
-
         return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', $doubleEncode);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -127,7 +127,7 @@ if (! function_exists('e')) {
         if ($value instanceof BackedEnum) {
             $value = $value->value;
         }
-        
+
         if (is_int($value) || is_float($value)) {
             return (string) $value;
         }


### PR DESCRIPTION
Prevent `int|float` to `string` implicit casts on `e(...)` method helper.

Using `bladestan` extension of phpstan it throw errors about blade `{{ }}` statements if you print a number.

Blade example:
```blade
@php($number = 31)

{{ $number }}
```

Error example:
```
Parameter #1 $value of function e expects
         BackedEnum|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|string|null, int<0,max> given.
```