### PR TITLE
[11.x] - Compare lowercased column names in getColumnType

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -293,7 +293,7 @@ class Builder
         $columns = $this->getColumns($table);
 
         foreach ($columns as $value) {
-            if (strtolower($value['name']) === $column) {
+            if (strtolower($value['name']) === strtolower($column)) {
                 return $fullDefinition ? $value['type'] : $value['type_name'];
             }
         }


### PR DESCRIPTION
I saw issue #51429 and wanted to comment that it is the responsibility of the caller to use lowercased names, but then looking at the implementation, the code already lowercases the column names it reads from the schema, so it should also be comparing them to a lowercased version of the passed in name.