### PR TITLE
[11.x] Add whenNestedLoaded to ConditionallyLoadsAttributes trait

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -282,7 +282,7 @@ trait ConditionallyLoadsAttributes
     /**
      * Retrieve a nested relationships if it has been loaded.
      *
-     * @param  string $relationship
+     * @param  string  $relationship
      * @param  mixed  $value
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
@@ -296,17 +296,15 @@ trait ConditionallyLoadsAttributes
         $relationInstance = $this->resource;
         $relationArray = explode('.', $relationship);
 
-        foreach($relationArray as $currentRelation) {
-
-            if(! $relationInstance?->relationLoaded($currentRelation)) {
+        foreach ($relationArray as $currentRelation) {
+            if (! $relationInstance?->relationLoaded($currentRelation)) {
                 return value($default);
             }
 
             $relationInstance = $relationInstance->{$currentRelation};
-            if($relationInstance instanceof \Illuminate\Database\Eloquent\Collection) {
+            if ($relationInstance instanceof \Illuminate\Database\Eloquent\Collection) {
                 $relationInstance = $relationInstance->first();
             }
-
         }
 
         if (func_num_args() === 1) {

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -280,6 +280,43 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve a nested relationships if it has been loaded.
+     *
+     * @param  string $relationship
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenNestedLoaded($relationship, $value = null, $default = null)
+    {
+        if (func_num_args() < 3) {
+            $default = new MissingValue;
+        }
+
+        $relationInstance = $this->resource;
+        $relationArray = explode('.', $relationship);
+
+        foreach($relationArray as $currentRelation) {
+
+            if(! $relationInstance?->relationLoaded($currentRelation)) {
+                return value($default);
+            }
+
+            $relationInstance = $relationInstance->{$currentRelation};
+            if($relationInstance instanceof \Illuminate\Database\Eloquent\Collection) {
+                $relationInstance = $relationInstance->first();
+            }
+
+        }
+
+        if (func_num_args() === 1) {
+            return $this->resource->{$relationArray[0]};
+        }
+
+        return value($value);
+    }
+
+    /**
      * Retrieve a relationship count if it exists.
      *
      * @param  string  $relationship


### PR DESCRIPTION
Dear sir
I have been created a method called whenNestedLoaded for the ConditionallyLoadsAttributes trait.
This method is used to retrieve a nested relationship if it has been loaded.
For example:
if user has a city and city has a country and we want to load the country of the user depending on the city and if no eager loading exists it will return a default value rather than creating a lazy load.
load the `UserResource`
```
UserResource::collection(User::query->with('city.country')->get());
```
use whenNestedLoaded inside the Resource
```
    public function toArray(Request $request): array
    {
        return [
            'id' => $this->id,
            'name' => $this->name,
            'country_name' => $this->whenNestedLoaded('city.country', fn() => $this->city->country->name, NULL),
        ];
    }
```