### PR TITLE
[11.x] Fix fluent-style scheduling 

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -29,7 +29,14 @@ trait ManagesFrequencies
      */
     public function between($startTime, $endTime)
     {
-        return $this->when($this->inTimeInterval($startTime, $endTime));
+        [$startTimeCarbon, $endTimeCarbon] = [
+            Carbon::parse($startTime, $this->timezone),
+            Carbon::parse($endTime, $this->timezone),
+        ];
+        $hourExpression = $startTimeCarbon->hour.'-'.$endTimeCarbon->hour;
+
+        return $this->when($this->inTimeInterval($startTime, $endTime))
+            ->spliceIntoPosition(2, $hourExpression);
     }
 
     /**
@@ -41,7 +48,14 @@ trait ManagesFrequencies
      */
     public function unlessBetween($startTime, $endTime)
     {
-        return $this->skip($this->inTimeInterval($startTime, $endTime));
+        [$startTimeCarbon, $endTimeCarbon] = [
+            Carbon::parse($startTime, $this->timezone),
+            Carbon::parse($endTime, $this->timezone),
+        ];
+        $hourExpression = '0-'.$startTimeCarbon->hour - 1 .','.$endTimeCarbon->hour + 1 .'-23';
+
+        return $this->skip($this->inTimeInterval($startTime, $endTime))
+            ->spliceIntoPosition(2, $hourExpression);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -52,7 +52,34 @@ trait ManagesFrequencies
             Carbon::parse($startTime, $this->timezone),
             Carbon::parse($endTime, $this->timezone),
         ];
-        $hourExpression = '0-'.$startTimeCarbon->hour - 1 .','.$endTimeCarbon->hour + 1 .'-23';
+
+        $startHour = $startTimeCarbon->hour;
+        $endHour = $endTimeCarbon->hour;
+        if($startHour === 0) {
+            $hourExpressionLeft = '';
+        } elseif ($startHour === 1) {
+            $hourExpressionLeft = '0';
+        } else {
+            $hourExpressionLeft = '0-'.$startTimeCarbon->hour - 1;
+        }
+
+        if($endHour === 23) {
+            $hourExpressionRight = '';
+        } elseif ($endHour === 22) {
+            $hourExpressionRight = '23';
+        } else {
+            $hourExpressionRight = $endTimeCarbon->hour + 1 . '-23';
+        }
+
+        if($hourExpressionLeft === '' && $hourExpressionRight === '') {
+            $hourExpression = '*';
+        } elseif($hourExpressionLeft === '') {
+            $hourExpression = $hourExpressionRight;
+        } elseif($hourExpressionRight === '') {
+            $hourExpression = $hourExpressionLeft;
+        } else {
+            $hourExpression = $hourExpressionLeft . ',' . $hourExpressionRight;
+        }
 
         return $this->skip($this->inTimeInterval($startTime, $endTime))
             ->spliceIntoPosition(2, $hourExpression);

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -130,6 +130,21 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * * * * * 30s  php artisan inspire ........... Next Due: 30 seconds from now');
     }
 
+    public function testDisplayScheduleBetween()
+    {
+        $this->schedule->command('inspire')->hourly()->between('6:00', '18:00');
+        $this->schedule->command('inspire')->everyMinute()->between('6:00', '18:00');
+        $this->schedule->command('inspire')->hourly()->UnlessBetween('2:00', '4:00');
+        $this->schedule->command('inspire')->everyMinute()->UnlessBetween('2:00', '4:00');
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('  0 6-18     * * *  php artisan inspire ........... Next Due: 6 hours from now')
+            ->expectsOutput('  * 6-18     * * *  php artisan inspire ........... Next Due: 6 hours from now')
+            ->expectsOutput('  0 0-1,5-23 * * *  php artisan inspire ............ Next Due: 1 hour from now')
+            ->expectsOutput('  * 0-1,5-23 * * *  php artisan inspire .......... Next Due: 1 minute from now');
+    }
+
     public function testClosureCommandsMayBeScheduled()
     {
         $closure = function () {

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -130,17 +130,37 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * * * * * 30s  php artisan inspire ........... Next Due: 30 seconds from now');
     }
 
+    public function testScheduleBetweenExpression()
+    {
+        $this->schedule->command('inspire')->hourly()->between('6:00', '18:00');
+        $this->schedule->command('inspire')->everyMinute()->between('6:00', '18:00');
+        $this->schedule->command('inspire')->hourly()->unlessBetween('6:00', '18:00');
+        $this->schedule->command('inspire')->everyMinute()->unlessBetween('6:00', '18:00');
+
+        $this->assertEquals('0 6-18 * * *', $this->schedule->events()[0]->expression);
+        $this->assertEquals('* 6-18 * * *', $this->schedule->events()[1]->expression);
+        $this->assertEquals('0 0-5,19-23 * * *', $this->schedule->events()[2]->expression);
+        $this->assertEquals('* 0-5,19-23 * * *', $this->schedule->events()[3]->expression);
+    }
+
     public function testDisplayScheduleBetween()
     {
         $this->schedule->command('inspire')->hourly()->between('6:00', '18:00');
         $this->schedule->command('inspire')->everyMinute()->between('6:00', '18:00');
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('  0 6-18 * * *  php artisan inspire ............... Next Due: 6 hours from now')
+            ->expectsOutput('  * 6-18 * * *  php artisan inspire ............... Next Due: 6 hours from now');
+    }
+
+    public function testDisplayScheduleUnlessBetween()
+    {
         $this->schedule->command('inspire')->hourly()->UnlessBetween('2:00', '4:00');
         $this->schedule->command('inspire')->everyMinute()->UnlessBetween('2:00', '4:00');
 
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
-            ->expectsOutput('  0 6-18     * * *  php artisan inspire ........... Next Due: 6 hours from now')
-            ->expectsOutput('  * 6-18     * * *  php artisan inspire ........... Next Due: 6 hours from now')
             ->expectsOutput('  0 0-1,5-23 * * *  php artisan inspire ............ Next Due: 1 hour from now')
             ->expectsOutput('  * 0-1,5-23 * * *  php artisan inspire .......... Next Due: 1 minute from now');
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -136,11 +136,13 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->everyMinute()->between('6:00', '18:00');
         $this->schedule->command('inspire')->hourly()->unlessBetween('6:00', '18:00');
         $this->schedule->command('inspire')->everyMinute()->unlessBetween('6:00', '18:00');
+        $this->schedule->command('inspire')->everyMinute()->unlessBetween('0:00', '18:00');
 
         $this->assertEquals('0 6-18 * * *', $this->schedule->events()[0]->expression);
         $this->assertEquals('* 6-18 * * *', $this->schedule->events()[1]->expression);
         $this->assertEquals('0 0-5,19-23 * * *', $this->schedule->events()[2]->expression);
         $this->assertEquals('* 0-5,19-23 * * *', $this->schedule->events()[3]->expression);
+        $this->assertEquals('* 19-23 * * *', $this->schedule->events()[4]->expression);
     }
 
     public function testDisplayScheduleBetween()


### PR DESCRIPTION
This pull request modifies the `between` and `unlessBetween` methods of the ManagesFrequencies trait.
In the previous `between` methods, the cron expression was not set and the schedule was not displayed correctly in the `php artisan schedule:list` command.
This fix improves this.
I have added a new test case and confirmed that the existing test also passes.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
