### PR TITLE
[11.x] Add `append` and `remove` with `Conditionable` trait

### DIFF
--- a/src/Illuminate/Validation/Rules/ArrayableRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayableRule.php
@@ -4,7 +4,6 @@ namespace Illuminate\Validation\Rules;
 
 use BackedEnum;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Arr;
 use UnitEnum;
 
 trait ArrayableRule

--- a/src/Illuminate/Validation/Rules/ArrayableRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayableRule.php
@@ -45,7 +45,7 @@ trait ArrayableRule
     }
 
     /**
-     * Append kays to the values.
+     * Append keys to the values.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return $this
@@ -62,7 +62,7 @@ trait ArrayableRule
     }
 
     /**
-     * Remove kays from the values.
+     * Remove keys from the values.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return $this

--- a/src/Illuminate/Validation/Rules/ArrayableRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayableRule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use BackedEnum;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use UnitEnum;
 
 trait ArrayableRule
@@ -52,6 +53,10 @@ trait ArrayableRule
      */
     public function append($values)
     {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
         $this->appends = is_array($values) ? $values : func_get_args();
 
         return $this;
@@ -65,6 +70,10 @@ trait ArrayableRule
      */
     public function remove($values)
     {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
         $this->removals = is_array($values) ? $values : func_get_args();
 
         return $this;

--- a/src/Illuminate/Validation/Rules/ArrayableRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayableRule.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use BackedEnum;
+use Illuminate\Contracts\Support\Arrayable;
+use UnitEnum;
+
+trait ArrayableRule
+{
+    /**
+     * The accepted values.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * The accepted appends.
+     *
+     * @var array|string
+     */
+    protected $appends = [];
+
+    /**
+     * The accepted removals.
+     *
+     * @var array|string
+     */
+    protected $removals = [];
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @return void
+     */
+    public function __construct($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->values = is_array($values) ? $values : func_get_args();
+    }
+
+    /**
+     * Append kays to the values.
+     *
+     * @param  array|string  $values
+     * @return $this
+     */
+    public function append($values)
+    {
+        $this->appends = is_array($values) ? $values : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Remove kays from the values.
+     *
+     * @param  array|string  $values
+     * @return $this
+     */
+    public function remove($values)
+    {
+        $this->removals = is_array($values) ? $values : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Format the array values.
+     * 
+     * @param  array  $values
+     * @return array
+     */
+    protected function formatArray($values)
+    {
+        return array_map(function ($value) {
+            $value = match (true) {
+                $value instanceof BackedEnum => $value->value,
+                $value instanceof UnitEnum => $value->name,
+                default => $value,
+            };
+
+            return '"' . str_replace('"', '""', $value) . '"';
+        }, $values);
+    }
+
+    /**
+     * Format the values into an array.
+     *
+     * @return array
+     */
+    protected function formatValues()
+    {
+        return array_values(array_filter(
+            array_diff(
+                array_unique(array_merge($this->formatArray($this->values), $this->formatArray($this->appends))),
+                $this->formatArray($this->removals)
+            ),
+        ));
+    }
+}

--- a/src/Illuminate/Validation/Rules/ArrayableRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayableRule.php
@@ -72,7 +72,7 @@ trait ArrayableRule
 
     /**
      * Format the array values.
-     * 
+     *
      * @param  array  $values
      * @return array
      */
@@ -85,7 +85,7 @@ trait ArrayableRule
                 default => $value,
             };
 
-            return '"' . str_replace('"', '""', $value) . '"';
+            return '"'.str_replace('"', '""', $value).'"';
         }, $values);
     }
 

--- a/src/Illuminate/Validation/Rules/ArrayableRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayableRule.php
@@ -48,7 +48,7 @@ trait ArrayableRule
     /**
      * Append kays to the values.
      *
-     * @param  array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return $this
      */
     public function append($values)
@@ -65,7 +65,7 @@ trait ArrayableRule
     /**
      * Remove kays from the values.
      *
-     * @param  array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return $this
      */
     public function remove($values)

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -16,6 +16,6 @@ class In implements Stringable
      */
     public function __toString()
     {
-        return 'in:' . implode(',', $this->formatValues());
+        return 'in:'.implode(',', $this->formatValues());
     }
 }

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,61 +2,20 @@
 
 namespace Illuminate\Validation\Rules;
 
