### PR TITLE
[11.x] Add the events to be displayed on the model:show command

### DIFF
--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -237,7 +237,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         return collect($model->dispatchesEvents())
             ->map(fn (string $class, string $event) => [
                 'event' => $event,
-                'class' => $class
+                'class' => $class,
             ])->values();
     }
 

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -238,7 +238,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         foreach ($model->dispatchesEvents() as $event => $class) {
             $formatted[] = [
                 'event' => $event,
-                'class' => $class
+                'class' => $class,
             ];
         }
 

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -90,6 +90,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             $this->getPolicy($model),
             $this->getAttributes($model),
             $this->getRelations($model),
+            $this->getEvents($model),
             $this->getObservers($model),
         );
 
@@ -226,6 +227,25 @@ class ShowModelCommand extends DatabaseInspectionCommand
     }
 
     /**
+     * Get the Events that the model dispatches
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getEvents($model)
+    {
+        $formatted = [];
+        foreach ($model->dispatchesEvents() as $event => $class) {
+            $formatted[] = [
+                'event' => $event,
+                'class' => $class
+            ];
+        }
+
+        return collect($formatted);
+    }
+
+    /**
      * Get the Observers watching this model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -268,14 +288,15 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  string  $policy
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
+     * @param  \Illuminate\Support\Collection  $events
      * @param  \Illuminate\Support\Collection  $observers
      * @return void
      */
-    protected function display($class, $database, $table, $policy, $attributes, $relations, $observers)
+    protected function display($class, $database, $table, $policy, $attributes, $relations, $events, $observers)
     {
         $this->option('json')
-            ? $this->displayJson($class, $database, $table, $policy, $attributes, $relations, $observers)
-            : $this->displayCli($class, $database, $table, $policy, $attributes, $relations, $observers);
+            ? $this->displayJson($class, $database, $table, $policy, $attributes, $relations, $events, $observers)
+            : $this->displayCli($class, $database, $table, $policy, $attributes, $relations, $events, $observers);
     }
 
     /**
@@ -287,10 +308,11 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  string  $policy
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
+     * @param  \Illuminate\Support\Collection  $events
      * @param  \Illuminate\Support\Collection  $observers
      * @return void
      */
-    protected function displayJson($class, $database, $table, $policy, $attributes, $relations, $observers)
+    protected function displayJson($class, $database, $table, $policy, $attributes, $relations, $events, $observers)
     {
         $this->output->writeln(
             collect([
@@ -300,6 +322,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'policy' => $policy,
                 'attributes' => $attributes,
                 'relations' => $relations,
+                'events' => $events,
                 'observers' => $observers,
             ])->toJson()
         );
@@ -314,10 +337,11 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  string  $policy
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
+     * @param  \Illuminate\Support\Collection  $events
      * @param  \Illuminate\Support\Collection  $observers
      * @return void
      */
-    protected function displayCli($class, $database, $table, $policy, $attributes, $relations, $observers)
+    protected function displayCli($class, $database, $table, $policy, $attributes, $relations, $events, $observers)
     {
         $this->newLine();
 
@@ -370,6 +394,19 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 sprintf('%s <fg=gray>%s</>', $relation['name'], $relation['type']),
                 $relation['related']
             );
+        }
+
+        $this->newLine();
+
+        $this->components->twoColumnDetail('<fg=green;options=bold>Events</>');
+
+        if ($events->count()) {
+            foreach ($events as $event) {
+                $this->components->twoColumnDetail(
+                    sprintf('%s', $event['event']),
+                    sprintf('%s', $event['class']),
+                );
+            }
         }
 
         $this->newLine();

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -234,15 +234,11 @@ class ShowModelCommand extends DatabaseInspectionCommand
      */
     protected function getEvents($model)
     {
-        $formatted = [];
-        foreach ($model->dispatchesEvents() as $event => $class) {
-            $formatted[] = [
+        return collect($model->dispatchesEvents())
+            ->map(fn (string $class, string $event) => [
                 'event' => $event,
-                'class' => $class,
-            ];
-        }
-
-        return collect($formatted);
+                'class' => $class
+            ])->values();
     }
 
     /**

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -227,7 +227,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     }
 
     /**
-     * Get the Events that the model dispatches
+     * Get the Events that the model dispatches.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Support\Collection

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -171,6 +171,16 @@ trait HasEvents
     }
 
     /**
+     * Returns the event map for the model
+     *
+     * @return array
+     */
+    public function dispatchesEvents()
+    {
+        return $this->dispatchesEvents;
+    }
+
+    /**
      * Register a model event with the dispatcher.
      *
      * @param  string  $event

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -171,16 +171,6 @@ trait HasEvents
     }
 
     /**
-     * Returns the event map for the model.
-     *
-     * @return array
-     */
-    public function dispatchesEvents()
-    {
-        return $this->dispatchesEvents;
-    }
-
-    /**
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
@@ -394,6 +384,16 @@ trait HasEvents
         foreach (array_values($instance->dispatchesEvents) as $event) {
             static::$dispatcher->forget($event);
         }
+    }
+
+    /**
+     * Get the event map for the model.
+     *
+     * @return array
+     */
+    public function dispatchesEvents()
+    {
+        return $this->dispatchesEvents;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -171,7 +171,7 @@ trait HasEvents
     }
 
     /**
-     * Returns the event map for the model
+     * Returns the event map for the model.
      *
      * @return array
      */


### PR DESCRIPTION
Currently the `model:show` command already provides a lot of information about the Model, even the observers, but if we have anything set on the `$dispatchesEvents`, they are not shown.

This PR adds a new section `Events` to the output of the command like shown below
![image](https://github.com/laravel/framework/assets/11641518/6068b753-4a9e-4f41-b83b-704278f8d06a)
