### PR TITLE
[11.x] Remove isset assumption on MYSQL Schema Connection

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -109,7 +109,7 @@ class MySqlSchemaState extends SchemaState
                         ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
                         : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
 
-        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_CA])) {
+        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_CA]) && $config['options'][\PDO::MYSQL_ATTR_SSL_CA]) {
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -68,6 +68,25 @@ class DatabaseMySqlSchemaStateTest extends TestCase
             ],
         ];
 
+        yield 'empty ssl_ca' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '127.0.0.1',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'host' => '127.0.0.1',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_CA => '',
+                ],
+            ],
+        ];
+
         yield 'unix socket' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
                 'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',


### PR DESCRIPTION
It is common for `PDO::MYSQL_ATTR_SSL_CA` to be set in `database.php` but have it disabled or empty, normally controlled by as an environment variable.

In the MySQL schema state, it is assumed that the PDO array element must contain data if it is set. 

This causes errors when dumping schema files or importing schema files during migrations.

I've added a check in the original if statement and a test that replicates the original behaviour.

