### PR TITLE
[11.x] Add dropForeign support on SQLiteGrammar (#51318)

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -171,7 +171,7 @@ abstract class Grammar extends BaseGrammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         throw new RuntimeException('This database driver does not support dropping foreign keys.');
     }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -594,7 +594,7 @@ class MySqlGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         $index = $this->wrap($command->index);
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -549,7 +549,7 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         $index = $this->wrap($command->index);
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -487,7 +487,7 @@ class SqlServerGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         $index = $this->wrap($command->index);
 


### PR DESCRIPTION
This pull request proposes an enhancement to Laravel's SQLiteGrammar in order to support the drop on foreign keys. It uses the same approach as `doctrine/dbal` which is recreating the table while removing the foreign key constraint and use the logic of the existing `compileChange` method to do so.

### Motivation

The motivation behind this enhancement is to provide developers the ability to use foreign keys on SQLite and be able to drop them.

### Use Cases

In a project that uses SQLite and foreign keys on a column. It is currently not possible to drop a column that has a foreign key constraint on it. Currently if we try to drop the foreign key, we receive the following exception: `This database driver does not support dropping foreign keys`. Therefore, the PR is to provide the ability to drop the foreign key before dropping the column.

For example, this migration will add a foreign key on the `user_id` of the `session` table.
```PHP
return new class extends Migration {
    /**
     * Run the migrations.
     */
    public function up(): void
    {
        Schema::create('users', function (Blueprint $table) {
            $table->id();
            $table->string('name');
            $table->string('email')->unique();
            $table->timestamp('email_verified_at')->nullable();
            $table->string('password');
            $table->rememberToken();
            $table->timestamps();
        });

        Schema::create('sessions', function (Blueprint $table) {
            $table->id();
            $table->foreignId('user_id')->nullable()->index()
                ->constrained('users')
                ->onUpdate('CASCADE')
                ->onDelete('CASCADE');

            $table->string('ip_address', 45)->nullable();
            $table->text('user_agent')->nullable();
            $table->longText('payload');
            $table->integer('last_activity')->index();
        });
    }
}
```

Then when trying to delete the column `user_id` which has a foreign key with the following migration will throw an exception when using the SQLite Driver.

```PHP
return new class extends Migration {
    /**
     * Run the migrations.
     */
    public function up(): void
    {
        Schema::table('sessions', function (Blueprint $table) {
            $table->dropIndex(['user_id']);
        });
        Schema::table('sessions', function (Blueprint $table) {
            $table->dropForeign(['user_id']);
        });
        Schema::table('sessions', function (Blueprint $table) {
            $table->dropColumn('user_id');
        });
    }
}
```

fix #51318