### PR TITLE
[11.x] Generate Mysql Database Model 

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -345,7 +345,6 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
     protected function insertModel()
     {
-
         $stub = $this->files->get($this->getStub());
 
         if ($this->input->getArgument('command') != 'make:model') {
@@ -353,18 +352,15 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         }
 
         switch (DB::connection()->getConfig('driver')) {
-
             case 'mysql':
                 $class = new ModelMysql($this);
                 $stub = $class->insertModelMysql($stub);
                 break;
             default:
                 $stub .= '';
-
         }
 
         return $stub;
-
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Database\QueryException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -350,13 +351,15 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             return $stub;
         }
 
-        switch (\DB::connection()->getConfig('driver')){
+        try {
+            switch (\DB::connection()->getConfig('driver')){
 
-            case 'mysql':
-                $class = new ModelMysql($this);
-                return $class->insertModelMysql($stub);
+                case 'mysql':
+                    $class = new ModelMysql($this);
+                    return $class->insertModelMysql($stub);
 
-        }
+            }
+        }catch (QueryException){}
 
         return $stub;
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -356,8 +356,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
             case 'mysql':
                 $class = new ModelMysql($this);
-                
-                return $class->insertModelMysql($stub);
+                $stub = $class->insertModelMysql($stub);
+                break;
+            default:
+                $stub .= '';
 
         }
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -337,9 +337,29 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function buildClass($name)
     {
-        $stub = $this->files->get($this->getStub());
+        $stub = $this->insertModel();
 
         return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    protected function insertModel(){
+
+        $stub = $this->files->get($this->getStub());
+
+        if($this->input->getArgument('command') != 'make:model'){
+            return $stub;
+        }
+
+        switch (\DB::connection()->getConfig('driver')){
+
+            case 'mysql':
+                $class = new ModelMysql($this);
+                return $class->insertModelMysql($stub);
+
+        }
+
+        return $stub;
+
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -4,8 +4,8 @@ namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
-use Illuminate\Database\QueryException;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Finder\Finder;
@@ -351,15 +351,13 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             return $stub;
         }
 
-        try {
-            switch (\DB::connection()->getConfig('driver')){
+        switch (DB::connection()->getConfig('driver')){
 
-                case 'mysql':
-                    $class = new ModelMysql($this);
-                    return $class->insertModelMysql($stub);
+            case 'mysql':
+                $class = new ModelMysql($this);
+                return $class->insertModelMysql($stub);
 
-            }
-        }catch (QueryException){}
+        }
 
         return $stub;
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -348,7 +348,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         $stub = $this->files->get($this->getStub());
 
-        if($this->input->getArgument('command') != 'make:model') {
+        if ($this->input->getArgument('command') != 'make:model') {
             return $stub;
         }
 
@@ -356,6 +356,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
             case 'mysql':
                 $class = new ModelMysql($this);
+                
                 return $class->insertModelMysql($stub);
 
         }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -343,15 +343,16 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
     }
 
-    protected function insertModel(){
+    protected function insertModel()
+    {
 
         $stub = $this->files->get($this->getStub());
 
-        if($this->input->getArgument('command') != 'make:model'){
+        if($this->input->getArgument('command') != 'make:model') {
             return $stub;
         }
 
-        switch (DB::connection()->getConfig('driver')){
+        switch (DB::connection()->getConfig('driver')) {
 
             case 'mysql':
                 $class = new ModelMysql($this);

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -164,7 +164,7 @@ class ModelMysql extends Command
             $nameFunction = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, 'UTF-8')));
             $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, 'UTF-8'));
 
