### PR TITLE
[11.x] Handle case when a seeder call includes php extension

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -85,6 +85,7 @@ class SeedCommand extends Command
     protected function getSeeder()
     {
         $class = $this->input->getArgument('class') ?? $this->input->getOption('class');
+        $class = str_replace('.php', '', $class);
 
         if (! str_contains($class, '\\')) {
             $class = 'Database\\Seeders\\'.$class;


### PR DESCRIPTION
I found myself frequently add "**.php**" to seeder when calling the command with "--class" arg, and I was bothered that Laravel isn't handling this simple yet common mistake, so I'm submitting this PR to address this issue.
