### PR TITLE
[11.x] Prevent implicit route model binding parameter name mismatches in controllers

### DIFF
--- a/src/Illuminate/Routing/Exceptions/ModelParameterMismatchException.php
+++ b/src/Illuminate/Routing/Exceptions/ModelParameterMismatchException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use Exception;
+
+class ModelParameterMismatchException extends Exception
+{
+}

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -3,14 +3,34 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
+use Illuminate\Routing\Exceptions\ModelParameterMismatchException;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 
 class ImplicitRouteBinding
 {
+    /**
+     * Indicates if an exception should be thrown when a route parameter mismatches the model name.
+     *
+     * @var bool
+     */
+    protected static $shouldPreventModelParameterMismatch = false;
+
+    /**
+     * Prevent when a route parameter mismatches the model name.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventModelParameterMismatch($value = true)
+    {
+        static::$shouldPreventModelParameterMismatch = $value;
+    }
+
     /**
      * Resolve the implicit route bindings for the given route.
      *
@@ -29,6 +49,8 @@ class ImplicitRouteBinding
 
         foreach ($route->signatureParameters(['subClass' => UrlRoutable::class]) as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
+                static::handleMissingParameter($parameter);
+
                 continue;
             }
 
@@ -63,6 +85,26 @@ class ImplicitRouteBinding
             }
 
             $route->setParameter($parameterName, $model);
+        }
+    }
+
+    /**
+     * Handle a missing parameter for a route binding.
+     *
+     * @param  \ReflectionParameter $parameter
+     */
+    protected static function handleMissingParameter($parameter)
+    {
+        if (
+            ! $parameter->isDefaultValueAvailable() &&
+            static::$shouldPreventModelParameterMismatch &&
+            is_subclass_of($model = $parameter->getType()->getName(), Model::class)
+        ) {
+            $modelName = Str::camel(class_basename($model));
+
+            throw new ModelParameterMismatchException(
+                "Route parameter name '{$parameter->getName()}' does not match expected model binding name '{$modelName}'."
+            );
         }
     }
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -91,7 +91,7 @@ class ImplicitRouteBinding
     /**
      * Handle a missing parameter for a route binding.
      *
-     * @param  \ReflectionParameter $parameter
+     * @param  \ReflectionParameter  $parameter
      */
     protected static function handleMissingParameter($parameter)
     {

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Routing\ImplicitRouteBinding;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
@@ -309,6 +310,53 @@ PHP);
 
         $response = $this->getJson("/post/{$post->id}/tag-slug/{$tag->slug}");
         $response->assertJsonFragment(['id' => $tag->id]);
+    }
+
+    public function testMismatchedRouteBindingDoesNotThrowExceptionWhenDisabled()
+    {
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+
+        Route::middleware(['web'])->group(function () {
+            Route::get('/user/{user}/', fn (ImplicitBindingUser $usr) => null);
+        });
+
+        $response = $this->getJson("/user/{$user->id}/");
+
+        $response->assertOk();
+    }
+
+    public function testMismatchedRouteBindingThrowsExceptionWhenEnabled()
+    {
+        ImplicitRouteBinding::preventModelParameterMismatch();
+
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+
+        Route::middleware(['web'])->group(function () {
+            Route::get('/user/{user}/', fn (ImplicitBindingUser $usr) => null);
+        });
+
+        $response = $this->getJson("/user/{$user->id}/");
+
+        $response->assertServerError();
+
+        ImplicitRouteBinding::preventModelParameterMismatch(false);
+    }
+
+    public function testMismatchedRouteBindingDoesNotThrowExceptionWhenEnabledAndParameterIsNullable()
+    {
+        ImplicitRouteBinding::preventModelParameterMismatch();
+
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+
+        Route::middleware(['web'])->group(function () {
+            Route::get('/user/{user}/', fn (ImplicitBindingUser $usr = null) => null);
+        });
+
+        $response = $this->getJson("/user/{$user->id}/");
+
+        $response->assertOk();
+
+        ImplicitRouteBinding::preventModelParameterMismatch(false);
     }
 }
 

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -358,6 +358,23 @@ PHP);
 
         ImplicitRouteBinding::preventModelParameterMismatch(false);
     }
+
+    public function testMismatchedRouteBindingDoesNotThrowExceptionWhenEnabledAndParameterIsSnakeOrCamelCase()
+    {
+        ImplicitRouteBinding::preventModelParameterMismatch();
+
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+
+        Route::middleware(['web'])->group(function () {
+            Route::get('/user/{privateUser}/bar', fn (ImplicitBindingUser $privateUser) => null);
+            Route::get('/user/{private_user}/foo', fn (ImplicitBindingUser $privateUser) => null);
+        });
+
+        $this->getJson("/user/{$user->id}/foo")->assertOk();
+        $this->getJson("/user/{$user->id}/bar")->assertOk();
+
+        ImplicitRouteBinding::preventModelParameterMismatch(false);
+    }
 }
 
 class ImplicitBindingUser extends Model


### PR DESCRIPTION
This PR is based on a question I asked on X, where I somewhat frequently scratch my head as to why a route model binding isn't working and a new model instance is tossed in via dependency injection. It's obvious when you show the routes together with the controller method (as you'll see below), but it's an easy mistake to make when you're in one file working with models named two or more words (`PhoneNumber`, `UserInvitation`, `ActivityLog`, etc.):

https://twitter.com/ste_bau/status/1788976209943986419

```php
Route::name('show')->get( 
    'phone-numbers/{phoneNumber}', 
    [PhoneNumberController::class, 'show'] 
); 

// ... 

public function show(PhoneNumber $number) // Named incorrectly - new instance created
{ 
    $number->exists; // false ❌
} 

public function show(PhoneNumber $phoneNumber) // Named correctly - existing model instance given
{ 
    $phoneNumber->exists; // true ✅
} 
```

This PR implements a way to enable throwing an exception when a model (similarly to `Model::shouldBeStrict()`) binding is missed:


```php
\Illuminate\Routing\ImplicitRouteBinding::preventModelParameterMismatch();
```

Then, when the first scenario above occurs, developers will immediately see the exception with clarity:

```php
public function show(PhoneNumber $number) // ❌ throws ModelParameterMismatchException
{ 
    // ...
}
```

```text
ModelParameterMismatchException: Route parameter name 'number' does not match expected model binding name 'phoneNumber'.
```

---

This PR doesn't affect nullable controller parameters:

```php
public function show(PhoneNumber $number = null); // ✅
```

It also does not affect explicit model bindings (as these are performed prior to implicit):

```php
Route::model('number', PhoneNumber::class); // ✅
```

Let me know your thoughts! No hard feelings on closure ❤️ .