### PR TITLE
Replace provider file content

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -501,13 +501,14 @@ abstract class ServiceProvider
             ->map(fn ($p) => '    '.$p.'::class,')
             ->implode(PHP_EOL);
 
-        $content = '<?php
+        $original = file_get_contents($path);
 
-return [
+        $replacement = 'return [
 '.$providers.'
 ];';
+        $content = preg_replace('/return\s\[[\s\S]+\];/m', $replacement, $original);
 
-        file_put_contents($path, $content.PHP_EOL);
+        file_put_contents($path, $content);
 
         return true;
     }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -506,7 +506,7 @@ abstract class ServiceProvider
         $replacement = 'return [
 '.$providers.'
 ];';
-        $content = preg_replace('/return\s\[[\s\S]+\];/m', $replacement, $original);
+        $content = preg_replace('/return\s\[[\s\S]*\];/m', $replacement, $original);
 
         file_put_contents($path, $content);
 


### PR DESCRIPTION
In one of my projects I'm enforcing `declare(strict_types=1);` with a QA rule.

That's how I found out that `ServiceProvider::addProviderToBootstrapFile()` replaces the whole file. After adding a provider, the strict type declaration was removed from the file and making my QA fail.

This PR improves on this, by only replacing the relevant part of the file (the array part). It does so by using regex. It isn't a perfect solution, but at least everything around the array would stay untouched. Because `bootstrap/providers.php` normally doesn't contain a lot of other code, I think this is fine for most general use-cases.