### PR TITLE
[11.x] Make Route::getControllerMethod() public

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -297,7 +297,7 @@ class Route
      *
      * @return string
      */
-    protected function getControllerMethod()
+    public function getControllerMethod()
     {
         return $this->parseControllerCallback()[1];
     }


### PR DESCRIPTION
I need to get the controller class and controller method for a route.

You can easily get the controller class but the controller method is protected so I had to copy the implementation which makes my code ugly.

Before:
```php
$controller = $route->getControllerClass();
$method = Str::parseCallback($route->action['uses'])[1];
```

After:
```php
$controller = $route->getControllerClass();
$method = $route->getControllerMethod();
```
