### PR TITLE
Fix return type docs for Mailer::send

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -293,7 +293,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  array  $data
      * @param  \Closure|string|null  $callback
-     * @return \Illuminate\Mail\SentMessage|null
+     * @return \Illuminate\Mail\SentMessage|null|mixed
      */
     public function send($view, array $data = [], $callback = null)
     {
@@ -348,7 +348,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send the given mailable.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
-     * @return \Illuminate\Mail\SentMessage|null
+     * @return \Illuminate\Mail\SentMessage|null|mixed
      */
     protected function sendMailable(MailableContract $mailable)
     {


### PR DESCRIPTION
If Mailer::send is passed a value that implements both `Illuminate\Contracts\Mail\Mailable` and `Illuminate\Contracts\Queue\ShouldQueue`, this method would return the id of the queued job (which is an int by defaut). Currently, this is not reflected in its return type. [This came up in a package](https://github.com/simonschaufi/laravel-dkim/pull/25) where `Mailer` was overriden with an explicit return type, which caused the method to fail under the circumstances described above.

Since `Mailer::queue` reports the return type being `mixed`, I would suggest to add that to `send` as well. However, I am aware that `mixed` would also include the other types, so it might as well just be `mixed`. I am not sure if `\Illuminate\Mail\SentMessage|null|mixed` or just `mixed` would be the better solution in this case.