### PR TITLE
[11.x] Set the value of `$this` in macro closures

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -21,6 +21,9 @@ trait Macroable
      *
      * @param  string  $name
      * @param  object|callable  $macro
+     *
+     * @param-closure-this static  $macro
+     *
      * @return void
      */
     public static function macro($name, $macro)


### PR DESCRIPTION
PHPStan 1.11.0 introduced a way to set the value of `$this` inside closures (https://phpstan.org/blog/phpstan-1-11-errors-identifiers-phpstan-pro-reboot#what-is-a-passed-closure-bound-to%3F). Setting this on the `Macroable` trait allows for all uses of that trait to benefit from the static analyser knowing the actual value of `$this`.