-            if (in_array($nameFunction,$createdFunctions)) {
+            if (in_array($nameFunction, $createdFunctions)) {
                 continue;
             }
 
@@ -182,9 +182,9 @@ class ModelMysql extends Command
     {
 
         $delimiter = '';
-        if (str_contains($text,  '(')) {
+        if (str_contains($text, '(')) {
             $delimiter = '(';
-        } elseif (str_contains($text,  ' ')) {
+        } elseif (str_contains($text, ' ')) {
             $delimiter = ' ';
         }
 

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
 class ModelMysql extends Command
 {
 
@@ -27,7 +30,7 @@ class ModelMysql extends Command
         try {
 
             $body = '';
-            $this->structureTable = \DB::select('describe `'.$this->tableName.'`');
+            $this->structureTable = DB::select('describe `'.$this->tableName.'`');
             $this->clearStructureTable();
 
             $body = $this->constFields($body);
@@ -45,7 +48,7 @@ class ModelMysql extends Command
 
             return implode($arrStub);
 
-        } catch (\Exception $e) {
+        } catch (QueryException $e) {
 
             return $stub;
 
@@ -113,7 +116,7 @@ class ModelMysql extends Command
     public function relationshipModel($body)
     {
 
-        $relationship = \DB::table('INFORMATION_SCHEMA.KEY_COLUMN_USAGE')
+        $relationship = DB::table('INFORMATION_SCHEMA.KEY_COLUMN_USAGE')
             ->whereNotNull('REFERENCED_TABLE_NAME')
             ->where([
                 'TABLE_SCHEMA' => getenv('DB_DATABASE'),
@@ -141,7 +144,7 @@ class ModelMysql extends Command
 
         }
 
-        $sqlRefrenceQuery = \DB::table('information_schema.table_constraints as i')
+        $sqlRefrenceQuery = DB::table('information_schema.table_constraints as i')
             ->select(
                 'i.table_name as nome_tabela','i.constraint_name as nome_fk','k.referenced_table_name as tabela_referencia',
                 'k.referenced_column_name as coluna_tabela_referencia','k.column_name as column_fk'

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Illuminate\Console;
+
+class ModelMysql extends Command
+{
+
+    /**
+     * Name table.
+     */
+    protected $tableName;
+
+    /**
+     * Structure table.
+     */
+    protected $structureTable;
+
+    public function __construct($_this)
+    {
+
+        $this->tableName = $_this->input->getArgument('name');
+
+    }
+
+    public function insertModelMysql($stub)
+    {
+        try {
+
+            $body = '';
+            $this->structureTable = \DB::select('describe `'.$this->tableName.'`');
+            $this->clearStructureTable();
+
+            $body = $this->constFields($body);
+            $body = $this->fillable($body);
+            $body = $this->casts($body);
+            $body = $this->relationshipModel($body);
+
+            $arrStub = array_slice(explode(PHP_EOL,$stub),0,9);
+            foreach ($arrStub as &$item) {
+                $item .= PHP_EOL;
+            }
+
+            $arrStub[] = $body;
+            $arrStub[] = "}".PHP_EOL;
+
+            return implode($arrStub);
+
+        } catch (\Exception $e) {
+
+            return $stub;
+
+        }
+
+    }
+
+    protected function clearStructureTable()
+    {
+
+        $arrColumnDrop = ['created_at','updated_at','deleted_at'];
+        $arrColumns = array_column($this->structureTable,'Field');
+
+
+        foreach ($arrColumnDrop as $item) {
+            $index = array_search($item,$arrColumns);
+            if($index !== false){
+                unset($this->structureTable[$index]);
+            }
+        }
+
+        ksort($this->structureTable);
+
+    }
+
+    protected function constFields($body)
+    {
+
+        $body .= PHP_EOL;
+        foreach ($this->structureTable as $column) {
+            $body .= $this->setText('const',$column->Field,null);
+        }
+
+        return $body;
+
+    }
+
+    protected function fillable($body){
+
+        $body .= PHP_EOL."\tprotected \$fillable = [".PHP_EOL;
+
+        foreach ($this->structureTable as $column) {
+            $body .= $this->setText('fillable',$column->Field,null);
+        }
+
+        $body .= "\t];".PHP_EOL;
+
+        return $body;
+
+    }
+
+    protected function casts($body){
+
+        $body .= PHP_EOL."\tprotected \$casts = [".PHP_EOL;
+
+        foreach ($this->structureTable as $column) {
+            $body .= $this->setText('cast',$column->Field,$this->typeData($column->Type));
+        }
+
+        $body .= "\t];".PHP_EOL;
+
+        return $body;
+    }
+
+    public function relationshipModel($body)
+    {
+
+        $relationship = \DB::table('INFORMATION_SCHEMA.KEY_COLUMN_USAGE')
+            ->whereNotNull('REFERENCED_TABLE_NAME')
+            ->where([
+                'TABLE_SCHEMA' => getenv('DB_DATABASE'),
+                'TABLE_NAME' => $this->tableName,
+            ])
+            ->get();
+
+        $body .= PHP_EOL.PHP_EOL;
+        $body .= "\t/**".PHP_EOL;
+        $body .= "\t* Relationships".PHP_EOL;
+        $body .= "\t*/".PHP_EOL;
+        $body .= PHP_EOL;
+
+        $createdFunctions = [];
+        foreach ($relationship as $value) {
+
+            $nameFunction   = lcfirst(str_replace(' ','',mb_convert_case(str_replace('_',' ',$value->REFERENCED_TABLE_NAME),MB_CASE_TITLE,"UTF-8")));
+            $tableReference = str_replace(' ','',mb_convert_case(str_replace('_',' ',$value->REFERENCED_TABLE_NAME),MB_CASE_TITLE,"UTF-8"));
+
+            $body .= "\t".'public function '.$nameFunction.'(){'.PHP_EOL;
+            $body .= "\t\t".'$this->belongsTo('.$tableReference.'::class, \''.$value->COLUMN_NAME.'\', \''.$value->REFERENCED_COLUMN_NAME.'\');'.PHP_EOL;
+            $body .= "\t".'}'.PHP_EOL.PHP_EOL;
+
+            $createdFunctions[] = $nameFunction;
+
+        }
+
+        $sqlRefrenceQuery = \DB::table('information_schema.table_constraints as i')
+            ->select(
+                'i.table_name as nome_tabela','i.constraint_name as nome_fk','k.referenced_table_name as tabela_referencia',
+                'k.referenced_column_name as coluna_tabela_referencia','k.column_name as column_fk'
+            )
+            ->leftJoin('information_schema.key_column_usage as k','i.constraint_name','k.constraint_name')
+            ->where([
+                'i.constraint_type' => 'FOREIGN KEY',
+                'i.TABLE_SCHEMA' => getenv('DB_DATABASE'),
+                'k.referenced_table_name' => $this->tableName,
+            ])
+            ->get();
+
+        foreach ($sqlRefrenceQuery as $reference) {
+
+            $nameFunction   = lcfirst(str_replace(' ','',mb_convert_case(str_replace('_',' ',$reference->nome_tabela),MB_CASE_TITLE,"UTF-8")));
+            $tableReference = str_replace(' ','',mb_convert_case(str_replace('_',' ',$reference->nome_tabela),MB_CASE_TITLE,"UTF-8"));
+
+            if(in_array($nameFunction,$createdFunctions)){
+                continue;
+            }
+
+            $body .= "\t".'public function '.$nameFunction.'(){'.PHP_EOL;
+            $body .= "\t\t".'$this->hasMany('.$tableReference.'::class, \''.$reference->column_fk.'\', \''.$reference->coluna_tabela_referencia.'\');'.PHP_EOL;
+            $body .= "\t".'}'.PHP_EOL.PHP_EOL;
+
+        }
+
+        return $body;
+
+    }
+
+    protected function typeData($text){
+
+        $delimiter = '';
+        if(str_contains($text, '(')){
+            $delimiter = '(';
+        }elseif (str_contains($text, ' ')){
+            $delimiter = ' ';
+        }
+
+        if($delimiter == ''){
+            return $text;
+        }
+
+        $text = explode($delimiter,$text)[0];
+
+        $arrTypeColumn = [
+            'varchar' => 'string',
+            'tinyint' => 'boolean'
+        ];
+
+        return key_exists($text,$arrTypeColumn)?$arrTypeColumn[$text]:$text;
+
+    }
+
+    protected function setText($type,$field,$typeData){
+
+        switch ($type){
+
+            case 'const':
+                return "\tpublic const FIELD_".strtoupper($field).' = \''.$field.'\';'.PHP_EOL;
+
+            case 'cast':
+                return "\t\tself::FIELD_".strtoupper($field).' => \''.$typeData.'\','.PHP_EOL;
+
+            case 'fillable':
+                return "\t\tself::FIELD_".strtoupper($field).','.PHP_EOL;
+
+        }
+
+    }
+
+}

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\DB;
 
 class ModelMysql extends Command
 {
-
     /**
      * Name table.
      */
@@ -20,15 +19,12 @@ class ModelMysql extends Command
 
     public function __construct($_this)
     {
-
         $this->tableName = $_this->input->getArgument('name');
-
     }
 
     public function insertModelMysql($stub)
     {
         try {
-
             $body = '';
             $this->structureTable = DB::select('describe `'.$this->tableName.'`');
             $this->clearStructureTable();
@@ -47,21 +43,16 @@ class ModelMysql extends Command
             $arrStub[] = '}'.PHP_EOL;
 
             return implode($arrStub);
-
         } catch (QueryException $e) {
-
             return $stub;
-
         }
 
     }
 
     protected function clearStructureTable()
     {
-
         $arrColumnDrop = ['created_at', 'updated_at', 'deleted_at'];
         $arrColumns = array_column($this->structureTable, 'Field');
-
 
         foreach ($arrColumnDrop as $item) {
             $index = array_search($item, $arrColumns);
@@ -71,24 +62,20 @@ class ModelMysql extends Command
         }
 
         ksort($this->structureTable);
-
     }
 
     protected function constFields($body)
     {
-
         $body .= PHP_EOL;
         foreach ($this->structureTable as $column) {
             $body .= $this->setText('const', $column->Field, null);
         }
 
         return $body;
-
     }
 
     protected function fillable($body)
     {
-
         $body .= PHP_EOL."\tprotected \$fillable = [".PHP_EOL;
 
         foreach ($this->structureTable as $column) {
@@ -98,12 +85,10 @@ class ModelMysql extends Command
         $body .= "\t];".PHP_EOL;
 
         return $body;
-
     }
 
     protected function casts($body)
     {
-
         $body .= PHP_EOL."\tprotected \$casts = [".PHP_EOL;
 
         foreach ($this->structureTable as $column) {
@@ -117,7 +102,6 @@ class ModelMysql extends Command
 
     public function relationshipModel($body)
     {
-
         $relationship = DB::table('INFORMATION_SCHEMA.KEY_COLUMN_USAGE')
             ->whereNotNull('REFERENCED_TABLE_NAME')
             ->where([
@@ -160,7 +144,6 @@ class ModelMysql extends Command
             ->get();
 
         foreach ($sqlRefrenceQuery as $reference) {
-
             $nameFunction = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, 'UTF-8')));
             $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, 'UTF-8'));
 
@@ -171,16 +154,13 @@ class ModelMysql extends Command
             $body .= "\t".'public function '.$nameFunction.'(){'.PHP_EOL;
             $body .= "\t\t".'$this->hasMany('.$tableReference.'::class, \''.$reference->column_fk.'\', \''.$reference->coluna_tabela_referencia.'\');'.PHP_EOL;
             $body .= "\t".'}'.PHP_EOL.PHP_EOL;
-
         }
 
         return $body;
-
     }
 
     protected function typeData($text)
     {
-
         $delimiter = '';
         if (str_contains($text, '(')) {
             $delimiter = '(';
@@ -200,14 +180,11 @@ class ModelMysql extends Command
         ];
 
         return key_exists($text, $arrTypeColumn) ? $arrTypeColumn[$text] : $text;
-
     }
 
     protected function setText($type, $field, $typeData)
     {
-
         switch ($type) {
-
             case 'const':
                 return "\tpublic const FIELD_".strtoupper($field).' = \''.$field.'\';'.PHP_EOL;
 
@@ -216,9 +193,7 @@ class ModelMysql extends Command
 
             case 'fillable':
                 return "\t\tself::FIELD_".strtoupper($field).','.PHP_EOL;
-
         }
-
     }
 
 }

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -38,13 +38,13 @@ class ModelMysql extends Command
             $body = $this->casts($body);
             $body = $this->relationshipModel($body);
 
-            $arrStub = array_slice(explode(PHP_EOL,$stub),0,9);
+            $arrStub = array_slice(explode(PHP_EOL,$stub), 0, 9);
             foreach ($arrStub as &$item) {
                 $item .= PHP_EOL;
             }
 
             $arrStub[] = $body;
-            $arrStub[] = "}".PHP_EOL;
+            $arrStub[] = '}'.PHP_EOL;
 
             return implode($arrStub);
 
@@ -59,13 +59,13 @@ class ModelMysql extends Command
     protected function clearStructureTable()
     {
 
-        $arrColumnDrop = ['created_at','updated_at','deleted_at'];
-        $arrColumns = array_column($this->structureTable,'Field');
+        $arrColumnDrop = ['created_at', 'updated_at', 'deleted_at'];
+        $arrColumns = array_column($this->structureTable, 'Field');
 
 
         foreach ($arrColumnDrop as $item) {
-            $index = array_search($item,$arrColumns);
-            if($index !== false){
+            $index = array_search($item, $arrColumns);
+            if($index !== false) {
                 unset($this->structureTable[$index]);
             }
         }
@@ -79,19 +79,20 @@ class ModelMysql extends Command
 
         $body .= PHP_EOL;
         foreach ($this->structureTable as $column) {
-            $body .= $this->setText('const',$column->Field,null);
+            $body .= $this->setText('const', $column->Field, null);
         }
 
         return $body;
 
     }
 
-    protected function fillable($body){
+    protected function fillable($body)
+    {
 
         $body .= PHP_EOL."\tprotected \$fillable = [".PHP_EOL;
 
         foreach ($this->structureTable as $column) {
-            $body .= $this->setText('fillable',$column->Field,null);
+            $body .= $this->setText('fillable', $column->Field,null);
         }
 
         $body .= "\t];".PHP_EOL;
@@ -100,12 +101,13 @@ class ModelMysql extends Command
 
     }
 
-    protected function casts($body){
+    protected function casts($body)
+    {
 
         $body .= PHP_EOL."\tprotected \$casts = [".PHP_EOL;
 
         foreach ($this->structureTable as $column) {
-            $body .= $this->setText('cast',$column->Field,$this->typeData($column->Type));
+            $body .= $this->setText('cast', $column->Field, $this->typeData($column->Type));
         }
 
         $body .= "\t];".PHP_EOL;
@@ -133,8 +135,8 @@ class ModelMysql extends Command
         $createdFunctions = [];
         foreach ($relationship as $value) {
 
-            $nameFunction   = lcfirst(str_replace(' ','',mb_convert_case(str_replace('_',' ',$value->REFERENCED_TABLE_NAME),MB_CASE_TITLE,"UTF-8")));
-            $tableReference = str_replace(' ','',mb_convert_case(str_replace('_',' ',$value->REFERENCED_TABLE_NAME),MB_CASE_TITLE,"UTF-8"));
+            $nameFunction   = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, "UTF-8")));
+            $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, "UTF-8"));
 
             $body .= "\t".'public function '.$nameFunction.'(){'.PHP_EOL;
             $body .= "\t\t".'$this->belongsTo('.$tableReference.'::class, \''.$value->COLUMN_NAME.'\', \''.$value->REFERENCED_COLUMN_NAME.'\');'.PHP_EOL;
@@ -146,10 +148,10 @@ class ModelMysql extends Command
 
         $sqlRefrenceQuery = DB::table('information_schema.table_constraints as i')
             ->select(
-                'i.table_name as nome_tabela','i.constraint_name as nome_fk','k.referenced_table_name as tabela_referencia',
-                'k.referenced_column_name as coluna_tabela_referencia','k.column_name as column_fk'
+                'i.table_name as nome_tabela', 'i.constraint_name as nome_fk', 'k.referenced_table_name as tabela_referencia',
+                'k.referenced_column_name as coluna_tabela_referencia', 'k.column_name as column_fk'
             )
-            ->leftJoin('information_schema.key_column_usage as k','i.constraint_name','k.constraint_name')
+            ->leftJoin('information_schema.key_column_usage as k', 'i.constraint_name', 'k.constraint_name')
             ->where([
                 'i.constraint_type' => 'FOREIGN KEY',
                 'i.TABLE_SCHEMA' => getenv('DB_DATABASE'),
@@ -159,10 +161,10 @@ class ModelMysql extends Command
 
         foreach ($sqlRefrenceQuery as $reference) {
 
-            $nameFunction   = lcfirst(str_replace(' ','',mb_convert_case(str_replace('_',' ',$reference->nome_tabela),MB_CASE_TITLE,"UTF-8")));
-            $tableReference = str_replace(' ','',mb_convert_case(str_replace('_',' ',$reference->nome_tabela),MB_CASE_TITLE,"UTF-8"));
+            $nameFunction   = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, "UTF-8")));
+            $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, "UTF-8"));
 
-            if(in_array($nameFunction,$createdFunctions)){
+            if(in_array($nameFunction,$createdFunctions)) {
                 continue;
             }
 
@@ -176,33 +178,35 @@ class ModelMysql extends Command
 
     }
 
-    protected function typeData($text){
+    protected function typeData($text)
+    {
 
         $delimiter = '';
-        if(str_contains($text, '(')){
+        if(str_contains($text,  '(')) {
             $delimiter = '(';
-        }elseif (str_contains($text, ' ')){
+        }elseif (str_contains($text,  ' ')) {
             $delimiter = ' ';
         }
 
-        if($delimiter == ''){
+        if($delimiter == '') {
             return $text;
         }
 
-        $text = explode($delimiter,$text)[0];
+        $text = explode($delimiter, $text)[0];
 
         $arrTypeColumn = [
             'varchar' => 'string',
-            'tinyint' => 'boolean'
+            'tinyint' => 'boolean',
         ];
 
-        return key_exists($text,$arrTypeColumn)?$arrTypeColumn[$text]:$text;
+        return key_exists($text, $arrTypeColumn) ? $arrTypeColumn[$text] : $text;
 
     }
 
-    protected function setText($type,$field,$typeData){
+    protected function setText($type,$field,$typeData)
+    {
 
-        switch ($type){
+        switch ($type) {
 
             case 'const':
                 return "\tpublic const FIELD_".strtoupper($field).' = \''.$field.'\';'.PHP_EOL;

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -46,7 +46,6 @@ class ModelMysql extends Command
         } catch (QueryException $e) {
             return $stub;
         }
-
     }
 
     protected function clearStructureTable()
@@ -118,7 +117,6 @@ class ModelMysql extends Command
 
         $createdFunctions = [];
         foreach ($relationship as $value) {
-
             $nameFunction = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, 'UTF-8')));
             $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, 'UTF-8'));
 
@@ -127,7 +125,6 @@ class ModelMysql extends Command
             $body .= "\t".'}'.PHP_EOL.PHP_EOL;
 
             $createdFunctions[] = $nameFunction;
-
         }
 
         $sqlRefrenceQuery = DB::table('information_schema.table_constraints as i')
@@ -195,5 +192,4 @@ class ModelMysql extends Command
                 return "\t\tself::FIELD_".strtoupper($field).','.PHP_EOL;
         }
     }
-
 }

--- a/src/Illuminate/Console/ModelMysql.php
+++ b/src/Illuminate/Console/ModelMysql.php
@@ -38,7 +38,7 @@ class ModelMysql extends Command
             $body = $this->casts($body);
             $body = $this->relationshipModel($body);
 
-            $arrStub = array_slice(explode(PHP_EOL,$stub), 0, 9);
+            $arrStub = array_slice(explode(PHP_EOL, $stub), 0, 9);
             foreach ($arrStub as &$item) {
                 $item .= PHP_EOL;
             }
@@ -65,7 +65,7 @@ class ModelMysql extends Command
 
         foreach ($arrColumnDrop as $item) {
             $index = array_search($item, $arrColumns);
-            if($index !== false) {
+            if ($index !== false) {
                 unset($this->structureTable[$index]);
             }
         }
@@ -92,7 +92,7 @@ class ModelMysql extends Command
         $body .= PHP_EOL."\tprotected \$fillable = [".PHP_EOL;
 
         foreach ($this->structureTable as $column) {
-            $body .= $this->setText('fillable', $column->Field,null);
+            $body .= $this->setText('fillable', $column->Field, null);
         }
 
         $body .= "\t];".PHP_EOL;
@@ -135,8 +135,8 @@ class ModelMysql extends Command
         $createdFunctions = [];
         foreach ($relationship as $value) {
 
-            $nameFunction   = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, "UTF-8")));
-            $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, "UTF-8"));
+            $nameFunction = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, 'UTF-8')));
+            $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $value->REFERENCED_TABLE_NAME), MB_CASE_TITLE, 'UTF-8'));
 
             $body .= "\t".'public function '.$nameFunction.'(){'.PHP_EOL;
             $body .= "\t\t".'$this->belongsTo('.$tableReference.'::class, \''.$value->COLUMN_NAME.'\', \''.$value->REFERENCED_COLUMN_NAME.'\');'.PHP_EOL;
