### PR TITLE
[11.x] Add query method to UrlGenerator contract docblock

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Contracts\Routing;
 
+/**
+ * @method string query(string $path, array $query, mixed $extra, bool|null $secure)
+ */
 interface UrlGenerator
 {
     /**

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Contracts\Routing;
 
 /**
- * @method string query(string $path, array $query, mixed $extra, bool|null $secure)
+ * @method string query(string $path, array $query = [], mixed $extra = [], bool|null $secure = null)
  */
 interface UrlGenerator
 {


### PR DESCRIPTION
#51075 added the very useful query helper to UrlGenerator

Since the UrlGenerator contract does not have this method, IDEs and static analyzer tools cannot understand or autocomplete it.

Adding it to the interface would be considered a breaking change, so I am using phpdoc here, and it can be added to the contract in Laravel 12 if preferred.