### PR TITLE
[10.x] Revert "[10.x]  Change ssl: broken pipe to broken pipe"

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -52,7 +52,7 @@ trait DetectsLostConnections
             'SSL: Connection timed out',
             'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
             'Temporary failure in name resolution',
-            'Broken pipe',
+            'SSL: Broken pipe',
             'SQLSTATE[08S01]: Communication link failure',
             'SQLSTATE[08006] [7] could not connect to server: Connection refused Is the server running on host',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: No route to host',


### PR DESCRIPTION
Reverts laravel/framework#51388. It's possible the query succeeded and the result could not be fetched due to a broken pipe. It's only safe to do this at the SSL negotiation phase, not the query sending/receiving rows phases. Laravel should never accidentally run a query twice.