### PR TITLE
[10.x] Backport: Fix SesV2Transport to use correct `EmailTags` argument

### DIFF
--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -51,7 +51,7 @@ class SesV2Transport extends AbstractTransport
         if ($message->getOriginalMessage() instanceof Message) {
             foreach ($message->getOriginalMessage()->getHeaders()->all() as $header) {
                 if ($header instanceof MetadataHeader) {
-                    $options['Tags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
+                    $options['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
                 }
             }
         }

--- a/tests/Mail/MailSesV2TransportTest.php
+++ b/tests/Mail/MailSesV2TransportTest.php
@@ -73,7 +73,7 @@ class MailSesV2TransportTest extends TestCase
             ->with(m::on(function ($arg) {
                 return $arg['Source'] === 'myself@example.com' &&
                     $arg['Destination']['ToAddresses'] === ['me@example.com', 'you@example.com'] &&
-                    $arg['Tags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
+                    $arg['EmailTags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
                     strpos($arg['Content']['Raw']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>') !== false;
             }))
             ->andReturn($sesResult);
@@ -111,7 +111,7 @@ class MailSesV2TransportTest extends TestCase
                             'region' => 'eu-west-1',
                             'options' => [
                                 'ConfigurationSetName' => 'Laravel',
-                                'Tags' => [
+                                'EmailTags' => [
                                     ['Name' => 'Laravel', 'Value' => 'Framework'],
                                 ],
                             ],
@@ -144,7 +144,7 @@ class MailSesV2TransportTest extends TestCase
 
         $this->assertSame([
             'ConfigurationSetName' => 'Laravel',
-            'Tags' => [
+            'EmailTags' => [
                 ['Name' => 'Laravel', 'Value' => 'Framework'],
             ],
         ], $transport->getOptions());


### PR DESCRIPTION
Backports #51265 to 10.x