### PR TITLE
[12.x] fix: update postgres grammar date format and time precision

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -639,6 +639,16 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Get the format for database stored dates.
+     *
+     * @return string
+     */
+    public function getDateFormat()
+    {
+        return 'Y-m-d H:i:s.uP';
+    }
+
+    /**
      * Compile a delete statement with joins or limit into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -12,6 +12,11 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * The default time precision for migrations.
+     */
+    public static ?int $defaultTimePrecision = 6;
+
+    /**
      * Create a database in the schema.
      *
      * @param  string  $name


### PR DESCRIPTION
Hello!

### Current Problem

As it currently stands, passing a string to Eloquent / QueryBuilder works exactly as expected, but passing a Carbon instance truncates the microseconds and timezone information causing serious data integrity issues. The Carbon instance contains all the information needed to fully define that timestamp---I should not lose information or wind up with an incorrectly serialized string when I pass a Carbon instance to Eloquent / QueryBuilder. I also should not experience different behaviour between passing a Carbon instance and passing an equivalent timestamp string.

PostgreSQL supports [`time[stamp] with time zone`](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME) fields with a resolution of 1 microsecond. However, the default grammar date format is `Y-m-d H:i:s` which truncates `DateTimeInterface` objects that are passed to queries.

This results in invalid queries and records being saved to / returned from the database. For example:

```php
$datetime = Carbon::now('America/Chicago'); // 2024-05-09 15:35:55.123456-05:00
// The timestamp is shifted by 5 hours and loses the microsecond resolution!
Model::create(['datetimetz' => $datetime); // saved in DB: 2024-05-09 15:35:55+00
```

This PR updates the PostgresGrammar date format to prevent the lose of information:

```php
$datetime = Carbon::now('America/Chicago'); // 2024-05-09 15:35:55.123456-05:00
// The timestamp has been properly converted to UTC for storage!
Model::create(['datetimetz' => $datetime); // saved in db: 2024-05-09 20:35:55.123456+00
```

and it updates the default timestamp precision for Postgres to 6 (the Postgres default). This means that the following is equivalent in Postgres:

```php
$table->timestampTz('created_at');
$table->timestampTz('created_at', precision: 6);
```


### Postgres Rounding Issue

There is a rounding issue when the database has a precision that's less than the serialized datetime. This is not a bug in Postgres---it follows the general rounding rules---however, it can catch the developer off guard if they're not aware of this. For example, a serialized date of `2024-05-09 23:59:59.999999+00` (could be given by Carbon's `now()->endOfDay()` for instance) would actually be rounded up to `2024-05-10 00:00:00` (when using a precision of 0) because it follows the prescribed rounding rules.

To avoid this rounding confusion, I converted **all timestamps** in our database to `timestamp with timezone` using the default precision of 6 (microseconds). All Postgres timestamps are stored using 8 bytes regardless of the precision or if it's with/without timezone, as detailed in the [Postgres docs](https://www.postgresql.org/docs/current/datatype-datetime.html). This means that there is *no storage benefit to using a lower precision*, and using the default precision (6) **completely negates the rounding issue**.

### Automatic Timezone Conversion

The main driver behind this push is to ensure that all timestamps are consistently handled and converted to UTC **by the framework/database** (and not by the developer) before being persisted or queried. Keep in mind that the Postgres `timestamp with timezone` does not actually store the timezone in the database, it just means that Postgres will automatically convert a timestamp to UTC before persisting / querying. When using `without timezone` the timestamp is used as-is without conversion, so if you pass a timestamp in a different timezone than your database (which should be in UTC), it will be stored as-is and not converted (which is very bad!).

Before this, we had simply defaulted to `timestamp(0) without timezone`, however, this meant that the developer had to manually convert every Carbon instance to UTC before passing it to Eloquent / QueryBuilder. This was a great source of bugs which resulted in incorrect timestamps being persisted to the database and incorrect results being retrieved from the database if the developer forgot to manually convert the Carbon instance to UTC.

Moving all timestamps to `timestamp with timezone` greatly improved the developer experience, cleaned up code, and eliminated an entire class of bugs because now timezone conversion is handled by the framework/database instead of the developer.

### Conclusion

I firmly believe that when using Postgres **all** timestamps should be `timestamp with timezone` with the default precision (6), I don't see any valid reason to deviate from this. This solves a lot of timezone conversion headaches and negates any rounding issues. I strongly recommend that the Laravel documentation should be updated to reflect this best practice when using Postgres.

By unilaterally adopting `timestamptz`/`timestamp with timezone`/`timestamp(6) with timezone` (all the same) for all of our timestamps, we:
  - leverage Postgres' automatic timezone conversion to UTC
  - eliminate the need for developers to manually convert Carbon instances to UTC
  - eliminate the rounding issue that comes from using a lower precision than the default (6)

The proposed change:
  - ensures that Carbon instances are serialized correctly
  - ensures a consistent behaviour between strings and Carbon instances that are passed to Eloquent / QueryBuilder

### Timestamp Conversion Query

For anyone who is interested, here is the query I used to convert all timestamps across the board:

<details>

Note that we only use the `public` schema but this can easily be modified to work with multiple schemas.

```php
<?php

$columns = DB::select(<<<'SQL'
    SELECT table_name, column_name
    FROM information_schema.columns
    WHERE table_schema = 'public'
        AND data_type IN ('timestamp without time zone', 'timestamp with time zone');
    SQL);

collect($columns)
    ->groupBy('table_name')
    ->each(function ($columns, $table): void {
        $alterStatement = collect($columns)
            ->map(fn ($column) => <<<SQL
                ALTER COLUMN {$column->column_name} SET DATA TYPE timestamp(6) with time zone
                SQL)
            ->join(', ');

        DB::statement(<<<SQL
            ALTER TABLE public.{$table}
            {$alterStatement};
            SQL);
    });
```

</details>


Thanks!