### PR TITLE
[11.x] Introduce `MixManifestNotFoundException` for handling missing Mix manifests

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -15,7 +15,7 @@ class Mix
      * @param  string  $manifestDirectory
      * @return \Illuminate\Support\HtmlString|string
      *
-     * @throws \Exception
+     * @throws \Illuminate\Foundation\MixManifestNotFoundException
      */
     public function __invoke($path, $manifestDirectory = '')
     {
@@ -49,7 +49,7 @@ class Mix
 
         if (! isset($manifests[$manifestPath])) {
             if (! is_file($manifestPath)) {
-                throw new Exception("Mix manifest not found at: {$manifestPath}");
+                throw new MixManifestNotFoundException("Mix manifest not found at: {$manifestPath}");
             }
 
             $manifests[$manifestPath] = json_decode(file_get_contents($manifestPath), true);

--- a/src/Illuminate/Foundation/MixManifestNotFoundException.php
+++ b/src/Illuminate/Foundation/MixManifestNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Exception;
+
+class MixManifestNotFoundException extends Exception
+{
+    //
+}


### PR DESCRIPTION
This PR introduces a new `MixManifestNotFoundException` to specifically handle missing `Mix` manifest files. This custom exception extends the base `\Exception` class and provides a more precise error handling mechanism for scenarios where the `Mix` manifest cannot be found.

By using a specific exception, we can distinguish Mix manifest errors from other exceptions, allowing for more precise error handling. This enables developers to implement custom exception handling logic more reliably. For example, developers can choose not to display custom error pages if the Mix manifest is missing. This is important because, without the Mix assets, the custom error pages might not render correctly.