### PR TITLE
[11.x] fix: remove use of Redis::COMPRESSION_ZSTD_MIN

### DIFF
--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -193,15 +193,6 @@ class PhpRedisCacheLockTest extends TestCase
         $lock->release();
         $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
 
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MIN);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
         $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MAX);
         $store->lock('foo')->forceRelease();
         $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -899,21 +899,6 @@ class RedisConnectionTest extends TestCase
                 ],
             ]))->connection();
 
-            $connections['compression_zstd_min'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 12,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_MIN,
-                        'name' => 'compression_zstd_min',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
             $connections['compression_zstd_max'] = (new RedisManager(new Application, 'phpredis', [
                 'cluster' => false,
                 'default' => [


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

Related Issue: https://github.com/phpredis/phpredis/issues/2487
php: 8.2
phpredis: 6.0.2

When running the tests locally I would receive ~40 failures for `Undefined constant Redis::COMPRESSION_ZSTD_MIN`. After a lot of debugging/recompiling phpredis/git bisecting I finally discovered that the constant was removed between phpredis 5.7.3 and 6.0.0 (`COMPRESSION_ZSTD_MAX` and `COMPRESSION_ZSTD_DEFAULT` are still defined).

Given that this constant is only referenced in the tests and other tests cases cover the max and default compression constants, I just opted to remove the references to this particular constant.

Thanks!