### PR TITLE
Possible fix for pivot models $table variable not respected / overridden

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use function class_uses_recursive;
+use function in_array;
 
 class BelongsToMany extends Relation
 {
@@ -336,6 +338,12 @@ class BelongsToMany extends Relation
     public function using($class)
     {
         $this->using = $class;
+
+        if (in_array(AsPivot::class, class_uses_recursive($class))) {
+            if ((new $class())->hasTableProperty()) {
+                $this->table = (new $class())->getTable();
+            }
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -169,6 +169,16 @@ trait AsPivot
     }
 
     /**
+     * Determine if the pivot model has a custom table filled as property.
+     *
+     * @return bool
+     */
+    public function hasTableProperty()
+    {
+        return isset($this->table);
+    }
+
+    /**
      * Get the foreign key column name.
      *
      * @return string

--- a/tests/Integration/Database/EloquentCustomPivotTableTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotTableTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Post;
+use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\PostTagPivot;
+use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\TagWithCustomPivot;
+use function dd;
+
+class EloquentCustomPivotTableTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+
+        Schema::create('projects', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('collaborators', function (Blueprint $table) {
+            $table->integer('eloquent_custom_pivot_table_user_id');
+            $table->integer('eloquent_custom_pivot_table_project_id');
+        });
+    }
+
+    public function testCustomTableIsUsedWhenAttaching()
+    {
+        $user = EloquentCustomPivotTableUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $project = EloquentCustomPivotTableProject::forceCreate([
+            'name' => 'Test EloquentCustomPivotTableProject',
+        ]);
+
+        $project->collaborators()->attach([$user->id]);
+
+
+        $this->assertSame('collaborators', $project->collaborators()->getTable());
+
+        //The next line throws an error
+        $this->assertInstanceOf(CustomPivotTableTestCollaborator::class, $project->collaborators[0]->pivot);
+
+        $this->assertEquals([
+            'eloquent_custom_pivot_table_user_id' => '1',
+            'eloquent_custom_pivot_table_project_id' => '1',
+        ], $project->collaborators[0]->toArray());
+    }
+}
+
+class EloquentCustomPivotTableUser extends Model
+{
+    public $table = 'users';
+    public $timestamps = false;
+}
+
+class EloquentCustomPivotTableProject extends Model
+{
+    public $table = 'projects';
+    public $timestamps = false;
+
+    public function collaborators()
+    {
+        return $this->belongsToMany(
+            EloquentCustomPivotTableUser::class
+        )->using(CustomPivotTableTestCollaborator::class);
+    }
+}
+
+class CustomPivotTableTestCollaborator extends Pivot
+{
+    public $timestamps = false;
+
+    protected $table = 'collaborators';
+}


### PR DESCRIPTION
This is more a proof of concept for a possible solution for issue #51410 as it adds functionality to the `->using()` function for a belongs to many relation that may be unnecessary.

I added a test that demonstrates that this fix solves the `->attach()` issue but the `->get()` functionality is still broken as it seems to not take in consideration the logic in the `->using()` function and defaults back to using the wrong table name (The error is also present in the test).

Keeping it as a draft for now as I'm not sure we want to add this extra complexity to the code base and also not sure if my solution is making any sense 😅 also the get functionality is still not working as expected/broken...