### PR TITLE
[11.x] Add `containsNone` in the Str and Stringable support classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -293,6 +293,25 @@ class Str
     }
 
     /**
+     * Determine if a given string contains none of the array values.
+     *
+     * @param  string  $haystack
+     * @param  iterable<string>  $needles
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public static function containsNone($haystack, $needles, $ignoreCase = false)
+    {
+        foreach ($needles as $needle) {
+            if (static::contains($haystack, $needle, $ignoreCase)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Convert the case of a string.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -202,6 +202,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string contains none of the array values.
+     *
+     * @param  iterable<string>  $needles
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public function containsNone($needles, $ignoreCase = false)
+    {
+        return Str::containsNone($this->value, $needles, $ignoreCase);
+    }
+
+    /**
      * Convert the case of a string.
      *
      * @param  int  $mode

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -354,6 +354,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals($expected, Str::containsAll($haystack, $needles, $ignoreCase));
     }
 
+    #[DataProvider('strContainsNoneProvider')]
+    public function testStrContainsNone($haystack, $needles, $expected, $ignoreCase = false)
+    {
+        $this->assertEquals($expected, Str::containsNone($haystack, $needles, $ignoreCase));
+    }
+
     public function testConvertCase()
     {
         // Upper Case Conversion
@@ -1211,6 +1217,18 @@ class SupportStrTest extends TestCase
             ['Taylor Otwell', ['taylor'], false, false],
             ['Taylor Otwell', ['taylor'], true, true],
             ['Taylor Otwell', ['taylor', 'xxx'], false, false],
+            ['Taylor Otwell', ['taylor', 'xxx'], false, true],
+        ];
+    }
+
+    public static function strContainsNoneProvider()
+    {
+        return [
+            ['Taylor Otwell', ['taylor', 'otwell'], true, false],
+            ['Taylor Otwell', ['taylor', 'otwell'], false, true],
+            ['Taylor Otwell', ['taylor'], true, false],
+            ['Taylor Otwell', ['taylor'], false, true],
+            ['Taylor Otwell', ['taylor', 'xxx'], true, false],
             ['Taylor Otwell', ['taylor', 'xxx'], false, true],
         ];
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -711,6 +711,18 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));
     }
 
+    public function testContainsNone()
+    {
+        $this->assertTrue($this->stringable('taylor otwell')->containsNone(['laravel']));
+        $this->assertTrue($this->stringable('taylor otwell')->containsNone(['laravel', 'framework']));
+        $this->assertTrue($this->stringable('taylor otwell')->containsNone(['Taylor', 'Otwell']));
+        $this->assertFalse($this->stringable('taylor otwell')->containsNone(['taylor', 'laravel', 'framework']));
+        $this->assertTrue($this->stringable('taylor otwell')->containsNone(['laravel'], true));
+        $this->assertTrue($this->stringable('taylor otwell')->containsNone(['laravel', 'framework'], true));
+        $this->assertFalse($this->stringable('taylor otwell')->containsNone(['Taylor', 'Otwell'], true));
+        $this->assertFalse($this->stringable('taylor otwell')->containsNone(['TAYLOR', 'laravel', 'framework'], true));
+    }
+
     public function testParseCallback()
     {
         $this->assertEquals(['Class', 'method'], $this->stringable('Class@method')->parseCallback('foo'));


### PR DESCRIPTION
This PR adds a complementary `containsNone()` function to the String and Stringable helper. This function supports the inverted logic of `containsAll()`. This is a non-breaking change as it introduces a new function with a similar signature.

```php
Str::containsNone('Laravel is a fantastic framework', ['Fluff', 'Bloat']); // true
Str::of('Laravel is a fantastic framework')->containsNone(['Fluff', 'Bloat'], true); // true
```

✅ Backward compatible: Added as a new function with an already familiar signature
✅ Reviewed the existing PR (#40396) closed because of the naming confusion, so carefully chose `containsNone`
✅ Added under both Str and Stringable support classes
✅ Included tests for both functions
✅ PR submitted to the current branch since non-breaking change
✅ Added a clever wordplay in the example provided 😉 