### PR TITLE
[11.x] Support passing default as named parameter in whenLoaded, whenAggregated, whenCounted

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -276,6 +276,10 @@ trait ConditionallyLoadsAttributes
             return;
         }
 
+        if ($value === null) {
+            $value = value(...);
+        }
+
         return value($value, $loadedValue);
     }
 
@@ -305,6 +309,10 @@ trait ConditionallyLoadsAttributes
 
         if ($this->resource->{$attribute} === null) {
             return;
+        }
+
+        if ($value === null) {
+            $value = value(...);
         }
 
         return value($value, $this->resource->{$attribute});
@@ -338,6 +346,10 @@ trait ConditionallyLoadsAttributes
 
         if ($this->resource->{$attribute} === null) {
             return;
+        }
+
+        if ($value === null) {
+            $value = value(...);
         }
 
         return value($value, $this->resource->{$attribute});

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipUsingNamedParameters.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipUsingNamedParameters.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithOptionalRelationshipUsingNamedParameters extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'author' => new AuthorResource($this->whenLoaded('author')),
+            'author_defaulting_to_null' => new AuthorResource($this->whenLoaded('author', default: null)),
+            'author_name' => $this->whenLoaded('author', fn ($author) => $author->name, 'Anonymous'),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -37,6 +37,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRela
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipAggregates;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipCounts;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipUsingNamedParameters;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithoutWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
@@ -606,6 +607,54 @@ class ResourceTest extends TestCase
         $response->assertExactJson([
             'data' => [
                 'id' => 5,
+            ],
+        ]);
+    }
+
+    public function testWhenLoadedUsingNamedDefaultParameterOnMissingRelation()
+    {
+        Route::get('/', function () {
+            $post = new Post(['id' => 1]);
+
+            return new PostResourceWithOptionalRelationshipUsingNamedParameters($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 1,
+                'author_defaulting_to_null' => null,
+                'author_name' => 'Anonymous',
+            ],
+        ]);
+    }
+
+    public function testWhenLoadedUsingNamedDefaultParameterOnLoadedRelation()
+    {
+        Route::get('/', function () {
+            $post = new Post(['id' => 1]);
+            $post->setRelation('author', new Author(['name' => 'jrrmartin']));
+
+            return new PostResourceWithOptionalRelationshipUsingNamedParameters($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 1,
+                'author' => ['name' => 'jrrmartin'],
+                'author_defaulting_to_null' => ['name' => 'jrrmartin'],
+                'author_name' => 'jrrmartin',
             ],
         ]);
     }


### PR DESCRIPTION
Because of the way named parameters affect `func_num_args()`, only specifying the required parameters and `$default` would result in the returned value being `null`

This will allow developers to use named arguments when passing `$default` to `whenLoaded()`, `whenAggregated()` and `whenCounted()` in Resources, in case the key should still exist in the output while maintaining the current behavior when only passing the required parameters.

Before:

```php
class PostResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'author' => new AuthorResource($this->whenLoaded('author', fn ($author) => $author, null)),
        ];
    }
}
```

After:

```php
class PostResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'author' => new AuthorResource($this->whenLoaded('author', default: null)),
        ];
    }
}
```

This will not affect existing Laravel users, as the addition is only being run when `$value` and/or `$default` is passed and `$value` is its default (`null`).