### PR TITLE
[11.x] Allow setting exit code in migrate:status --pending

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -63,7 +63,7 @@ class StatusCommand extends BaseCommand
             $batches = $this->migrator->getRepository()->getMigrationBatches();
 
             $migrations = $this->getStatusFor($ran, $batches)
-                ->when($this->hasOption('pending'), fn ($collection) => $collection->filter(function ($migration) {
+                ->when($this->option('pending') !== false, fn ($collection) => $collection->filter(function ($migration) {
                     return str($migration[1])->contains('Pending');
                 }));
 
@@ -78,7 +78,7 @@ class StatusCommand extends BaseCommand
                     );
 
                 $this->newLine();
-            } elseif ($this->hasOption('pending')) {
+            } elseif ($this->option('pending') !== false) {
                 $this->components->info('No pending migrations');
             } else {
                 $this->components->info('No migrations found');
@@ -134,7 +134,7 @@ class StatusCommand extends BaseCommand
     {
         return [
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
-            ['pending', null, InputOption::VALUE_OPTIONAL, 'Only list pending migrations'],
+            ['pending', null, InputOption::VALUE_OPTIONAL, 'Only list pending migrations', false],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
         ];

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -84,7 +84,7 @@ class StatusCommand extends BaseCommand
                 $this->components->info('No migrations found');
             }
 
-            if($this->option('pending') && $migrations->some(fn ($m) => str($m[1])->contains('Pending'))) {
+            if ($this->option('pending') && $migrations->some(fn ($m) => str($m[1])->contains('Pending'))) {
                 return $this->option('pending');
             }
         });

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -63,7 +63,7 @@ class StatusCommand extends BaseCommand
             $batches = $this->migrator->getRepository()->getMigrationBatches();
 
             $migrations = $this->getStatusFor($ran, $batches)
-                ->when($this->option('pending'), fn ($collection) => $collection->filter(function ($migration) {
+                ->when($this->hasOption('pending'), fn ($collection) => $collection->filter(function ($migration) {
                     return str($migration[1])->contains('Pending');
                 }));
 
@@ -78,10 +78,14 @@ class StatusCommand extends BaseCommand
                     );
 
                 $this->newLine();
-            } elseif ($this->option('pending')) {
+            } elseif ($this->hasOption('pending')) {
                 $this->components->info('No pending migrations');
             } else {
                 $this->components->info('No migrations found');
+            }
+
+            if($this->option('pending') && $migrations->some(fn ($m) => str($m[1])->contains('Pending'))) {
+                return $this->option('pending');
             }
         });
     }
@@ -130,7 +134,7 @@ class StatusCommand extends BaseCommand
     {
         return [
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
-            ['pending', null, InputOption::VALUE_NONE, 'Only list pending migrations'],
+            ['pending', null, InputOption::VALUE_OPTIONAL, 'Only list pending migrations'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
         ];


### PR DESCRIPTION
When we deploy our Laravel application with docker, we first launch a job that does the following:

```shell
php artisan down
php artisan migrate
php artisan up
```

We use the down command with the cache driver to bring down the other containers (workers, schedulers, ...)

The issue with this setup is that we run the down command even if there are no pending migrations.

With this PR the following is possible
```shell
php artisan migrate:status --pending=100

exit_code=$?

if [ $exit_code -eq 100 ]; then
    # this code is skipped when there are no pending migrations
    php artisan down
    php artisan migrate
    php artisan up
fi
```

Syntax for the command option is inspired by the artisan migrate --isolate 