### PR TITLE
Add unshift method to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -996,6 +996,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Prepend one or more items to the beginning of the collection.
+     *
+     * @param  TValue  ...$values
+     * @return $this
+     */
+    public function unshift(...$values)
+    {
+        array_unshift($this->items, ...$values);
+
+        return $this;
+    }
+
+    /**
      * Push all of the given items onto the collection.
      *
      * @template TConcatKey of array-key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3788,6 +3788,51 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testUnshiftWithOneItem()
+    {
+        $expected = [
+            0 => 'Jonny from Laroe',
+            1 => ['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'],
+            2 => ['a', 'b', 'c'],
+            3 => 4,
+            4 => 5,
+            5 => 6,
+        ];
+
+        $data = new Collection([4, 5, 6]);
+        $data->unshift(['a', 'b', 'c']);
+        $data->unshift(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $actual = $data->unshift('Jonny from Laroe')->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testUnshiftWithMultipleItems()
+    {
+        $expected = [
+            0 => 'a',
+            1 => 'b',
+            2 => 'c',
+            3 => 'Jonny',
+            4 => 'from',
+            5 => 'Laroe',
+            6 => 'Jonny',
+            7 => 'from',
+            8 => 'Laroe',
+            9 => 4,
+            10 => 5,
+            11 => 6,
+        ];
+
+        $data = new Collection([4, 5, 6]);
+        $data->unshift('Jonny', 'from', 'Laroe');
+        $data->unshift(...[11 => 'Jonny', 12 => 'from', 13 => 'Laroe']);
+        $data->unshift(...collect(['a', 'b', 'c']));
+        $actual = $data->unshift(...[])->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
     #[DataProvider('collectionClassProvider')]
     public function testZip($collection)
     {


### PR DESCRIPTION
It can be disorienting coming from [other](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift) [languages](https://ruby-doc.org/core-2.5.1/Array.html#method-i-unshift) (including [vanilla PHP](https://www.php.net/manual/en/function.array-unshift.php)) that Collections don't have an `unshift()` method. This is the sibling of `push()`.

The closest thing is `prepend()`, but that specifically prepends _one_ item, and can't be made variadic because it has a second `key` argument.

This has been brought up before (https://github.com/laravel/framework/pull/36830, https://github.com/laravel/framework/pull/37237), but I think those PRs missed the mark in that they weren't variadic, like `push()`.