### PR TITLE
[11.x] create new "has" validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1304,6 +1304,29 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate an attribute has a list of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateHas($attribute, $value, $parameters)
+    {
+        if (!is_array($value)) {
+            return false;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (!in_array($parameter, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute is a valid HEX color.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1313,12 +1313,12 @@ trait ValidatesAttributes
      */
     public function validateHas($attribute, $value, $parameters)
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
         foreach ($parameters as $parameter) {
-            if (!in_array($parameter, $value)) {
+            if (! in_array($parameter, $value)) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -501,6 +501,29 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate an attribute has a list of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateContains($attribute, $value, $parameters)
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (! in_array($parameter, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that the password of the currently authenticated user matches the given value.
      *
      * @param  string  $attribute
@@ -1301,29 +1324,6 @@ trait ValidatesAttributes
     public function validateUppercase($attribute, $value, $parameters)
     {
         return Str::upper($value) === $value;
-    }
-
-    /**
-     * Validate an attribute has a list of values.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
-     * @return bool
-     */
-    public function validateHas($attribute, $value, $parameters)
-    {
-        if (! is_array($value)) {
-            return false;
-        }
-
-        foreach ($parameters as $parameter) {
-            if (! in_array($parameter, $value)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3789,26 +3789,26 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(2, $v->messages()->first('items'));
     }
 
-    public function testValidateHas()
+    public function testValidateContains()
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans, ['name' => 0], ['name' => 'has:bar']);
+        $v = new Validator($trans, ['name' => 0], ['name' => 'contains:bar']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:baz']);
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:baz']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:baz,buzz']);
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:baz,buzz']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:foo,buzz']);
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:foo,buzz']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:foo']);
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:foo']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:foo,bar']);
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'contains:foo,bar']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3789,6 +3789,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(2, $v->messages()->first('items'));
     }
 
+    public function testValidateHas()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['name' => 0], ['name' => 'has:bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:baz,buzz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:foo,buzz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:foo']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'has:foo,bar']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateIn()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
currently we have the "in" rule, which checks if given input is in a list of approved values. this new "has" rule is kind of the opposite of that. it checks that expected values are included in the given array of input.

for example, assume you are setting up the ability to restrict access to certain IP addresses. you might setup some rules like this:

```php
return [
    'allowed_ips'   => ['present', 'nullable', 'array'],
    'allowed_ips.*' => ['required', 'ip'],
];
```

However, you want to make sure the current user's current IP address is included in the provided array of input. Current rules do not provide a way to do this. With the new `has` rule, the rules would change to:

```php
return [
    'allowed_ips'   => ['present', 'nullable', 'array', 'has:' . $request->ip()],
    'allowed_ips.*' => ['required', 'ip'],
];
```

You may also pass multiple parameters to the `has` rule, which would require all of the passed parameters to exist in the given input.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
