### PR TITLE
 [11.x] Allow adding array or string for web and api routes in bootstrap/app.php

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -186,7 +186,8 @@ class ApplicationBuilder
         ?string $pages,
         ?string $health,
         string $apiPrefix,
-        ?callable $then) {
+        ?callable $then)
+        {
         return function () use ($web, $api, $pages, $health, $apiPrefix, $then) {
             if ((is_string($api) || is_array($api)) !== false) {
                 if (is_array($api)) {

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -148,7 +148,8 @@ class ApplicationBuilder
         ?string $pages = null,
         ?string $health = null,
         string $apiPrefix = 'api',
-        ?callable $then = null) {
+        ?callable $then = null)
+        {
         if (is_null($using) && (is_string($web) || is_array($web) || is_string($api) || is_array($api) || is_string($pages) || is_string($health)) || is_callable($then)) {
             $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $then);
         }

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -174,8 +174,8 @@ class ApplicationBuilder
     /**
      * Create the routing callback for the application.
      *
-     * @param  string|array|null  $web
-     * @param  string|array|null  $api
+     * @param  array|string|null  $web
+     * @param  array|string|null  $api
      * @param  string|null  $pages
      * @param  string|null  $health
      * @param  string  $apiPrefix
@@ -183,14 +183,14 @@ class ApplicationBuilder
      * @return \Closure
      */
     protected function buildRoutingCallback(string|array|null $web = null,
-        string|array|null $api = null,
+        array|string|null $api = null,
         ?string $pages,
         ?string $health,
         string $apiPrefix,
         ?callable $then)
     {
         return function () use ($web, $api, $pages, $health, $apiPrefix, $then) {
-            if ((is_string($api) || is_array($api)) !== false) {
+            if (is_string($api) || is_array($api)) {
                 if (is_array($api)) {
                     foreach ($api as $apiRoute) {
                         if (realpath($apiRoute) !== false) {
@@ -210,7 +210,7 @@ class ApplicationBuilder
                 });
             }
 
-            if ((is_string($web) || is_array($web)) !== false) {
+            if (is_string($web) || is_array($web)) {
                 if (is_array($web)) {
                     foreach ($web as $webRoute) {
                         if (realpath($webRoute) !== false) {

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -250,7 +250,7 @@ class ApplicationBuilder
             $middleware = (new Middleware)
                 ->redirectGuestsTo(fn () => route('login'));
 
-            if (!is_null($callback)) {
+            if (! is_null($callback)) {
                 $callback($middleware);
             }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -149,7 +149,7 @@ class ApplicationBuilder
         ?string $health = null,
         string $apiPrefix = 'api',
         ?callable $then = null)
-        {
+    {
         if (is_null($using) && (is_string($web) || is_array($web) || is_string($api) || is_array($api) || is_string($pages) || is_string($health)) || is_callable($then)) {
             $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $then);
         }
@@ -188,7 +188,7 @@ class ApplicationBuilder
         ?string $health,
         string $apiPrefix,
         ?callable $then)
-        {
+    {
         return function () use ($web, $api, $pages, $health, $apiPrefix, $then) {
             if ((is_string($api) || is_array($api)) !== false) {
                 if (is_array($api)) {

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -131,8 +131,8 @@ class ApplicationBuilder
      * Register the routing services for the application.
      *
      * @param  \Closure|null  $using
-     * @param  string|null  $web
-     * @param  string|null  $api
+     * @param  string|array|null  $web
+     * @param  string|array|null  $api
      * @param  string|null  $commands
      * @param  string|null  $channels
      * @param  string|null  $pages
@@ -143,7 +143,7 @@ class ApplicationBuilder
     public function withRouting(
         ?Closure $using = null,
         string|array $web = null,
-        ?string $api = null,
+        string|array $api = null,
         ?string $commands = null,
         ?string $channels = null,
         ?string $pages = null,
@@ -175,8 +175,8 @@ class ApplicationBuilder
     /**
      * Create the routing callback for the application.
      *
-     * @param  string|null  $web
-     * @param  string|null  $api
+     * @param  string|array|null  $web
+     * @param  string|array|null  $api
      * @param  string|null  $pages
      * @param  string|null  $health
      * @param  string  $apiPrefix
@@ -184,8 +184,8 @@ class ApplicationBuilder
      * @return \Closure
      */
     protected function buildRoutingCallback(
-        string|array $web,
-        string|array $api,
+        string|array $web = null,
+        string|array $api = null,
         ?string $pages,
         ?string $health,
         string $apiPrefix,

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -131,8 +131,8 @@ class ApplicationBuilder
      * Register the routing services for the application.
      *
      * @param  \Closure|null  $using
-     * @param  string|array|null  $web
-     * @param  string|array|null  $api
+     * @param  array|string|null  $web
+     * @param  array|string|null  $api
      * @param  string|null  $commands
      * @param  string|null  $channels
      * @param  string|null  $pages
@@ -141,8 +141,8 @@ class ApplicationBuilder
      * @return $this
      */
     public function withRouting(?Closure $using = null,
-        string|array|null $web = null,
-        string|array|null $api = null,
+        array|string|null $web = null,
+        array|string|null $api = null,
         ?string $commands = null,
         ?string $channels = null,
         ?string $pages = null,
@@ -182,7 +182,7 @@ class ApplicationBuilder
      * @param  callable|null  $then
      * @return \Closure
      */
-    protected function buildRoutingCallback(string|array|null $web = null,
+    protected function buildRoutingCallback(array|string|null $web = null,
         array|string|null $api = null,
         ?string $pages,
         ?string $health,

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -96,7 +96,7 @@ class ApplicationBuilder
             AppEventServiceProvider::disableEventDiscovery();
         }
 
-        if (!isset($this->pendingProviders[AppEventServiceProvider::class])) {
+        if (! isset($this->pendingProviders[AppEventServiceProvider::class])) {
             $this->app->booting(function () {
                 $this->app->register(AppEventServiceProvider::class);
             });
@@ -117,7 +117,7 @@ class ApplicationBuilder
     public function withBroadcasting(string $channels, array $attributes = [])
     {
         $this->app->booted(function () use ($channels, $attributes) {
-            Broadcast::routes(!empty($attributes) ? $attributes : null);
+            Broadcast::routes(! empty($attributes) ? $attributes : null);
 
             if (file_exists($channels)) {
                 require $channels;
@@ -208,7 +208,7 @@ class ApplicationBuilder
                 Route::middleware('web')->get($health, function () {
                     Event::dispatch(new DiagnosingHealth);
 
-                    return View::file(__DIR__ . '/../resources/health-up.blade.php');
+                    return View::file(__DIR__.'/../resources/health-up.blade.php');
                 });
             }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -141,8 +141,8 @@ class ApplicationBuilder
      * @return $this
      */
     public function withRouting(?Closure $using = null,
-        string|array $web = null,
-        string|array $api = null,
+        string|array|null $web = null,
+        string|array|null $api = null,
         ?string $commands = null,
         ?string $channels = null,
         ?string $pages = null,
@@ -182,8 +182,8 @@ class ApplicationBuilder
      * @param  callable|null  $then
      * @return \Closure
      */
-    protected function buildRoutingCallback(string|array $web = null,
-        string|array $api = null,
+    protected function buildRoutingCallback(string|array|null $web = null,
+        string|array|null $api = null,
         ?string $pages,
         ?string $health,
         string $apiPrefix,

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -140,8 +140,7 @@ class ApplicationBuilder
      * @param  callable|null  $then
      * @return $this
      */
-    public function withRouting(
-        ?Closure $using = null,
+    public function withRouting(?Closure $using = null,
         string|array $web = null,
         string|array $api = null,
         ?string $commands = null,
@@ -149,8 +148,7 @@ class ApplicationBuilder
         ?string $pages = null,
         ?string $health = null,
         string $apiPrefix = 'api',
-        ?callable $then = null
-    ) {
+        ?callable $then = null) {
         if (is_null($using) && (is_string($web) || is_array($web) || is_string($api) || is_array($api) || is_string($pages) || is_string($health)) || is_callable($then)) {
             $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $then);
         }
@@ -183,14 +181,12 @@ class ApplicationBuilder
      * @param  callable|null  $then
      * @return \Closure
      */
-    protected function buildRoutingCallback(
-        string|array $web = null,
+    protected function buildRoutingCallback(string|array $web = null,
         string|array $api = null,
         ?string $pages,
         ?string $health,
         string $apiPrefix,
-        ?callable $then
-    ) {
+        ?callable $then) {
         return function () use ($web, $api, $pages, $health, $apiPrefix, $then) {
             if ((is_string($api) || is_array($api)) !== false) {
                 if (is_array($api)) {
@@ -224,11 +220,9 @@ class ApplicationBuilder
                 }
             }
 
-            if (
-                is_string($pages) &&
+            if (is_string($pages) &&
                 realpath($pages) !== false &&
-                class_exists(Folio::class)
-            ) {
+                class_exists(Folio::class)) {
                 Folio::route($pages, middleware: $this->pageMiddleware);
             }
 


### PR DESCRIPTION
> This PR is Resubmitted after Taylor feedback

This pull request proposes an enhancement to Laravel's `bootstrap/app.php` file, enabling developers to add routes in array format or as strings for both web and api route groups.

### Motivation

The motivation behind this enhancement is to provide developers with greater flexibility and convenience when defining routes, particularly in scenarios where applications have different guards and need to create different routes for each guard rather than writing require/require_once in route file.


### Use Cases

In projects where route management becomes complex due to the proliferation of routes or diverse authentication scenarios, this will simplifies the process by enabling developers to organize routes into multiple route files effortlessly. By allowing routes to be defined in array format, developers can easily create separate route files corresponding to different functionalities, user roles, or authentication guards. This approach promotes code organization and maintainability, as each route file can focus on a specific aspect of the application, making it easier to understand and manage.

## Additional Context

I'm developing an ecommerce website with five different guards, and I want to include separate route files for each guard. Using `require` or `require_once` made my code look outdated, and I disliked it. Let's simplify by allowing arrays as well in the `$web` parameter of `withRouting()` method in `Illuminate\Foundation\Application`


![carbon](https://github.com/laravel/framework/assets/49310993/5a8a273e-73e8-4cf2-a4cc-074e0a224ad2)
