### PR TITLE
[11.x] Add `InteractsWithInput` methods to `ValidatedInput`

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -40,7 +40,7 @@ class ValidatedInput implements ValidatedData
         $keys = is_array($keys) ? $keys : func_get_args();
 
         foreach ($keys as $key) {
-            if (! Arr::has($this->input, $key)) {
+            if (! Arr::has($this->all(), $key)) {
                 return false;
             }
         }
@@ -69,7 +69,7 @@ class ValidatedInput implements ValidatedData
     {
         $results = [];
 
-        $input = $this->input;
+        $input = $this->all();
 
         $placeholder = new stdClass;
 
@@ -94,7 +94,7 @@ class ValidatedInput implements ValidatedData
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        $results = $this->input;
+        $results = $this->all();
 
         Arr::forget($results, $keys);
 
@@ -109,7 +109,7 @@ class ValidatedInput implements ValidatedData
      */
     public function merge(array $items)
     {
-        return new static(array_merge($this->input, $items));
+        return new static(array_merge($this->all(), $items));
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -173,7 +173,7 @@ class ValidatedInput implements ValidatedData
      */
     public function __isset($name)
     {
-        return isset($this->input[$name]);
+        return $this->exists($name);
     }
 
     /**
@@ -195,7 +195,7 @@ class ValidatedInput implements ValidatedData
      */
     public function offsetExists($key): bool
     {
-        return isset($this->input[$key]);
+        return $this->exists($key);
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -290,4 +290,23 @@ class ValidatedInput implements ValidatedData
         return $this;
     }
 
+    /**
+     * Determine if the validated inputs contains a non-empty value for an input item.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function filled($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->isEmptyString($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -347,4 +347,25 @@ class ValidatedInput implements ValidatedData
         return false;
     }
 
+    /**
+     * Apply the callback if the validated inputs contains a non-empty value for the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenFilled($key, callable $callback, callable $default = null)
+    {
+        if ($this->filled($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -476,4 +476,16 @@ class ValidatedInput implements ValidatedData
         return intval($this->input($key, $default));
     }
 
+    /**
+     * Retrieve input as a float value.
+     *
+     * @param  string  $key
+     * @param  float  $default
+     * @return float
+     */
+    public function float($key, $default = 0.0)
+    {
+        return floatval($this->input($key, $default));
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -115,11 +115,12 @@ class ValidatedInput implements ValidatedData
     /**
      * Get the input as a collection.
      *
+     * @param  array|string|null  $key
      * @return \Illuminate\Support\Collection
      */
-    public function collect()
+    public function collect($key = null)
     {
-        return new Collection($this->input);
+        return collect(is_array($key) ? $this->only($key) : $this->input($key));
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -254,4 +254,19 @@ class ValidatedInput implements ValidatedData
         return $this->has($key);
     }
 
+    /**
+     * Determine if the validated inputs contains any of the given inputs.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function hasAny($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $input = $this->all();
+
+        return Arr::hasAny($input, $keys);
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -402,4 +402,14 @@ class ValidatedInput implements ValidatedData
         return ! is_bool($value) && ! is_array($value) && trim((string) $value) === '';
     }
 
+    /**
+     * Get the keys for all of the input.
+     *
+     * @return array
+     */
+    public function keys()
+    {
+        return array_keys($this->input());
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -389,4 +389,17 @@ class ValidatedInput implements ValidatedData
         return $this;
     }
 
+    /**
+     * Determine if the given input key is an empty string for "filled".
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isEmptyString($key)
+    {
+        $value = $this->input($key);
+
+        return ! is_bool($value) && ! is_array($value) && trim((string) $value) === '';
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -412,4 +412,18 @@ class ValidatedInput implements ValidatedData
         return array_keys($this->input());
     }
 
+    /**
+     * Retrieve an input item from the validated inputs.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function input($key = null, $default = null)
+    {
+        return data_get(
+            $this->all(), $key, $default
+        );
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -450,4 +450,18 @@ class ValidatedInput implements ValidatedData
         return str($this->input($key, $default));
     }
 
+    /**
+     * Retrieve input as a boolean value.
+     *
+     * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.
+     *
+     * @param  string|null  $key
+     * @param  bool  $default
+     * @return bool
+     */
+    public function boolean($key = null, $default = false)
+    {
+        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -433,6 +433,18 @@ class ValidatedInput implements ValidatedData
      * @param  mixed  $default
      * @return \Illuminate\Support\Stringable
      */
+    public function str($key, $default = null)
+    {
+        return $this->string($key, $default);
+    }
+
+    /**
+     * Retrieve input from the validated inputs as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
     public function string($key, $default = null)
     {
         return str($this->input($key, $default));

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -269,4 +269,25 @@ class ValidatedInput implements ValidatedData
         return Arr::hasAny($input, $keys);
     }
 
+    /**
+     * Apply the callback if the validated inputs contains the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenHas($key, callable $callback, callable $default = null)
+    {
+        if ($this->has($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -426,4 +426,16 @@ class ValidatedInput implements ValidatedData
         );
     }
 
+    /**
+     * Retrieve input from the validated inputs as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function string($key, $default = null)
+    {
+        return str($this->input($key, $default));
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -242,4 +242,16 @@ class ValidatedInput implements ValidatedData
     {
         return new ArrayIterator($this->input);
     }
+
+    /**
+     * Determine if the validated inputs contains a given input item key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function exists($key)
+    {
+        return $this->has($key);
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use ArrayIterator;
 use Illuminate\Contracts\Support\ValidatedData;
+use Illuminate\Support\Facades\Date;
 use stdClass;
 use Traversable;
 
@@ -486,6 +487,29 @@ class ValidatedInput implements ValidatedData
     public function float($key, $default = 0.0)
     {
         return floatval($this->input($key, $default));
+    }
+
+    /**
+     * Retrieve input from the validated inputs as a Carbon instance.
+     *
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
+     */
+    public function date($key, $format = null, $tz = null)
+    {
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
+        if (is_null($format)) {
+            return Date::parse($this->input($key), $tz);
+        }
+
+        return Date::createFromFormat($format, $this->input($key), $tz);
     }
 
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -151,7 +151,7 @@ class ValidatedInput implements ValidatedData
      */
     public function __get($name)
     {
-        return $this->input[$name];
+        return $this->input($name);
     }
 
     /**
@@ -206,7 +206,7 @@ class ValidatedInput implements ValidatedData
      */
     public function offsetGet($key): mixed
     {
-        return $this->input[$key];
+        return $this->input($key);
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -512,4 +512,24 @@ class ValidatedInput implements ValidatedData
         return Date::createFromFormat($format, $this->input($key), $tz);
     }
 
+    /**
+     * Retrieve input from the validated inputs as an enum.
+     *
+     * @template TEnum
+     *
+     * @param  string  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @return TEnum|null
+     */
+    public function enum($key, $enumClass)
+    {
+        if ($this->isNotFilled($key) ||
+            ! enum_exists($enumClass) ||
+            ! method_exists($enumClass, 'tryFrom')) {
+            return null;
+        }
+
+        return $enumClass::tryFrom($this->input($key));
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -328,4 +328,23 @@ class ValidatedInput implements ValidatedData
         return true;
     }
 
+    /**
+     * Determine if the validated inputs contains a non-empty value for any of the given inputs.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function anyFilled($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        foreach ($keys as $key) {
+            if ($this->filled($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -309,4 +309,23 @@ class ValidatedInput implements ValidatedData
         return true;
     }
 
+    /**
+     * Determine if the validated inputs contains an empty value for an input item.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function isNotFilled($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! $this->isEmptyString($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -534,6 +534,19 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Dump the validated inputs items and end the script.
+     *
+     * @param  mixed  ...$keys
+     * @return never
+     */
+    public function dd(...$keys)
+    {
+        $this->dump(...$keys);
+
+        exit(1);
+    }
+
+    /**
      * Dump the items.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -368,4 +368,25 @@ class ValidatedInput implements ValidatedData
         return $this;
     }
 
+    /**
+     * Apply the callback if the validated inputs is missing the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenMissing($key, callable $callback, callable $default = null)
+    {
+        if ($this->missing($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -464,4 +464,16 @@ class ValidatedInput implements ValidatedData
         return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
     }
 
+    /**
+     * Retrieve input as an integer value.
+     *
+     * @param  string  $key
+     * @param  int  $default
+     * @return int
+     */
+    public function integer($key, $default = 0)
+    {
+        return intval($this->input($key, $default));
+    }
+
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -96,7 +96,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Determine if the validated input contains a non-empty value for an input key.
+     * Determine if the validated input contains a non-empty value for an input item.
      *
      * @param  string|array  $key
      * @return bool
@@ -115,7 +115,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Determine if the validated input contains an empty value for an input key.
+     * Determine if the validated input contains an empty value for an input item.
      *
      * @param  string|array  $key
      * @return bool
@@ -134,7 +134,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Determine if the validated input contains a non-empty value for any of the given input keys.
+     * Determine if the validated input contains a non-empty value for any of the given input items.
      *
      * @param  string|array  $keys
      * @return bool
@@ -174,7 +174,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Determine if the given input key is an empty string.
+     * Determine if the given input item is an empty string.
      *
      * @param  string  $key
      * @return bool
@@ -483,7 +483,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Determine if an input key is set.
+     * Determine if an input item is set.
      *
      * @return bool
      */
@@ -493,7 +493,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Remove an input key.
+     * Remove an input item.
      *
      * @param  string  $name
      * @return void

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -174,6 +174,19 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Determine if the given input key is an empty string.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isEmptyString($key)
+    {
+        $value = $this->input($key);
+
+        return ! is_bool($value) && ! is_array($value) && trim((string) $value) === '';
+    }
+
+    /**
      * Determine if the validated input is missing one or more keys.
      *
      * @param  mixed  $keys
@@ -203,19 +216,6 @@ class ValidatedInput implements ValidatedData
         }
 
         return $this;
-    }
-
-    /**
-     * Determine if the given input key is an empty string for "filled".
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isEmptyString($key)
-    {
-        $value = $this->input($key);
-
-        return ! is_bool($value) && ! is_array($value) && trim((string) $value) === '';
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -32,6 +32,17 @@ class ValidatedInput implements ValidatedData
     /**
      * Determine if the validated input has one or more keys.
      *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function exists($key)
+    {
+        return $this->has($key);
+    }
+
+    /**
+     * Determine if the validated input has one or more keys.
+     *
      * @param  mixed  $keys
      * @return bool
      */
@@ -49,6 +60,120 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Determine if the validated input contains any of the given keys.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function hasAny($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $input = $this->all();
+
+        return Arr::hasAny($input, $keys);
+    }
+
+    /**
+     * Apply the callback if the validated input contains the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenHas($key, callable $callback, callable $default = null)
+    {
+        if ($this->has($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validated input contains a non-empty value for an input key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function filled($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->isEmptyString($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the validated input contains an empty value for an input key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function isNotFilled($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! $this->isEmptyString($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the validated input contains a non-empty value for any of the given input keys.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function anyFilled($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        foreach ($keys as $key) {
+            if ($this->filled($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Apply the callback if the validated input contains a non-empty value for the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenFilled($key, callable $callback, callable $default = null)
+    {
+        if ($this->filled($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the validated input is missing one or more keys.
      *
      * @param  mixed  $keys
@@ -57,6 +182,169 @@ class ValidatedInput implements ValidatedData
     public function missing($keys)
     {
         return ! $this->has($keys);
+    }
+
+    /**
+     * Apply the callback if the validated input is missing the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenMissing($key, callable $callback, callable $default = null)
+    {
+        if ($this->missing($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Determine if the given input key is an empty string for "filled".
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isEmptyString($key)
+    {
+        $value = $this->input($key);
+
+        return ! is_bool($value) && ! is_array($value) && trim((string) $value) === '';
+    }
+
+    /**
+     * Get the keys for all of the input.
+     *
+     * @return array
+     */
+    public function keys()
+    {
+        return array_keys($this->input());
+    }
+
+    /**
+     * Retrieve an input item from the validated input.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function input($key = null, $default = null)
+    {
+        return data_get(
+            $this->all(), $key, $default
+        );
+    }
+
+    /**
+     * Retrieve input from the validated input as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function str($key, $default = null)
+    {
+        return $this->string($key, $default);
+    }
+
+    /**
+     * Retrieve input from the validated input as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function string($key, $default = null)
+    {
+        return str($this->input($key, $default));
+    }
+
+    /**
+     * Retrieve input as a boolean value.
+     *
+     * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.
+     *
+     * @param  string|null  $key
+     * @param  bool  $default
+     * @return bool
+     */
+    public function boolean($key = null, $default = false)
+    {
+        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Retrieve input as an integer value.
+     *
+     * @param  string  $key
+     * @param  int  $default
+     * @return int
+     */
+    public function integer($key, $default = 0)
+    {
+        return intval($this->input($key, $default));
+    }
+
+    /**
+     * Retrieve input as a float value.
+     *
+     * @param  string  $key
+     * @param  float  $default
+     * @return float
+     */
+    public function float($key, $default = 0.0)
+    {
+        return floatval($this->input($key, $default));
+    }
+
+    /**
+     * Retrieve input from the validated input as a Carbon instance.
+     *
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
+     */
+    public function date($key, $format = null, $tz = null)
+    {
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
+        if (is_null($format)) {
+            return Date::parse($this->input($key), $tz);
+        }
+
+        return Date::createFromFormat($format, $this->input($key), $tz);
+    }
+
+    /**
+     * Retrieve input from the validated input as an enum.
+     *
+     * @template TEnum
+     *
+     * @param  string  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @return TEnum|null
+     */
+    public function enum($key, $enumClass)
+    {
+        if ($this->isNotFilled($key) ||
+            ! enum_exists($enumClass) ||
+            ! method_exists($enumClass, 'tryFrom')) {
+            return null;
+        }
+
+        return $enumClass::tryFrom($this->input($key));
     }
 
     /**
@@ -131,6 +419,34 @@ class ValidatedInput implements ValidatedData
     public function all()
     {
         return $this->input;
+    }
+
+    /**
+     * Dump the validated input items and end the script.
+     *
+     * @param  mixed  ...$keys
+     * @return never
+     */
+    public function dd(...$keys)
+    {
+        $this->dump(...$keys);
+
+        exit(1);
+    }
+
+    /**
+     * Dump the items.
+     *
+     * @param  mixed  $keys
+     * @return $this
+     */
+    public function dump($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        VarDumper::dump(count($keys) > 0 ? $this->only($keys) : $this->all());
+
+        return $this;
     }
 
     /**
@@ -244,321 +560,5 @@ class ValidatedInput implements ValidatedData
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->input);
-    }
-
-    /**
-     * Determine if the validated inputs contains a given input item key.
-     *
-     * @param  string|array  $key
-     * @return bool
-     */
-    public function exists($key)
-    {
-        return $this->has($key);
-    }
-
-    /**
-     * Determine if the validated inputs contains any of the given inputs.
-     *
-     * @param  string|array  $keys
-     * @return bool
-     */
-    public function hasAny($keys)
-    {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        $input = $this->all();
-
-        return Arr::hasAny($input, $keys);
-    }
-
-    /**
-     * Apply the callback if the validated inputs contains the given input item key.
-     *
-     * @param  string  $key
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
-     */
-    public function whenHas($key, callable $callback, callable $default = null)
-    {
-        if ($this->has($key)) {
-            return $callback(data_get($this->all(), $key)) ?: $this;
-        }
-
-        if ($default) {
-            return $default();
-        }
-
-        return $this;
-    }
-
-    /**
-     * Determine if the validated inputs contains a non-empty value for an input item.
-     *
-     * @param  string|array  $key
-     * @return bool
-     */
-    public function filled($key)
-    {
-        $keys = is_array($key) ? $key : func_get_args();
-
-        foreach ($keys as $value) {
-            if ($this->isEmptyString($value)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Determine if the validated inputs contains an empty value for an input item.
-     *
-     * @param  string|array  $key
-     * @return bool
-     */
-    public function isNotFilled($key)
-    {
-        $keys = is_array($key) ? $key : func_get_args();
-
-        foreach ($keys as $value) {
-            if (! $this->isEmptyString($value)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Determine if the validated inputs contains a non-empty value for any of the given inputs.
-     *
-     * @param  string|array  $keys
-     * @return bool
-     */
-    public function anyFilled($keys)
-    {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        foreach ($keys as $key) {
-            if ($this->filled($key)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Apply the callback if the validated inputs contains a non-empty value for the given input item key.
-     *
-     * @param  string  $key
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
-     */
-    public function whenFilled($key, callable $callback, callable $default = null)
-    {
-        if ($this->filled($key)) {
-            return $callback(data_get($this->all(), $key)) ?: $this;
-        }
-
-        if ($default) {
-            return $default();
-        }
-
-        return $this;
-    }
-
-    /**
-     * Apply the callback if the validated inputs is missing the given input item key.
-     *
-     * @param  string  $key
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
-     */
-    public function whenMissing($key, callable $callback, callable $default = null)
-    {
-        if ($this->missing($key)) {
-            return $callback(data_get($this->all(), $key)) ?: $this;
-        }
-
-        if ($default) {
-            return $default();
-        }
-
-        return $this;
-    }
-
-    /**
-     * Determine if the given input key is an empty string for "filled".
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isEmptyString($key)
-    {
-        $value = $this->input($key);
-
-        return ! is_bool($value) && ! is_array($value) && trim((string) $value) === '';
-    }
-
-    /**
-     * Get the keys for all of the input.
-     *
-     * @return array
-     */
-    public function keys()
-    {
-        return array_keys($this->input());
-    }
-
-    /**
-     * Retrieve an input item from the validated inputs.
-     *
-     * @param  string|null  $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    public function input($key = null, $default = null)
-    {
-        return data_get(
-            $this->all(), $key, $default
-        );
-    }
-
-    /**
-     * Retrieve input from the validated inputs as a Stringable instance.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
-     */
-    public function str($key, $default = null)
-    {
-        return $this->string($key, $default);
-    }
-
-    /**
-     * Retrieve input from the validated inputs as a Stringable instance.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
-     */
-    public function string($key, $default = null)
-    {
-        return str($this->input($key, $default));
-    }
-
-    /**
-     * Retrieve input as a boolean value.
-     *
-     * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.
-     *
-     * @param  string|null  $key
-     * @param  bool  $default
-     * @return bool
-     */
-    public function boolean($key = null, $default = false)
-    {
-        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
-    }
-
-    /**
-     * Retrieve input as an integer value.
-     *
-     * @param  string  $key
-     * @param  int  $default
-     * @return int
-     */
-    public function integer($key, $default = 0)
-    {
-        return intval($this->input($key, $default));
-    }
-
-    /**
-     * Retrieve input as a float value.
-     *
-     * @param  string  $key
-     * @param  float  $default
-     * @return float
-     */
-    public function float($key, $default = 0.0)
-    {
-        return floatval($this->input($key, $default));
-    }
-
-    /**
-     * Retrieve input from the validated inputs as a Carbon instance.
-     *
-     * @param  string  $key
-     * @param  string|null  $format
-     * @param  string|null  $tz
-     * @return \Illuminate\Support\Carbon|null
-     *
-     * @throws \Carbon\Exceptions\InvalidFormatException
-     */
-    public function date($key, $format = null, $tz = null)
-    {
-        if ($this->isNotFilled($key)) {
-            return null;
-        }
-
-        if (is_null($format)) {
-            return Date::parse($this->input($key), $tz);
-        }
-
-        return Date::createFromFormat($format, $this->input($key), $tz);
-    }
-
-    /**
-     * Retrieve input from the validated inputs as an enum.
-     *
-     * @template TEnum
-     *
-     * @param  string  $key
-     * @param  class-string<TEnum>  $enumClass
-     * @return TEnum|null
-     */
-    public function enum($key, $enumClass)
-    {
-        if ($this->isNotFilled($key) ||
-            ! enum_exists($enumClass) ||
-            ! method_exists($enumClass, 'tryFrom')) {
-            return null;
-        }
-
-        return $enumClass::tryFrom($this->input($key));
-    }
-
-    /**
-     * Dump the validated inputs items and end the script.
-     *
-     * @param  mixed  ...$keys
-     * @return never
-     */
-    public function dd(...$keys)
-    {
-        $this->dump(...$keys);
-
-        exit(1);
-    }
-
-    /**
-     * Dump the items.
-     *
-     * @param  mixed  $keys
-     * @return $this
-     */
-    public function dump($keys = [])
-    {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        VarDumper::dump(count($keys) > 0 ? $this->only($keys) : $this->all());
-
-        return $this;
     }
 }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -6,6 +6,7 @@ use ArrayIterator;
 use Illuminate\Contracts\Support\ValidatedData;
 use Illuminate\Support\Facades\Date;
 use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
 class ValidatedInput implements ValidatedData
@@ -532,4 +533,18 @@ class ValidatedInput implements ValidatedData
         return $enumClass::tryFrom($this->input($key));
     }
 
+    /**
+     * Dump the items.
+     *
+     * @param  mixed  $keys
+     * @return $this
+     */
+    public function dump($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        VarDumper::dump(count($keys) > 0 ? $this->only($keys) : $this->all());
+
+        return $this;
+    }
 }

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -2,7 +2,11 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\ValidatedInput;
+use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
 use PHPUnit\Framework\TestCase;
 
 class ValidatedInputTest extends TestCase
@@ -43,5 +47,482 @@ class ValidatedInputTest extends TestCase
         $inputB = new ValidatedInput(['name' => 'Taylor', 'votes' => 100]);
 
         $this->assertEquals(true, $inputB->has(['name', 'votes']));
+    }
+
+    public function test_exists_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertTrue($input->exists('name'));
+        $this->assertTrue($input->exists('surname'));
+        $this->assertTrue($input->exists(['name', 'surname']));
+        $this->assertTrue($input->exists('foo.bar'));
+        $this->assertTrue($input->exists(['name', 'foo.baz']));
+        $this->assertTrue($input->exists(['name', 'foo']));
+        $this->assertTrue($input->exists('foo'));
+
+        $this->assertFalse($input->exists('votes'));
+        $this->assertFalse($input->exists(['name', 'votes']));
+        $this->assertFalse($input->exists(['votes', 'foo.bar']));
+    }
+
+    public function test_has_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertTrue($input->has('name'));
+        $this->assertTrue($input->has('surname'));
+        $this->assertTrue($input->has(['name', 'surname']));
+        $this->assertTrue($input->has('foo.bar'));
+        $this->assertTrue($input->has(['name', 'foo.baz']));
+        $this->assertTrue($input->has(['name', 'foo']));
+        $this->assertTrue($input->has('foo'));
+
+        $this->assertFalse($input->has('votes'));
+        $this->assertFalse($input->has(['name', 'votes']));
+        $this->assertFalse($input->has(['votes', 'foo.bar']));
+    }
+
+    public function test_has_any_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertTrue($input->hasAny('name'));
+        $this->assertTrue($input->hasAny('surname'));
+        $this->assertTrue($input->hasAny('foo.bar'));
+        $this->assertTrue($input->hasAny(['name', 'surname']));
+        $this->assertTrue($input->hasAny(['name', 'foo.bat']));
+        $this->assertTrue($input->hasAny(['votes', 'foo']));
+
+        $this->assertFalse($input->hasAny('votes'));
+        $this->assertFalse($input->hasAny(['votes', 'foo.bat']));
+    }
+
+    public function test_when_has_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'age' => '', 'foo' => ['bar' => null]]);
+
+        $name = $age = $city = $foo = $bar = $baz = false;
+
+        $input->whenHas('name', function ($value) use (&$name) {
+            $name = $value;
+        });
+
+        $input->whenHas('age', function ($value) use (&$age) {
+            $age = $value;
+        });
+
+        $input->whenHas('city', function ($value) use (&$city) {
+            $city = $value;
+        });
+
+        $input->whenHas('foo', function ($value) use (&$foo) {
+            $foo = $value;
+        });
+
+        $input->whenHas('foo.bar', function ($value) use (&$bar) {
+            $bar = $value;
+        });
+
+        $input->whenHas('foo.baz', function () use (&$baz) {
+            $baz = 'test';
+        }, function () use (&$baz) {
+            $baz = true;
+        });
+
+        $this->assertSame('Fatih', $name);
+        $this->assertSame('', $age);
+        $this->assertFalse($city);
+        $this->assertEquals(['bar' => null], $foo);
+        $this->assertTrue($baz);
+        $this->assertNull($bar);
+    }
+
+    public function test_filled_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertTrue($input->filled('name'));
+        $this->assertTrue($input->filled('surname'));
+        $this->assertTrue($input->filled(['name', 'surname']));
+        $this->assertTrue($input->filled(['name', 'foo']));
+        $this->assertTrue($input->filled('foo'));
+
+        $this->assertFalse($input->filled('foo.bar'));
+        $this->assertFalse($input->filled(['name', 'foo.baz']));
+        $this->assertFalse($input->filled('votes'));
+        $this->assertFalse($input->filled(['name', 'votes']));
+        $this->assertFalse($input->filled(['votes', 'foo.bar']));
+    }
+
+    public function test_is_not_filled_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertFalse($input->isNotFilled('name'));
+        $this->assertFalse($input->isNotFilled('surname'));
+        $this->assertFalse($input->isNotFilled(['name', 'surname']));
+        $this->assertFalse($input->isNotFilled(['name', 'foo']));
+        $this->assertFalse($input->isNotFilled('foo'));
+        $this->assertFalse($input->isNotFilled(['name', 'foo.baz']));
+        $this->assertFalse($input->isNotFilled(['name', 'votes']));
+
+        $this->assertTrue($input->isNotFilled('foo.bar'));
+        $this->assertTrue($input->isNotFilled('votes'));
+        $this->assertTrue($input->isNotFilled(['votes', 'foo.bar']));
+    }
+
+    public function test_any_filled_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertTrue($input->anyFilled('name'));
+        $this->assertTrue($input->anyFilled('surname'));
+        $this->assertTrue($input->anyFilled(['name', 'surname']));
+        $this->assertTrue($input->anyFilled(['name', 'foo']));
+        $this->assertTrue($input->anyFilled('foo'));
+        $this->assertTrue($input->anyFilled(['name', 'foo.baz']));
+        $this->assertTrue($input->anyFilled(['name', 'votes']));
+
+        $this->assertFalse($input->anyFilled('foo.bar'));
+        $this->assertFalse($input->anyFilled('votes'));
+        $this->assertFalse($input->anyFilled(['votes', 'foo.bar']));
+    }
+
+    public function test_when_filled_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'age' => '', 'foo' => ['bar' => null]]);
+
+        $name = $age = $city = $foo = $bar = $baz = false;
+
+        $input->whenFilled('name', function ($value) use (&$name) {
+            $name = $value;
+        });
+
+        $input->whenFilled('age', function ($value) use (&$age) {
+            $age = $value;
+        });
+
+        $input->whenFilled('city', function ($value) use (&$city) {
+            $city = $value;
+        });
+
+        $input->whenFilled('foo', function ($value) use (&$foo) {
+            $foo = $value;
+        });
+
+        $input->whenFilled('foo.bar', function ($value) use (&$bar) {
+            $bar = $value;
+        });
+
+        $input->whenFilled('foo.baz', function () use (&$baz) {
+            $baz = 'test';
+        }, function () use (&$baz) {
+            $baz = true;
+        });
+
+        $this->assertSame('Fatih', $name);
+        $this->assertEquals(['bar' => null], $foo);
+        $this->assertTrue($baz);
+        $this->assertFalse($age);
+        $this->assertFalse($city);
+        $this->assertFalse($bar);
+    }
+
+    public function test_missing_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertFalse($input->missing('name'));
+        $this->assertFalse($input->missing('surname'));
+        $this->assertFalse($input->missing(['name', 'surname']));
+        $this->assertFalse($input->missing('foo.bar'));
+        $this->assertFalse($input->missing(['name', 'foo.baz']));
+        $this->assertFalse($input->missing(['name', 'foo']));
+        $this->assertFalse($input->missing('foo'));
+
+        $this->assertTrue($input->missing('votes'));
+        $this->assertTrue($input->missing(['name', 'votes']));
+        $this->assertTrue($input->missing(['votes', 'foo.bar']));
+    }
+
+    public function test_when_missing_method()
+    {
+        $input = new ValidatedInput(['foo' => ['bar' => null]]);
+
+        $name = $age = $city = $foo = $bar = $baz = false;
+
+        $input->whenMissing('name', function () use (&$name) {
+            $name = 'Fatih';
+        });
+
+        $input->whenMissing('age', function () use (&$age) {
+            $age = '';
+        });
+
+        $input->whenMissing('city', function () use (&$city) {
+            $city = null;
+        });
+
+        $input->whenMissing('foo', function ($value) use (&$foo) {
+            $foo = $value;
+        });
+
+        $input->whenMissing('foo.baz', function () use (&$baz) {
+            $baz = true;
+        });
+
+        $input->whenMissing('foo.bar', function () use (&$bar) {
+            $bar = 'test';
+        }, function () use (&$bar) {
+            $bar = true;
+        });
+
+        $this->assertSame('Fatih', $name);
+        $this->assertSame('', $age);
+        $this->assertNull($city);
+        $this->assertFalse($foo);
+        $this->assertTrue($baz);
+        $this->assertTrue($bar);
+    }
+
+    public function test_keys_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertEquals(['name', 'surname', 'foo'], $input->keys());
+    }
+
+    public function test_all_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertEquals(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']], $input->all());
+    }
+
+    public function test_input_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertSame('Fatih', $input->input('name'));
+        $this->assertSame(null, $input->input('foo.bar'));
+        $this->assertSame('test', $input->input('foo.bat', 'test'));
+    }
+
+    public function test_str_method()
+    {
+        $input = new ValidatedInput([
+            'int' => 123,
+            'int_str' => '456',
+            'float' => 123.456,
+            'float_str' => '123.456',
+            'float_zero' => 0.000,
+            'float_str_zero' => '0.000',
+            'str' => 'abc',
+            'empty_str' => '',
+            'null' => null,
+        ]);
+
+        $this->assertTrue($input->str('int') instanceof Stringable);
+        $this->assertTrue($input->str('int') instanceof Stringable);
+        $this->assertTrue($input->str('unknown_key') instanceof Stringable);
+        $this->assertSame('123', $input->str('int')->value());
+        $this->assertSame('456', $input->str('int_str')->value());
+        $this->assertSame('123.456', $input->str('float')->value());
+        $this->assertSame('123.456', $input->str('float_str')->value());
+        $this->assertSame('0', $input->str('float_zero')->value());
+        $this->assertSame('0.000', $input->str('float_str_zero')->value());
+        $this->assertSame('', $input->str('empty_str')->value());
+        $this->assertSame('', $input->str('null')->value());
+        $this->assertSame('', $input->str('unknown_key')->value());
+    }
+
+    public function test_string_method()
+    {
+        $input = new ValidatedInput([
+            'int' => 123,
+            'int_str' => '456',
+            'float' => 123.456,
+            'float_str' => '123.456',
+            'float_zero' => 0.000,
+            'float_str_zero' => '0.000',
+            'str' => 'abc',
+            'empty_str' => '',
+            'null' => null,
+        ]);
+
+        $this->assertTrue($input->string('int') instanceof Stringable);
+        $this->assertTrue($input->string('int') instanceof Stringable);
+        $this->assertTrue($input->string('unknown_key') instanceof Stringable);
+        $this->assertSame('123', $input->string('int')->value());
+        $this->assertSame('456', $input->string('int_str')->value());
+        $this->assertSame('123.456', $input->string('float')->value());
+        $this->assertSame('123.456', $input->string('float_str')->value());
+        $this->assertSame('0', $input->string('float_zero')->value());
+        $this->assertSame('0.000', $input->string('float_str_zero')->value());
+        $this->assertSame('', $input->string('empty_str')->value());
+        $this->assertSame('', $input->string('null')->value());
+        $this->assertSame('', $input->string('unknown_key')->value());
+    }
+
+    public function test_boolean_method()
+    {
+        $input = new ValidatedInput([
+            'with_trashed' => 'false',
+            'download' => true,
+            'checked' => 1,
+            'unchecked' => '0',
+            'with_on' => 'on',
+            'with_yes' => 'yes',
+        ]);
+
+        $this->assertTrue($input->boolean('checked'));
+        $this->assertTrue($input->boolean('download'));
+        $this->assertFalse($input->boolean('unchecked'));
+        $this->assertFalse($input->boolean('with_trashed'));
+        $this->assertFalse($input->boolean('some_undefined_key'));
+        $this->assertTrue($input->boolean('with_on'));
+        $this->assertTrue($input->boolean('with_yes'));
+    }
+
+    public function test_integer_method()
+    {
+        $input = new ValidatedInput([
+            'int' => '123',
+            'raw_int' => 456,
+            'zero_padded' => '078',
+            'space_padded' => ' 901',
+            'nan' => 'nan',
+            'mixed' => '1ab',
+            'underscore_notation' => '2_000',
+            'null' => null,
+        ]);
+
+        $this->assertSame(123, $input->integer('int'));
+        $this->assertSame(456, $input->integer('raw_int'));
+        $this->assertSame(78, $input->integer('zero_padded'));
+        $this->assertSame(901, $input->integer('space_padded'));
+        $this->assertSame(0, $input->integer('nan'));
+        $this->assertSame(1, $input->integer('mixed'));
+        $this->assertSame(2, $input->integer('underscore_notation'));
+        $this->assertSame(123456, $input->integer('unknown_key', 123456));
+        $this->assertSame(0, $input->integer('null'));
+        $this->assertSame(0, $input->integer('null', 123456));
+    }
+
+    public function test_float_method()
+    {
+        $input = new ValidatedInput([
+            'float' => '1.23',
+            'raw_float' => 45.6,
+            'decimal_only' => '.6',
+            'zero_padded' => '0.78',
+            'space_padded' => ' 90.1',
+            'nan' => 'nan',
+            'mixed' => '1.ab',
+            'scientific_notation' => '1e3',
+            'null' => null,
+        ]);
+
+        $this->assertSame(1.23, $input->float('float'));
+        $this->assertSame(45.6, $input->float('raw_float'));
+        $this->assertSame(.6, $input->float('decimal_only'));
+        $this->assertSame(0.78, $input->float('zero_padded'));
+        $this->assertSame(90.1, $input->float('space_padded'));
+        $this->assertSame(0.0, $input->float('nan'));
+        $this->assertSame(1.0, $input->float('mixed'));
+        $this->assertSame(1e3, $input->float('scientific_notation'));
+        $this->assertSame(123.456, $input->float('unknown_key', 123.456));
+        $this->assertSame(0.0, $input->float('null'));
+        $this->assertSame(0.0, $input->float('null', 123.456));
+    }
+
+    public function test_date_method()
+    {
+        $input = new ValidatedInput([
+            'as_null' => null,
+            'as_invalid' => 'invalid',
+
+            'as_datetime' => '24-01-01 16:30:25',
+            'as_format' => '1704126625',
+            'as_timezone' => '24-01-01 13:30:25',
+
+            'as_date' => '2024-01-01',
+            'as_time' => '16:30:25',
+        ]);
+
+        $current = Carbon::create(2024, 1, 1, 16, 30, 25);
+
+        $this->assertNull($input->date('as_null'));
+        $this->assertNull($input->date('doesnt_exists'));
+
+        $this->assertEquals($current, $input->date('as_datetime'));
+        $this->assertEquals($current->format('Y-m-d H:i:s P'), $input->date('as_format', 'U')->format('Y-m-d H:i:s P'));
+        $this->assertEquals($current, $input->date('as_timezone', null, 'America/Santiago'));
+
+        $this->assertTrue($input->date('as_date')->isSameDay($current));
+        $this->assertTrue($input->date('as_time')->isSameSecond('16:30:25'));
+    }
+
+    public function test_enum_method()
+    {
+        $input = new ValidatedInput([
+            'valid_enum_value' => 'Hello world',
+            'invalid_enum_value' => 'invalid',
+        ]);
+
+        $this->assertNull($input->enum('doesnt_exists', StringBackedEnum::class));
+
+        $this->assertEquals(StringBackedEnum::HELLO_WORLD, $input->enum('valid_enum_value', StringBackedEnum::class));
+
+        $this->assertNull($input->enum('invalid_enum_value', StringBackedEnum::class));
+    }
+
+    public function test_collect_method()
+    {
+        $input = new ValidatedInput(['users' => [1, 2, 3]]);
+
+        $this->assertInstanceOf(Collection::class, $input->collect('users'));
+        $this->assertTrue($input->collect('developers')->isEmpty());
+        $this->assertEquals([1, 2, 3], $input->collect('users')->all());
+        $this->assertEquals(['users' => [1, 2, 3]], $input->collect()->all());
+
+        $input = new ValidatedInput(['text-payload']);
+        $this->assertEquals(['text-payload'], $input->collect()->all());
+
+        $input = new ValidatedInput(['email' => 'test@example.com']);
+        $this->assertEquals(['test@example.com'], $input->collect('email')->all());
+
+        $input = new ValidatedInput([]);
+        $this->assertInstanceOf(Collection::class, $input->collect());
+        $this->assertTrue($input->collect()->isEmpty());
+
+        $input = new ValidatedInput(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com']);
+        $this->assertInstanceOf(Collection::class, $input->collect(['users']));
+        $this->assertTrue($input->collect(['developers'])->isEmpty());
+        $this->assertTrue($input->collect(['roles'])->isNotEmpty());
+        $this->assertEquals(['roles' => [4, 5, 6]], $input->collect(['roles'])->all());
+        $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $input->collect(['users', 'email'])->all());
+        $this->assertEquals(collect(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $input->collect(['roles', 'foo']));
+        $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $input->collect()->all());
+    }
+
+    public function test_only_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertEquals(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null]], $input->only('name', 'surname', 'foo.bar'));
+        $this->assertEquals(['name' => 'Fatih', 'foo' => ['bar' => null, 'baz' => '']], $input->only('name', 'foo'));
+        $this->assertEquals(['foo' => ['baz' => '']], $input->only('foo.baz'));
+        $this->assertEquals(['name' => 'Fatih'], $input->only('name'));
+    }
+
+    public function test_except_method()
+    {
+        $input = new ValidatedInput(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertEquals(['name' => 'Fatih', 'surname' => 'AYDIN', 'foo' => ['bar' => null]], $input->except('foo.baz'));
+        $this->assertEquals(['surname' => 'AYDIN'], $input->except('name', 'foo'));
+        $this->assertEquals([], $input->except('name', 'surname', 'foo'));
     }
 }


