### PR TITLE
[11.x] Add ``target`` existence validation and forcible creation to ``storage:link`` command

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -33,10 +33,21 @@ class StorageLinkCommand extends Command
     {
         $relative = $this->option('relative');
 
+        $force = $this->option('force');
+
         foreach ($this->links() as $link => $target) {
-            if (file_exists($link) && ! $this->isRemovableSymlink($link, $this->option('force'))) {
+            if (! file_exists($target) && ! $force) {
+                $this->components->error("The [$target] target does not exist.");
+                continue;
+            }
+
+            if (file_exists($link) && ! $this->isRemovableSymlink($link, $force)) {
                 $this->components->error("The [$link] link already exists.");
                 continue;
+            }
+
+            if (! file_exists($target)) {
+                $this->laravel->make('files')->ensureDirectoryExists($target);
             }
 
             if (is_link($link)) {


### PR DESCRIPTION
This PR adds following to the ```StorageLinkCommand```
-  ``target`` existence  validation 
- ability to create nonexistent ``target`` directory with ``--force`` option
