### PR TITLE
[11.x] Optimize benchmark and Collection average

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -85,13 +85,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $callback = $this->valueRetriever($callback);
 
-        $items = $this
-            ->map(fn ($value) => $callback($value))
-            ->filter(fn ($value) => ! is_null($value));
+        // Reduce the array to the sum and the count of non-null values.
+        $reduced = $this
+            ->reduce(
+                fn (array $reduce, mixed $value): array => ! is_null($retrieved = $callback($value))
+                    ? [$reduce[0] + $retrieved, $reduce[1] + 1]
+                    : $reduce,
+                [0, 0]
+            );
 
-        if ($count = $items->count()) {
-            return $items->sum() / $count;
-        }
+        return $reduced[1] ? $reduced[0] / $reduced[1] : null;
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -76,28 +76,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get the average value of a given key.
-     *
-     * @param  (callable(TValue): float|int)|string|null  $callback
-     * @return float|int|null
-     */
-    public function avg($callback = null)
-    {
-        $callback = $this->valueRetriever($callback);
-
-        // Reduce the array to the sum and the count of non-null values.
-        $reduced = $this
-            ->reduce(
-                fn (array $reduce, mixed $value): array => ! is_null($retrieved = $callback($value))
-                    ? [$reduce[0] + $retrieved, $reduce[1] + 1]
-                    : $reduce,
-                [0, 0]
-            );
-
-        return $reduced[1] ? $reduced[0] / $reduced[1] : null;
-    }
-
-    /**
      * Get the median of a given key.
      *
      * @param  string|array<array-key, string>|null  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -155,17 +155,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the average value of a given key.
-     *
-     * @param  (callable(TValue): float|int)|string|null  $callback
-     * @return float|int|null
-     */
-    public function avg($callback = null)
-    {
-        return $this->collect()->avg($callback);
-    }
-
-    /**
      * Get the median of a given key.
      *
      * @param  string|array<array-key, string>|null  $key

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -527,6 +527,28 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the average value of a given key.
+     *
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
+     */
+    public function avg($callback = null)
+    {
+        $callback = $this->valueRetriever($callback);
+
+        // Reduce the array to the sum and the count of non-null values.
+        $reduced = $this
+            ->reduce(
+                fn (array $reduce, mixed $value): array => ! is_null($retrieved = $callback($value))
+                    ? [$reduce[0] + $retrieved, $reduce[1] + 1]
+                    : $reduce,
+                [0, 0]
+            );
+
+        return $reduced[1] ? $reduced[0] / $reduced[1] : null;
+    }
+
+    /**
      * Apply the callback if the collection is empty.
      *
      * @template TWhenEmptyReturnType

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -539,10 +539,15 @@ trait EnumeratesValues
         // Reduce the array to the sum and the count of non-null values.
         $reduced = $this
             ->reduce(
-                fn (array $reduce, mixed $value): array => ! is_null($retrieved = $callback($value))
-                    ? [$reduce[0] + $retrieved, $reduce[1] + 1]
-                    : $reduce,
-                [0, 0]
+                static function (array &$reduce, mixed $value) use ($callback): array {
+                    if ( !is_null($retrieved = $callback($value))) {
+                        $reduce[0] += $retrieved;
+                        $reduce[1]++;
+                    }
+
+                    return $reduce;
+                },
+                [0, 0],
             );
 
         return $reduced[1] ? $reduced[0] / $reduced[1] : null;

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -540,7 +540,7 @@ trait EnumeratesValues
         $reduced = $this
             ->reduce(
                 static function (array &$reduce, mixed $value) use ($callback): array {
-                    if ( !is_null($retrieved = $callback($value))) {
+                    if (! is_null($retrieved = $callback($value))) {
                         $reduce[0] += $retrieved;
                         $reduce[1]++;
                     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4060,6 +4060,9 @@ class SupportCollectionTest extends TestCase
         $c = new $collection([1, 2, 3, 4, 5]);
         $this->assertEquals(3, $c->avg());
 
+        $c = new $collection([1, 2, 3, 4, null]);
+        $this->assertEquals(2.5, $c->avg());
+
         $c = new $collection;
         $this->assertNull($c->avg());
 


### PR DESCRIPTION
`Benchmark::measure()` will now use a lazy collection instead of a regular one, which reduces the memory print to almost nothing. Furthermore, the average is calculated using a simple passed-by-reference counter. This allows the benchmark function to use millions more iterations without running into memory issues, since all that is needed is a single variable.

Additionally, I noticed that the `Collection->average()` function was implemented very inefficiently as well (with 2 loops and a complete collection of all to-be-averaged values). The new implementation solves it using a simple loop and a reduce argument.

The reducer is an array starting as `[0, 0]` where the first item will be the sum of the values, and the second item the count of all non-null values.