### PR TITLE
[11.x] Introduce firstOrFail for Database Query Builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\RecordsNotFoundException;
+use Illuminate\Database\RecordNotFoundException;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -333,6 +334,22 @@ trait BuildsQueries
     public function first($columns = ['*'])
     {
         return $this->take(1)->get($columns)->first();
+    }
+
+     /**
+     * Execute the query and get the first result or throw an exception.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     * @throws \Illuminate\Database\RecordNotFoundException
+     */
+    public function firstOrFail($columns = ['*'], $message = null)
+    {
+        if (! is_null($result = $this->first($columns))) {
+            return $result;
+        }
+
+        throw new RecordNotFoundException($message ?: "No record found for the given query.");
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -6,8 +6,8 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\RecordNotFoundException;
+use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -336,7 +336,7 @@ trait BuildsQueries
         return $this->take(1)->get($columns)->first();
     }
 
-     /**
+    /**
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array|string  $columns
@@ -349,7 +349,7 @@ trait BuildsQueries
             return $result;
         }
 
-        throw new RecordNotFoundException($message ?: "No record found for the given query.");
+        throw new RecordNotFoundException($message ?: 'No record found for the given query.');
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -340,7 +340,7 @@ trait BuildsQueries
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     * @return \Illuminate\Database\Eloquent\Model|object|static
      * @throws \Illuminate\Database\RecordNotFoundException
      */
     public function firstOrFail($columns = ['*'], $message = null)

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -341,11 +341,12 @@ trait BuildsQueries
      *
      * @param  array|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|object|static
