### PR TITLE
[ 11.x ] Adds ability to manually fail a command from outside the handle() method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -210,11 +210,39 @@ class Command extends SymfonyCommand
 
         try {
             return (int) $this->laravel->call([$this, $method]);
+        } catch (ManuallyFailedException $e) {
+            $this->error($e->getMessage());
+
+            return static::FAILURE;
         } finally {
             if ($this instanceof Isolatable && $this->option('isolated') !== false) {
                 $this->commandIsolationMutex()->forget($this);
             }
         }
+    }
+
+    /**
+     * Fail the command manually.
+     *
+     * @param  \Throwable|string|null  $exception
+     * @return void
+     */
+    public function fail($exception = null)
+    {
+        if (is_null($exception)) {
+            $exception = 'Command Failed Manually.';
+        }
+
+        if (is_string($exception)) {
+            $exception = new ManuallyFailedException($exception);
+        }
+
+        if ($exception instanceof \Throwable) {
+            throw $exception;
+        }
+
+        $msg = 'The command was failed manually, but the Command::fail method expects a string or an instance of Throwable.';
+        throw new \InvalidArgumentException($msg);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class Command extends SymfonyCommand
 {
@@ -211,7 +212,7 @@ class Command extends SymfonyCommand
         try {
             return (int) $this->laravel->call([$this, $method]);
         } catch (ManuallyFailedException $e) {
-            $this->error($e->getMessage());
+            $this->components->error($e->getMessage());
 
             return static::FAILURE;
         } finally {
@@ -219,30 +220,6 @@ class Command extends SymfonyCommand
                 $this->commandIsolationMutex()->forget($this);
             }
         }
-    }
-
-    /**
-     * Fail the command manually.
-     *
-     * @param  \Throwable|string|null  $exception
-     * @return void
-     */
-    public function fail($exception = null)
-    {
-        if (is_null($exception)) {
-            $exception = 'Command Failed Manually.';
-        }
-
-        if (is_string($exception)) {
-            $exception = new ManuallyFailedException($exception);
-        }
-
-        if ($exception instanceof \Throwable) {
-            throw $exception;
-        }
-
-        $msg = 'The command was failed manually, but the Command::fail method expects a string or an instance of Throwable.';
-        throw new \InvalidArgumentException($msg);
     }
 
     /**
@@ -280,6 +257,25 @@ class Command extends SymfonyCommand
         }
 
         return $command;
+    }
+
+    /**
+     * Fail the command manually.
+     *
+     * @param  \Throwable|string|null  $exception
+     * @return void
+     */
+    public function fail(Throwable|string|null $exception = null)
+    {
+        if (is_null($exception)) {
+            $exception = 'Command failed manually.';
+        }
+
+        if (is_string($exception)) {
+            $exception = new ManuallyFailedException($exception);
+        }
+
+        throw $exception;
     }
 
     /**

--- a/src/Illuminate/Console/ManuallyFailedException.php
+++ b/src/Illuminate/Console/ManuallyFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Console;
+
+use RuntimeException;
+
+class ManuallyFailedException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Closure;
 use Illuminate\Console\Command;
+use Illuminate\Console\ManuallyFailedException;
 use Illuminate\Support\Facades\Schedule;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionFunction;
@@ -58,9 +59,15 @@ class ClosureCommand extends Command
             }
         }
 
-        return (int) $this->laravel->call(
-            $this->callback->bindTo($this, $this), $parameters
-        );
+        try {
+            return (int) $this->laravel->call(
+                $this->callback->bindTo($this, $this), $parameters
+            );
+        } catch (ManuallyFailedException $e) {
+            $this->components->error($e->getMessage());
+
+            return static::FAILURE;
+        }
     }
 
     /**

--- a/tests/Integration/Console/CommandManualFailTest.php
+++ b/tests/Integration/Console/CommandManualFailTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Command;
+use Illuminate\Console\ManuallyFailedException;
+use Orchestra\Testbench\TestCase;
+
+class CommandManualFailTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Artisan::starting(function ($artisan) {
+            $artisan->resolveCommands([
+                FailingCommandStub::class,
+            ]);
+        });
+
+        parent::setUp();
+    }
+
+    public function testFailArtisanCommandManually()
+    {
+        $this->artisan('app:fail')->assertFailed();
+    }
+    
+    public function testCreatesAnExceptionFromString()
+    {
+        $this->expectException(ManuallyFailedException::class);
+        $command = new Command;
+        $command->fail('Whoops!');
+    }
+    
+    public function testCreatesAnExceptionFromNull()
+    {
+        $this->expectException(ManuallyFailedException::class);
+        $command = new Command;
+        $command->fail();
+    }
+}
+
+class FailingCommandStub extends Command
+{
+    protected $signature = 'app:fail';
+
+    public function handle()
+    {
+        $this->trigger_failure();
+
+        // This should never be reached.
+        return static::SUCCESS;
+    }
+
+    protected function trigger_failure()
+    {
+        $this->fail('Whoops!');
+    }
+}

--- a/tests/Integration/Console/CommandManualFailTest.php
+++ b/tests/Integration/Console/CommandManualFailTest.php
@@ -24,14 +24,14 @@ class CommandManualFailTest extends TestCase
     {
         $this->artisan('app:fail')->assertFailed();
     }
-    
+
     public function testCreatesAnExceptionFromString()
     {
         $this->expectException(ManuallyFailedException::class);
         $command = new Command;
         $command->fail('Whoops!');
     }
-    
+
     public function testCreatesAnExceptionFromNull()
     {
         $this->expectException(ManuallyFailedException::class);


### PR DESCRIPTION
In a large and complex artisan command where smaller bits are extracted into separate methods (each of which is a possible failure point), we have a couple of options to exit with a non-zero exit code without dumping the entire Exception.

We can wrap the method call in a `try/catch`, and return in the catch block.
```php
    public function handle()
    {
        try {
            $this->trigger_failure();
        } catch (ManuallyFailedException $e) {
            $this->error($e->getMessage());

            return static::FAILURE;
        }
    }

    protected function trigger_failure()
    {
        throw new ManuallyFailedException("whoops!");
    }
```

We can use a return value and wrap it in an if block.
```php
    public function handle()
    {
        [$result, $error] = $this->trigger_failure();
        if (!is_null($error)) {
            $this->error($error->message);

            return static::FAILURE;
        }
    }

    protected function trigger_failure()
    {
        return [false, (object) [
            'message' => 'whoops!',
        ]];
    }
```

These obviously work just fine, but it's a paper cut I've run into many times. The Queue has a `$this->fail()` convenience method, so I've implemented one on the `Command` class to mimic it. This new approach feels more readable, and more intuitive. Since we're only working with a __custom__ Exception, backwards compatibility is fully maintained. Here's an example of this new method of failing a command outside of the `handle()` method:
```php
    public function handle()
    {
        $this->trigger_failure();
    }

    protected function trigger_failure()
    {
        $this->fail('Whoops!');
    }
```