### PR TITLE
[11.x] MailMakeCommand: Add new `--view` option

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -48,6 +49,10 @@ class MailMakeCommand extends GeneratorCommand
         if ($this->option('markdown') !== false) {
             $this->writeMarkdownTemplate();
         }
+
+        if ($this->option('view') !== false) {
+            $this->writeView();
+        }
     }
 
     /**
@@ -69,6 +74,30 @@ class MailMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Write the Blade template for the mailable.
+     *
+     * @return void
+     */
+    protected function writeView()
+    {
+        $path = $this->viewPath(
+            str_replace('.', '/', $this->getView()) . '.blade.php'
+        );
+
+        if (!$this->files->isDirectory(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0755, true);
+        }
+
+        $stub = str_replace(
+            '{{ quote }}',
+            Inspiring::quotes()->random(),
+            file_get_contents(__DIR__ . '/stubs/view.stub')
+        );
+
+        $this->files->put($path, $stub);
+    }
+
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name
@@ -82,7 +111,7 @@ class MailMakeCommand extends GeneratorCommand
             parent::buildClass($name)
         );
 
-        if ($this->option('markdown') !== false) {
+        if ($this->option('markdown') !== false || $this->option('view') !== false) {
             $class = str_replace(['DummyView', '{{ view }}'], $this->getView(), $class);
         }
 
@@ -96,7 +125,7 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function getView()
     {
-        $view = $this->option('markdown');
+        $view = $this->option('markdown') ?: $this->option('view');
 
         if (! $view) {
             $name = str_replace('\\', '/', $this->argument('name'));
@@ -116,10 +145,15 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->resolveStubPath(
-            $this->option('markdown') !== false
-                ? '/stubs/markdown-mail.stub'
-                : '/stubs/mail.stub');
+        if ($this->option('markdown') !== false) {
+            return $this->resolveStubPath('/stubs/markdown-mail.stub');
+        }
+
+        if ($this->option('view') !== false) {
+            return $this->resolveStubPath('/stubs/view-mail.stub');
+        }
+
+        return $this->resolveStubPath('/stubs/mail.stub');
     }
 
     /**
@@ -156,6 +190,7 @@ class MailMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists'],
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable', false],
+            ['view', null, InputOption::VALUE_OPTIONAL, 'Create a new Blade template for the mailable', false],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -84,9 +84,7 @@ class MailMakeCommand extends GeneratorCommand
             str_replace('.', '/', $this->getView()) . '.blade.php'
         );
 
-        if (!$this->files->isDirectory(dirname($path))) {
-            $this->files->makeDirectory(dirname($path), 0755, true);
-        }
+        $this->files->ensureDirectoryExists(dirname($path));
 
         $stub = str_replace(
             '{{ quote }}',

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -66,9 +66,7 @@ class MailMakeCommand extends GeneratorCommand
             str_replace('.', '/', $this->getView()).'.blade.php'
         );
 
-        if (! $this->files->isDirectory(dirname($path))) {
-            $this->files->makeDirectory(dirname($path), 0755, true);
-        }
+        $this->files->ensureDirectoryExists(dirname($path));
 
         $this->files->put($path, file_get_contents(__DIR__.'/stubs/markdown.stub'));
     }

--- a/src/Illuminate/Foundation/Console/stubs/view-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-mail.stub
@@ -1,0 +1,53 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class {{ class }} extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '{{ subject }}',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: '{{ view }}',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -46,6 +46,22 @@ class MailMakeCommandTest extends TestCase
         ], 'resources/views/foo-mail.blade.php');
     }
 
+    public function testItCanGenerateMailFileWithViewOption()
+    {
+        $this->artisan('make:mail', ['name' => 'FooMail', '--view' => 'foo-mail'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Mail;',
+            'use Illuminate\Mail\Mailable;',
+            'class FooMail extends Mailable',
+            'return new Content(',
+            "view: 'foo-mail',",
+        ], 'app/Mail/FooMail.php');
+
+        $this->assertFilenameExists('resources/views/foo-mail.blade.php');
+    }
+
     public function testItCanGenerateMailFileWithTest()
     {
         $this->artisan('make:mail', ['name' => 'FooMail', '--test' => true])


### PR DESCRIPTION
This pull request adds a new `--view` option to the `make:mail` command that will create a new empty Blade file and configure the `Mailable` to use it by default.

It behaves the same way as the existing `--markdown` option.

I imagine this would be a nice and small workflow optimisation for folks, including myself. I'm always creating new Blade views for regular HTML emails and manually updating the `Mailable`.