### PR TITLE
[11.x] Fix array rule typehint

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -64,7 +64,7 @@ class Rule
      * Get an array rule builder instance.
      *
      * @param  array|null  $keys
-     * @return \Illuminate\Validation\ArrayRule
+     * @return \Illuminate\Validation\Rules\ArrayRule
      */
     public static function array($keys = null)
     {


### PR DESCRIPTION
ArrayRule was recently added in #51250, but the typehinted return from the static rule helper references the wrong namespace.