### PR TITLE
[11.x]Add a transaction shortcut static method to Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1857,6 +1857,20 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Execute a Closure within a transaction.
+     *
+     * @param  \Closure  $callback
+     * @param  int  $attempts
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    public static function transaction($callback, $attempts = 1)
+    {
+        return (new static)->getConnection()->transaction($callback, $attempts);
+    }
+
+    /**
      * Get the table associated with the model.
      *
      * @return string


### PR DESCRIPTION
Previous use case:
```php
$model = new SomeModel(); // connection is not default
$model->getConnection()->transaction(function () {
   // There is a lot of database processing based on this connection
});
```
This will result in repetitive code, which we can extract as a convenient method.

It could be that way, though
```php
DB::connection('name not default')->transaction(function () {
   // There is a lot of database processing based on this connection
});
```
However, this is not very maintainable, and if the name is changed or used in too many places, it will add a lot of work and even potential online problems.

----

Now, that's all it takes.
```php
SomeModel::transaction(function () {
   // There is a lot of database processing based on this connection
});
```
It's not a big change, but I think the code is a lot cleaner.