### PR TITLE
[11.x] Add find command

### DIFF
--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -95,7 +95,7 @@ class FindCommand extends Command
     /**
      * Execute the found command.
      *
-     * @param \Symfony\Component\Console\Command\Command  $command
+     * @param  \Symfony\Component\Console\Command\Command  $command
      */
     protected function executeFoundCommand(SymfonyCommand $command): void
     {
@@ -156,7 +156,7 @@ class FindCommand extends Command
     /**
      * Search for command and return the result prioritized.
      *
-     * @param string  $value
+     * @param  string  $value
      *
      * @return array
      */
@@ -204,10 +204,10 @@ class FindCommand extends Command
                 $definition = $command->getDefinition();
                 $arguments = $definition->getArguments();
                 $options = $definition->getOptions();
-                $deep = implode(PHP_EOL, (array_merge(
+                $deep = implode(PHP_EOL, array_merge(
                     Arr::map($arguments, fn (InputArgument $argument) => $argument->getDescription()),
                     Arr::map($options, fn (InputOption $option) => $option->getDescription()),
-                )));
+                ));
 
                 return [
                     'object' => $command,

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -72,6 +72,11 @@ class FindCommand extends Command
             required: true
         );
 
+        if (windows_os() && $command == $this->getName()) {
+            $this->searchCommand();
+            return;
+        }
+
         (new DescriptorHelper())->describe($this->output, $this->commands[$command]);
 
         $action = select(

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\search;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\textarea;
+
+#[AsCommand(name: 'find')]
+class FindCommand extends Command
+{
+    use Conditionable;
+
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'find {--deep : Search in the arguments and options descriptions too}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Search console command';
+
+    /**
+     * The array of available commands.
+     *
+     * @var array
+     */
+    protected array $commands;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle(): void
+    {
+        $this->collectCommands();
+        $this->searchCommand();
+    }
+
+    /**
+     * Search for a command.
+     *
+     * @return void
+     */
+    protected function searchCommand(): void
+    {
+        $command = search(
+            label: 'Search for command',
+            options: fn (string $value) => $this->search($value),
+            required: true
+        );
+
+        (new DescriptorHelper())->describe($this->output, $this->commands[$command]['object']);
+
+        $action = select(
+            label: 'Choose a action',
+            options: [
+                'Execute the command',
+                'Search for another command',
+                'Exit',
+            ],
+        );
+
+        if ($action == 'Execute the command') {
+            $this->executeFoundCommand($this->commands[$command]['object']);
+
+            return;
+        }
+
+        if ($action == 'Search for another command') {
+            $this->searchCommand();
+        }
+    }
+
+    /**
+     * Execute the found command.
+     *
+     * @param \Symfony\Component\Console\Command\Command  $command
+     */
+    protected function executeFoundCommand(SymfonyCommand $command): void
+    {
+        note(sprintf('Execute the „%s“ command', $command->getName()));
+        $arguments = [];
+        $definition = $command->getDefinition();
+        $array = array_merge($definition->getArguments(), $definition->getOptions());
+
+        foreach ($array as $key => $input) {
+            if (in_array($key, ['help', 'quiet', 'ansi', 'version', 'no-interaction', 'verbose'])) {
+                continue;
+            }
+
+            if ($input instanceof InputOption) {
+                $key = '--'.$key;
+
+                if (! $input->acceptValue()) {
+                    $arguments[$key] = confirm(
+                        label: $input->getName(),
+                        default: (bool) $input->getDefault(),
+                        required: false,
+                        hint: $input->getDescription(),
+                    );
+
+                    continue;
+                }
+            }
+
+            /* @var \Symfony\Component\Console\Input\InputArgument|\Symfony\Component\Console\Input\InputOption $input */
+            if ($input->isArray()) {
+                $arguments[$key] = textarea(
+                    label: $input->getName(),
+                    placeholder: 'one value in each line',
+                    default: implode(PHP_EOL, (array) $input->getDefault()),
+                    required: $input instanceof InputArgument && $input->isRequired(),
+                    hint: $input->getDescription(),
+                );
+                $arguments[$key] = array_filter(
+                    array_map('trim', explode(PHP_EOL, $arguments[$key]))
+                );
+
+                continue;
+            }
+
+            $arguments[$key] = text(
+                label: $input->getName(),
+                default: (string) $input->getDefault(),
+                required: $input instanceof InputArgument && $input->isRequired(),
+                hint: $input->getDescription(),
+            );
+        }
+
+        $arguments = array_filter($arguments, fn ($argument) => $argument !== '');
+
+        $this->call($command->getName(), $arguments);
+    }
+
+    /**
+     * Search for command and return the result prioritized.
+     *
+     * @param string  $value
+     *
+     * @return array
+     */
+    protected function search(string $value): array
+    {
+        if (empty(trim($value))) {
+            return [];
+        }
+
+        $value = preg_split('/\s+/', $value, flags: PREG_SPLIT_NO_EMPTY);
+
+        $result = array_merge(
+            Arr::where($this->commands, fn (array $command) => $command['name'] == $value),
+            Arr::where($this->commands, fn (array $command) => Str::containsAll($command['name'], $value, true)),
+            Arr::where($this->commands, fn (array $command) => Str::containsAll($command['description'], $value, true)),
+            $this->when(
+                $this->option('deep'),
+                fn () => Arr::where($this->commands, fn (array $command) => Str::containsAll($command['deep'], $value, true)),
+                fn () => []
+            ),
+        );
+
+        if (windows_os()) {
+            $result[] = [
+                'name' => $this->getName(),
+                'label' => $this->getDescription(),
+            ];
+        }
+
+        return Arr::pluck($result, 'label', 'name');
+    }
+
+    /**
+     * Collect available commands.
+     *
+     * @return void
+     */
+    protected function collectCommands(): void
+    {
+        $description = new ApplicationDescription($this->getApplication());
+
+        $this->commands = collect($description->getCommands())
+            ->filter(fn (SymfonyCommand $command, string $key) => ! $command instanceof $this)
+            ->map(function (SymfonyCommand $command) {
+                $definition = $command->getDefinition();
+                $arguments = $definition->getArguments();
+                $options = $definition->getOptions();
+                $deep = implode(PHP_EOL, (array_merge(
+                    Arr::map($arguments, fn (InputArgument $argument) => $argument->getDescription()),
+                    Arr::map($options, fn (InputOption $option) => $option->getDescription()),
+                )));
+
+                return [
+                    'object' => $command,
+                    'name' => $command->getName(),
+                    'description' => $command->getDescription(),
+                    'label' => windows_os() ? $command->getDescription() :
+                        sprintf('[%s] %s', $command->getName(), $command->getDescription()),
+                    'deep' => $deep,
+                ];
+            })
+            ->toArray();
+    }
+}

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -74,6 +74,7 @@ class FindCommand extends Command
 
         if (windows_os() && $command == $this->getName()) {
             $this->searchCommand();
+
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -192,7 +192,7 @@ class FindCommand extends Command
     /**
      * Get the deep search items.
      *
-     * @param array  $value
+     * @param  array  $value
      * @return array
      */
     protected function deepSearchItems(array $value): array

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -175,14 +175,16 @@ class FindCommand extends Command
             Arr::where($this->commands, fn (SymfonyCommand $command) => Str::containsAll($command->getDescription(), $value, true)),
             $this->when(
                 $this->option('deep'),
-                function (SymfonyCommand $command) use ($value) {
-                    $definition = $command->getDefinition();
-                    $deep = implode(PHP_EOL, array_merge(
-                        Arr::map($definition->getArguments(), fn (InputArgument $argument) => $argument->getDescription()),
-                        Arr::map($definition->getOptions(), fn (InputOption $option) => $option->getDescription()),
-                    ));
+                function () use ($value) {
+                    return Arr::where($this->commands, function (SymfonyCommand $command) use ($value) {
+                        $definition = $command->getDefinition();
+                        $deep = implode(PHP_EOL, array_merge(
+                            Arr::map($definition->getArguments(), fn (InputArgument $argument) => $argument->getDescription()),
+                            Arr::map($definition->getOptions(), fn (InputOption $option) => $option->getDescription()),
+                        ));
 
-                    return Str::containsAll($deep, $value, true);
+                        return Str::containsAll($deep, $value, true);
+                    });
                 },
                 fn () => []
             ),

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -157,7 +157,6 @@ class FindCommand extends Command
      * Search for command and return the result prioritized.
      *
      * @param  string  $value
-     *
      * @return array
      */
     protected function search(string $value): array

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -53,6 +53,7 @@ use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
+use Illuminate\Foundation\Console\FindCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
@@ -135,6 +136,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,
+        'Find' => FindCommand::class,
         'KeyGenerate' => KeyGenerateCommand::class,
         'Optimize' => OptimizeCommand::class,
         'OptimizeClear' => OptimizeClearCommand::class,


### PR DESCRIPTION
In Laravel apps with many commands, I always have the problem that the list command is simply too long.
I therefore created a command to search the commands.

The name and description of the available commands are used for the search.

```shell
php artisan find
```

![preview](https://github.com/laravel/framework/assets/26193232/4967fb51-7e9c-4d1a-acac-d61b22779f6f)

With the `deep` option, the descriptions of the arguments and options are used in addition to the search.

```shell
php artisan find --deep
```

![Aufzeichnung2024-05-10223329-ezgif com-video-to-gif-converter](https://github.com/laravel/framework/assets/26193232/f226c031-825c-44eb-af98-9a7c599289bb)

After selecting a command that has been found, the help for the command is displayed and the following 3 options are available:
- Execute the command
- Search for another command
- Exit

The "Execute the command" option takes some getting used to for some commands. With the "make:model" command, for example, you have the option "all" and if you select this, the other options are still queried.