### PR TITLE
[11.x] Add the `getOr` eloquent method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -751,6 +751,28 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Execute the query as a "select" statement or call a callback.
+     *
+     * @param  array|string  $columns
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Collection|static[]|mixed
+     */
+    public function getOr($columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if(count($models = $this->get($columns)) > 0) {
+            return $models;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Eager load the relationships for the models.
      *
      * @param  array  $models

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -765,7 +765,7 @@ class Builder implements BuilderContract
             $columns = ['*'];
         }
 
-        if(count($models = $this->get($columns)) > 0) {
+        if (count($models = $this->get($columns)) > 0) {
             return $models;
         }
 


### PR DESCRIPTION
This method is similar to the [firstOr](https://github.com/laravel/framework/blob/5710fdb8bf36df501405c705f7d2ea4720d2b9d3/src/Illuminate/Database/Eloquent/Builder.php#L639) method, Let's quickly jump into the code to demonstrate how it works:

## Previously

```PHP
use App\Models\User;

$users = User::where('id', '>', 3)->get();

if (empty($users) || count($users) < 1) {
    return 'There are no users';
}

return $users;
```

## Later

```PHP
use App\Models\User;

return User::where('id', '>', 3)->getOr(fn () => 'There are no users');
```

Yeah, we have done the same job in a nutshell. 🤵