### PR TITLE
[11.x] refactor(queue): update getConfig to handle empty and "default" connection names

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -213,7 +213,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if (! is_null($name) && (! empty(trim($name)) && $name !== 'null' && $name !== 'default')) {
             return $this->app['config']["queue.connections.{$name}"];
         }
 


### PR DESCRIPTION

This PR updates the getConfig() method in the queue configuration class to better handle edge cases when retrieving the connection configuration. The updated method now accounts for cases where the connection name is empty, consists only of whitespace, or is set to 'default' (as text).


This change is made to make some queues scripts more flexible by accepting the connection name as "default." Additionally, if the connection name is empty, it will use the default connection from Queue.php.

I find it confusing that the command cannot use the connection name "default."

```shell
php artisan queue:work default
php artisan queue:work "default"
```
Result:
![image](https://github.com/laravel/framework/assets/543450/906da568-de69-4281-9cc0-6ffbc75d1e9a)


### Possible Breaking Change
If there is a connection named "default," Laravel will use the config from queue.connections.default instead of the connection defined with the name "default." Therefore, it might be better to only allow empty spaces and not the name "default." 

To be decided: whether "default" will be allowed as a parameter to use the queue.connections.default.

Any changes or suggestions are welcome.  :)


Before the method supported already these connection names:
```shell
php artisan queue:work redis
php artisan queue:work null
php artisan queue:work "null"
php artisan queue:work ""
```

The method now supports these parameters:
```shell
php artisan queue:work default
php artisan queue:work "default"
php artisan queue:work " "  (1 space)
php artisan queue:work "    " ( x spaces)
```




Docs : https://laravel.com/docs/11.x/queues#specifying-the-connection-queue

Thanks 