### PR TITLE
[11.x] Optimize boostrap time by using hashtable to store providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -99,7 +99,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * All of the registered service providers.
      *
-     * @var \Illuminate\Support\ServiceProvider[]
+     * @var array<string, \Illuminate\Support\ServiceProvider>
      */
     protected $serviceProviders = [];
 
@@ -893,7 +893,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function getProvider($provider)
     {
-        return array_values($this->getProviders($provider))[0] ?? null;
+        $name = is_string($provider) ? $provider : get_class($provider);
+
+        return $this->serviceProviders[$name] ?? null;
     }
 
     /**
@@ -928,9 +930,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     protected function markAsRegistered($provider)
     {
-        $this->serviceProviders[] = $provider;
-
-        $this->loadedProviders[get_class($provider)] = true;
+        $class = get_class($provider);
+        $this->serviceProviders[$class] = $provider;
+        $this->loadedProviders[$class] = true;
     }
 
     /**
@@ -1384,7 +1386,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Get the service providers that have been loaded.
      *
-     * @return array
+     * @return array<string, boolean>
      */
     public function getLoadedProviders()
     {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -931,7 +931,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected function markAsRegistered($provider)
     {
         $class = get_class($provider);
+
         $this->serviceProviders[$class] = $provider;
+
         $this->loadedProviders[$class] = true;
     }
 


### PR DESCRIPTION
It should slightly optimize bootstrap time, especially for large applications with many providers. I've encountered that the method getProvider has O(n) complexity, but it could be optimized to O(1).

- Application::register
- Application::getProvider

<img width="397" alt="Screenshot 2024-05-08 at 15 30 05" src="https://github.com/laravel/framework/assets/6762480/5fe32687-287f-478e-89a6-5a049fd1dcb8">

Of course, this time from Blackfire is not true, and the original value is smaller, but still executing that function ~63k times isn't a good thing. 

Seems like serviceProviders hashtable is enough, and we can get rid of loadedProviders.