### PR TITLE
[10.x] ` Str apa ` Add whitespace after punctuations

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1310,6 +1310,12 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
+        foreach ($endPunctuation as $punctuation) {
+            $value = static::replace($punctuation, "$punctuation ", $value);
+        }
+
+        $value = trim($value);
+
         $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
 
         for ($i = 0; $i < count($words); $i++) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1314,8 +1314,6 @@ class Str
             $value = static::replace($punctuation, "$punctuation ", $value);
         }
 
-        $value = trim($value);
-
         $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
 
         for ($i = 0; $i < count($words); $i++) {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -84,6 +84,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Bond. James Bond.', Str::apa('bond. james bond.'));
         $this->assertSame('Bond. James Bond.', Str::apa('BOND. JAMES BOND.'));
         $this->assertSame('Bond. James Bond.', Str::apa('Bond. James Bond.'));
+        $this->assertSame('Bond. James Bond.', Str::apa('Bond.James Bond.'));
 
         $this->assertSame('Self-Report', Str::apa('self-report'));
         $this->assertSame('Self-Report', Str::apa('Self-report'));
@@ -108,6 +109,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('Устное Слово – Не Воробей. Как Только Он Вылетит, Его Не Поймаешь.', Str::apa('устное слово – не воробей. как только он вылетит, его не поймаешь.'));
         $this->assertSame('Устное Слово – Не Воробей. Как Только Он Вылетит, Его Не Поймаешь.', Str::apa('Устное Слово – Не Воробей. Как Только Он Вылетит, Его Не Поймаешь.'));
         $this->assertSame('Устное Слово – Не Воробей. Как Только Он Вылетит, Его Не Поймаешь.', Str::apa('УСТНОЕ СЛОВО – НЕ ВОРОБЕЙ. КАК ТОЛЬКО ОН ВЫЛЕТИТ, ЕГО НЕ ПОЙМАЕШЬ.'));
+        $this->assertSame('Устное Слово – Не Воробей. Как Только Он Вылетит, Его Не Поймаешь.', Str::apa('УСТНОЕ СЛОВО – НЕ ВОРОБЕЙ.КАК ТОЛЬКО ОН ВЫЛЕТИТ,ЕГО НЕ ПОЙМАЕШЬ.'));
+
+        $this->assertSame('Real Change, Enduring Change! Happens One Step at a Time.', Str::apa('Real change,enduring change!happens one step at a time.'));
+        $this->assertSame('Real Change, Enduring Change! Happens One Step at a Time.', Str::apa('Real change,enduring change!happens one step at a time.  '));
+        $this->assertSame('Real Change, Enduring Change! Happens One Step at a Time.', Str::apa('rEaL cHaNgE,eNdUrInG cHaNgE!hApPenS oNe StEp At A tImE.  '));
 
         $this->assertSame('', Str::apa(''));
         $this->assertSame('   ', Str::apa('   '));


### PR DESCRIPTION
Helloo :wave:

This PR Adds whitespace after each punctuation except the last one when using ` Str apa ` style.

See: https://apastyle.apa.org/style-grammar-guidelines/punctuation/space-after-period

### Code
```php
Str::apa('Real change,enduring change!happens one step at a time.  ');
````

#### Expected
Real Change, Enduring Change! Happens One Step at a Time.

#### Actual
Real Change,enduring Change!happens One Step at a Time.