### PR DESCRIPTION
We cannot use `integer`, `string`, `boolean`, `date` etc methods via `$request->safe()`. 

When we want to use these methods via `$request`, it does not guarantee that the data is validated. With this PR, the following methods will be available based on validated data.

Also this PR will not cause a major change. 

Example: 
```php
$request->safe()->filled('test');
$request->safe()->boolean('test');
```

### Added
- **exists**: Determine if the validated inputs contains a given input item key.
- **hasAny**: Determine if the validated inputs contains any of the given inputs.
- **whenHas**: Apply the callback if the validated inputs contains the given input item key.
- **filled**: Determine if the validated inputs contains a non-empty value for an input item.
- **isNotFilled**: Determine if the validated inputs contains an empty value for an input item.
- **anyFilled**: Determine if the validated inputs contains a non-empty value for any of the given inputs.
- **whenFilled**: Apply the callback if the validated inputs contains a non-empty value for the given input item key.
- **whenMissing**: Apply the callback if the validated inputs is missing the given input item key.
- **keys**: Get the keys for all of the validated input.
- **input**: Retrieve an input item from the validated inputs.
- **str**: Retrieve input from the validated inputs as a Stringable instance.
- **string**: Retrieve input from the validated inputs as a Stringable instance.
- **boolean**: Retrieve input as a boolean value.
- **integer**: Retrieve input as an integer value.
- **float**: Retrieve input as a float value.
- **date**: Retrieve input from the validated inputs as a Carbon instance.
- **enum**: Retrieve input from the validated inputs as an enum.
- **dd**: Dump the validated inputs items and end the script.
- **dump**: Dump the items.

### Changed
- Add `$key` prop to `collect` method in `ValidatedInput`