@@ -161,10 +161,10 @@ class ModelMysql extends Command
 
         foreach ($sqlRefrenceQuery as $reference) {
 
-            $nameFunction   = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, "UTF-8")));
-            $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, "UTF-8"));
+            $nameFunction = lcfirst(str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, 'UTF-8')));
+            $tableReference = str_replace(' ', '', mb_convert_case(str_replace('_', ' ', $reference->nome_tabela), MB_CASE_TITLE, 'UTF-8'));
 
-            if(in_array($nameFunction,$createdFunctions)) {
+            if (in_array($nameFunction,$createdFunctions)) {
                 continue;
             }
 
@@ -182,13 +182,13 @@ class ModelMysql extends Command
     {
 
         $delimiter = '';
-        if(str_contains($text,  '(')) {
+        if (str_contains($text,  '(')) {
             $delimiter = '(';
-        }elseif (str_contains($text,  ' ')) {
+        } elseif (str_contains($text,  ' ')) {
             $delimiter = ' ';
         }
 
-        if($delimiter == '') {
+        if ($delimiter == '') {
             return $text;
         }
 
@@ -203,7 +203,7 @@ class ModelMysql extends Command
 
     }
 
-    protected function setText($type,$field,$typeData)
+    protected function setText($type, $field, $typeData)
     {
 
         switch ($type) {


### PR DESCRIPTION
## Development to generate the model by capturing the data from the informed table.

Generating the main components:

1. Field Constants: These constants represent the names of the fields in the associated database table.
2. Fillable: The $fillable property contains an array of field names that Laravel will allow for mass assignment.
3. Casts: The $casts property is an array where you can define how Laravel should convert data types when looking in your database.
4. Relationships: The relationship function is a method that defines a relationship between the current Model A and Model B. Specifically, this function defines a "belongs to" (belongsTo) relationship.

## Below is an example of a generated model:

```
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Database\Eloquent\Model;

class users extends Model
{

	public const FIELD_ID = 'id';
	public const FIELD_NAME = 'name';
	public const FIELD_ADDRESS_ID = 'address_id';


	protected $fillable = [
		self::FIELD_ID,
		self::FIELD_NAME,
		self::FIELD_ADDRESS_ID,
	];

	protected $casts = [
		self::FIELD_ID => 'bigint',
		self::FIELD_NAME => 'string',
		self::FIELD_ADDRESS_ID  => 'bigint',
	];


	/**
	* Relationships
	*/

	public function address(){
		$this->belongsTo(Address::class, 'address_id', 'id');
	}

}
```
