### PR TITLE
[11.x] Collection average/avg optimization

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -76,25 +76,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get the average value of a given key.
-     *
-     * @param  (callable(TValue): float|int)|string|null  $callback
-     * @return float|int|null
-     */
-    public function avg($callback = null)
-    {
-        $callback = $this->valueRetriever($callback);
-
-        $items = $this
-            ->map(fn ($value) => $callback($value))
-            ->filter(fn ($value) => ! is_null($value));
-
-        if ($count = $items->count()) {
-            return $items->sum() / $count;
-        }
-    }
-
-    /**
      * Get the median of a given key.
      *
      * @param  string|array<array-key, string>|null  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -155,17 +155,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the average value of a given key.
-     *
-     * @param  (callable(TValue): float|int)|string|null  $callback
-     * @return float|int|null
-     */
-    public function avg($callback = null)
-    {
-        return $this->collect()->avg($callback);
-    }
-
-    /**
      * Get the median of a given key.
      *
      * @param  string|array<array-key, string>|null  $key

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -181,7 +181,8 @@ trait EnumeratesValues
      * @param  (callable(TValue): float|int)|string|null  $callback
      * @return float|int|null
      */
-    public function avg($callback = null) {
+    public function avg($callback = null)
+    {
         $callback = $this->valueRetriever($callback);
 
         // Reduce the array to the sum and the count of non-null values.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -176,6 +176,32 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the average value of a given key.
+     *
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
+     */
+    public function avg($callback = null) {
+        $callback = $this->valueRetriever($callback);
+
+        // Reduce the array to the sum and the count of non-null values.
+        $reduced = $this
+            ->reduce(
+                static function (array &$reduce, mixed $value) use ($callback): array {
+                    if (! is_null($retrieved = $callback($value))) {
+                        $reduce[0] += $retrieved;
+                        $reduce[1]++;
+                    }
+
+                    return $reduce;
+                },
+                [0, 0],
+            );
+
+        return $reduced[1] ? $reduced[0] / $reduced[1] : null;
+    }
+
+    /**
      * Alias for the "avg" method.
      *
      * @param  (callable(TValue): float|int)|string|null  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -185,19 +185,14 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        // Reduce the array to the sum and the count of non-null values.
-        $reduced = $this
-            ->reduce(
-                static function (array &$reduce, mixed $value) use ($callback): array {
-                    if (! is_null($retrieved = $callback($value))) {
-                        $reduce[0] += $retrieved;
-                        $reduce[1]++;
-                    }
+        $reduced = $this->reduce(static function (&$reduce, $value) use ($callback) {
+            if (! is_null($resolved = $callback($value))) {
+                $reduce[0] += $resolved;
+                $reduce[1]++;
+            }
 
-                    return $reduce;
-                },
-                [0, 0],
-            );
+            return $reduce;
+        }, [0, 0]);
 
         return $reduced[1] ? $reduced[0] / $reduced[1] : null;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4076,6 +4076,9 @@ class SupportCollectionTest extends TestCase
             (object) ['foo' => 6],
         ]);
         $this->assertEquals(3, $c->avg('foo'));
+
+        $c = new $collection([0]);
+        $this->assertEquals(0, $c->avg());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
This PR includes an algorithm improvement for the Collection `avg()` and `average()` function.

The previous code used an inefficient `map+filter+count`, whereas the new implementation does it all at once with a reducer.

### Algo explanation

1. Start with a reducer array with 2 empty elements `[0, 0]`
2. Loop/reduce the array:
   - add (sum) all non-null values to the first array element
   - increment the second array element with 1 (the count)
3. After loop: `$avg = $reduced[0] / $reduced[1]`

Additionally, the function has been moved to the `EnumeratesValues` trait so the lazy collection can also benefit from this optimization. It also works as expected with `yield`.

### Benchmark [(gist)](https://gist.github.com/bert-w/445962b06d1d6abc528824980879fe8f)

| Size     | Old (ms)  | New (ms)   | % Improvement |
|----------|-----------|------------|---------------|
| 10       | 0.0707    | 0.0614     | 13.14%        |
| 100      | 0.3149    | 0.221      | 29.78%        |
| 1,000    | 3.1159    | 2.2254     | 28.57%        |
| 10,000   | 31.0282   | 23.3528    | 24.71%        |
| 100,000  | 315.3512  | 232.7599   | 26.22%        |
| 1,000,000| 3,219.9169| 2,151.9144 | 33.17%        |
