### PR TITLE
[11.x] Adds an app getter to the ViewServiceProvider.

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -170,4 +170,15 @@ class ViewServiceProvider extends ServiceProvider
             return $compiler;
         });
     }
+
+    /**
+     * Set the application instance used by the service provider.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function setApplication($app)
+    {
+        $this->app = $app;
+    }
 }


### PR DESCRIPTION
This PR is a first step towards solving a [memory leak](https://github.com/laravel/octane/issues/887) in laravel/octane.

Octane needs to be able to reset the application instance in the `ViewServiceProvider` since the provider changes the state of the original $app when re-registering the Blade engine (see `ViewServiceProvider:166`)
