### PR TITLE
[11.x] Add isCurrentlyOwnedBy function to lock

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -144,6 +144,16 @@ abstract class Lock implements LockContract
     }
 
     /**
+     * Determines whether this lock is owned by the given identifier.
+     *
+     * @return bool
+     */
+    public function isCurrentlyOwnedBy($owner = null)
+    {
+        return $this->getCurrentOwner() === $owner;
+    }
+
+    /**
      * Determines whether this lock is allowed to release the lock in the driver.
      *
      * @return bool

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -144,23 +144,24 @@ abstract class Lock implements LockContract
     }
 
     /**
-     * Determines whether this lock is owned by the given identifier.
-     *
-     * @return bool
-     */
-    public function isCurrentlyOwnedBy($owner = null)
-    {
-        return $this->getCurrentOwner() === $owner;
-    }
-
-    /**
      * Determines whether this lock is allowed to release the lock in the driver.
      *
      * @return bool
      */
     public function isOwnedByCurrentProcess()
     {
-        return $this->getCurrentOwner() === $this->owner;
+        return $this->isOwnedBy($this->owner);
+    }
+
+    /**
+     * Determine whether this lock is owned by the given identifier.
+     *
+     * @param  string|null  $owner
+     * @return bool
+     */
+    public function isOwnedBy($owner)
+    {
+        return $this->getCurrentOwner() === $owner;
     }
 
     /**

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -104,9 +104,12 @@ class FileCacheLockTest extends TestCase
         Cache::lock('foo')->forceRelease();
 
         $firstLock = Cache::lock('foo', 10);
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
         $this->assertTrue($firstLock->get());
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('file')->restoreLock('foo', 'other_owner');
+        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -104,12 +104,12 @@ class FileCacheLockTest extends TestCase
         Cache::lock('foo')->forceRelease();
 
         $firstLock = Cache::lock('foo', 10);
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
+        $this->assertTrue($firstLock->isOwnedBy(null));
         $this->assertTrue($firstLock->get());
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($firstLock->isOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('file')->restoreLock('foo', 'other_owner');
-        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($secondLock->isOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -97,9 +97,12 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
         Cache::store('memcached')->lock('foo')->forceRelease();
 
         $firstLock = Cache::store('memcached')->lock('foo', 10);
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
         $this->assertTrue($firstLock->get());
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('memcached')->restoreLock('foo', 'other_owner');
+        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -97,12 +97,12 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
         Cache::store('memcached')->lock('foo')->forceRelease();
 
         $firstLock = Cache::store('memcached')->lock('foo', 10);
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
+        $this->assertTrue($firstLock->isOwnedBy(null));
         $this->assertTrue($firstLock->get());
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($firstLock->isOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('memcached')->restoreLock('foo', 'other_owner');
-        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($secondLock->isOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -126,9 +126,12 @@ class RedisCacheLockTest extends TestCase
         Cache::store('redis')->lock('foo')->forceRelease();
 
         $firstLock = Cache::store('redis')->lock('foo', 10);
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
         $this->assertTrue($firstLock->get());
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('redis')->restoreLock('foo', 'other_owner');
+        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -126,12 +126,12 @@ class RedisCacheLockTest extends TestCase
         Cache::store('redis')->lock('foo')->forceRelease();
 
         $firstLock = Cache::store('redis')->lock('foo', 10);
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
+        $this->assertTrue($firstLock->isOwnedBy(null));
         $this->assertTrue($firstLock->get());
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($firstLock->isOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('redis')->restoreLock('foo', 'other_owner');
-        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($secondLock->isOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -56,4 +56,16 @@ class DatabaseLockTest extends DatabaseTestCase
 
         $otherLock->release();
     }
+
+    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    {
+        $firstLock = Cache::store('database')->lock('foo');
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
+        $this->assertTrue($firstLock->get());
+        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
+
+        $secondLock = Cache::store('database')->restoreLock('foo', 'other_owner');
+        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertFalse($secondLock->isOwnedByCurrentProcess());
+    }
 }

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -60,12 +60,12 @@ class DatabaseLockTest extends DatabaseTestCase
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
     {
         $firstLock = Cache::store('database')->lock('foo');
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy(null));
+        $this->assertTrue($firstLock->isOwnedBy(null));
         $this->assertTrue($firstLock->get());
-        $this->assertTrue($firstLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($firstLock->isOwnedBy($firstLock->owner()));
 
         $secondLock = Cache::store('database')->restoreLock('foo', 'other_owner');
-        $this->assertTrue($secondLock->isCurrentlyOwnedBy($firstLock->owner()));
+        $this->assertTrue($secondLock->isOwnedBy($firstLock->owner()));
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }


### PR DESCRIPTION
This PR adds support for checking the current owner of a lock. I consider this PR as a follow up to: https://github.com/laravel/framework/pull/49249

We have a use case where we want to check if a given lock is active or not (if it's locked then we don't want to make a function call). Currently I can check if the lock I've created is owned by the process or not with the `isOwnedByCurrentProcess` but, if the lock is not active, the result will be `false` and I cannot check if it's false because it's not locked, or its owned by another process. 