### PR TITLE
[12.x] Use native MariaDB CLI commands

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -133,7 +133,7 @@ class DbCommand extends Command
     {
         return [
             'mysql' => 'mysql',
-            'mariadb' => 'mysql',
+            'mariadb' => 'mariadb',
             'pgsql' => 'psql',
             'sqlite' => 'sqlite3',
             'sqlsrv' => 'sqlcmd',

--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -5,13 +5,30 @@ namespace Illuminate\Database\Schema;
 class MariaDbSchemaState extends MySqlSchemaState
 {
     /**
+     * Load the given schema file into the database.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function load($path)
+    {
+        $command = 'mariadb '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+
+        $process = $this->makeProcess($command)->setTimeout(null);
+
+        $process->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
+            'LARAVEL_LOAD_PATH' => $path,
+        ]));
+    }
+
+    /**
      * Get the base dump command arguments for MariaDB as a string.
      *
      * @return string
      */
     protected function baseDumpCommand()
     {
-        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
+        $command = 'mariadb-dump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';
     }


### PR DESCRIPTION
Follow-up to https://github.com/laravel/sail/pull/693 and extended version of #51355:
Use MariaDB's native commands `mariadb-dump` for schema dumps and `mariadb` for schema loads and CLI sessions. I removed the `column-statistics` argument because `mariadb-dump` doesn't support it.

The PR targets Laravel 12 because users of the MariaDB driver need to make sure that these commands are available in their local and/or server environments.