### PR TITLE
[10.x]  Change ssl: broken pipe to broken pipe

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -52,7 +52,7 @@ trait DetectsLostConnections
             'SSL: Connection timed out',
             'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
             'Temporary failure in name resolution',
-            'SSL: Broken pipe',
+            'Broken pipe',
             'SQLSTATE[08S01]: Communication link failure',
             'SQLSTATE[08006] [7] could not connect to server: Connection refused Is the server running on host',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: No route to host',


### PR DESCRIPTION
I encountered a similar case as #36601 

When without using SSL connection to database, error does not include string `SSL` in message. 

```
PDO::prepare(): Send of 86 bytes failed with errno=32 Broken pipe (Connection: mysql, SQL: select * from `users` where `uid` = 793d85e0-fe04-4482-a39d-03de71c78f45 and `deleted_at` is null limit 1) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 0): PDO::prepare(): Send of 86 bytes failed with errno=32 Broken pipe (Connection: mysql, SQL: select * from `users` where `uid` = 793d85e0-fe04-4482-a39d-03de71c78f45 and `deleted_at` is null limit 1) at /var/www/vendor/laravel/framework/src/Illuminate/Database/Connection.php:829)
```

After above error is thrown once, subsequent queries have no errors. Therefore, my guess is [this function](https://github.com/laravel/framework/blob/55b95392812ef97fc94714fb591a670927335f9c/src/Illuminate/Database/Connection.php#L978) cannot catch it.  
