### PR TITLE
[11.x] Unnecessary closure wrapping in `DatabaseBatchRepository::transaction`

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -309,7 +309,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function transaction(Closure $callback)
     {
-        return $this->connection->transaction(fn () => $callback());
+        return $this->connection->transaction($callback);
     }
 
     /**


### PR DESCRIPTION
`$callback` is already a closure. No need to wrap it.