### PR TITLE
[11.x] Allow factory to link to parent model without defining relationship model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -49,7 +49,6 @@ class BelongsToRelationship
      */
     public function attributesFor(Model $model)
     {
-
         // Auto handle a 'belongsTo' relationship when no relation method found in the model linked to factory
         if (method_exists($model, $this->relationship)) {
             $relationship = $model->{$this->relationship}();

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -54,7 +54,8 @@ class BelongsToRelationship
         if (method_exists($model, $this->relationship)) {
             $relationship = $model->{$this->relationship}();
         } else {
-            $relationship = $model->belongsTo($this->factory->modelName(), relation: $this->relationship);
+            $related = $this->factory instanceof Factory ? $this->factory->modelName() : $this->factory::class;
+            $relationship = $model->belongsTo($related, relation: $this->relationship);
         }
 
         return $relationship instanceof MorphTo ? [

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -49,7 +49,13 @@ class BelongsToRelationship
      */
     public function attributesFor(Model $model)
     {
-        $relationship = $model->{$this->relationship}();
+
+        // Auto handle a 'belongsTo' relationship when no relation method found in the model linked to factory
+        if (method_exists($model, $this->relationship)) {
+            $relationship = $model->{$this->relationship}();
+        } else {
+            $relationship = $model->belongsTo($this->factory->modelName(), relation: $this->relationship);
+        }
 
         return $relationship instanceof MorphTo ? [
             $relationship->getMorphType() => $this->factory instanceof Factory ? $this->factory->newModel()->getMorphClass() : $this->factory->getMorphClass(),

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -331,6 +331,21 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestPost::all());
     }
 
+    public function test_belongs_to_relationship_with_existing_model_instance_and_relation_method_not_exist()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+        $posts = FactoryTestPostFactoryWithModelWithoutDefinedRelationship::times(3)
+            ->for($user, 'user')
+            ->create();
+
+        $this->assertCount(3, $posts->filter(function ($post) use ($user) {
+            return $post->belongsTo(FactoryTestUser::class, 'user_id')->is($user);
+        }));
+
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
+    }
+
     public function test_morph_to_relationship()
     {
         $posts = FactoryTestCommentFactory::times(3)
@@ -914,6 +929,16 @@ class FactoryTestPost extends Eloquent
     {
         return $this->morphMany(FactoryTestComment::class, 'commentable');
     }
+}
+
+class FactoryTestPostFactoryWithModelWithoutDefinedRelationship extends FactoryTestPostFactory
+{
+    protected $model = FactoryTestPostWithoutDefinedRelationship::class;
+}
+
+class FactoryTestPostWithoutDefinedRelationship extends Eloquent
+{
+    protected $table = 'posts';
 }
 
 class FactoryTestCommentFactory extends Factory


### PR DESCRIPTION
**Situation**

When doing some testing in a project, I've face a thing which could happened in some situations.

Imagine we have a model `Computer` and another which is `ComputerReport`.

Let's say we would like to build a view to show a list of every computers (`Computer`), and inside of a specific computer view, show all the linked reports (`ComputerReport`). In this really simple situation, I think we'll have a relationship method like `->reports()` on our `Computer` model, but I think it's useless to have a relation like `->computer()` on the `ComputerReport` model as we'll never use it.

**The problem**

When writing the testing logic :

```php
$computer = Computer::factory()->create(['name' => 'My Computer']);
ComputerReport::factory()->for($computer)->create();
```

We'll be facing the following problem :

`Call to undefined method App\Models\ComputerReport::computer()`

Because the logic just don't find the missing `->computer()` method in our `ComputerReport` model.

**Solution**

So, this PR make it work in this type of situation and don't force us to fill our model with logic which is only needed during testing. This is done though a `belongsTo` relation.