### PR TITLE
[11.x] Fix return type hint of resolveRouteBindingQuery

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -43,7 +43,7 @@ trait HasUlids
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     * @return \Illuminate\Database\Query\Builder
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -43,7 +43,7 @@ trait HasUuids
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     * @return \Illuminate\Database\Query\Builder
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2131,7 +2131,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     * @return \Illuminate\Database\Query\Builder
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {


### PR DESCRIPTION
When overriding `resolveRouteBinding` (as suggested by the docs) to remove a global scope:

```php
public function resolveRouteBinding($value, $field = null): ?User
{
    return $this->resolveRouteBindingQuery($this, $value, $field)
        ->withoutGlobalScope(ActiveUserScope::class)
        ->first();
}
```

results in the following PHPStan error:

    "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\:\\:withoutGlobalScope\\(\\)\\.$#"

Because a Builder is returned, not a Relation.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
