### PR TITLE
[11.x] SQLite: Add support for strict tables

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -283,6 +283,17 @@ class Blueprint
     }
 
     /**
+     * Indicate that the table should be created in strict mode.
+     * This only affects SQLite v3.37.0 and later.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function strict()
+    {
+        return $this->addCommand('strict');
+    }
+
+    /**
      * Specify the storage engine that should be used for the table.
      *
      * @param  string  $engine

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -140,12 +140,13 @@ class SQLiteGrammar extends Grammar
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('%s table %s (%s%s%s)',
+        return sprintf('%s table %s (%s%s%s)%s',
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint)),
             $this->addForeignKeys($this->getCommandsByName($blueprint, 'foreign')),
-            $this->addPrimaryKeys($this->getCommandByName($blueprint, 'primary'))
+            $this->addPrimaryKeys($this->getCommandByName($blueprint, 'primary')),
+            $this->getCommandByName($blueprint, 'strict') ? ' strict' : '',
         );
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -56,6 +56,19 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create temporary table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
     }
 
+    public function testCreateStrictTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->strict();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table "users" ("id" integer primary key autoincrement not null, "email" varchar not null) strict', $statements[0]);
+    }
+
     public function testDropTable()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This pull request adds support for strict tables in SQLite.

```php
Schema::create('users', function (Blueprint $table) {
	$table->id();
	$table->strict(); // This makes the table "STRICT".
});
```

I think this is a worthy addition to the framework, but I'm not entirely sure I've gone the right way about doing it.

a) It feels weird having a method specific to this one SQLite feature on the `Blueprint` class.
b) Should this be something that you call inside of the `Schema::create()` callback?

I considered adding a specific `createStrict()` method, but that doesn't feel like a "Laravel-esque" thing to do?
I also thought about making `Schema::create(...)->strict()`, but that would be a bit of a refactor since the `Schema::create()` method returns `void` atm.

I'm not sure. Some opinions and thoughts would be much appreciated.