### PR TITLE
[11.x] Fixes view engine resolvers leaking app instance

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -135,7 +135,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerFileEngine($resolver)
     {
         $resolver->register('file', function () {
-            return new FileEngine($this->app['files']);
+            return new FileEngine(app()->make('files'));
         });
     }
 
@@ -148,7 +148,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerPhpEngine($resolver)
     {
         $resolver->register('php', function () {
-            return new PhpEngine($this->app['files']);
+            return new PhpEngine(app()->make('files'));
         });
     }
 
@@ -161,9 +161,14 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            $compiler = new CompilerEngine($this->app['blade.compiler'], $this->app['files']);
+            $app = app();
 
-            $this->app->terminating(static function () use ($compiler) {
+            $compiler = new CompilerEngine(
+                $app->make('blade.compiler'),
+                $app->make('files'),
+            );
+
+            $app->terminating(static function () use ($compiler) {
                 $compiler->forgetCompiledOrNotExpired();
             });
 


### PR DESCRIPTION
This pull request fixes view engine resolvers leaking app instance in Octane: https://github.com/laravel/octane/issues/887.

Note that I've spend a few time trying to write tests for this; but is not easy with our current Octane setup.