### PR TITLE
[11.x] add getOptions method to the eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -716,6 +716,26 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get options data to use in select box.
+     *
+     * @param  string  $label
+     * @param  string  $value
+     * @param  string  $labelKey
+     * @param  string  $valueKey
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getOptions($label = 'name', $value = 'id', $labelKey = 'label', $valueKey = 'value')
+    {
+        return $this->applyScopes()
+        ->pluck($label, $value)
+        ->map(fn($labelItem, $valueItem) => [
+            $labelKey => $labelItem,
+            $valueKey => $valueItem,
+        ])
+        ->values();
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -728,7 +728,7 @@ class Builder implements BuilderContract
     {
         return $this->applyScopes()
         ->pluck($label, $value)
-        ->map(fn($labelItem, $valueItem) => [
+        ->map(fn ($labelItem, $valueItem) => [
             $labelKey => $labelItem,
             $valueKey => $valueItem,
         ])


### PR DESCRIPTION
Dear sir
I have been created a method called getOptions for the eloquent builder.
This method is used to retrieve the options data for the select box.
For example:
```
\App\Models\User::query()->getOptions();
```
This will return collection with `label` and `value` keys with the name as label and id as a value by default. 
In addition to, you can customize all the keys names as a parameters. 