### PR TITLE
[11.x] Fixes doc block in `Connector.php`

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -75,7 +75,7 @@ class Connector
      * @param  array  $options
      * @return \PDO
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     protected function tryAgainIfCausedByLostConnection(Throwable $e, $dsn, $username, $password, $options)
     {


### PR DESCRIPTION
This PR, fixes doc block in `tryAgainIfCausedByLostConnection` method.

The `@throws \Exception` has been changed to `@throws \Throwable`, which seems more appropriate, as the parameter `$e` is of type `Throwable`. 

Additionally, `Exception` itself extends `Throwable`.

```php

// Before
* @throws \Exception
*/
protected function tryAgainIfCausedByLostConnection(Throwable $e, $dsn, $username, $password, $options)

// After
* @throws \Throwable
*/
protected function tryAgainIfCausedByLostConnection(Throwable $e, $dsn, $username, $password, $options)
```