-use BackedEnum;
-use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\Conditionable;
 use Stringable;
-use UnitEnum;
 
 class In implements Stringable
 {
-    /**
-     * The name of the rule.
-     *
-     * @var string
-     */
-    protected $rule = 'in';
-
-    /**
-     * The accepted values.
-     *
-     * @var array
-     */
-    protected $values;
-
-    /**
-     * Create a new in rule instance.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
-     * @return void
-     */
-    public function __construct($values)
-    {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        $this->values = is_array($values) ? $values : func_get_args();
-    }
+    use ArrayableRule, Conditionable;
 
     /**
      * Convert the rule to a validation string.
      *
      * @return string
-     *
-     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
-            $value = match (true) {
-                $value instanceof BackedEnum => $value->value,
-                $value instanceof UnitEnum => $value->name,
-                default => $value,
-            };
-
-            return '"'.str_replace('"', '""', $value).'"';
-        }, $this->values);
-
-        return $this->rule.':'.implode(',', $values);
+        return 'in:' . implode(',', $this->formatValues());
     }
 }

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,41 +2,12 @@
 
 namespace Illuminate\Validation\Rules;
 
-use BackedEnum;
-use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\Conditionable;
 use Stringable;
-use UnitEnum;
 
 class NotIn implements Stringable
 {
-    /**
-     * The name of the rule.
-     *
-     * @var string
-     */
-    protected $rule = 'not_in';
-
-    /**
-     * The accepted values.
-     *
-     * @var array
-     */
-    protected $values;
-
-    /**
-     * Create a new "not in" rule instance.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
-     * @return void
-     */
-    public function __construct($values)
-    {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        $this->values = is_array($values) ? $values : func_get_args();
-    }
+    use ArrayableRule, Conditionable;
 
     /**
      * Convert the rule to a validation string.
@@ -45,16 +16,6 @@ class NotIn implements Stringable
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
-            $value = match (true) {
-                $value instanceof BackedEnum => $value->value,
-                $value instanceof UnitEnum => $value->name,
-                default => $value,
-            };
-
-            return '"'.str_replace('"', '""', $value).'"';
-        }, $this->values);
-
-        return $this->rule.':'.implode(',', $values);
+        return 'not_in:'.implode(',', $this->formatValues());
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -68,5 +68,17 @@ class ValidationInRuleTest extends TestCase
         $rule = Rule::in([PureEnum::one]);
 
         $this->assertSame('in:"one"', (string) $rule);
+
+        $rule = Rule::in([PureEnum::one])->when(true, function ($rule) {
+            return $rule->append(PureEnum::two);
+        });
+
+        $this->assertSame('in:"one","two"', (string) $rule);
+
+        $rule = Rule::in([PureEnum::one, PureEnum::two])->when(true, function ($rule) {
+            return $rule->remove(PureEnum::two);
+        });
+
+        $this->assertSame('in:"one"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -64,5 +64,17 @@ class ValidationNotInRuleTest extends TestCase
         $rule = Rule::notIn([PureEnum::one]);
 
         $this->assertSame('not_in:"one"', (string) $rule);
+
+        $rule = Rule::notIn([PureEnum::one])->when(true, function ($rule) {
+            return $rule->append(PureEnum::two);
+        });
+
+        $this->assertSame('not_in:"one","two"', (string) $rule);
+
+        $rule = Rule::notIn([PureEnum::one, PureEnum::two])->when(true, function ($rule) {
+            return $rule->remove(PureEnum::two);
+        });
+
+        $this->assertSame('not_in:"one"', (string) $rule);
     }
 }


### PR DESCRIPTION
This PR introduces the `append` and `remove` functionalities to use the `Conditionable` trait within the `In` and `NotIn` rule.

Before:

```php
$request->validate([
    'zones' => [
        'required',
        Rule::when(
            $request->user()->isAdmin(),
            fn() => Rule::in(['first-zone', 'second-zone']),
            fn() => Rule::in(['first-zone']),
        ),
    ],
]);
```

After:

```php
$request->validate([
    'zones' => [
        'required',
        Rule::in(['first-zone', 'second-zone'])->when(
            $request->user()->isAdmin(), 
            fn() => $rule->remove('first-zone'),
            fn() => $rule->append('other-zone'),
        ),
    ],
]);
```