### PR TITLE
[11.x] Adds `without` array helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -937,6 +937,18 @@ class Arr
     }
 
     /**
+     * Filter items where the value is not equal to the parameter
+     *
+     * @param  array  $array
+     * @param  mixed  $without
+     * @return array
+     */
+    public static function without($array, $without)
+    {
+        return static::where($array, fn ($value) => $value != $without);
+    }
+
+    /**
      * If the given value is not an array and not null, wrap it in one.
      *
      * @param  mixed  $value

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1392,4 +1392,35 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::select($array, 'name'));
     }
+
+    public function testWithout()
+    {
+        $this->assertEquals(
+            [1 => 2, 2 => 3],
+            Arr::without([1, 2, 3], 1)
+        );
+
+        $this->assertEquals(
+            [0 => 'foo', 2 => 'baz'],
+            Arr::without(['foo', 'bar', 'baz'], 'bar')
+        );
+
+        $this->assertEquals([
+            (object) ['name' => 'John'],
+            (object) ['name' => 'Mike'],
+        ], Arr::without([
+            (object) ['name' => 'John'],
+            (object) ['name' => 'Mike'],
+            (object) ['name' => 'Peter'],
+        ], (object) ['name' => 'Peter']));
+
+        $this->assertEquals([
+            'firstKey' => 'firstValue',
+            'thirdKey' => 'thirdValue',
+        ], Arr::without([
+            'firstKey' => 'firstValue',
+            'secondKey' => 'secondValue',
+            'thirdKey' => 'thirdValue',
+        ], 'secondValue'));
+    }
 }


### PR DESCRIPTION
`without` removes a value from an array

```php
Arr::without([10, 20, 30], 30);
// [10, 20]
```