### PR TITLE
[11.x] Refactor to use class name instead of string representation

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -15,6 +15,7 @@ use ReflectionFunction;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Terminal;
+use Illuminate\Routing\RedirectController;
 
 #[AsCommand(name: 'route:list')]
 class RouteListCommand extends Command
@@ -244,8 +245,8 @@ class RouteListCommand extends Command
     protected function isFrameworkController(Route $route)
     {
         return in_array($route->getControllerClass(), [
-            '\Illuminate\Routing\RedirectController',
-            '\Illuminate\Routing\ViewController',
+            RedirectController::class,
+            ViewController::class,
         ], true);
     }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Routing\RedirectController;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\ViewController;
@@ -15,7 +16,6 @@ use ReflectionFunction;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Terminal;
-use Illuminate\Routing\RedirectController;
 
 #[AsCommand(name: 'route:list')]
 class RouteListCommand extends Command

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -256,7 +256,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        return $this->any($uri, '\Illuminate\Routing\RedirectController')
+        return $this->any($uri, RedirectController::class)
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);
     }
@@ -285,7 +285,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function view($uri, $view, $data = [], $status = 200, array $headers = [])
     {
-        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
+        return $this->match(['GET', 'HEAD'], $uri, ViewController::class)
                 ->setDefaults([
                     'view' => $view,
                     'data' => $data,


### PR DESCRIPTION
These changes improve code readability and help the programmer easily understand which class is actually being used. also, IDE can provide more information about the class with this approach, such as automatic suggestions (autocomplete), refactoring capabilities, and better code analysis.


The changes have no impact on the existing code behavior, and the tests run successfully.

Thanks!