+     *
      * @throws \Illuminate\Database\RecordNotFoundException
      */
     public function firstOrFail($columns = ['*'], $message = null)
     {
-        if (! is_null($result = $this->first($columns))) {
+        if (!is_null($result = $this->first($columns))) {
             return $result;
         }
 
@@ -389,22 +390,22 @@ trait BuildsQueries
      */
     protected function paginateUsingCursor($perPage, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {
-        if (! $cursor instanceof Cursor) {
+        if (!$cursor instanceof Cursor) {
             $cursor = is_string($cursor)
                 ? Cursor::fromEncoded($cursor)
                 : CursorPaginator::resolveCurrentCursor($cursorName, $cursor);
         }
 
-        $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
+        $orders = $this->ensureOrderForCursorPagination(!is_null($cursor) && $cursor->pointsToPreviousItems());
 
-        if (! is_null($cursor)) {
+        if (!is_null($cursor)) {
             // Reset the union bindings so we can add the cursor where in the correct position...
             $this->setBindings([], 'union');
 
             $addCursorConditions = function (self $builder, $previousColumn, $originalColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
                 $unionBuilders = $builder->getUnionBuilders();
 
-                if (! is_null($previousColumn)) {
+                if (!is_null($previousColumn)) {
                     $originalColumn ??= $this->getOriginalColumnNameForCursorPagination($this, $previousColumn);
 
                     $builder->where(
@@ -488,7 +489,7 @@ trait BuildsQueries
     {
         $columns = $builder instanceof Builder ? $builder->getQuery()->getColumns() : $builder->getColumns();
 
-        if (! is_null($columns)) {
+        if (!is_null($columns)) {
             foreach ($columns as $column) {
                 if (($position = strripos($column, ' as ')) !== false) {
                     $original = substr($column, 0, $position);
@@ -518,7 +519,11 @@ trait BuildsQueries
     protected function paginator($items, $total, $perPage, $currentPage, $options)
     {
         return Container::getInstance()->makeWith(LengthAwarePaginator::class, compact(
-            'items', 'total', 'perPage', 'currentPage', 'options'
+            'items',
+            'total',
+            'perPage',
+            'currentPage',
+            'options'
         ));
     }
 
@@ -534,7 +539,10 @@ trait BuildsQueries
     protected function simplePaginator($items, $perPage, $currentPage, $options)
     {
         return Container::getInstance()->makeWith(Paginator::class, compact(
-            'items', 'perPage', 'currentPage', 'options'
+            'items',
+            'perPage',
+            'currentPage',
+            'options'
         ));
     }
 
@@ -550,7 +558,10 @@ trait BuildsQueries
     protected function cursorPaginator($items, $perPage, $cursor, $options)
     {
         return Container::getInstance()->makeWith(CursorPaginator::class, compact(
-            'items', 'perPage', 'cursor', 'options'
+            'items',
+            'perPage',
+            'cursor',
+            'options'
         ));
     }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -341,7 +341,7 @@ trait BuildsQueries
      *
      * @param  array|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|object|static
-     * 
+     *
      * @throws \Illuminate\Database\RecordNotFoundException
      */
     public function firstOrFail($columns = ['*'], $message = null)

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -341,6 +341,7 @@ trait BuildsQueries
      *
      * @param  array|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|object|static
+     * 
      * @throws \Illuminate\Database\RecordNotFoundException
      */
     public function firstOrFail($columns = ['*'], $message = null)

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -341,12 +341,11 @@ trait BuildsQueries
      *
      * @param  array|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|object|static
-     *
      * @throws \Illuminate\Database\RecordNotFoundException
      */
     public function firstOrFail($columns = ['*'], $message = null)
     {
-        if (!is_null($result = $this->first($columns))) {
+        if (! is_null($result = $this->first($columns))) {
             return $result;
         }
 
@@ -390,22 +389,22 @@ trait BuildsQueries
      */
     protected function paginateUsingCursor($perPage, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {
-        if (!$cursor instanceof Cursor) {
+        if (! $cursor instanceof Cursor) {
             $cursor = is_string($cursor)
                 ? Cursor::fromEncoded($cursor)
                 : CursorPaginator::resolveCurrentCursor($cursorName, $cursor);
         }
 
-        $orders = $this->ensureOrderForCursorPagination(!is_null($cursor) && $cursor->pointsToPreviousItems());
+        $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
 
-        if (!is_null($cursor)) {
+        if (! is_null($cursor)) {
             // Reset the union bindings so we can add the cursor where in the correct position...
             $this->setBindings([], 'union');
 
             $addCursorConditions = function (self $builder, $previousColumn, $originalColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
                 $unionBuilders = $builder->getUnionBuilders();
 
-                if (!is_null($previousColumn)) {
+                if (! is_null($previousColumn)) {
                     $originalColumn ??= $this->getOriginalColumnNameForCursorPagination($this, $previousColumn);
 
                     $builder->where(
@@ -489,7 +488,7 @@ trait BuildsQueries
     {
         $columns = $builder instanceof Builder ? $builder->getQuery()->getColumns() : $builder->getColumns();
 
-        if (!is_null($columns)) {
+        if (! is_null($columns)) {
             foreach ($columns as $column) {
                 if (($position = strripos($column, ' as ')) !== false) {
                     $original = substr($column, 0, $position);
@@ -519,11 +518,7 @@ trait BuildsQueries
     protected function paginator($items, $total, $perPage, $currentPage, $options)
     {
         return Container::getInstance()->makeWith(LengthAwarePaginator::class, compact(
-            'items',
-            'total',
-            'perPage',
-            'currentPage',
-            'options'
+            'items', 'total', 'perPage', 'currentPage', 'options'
         ));
     }
 
@@ -539,10 +534,7 @@ trait BuildsQueries
     protected function simplePaginator($items, $perPage, $currentPage, $options)
     {
         return Container::getInstance()->makeWith(Paginator::class, compact(
-            'items',
-            'perPage',
-            'currentPage',
-            'options'
+            'items', 'perPage', 'currentPage', 'options'
         ));
     }
 
@@ -558,10 +550,7 @@ trait BuildsQueries
     protected function cursorPaginator($items, $perPage, $cursor, $options)
     {
         return Container::getInstance()->makeWith(CursorPaginator::class, compact(
-            'items',
-            'perPage',
-            'cursor',
-            'options'
+            'items', 'perPage', 'cursor', 'options'
         ));
     }
 

--- a/src/Illuminate/Database/RecordNotFoundException.php
+++ b/src/Illuminate/Database/RecordNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class RecordNotFoundException extends RuntimeException
+{
+    //
+}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2775,6 +2775,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? limit 1', [1], true)->andReturn([]);
 
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [])->andReturn([]);
+
         $this->expectException(RecordNotFoundException::class);
         $this->expectExceptionMessage("No record found for the given query.");
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Query\JoinClause;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Illuminate\Database\Query\Processors\PostgresProcessor;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\RecordNotFoundException;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
@@ -2756,6 +2757,28 @@ class DatabaseQueryBuilderTest extends TestCase
         });
         $results = $builder->from('users')->where('id', '=', 1)->first();
         $this->assertEquals(['foo' => 'bar'], $results);
+    }
+
+    public function testFirstOrFailMethodReturnsFirstResult()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? limit 1', [1], true)->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->firstOrFail();
+        $this->assertEquals(['foo' => 'bar'], $results);
+    }
+
+    public function testFirstOrFailMethodThrowsRecordNotFoundException()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? limit 1', [1], true)->andReturn([]);
+
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage("No record found for the given query.");
+
+        $builder->from('users')->where('id', '=', 1)->firstOrFail();
     }
 
     public function testPluckMethodGetsCollectionOfColumnValues()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2778,7 +2778,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [])->andReturn([]);
 
         $this->expectException(RecordNotFoundException::class);
-        $this->expectExceptionMessage("No record found for the given query.");
+        $this->expectExceptionMessage('No record found for the given query.');
 
         $builder->from('users')->where('id', '=', 1)->firstOrFail();
     }


### PR DESCRIPTION

**Introduce `firstOrFail` for Database Query Builder:**

This pull request introduces the `firstOrFail` method to the `BuildsQueries` class within Laravel's database query builder. This method mirrors the functionality of the existing `firstOrFail` method available in Eloquent models, providing a convenient way to retrieve the first result of a query or throw an exception if no record is found.

**Benefits:**

* **Improved Code Readability:** Using `firstOrFail` in your database queries can enhance code readability and maintain consistency with Eloquent usage.
* **Reduced Boilerplate:** This eliminates the need for explicit checks for null results followed by exception handling, streamlining your code.
* **Error Handling Consistency:** It enforces consistent error handling in both database queries and Eloquent models.

**Implementation Details:**

* The new `firstOrFail` method accepts two arguments:
    * `$columns` (optional): An array or string specifying the columns to select (defaults to `'*'`).
    * `$message` (optional): A custom message to include in the thrown `RecordNotFoundException`.
* The method first calls `first($columns)` to retrieve the first result.
* If a result is found, it's returned directly.
* If no record is found, a `RecordNotFoundException` is thrown with the provided message (or a default message if none is given).

**Testing:**

* Two unit tests are included in `DatabaseQueryBuilderTest`:
    * `testFirstOrFailMethodReturnsFirstResult` verifies that the method correctly returns the first result when found.
    * `testFirstOrFailMethodThrowsRecordNotFoundException` ensures the method throws a `RecordNotFoundException` when no record exists.

**Adoption:**

Once merged, this method can be used directly in your database queries to retrieve the first result or gracefully handle situations where no record is found.

**Example Usage:**

```php
$user = DB::table('flights')->firstOrFail();

// Or with where()
$user = DB::table('users')->where('id', 1)->firstOrFail();

// Or with a custom message
$post = DB::table('posts')->where('slug', 'my-post')->firstOrFail(message: 'No post found with that slug');
```


Thank You!
