### PR TITLE
[12.x] Preserve numeric keys on the first level of the validator rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1205,9 +1205,9 @@ class Validator implements ValidatorContract
         $response = (new ValidationRuleParser($this->data))
                             ->explode(ValidationRuleParser::filterConditionalRules($rules, $this->data));
 
-        $this->rules = array_merge_recursive(
-            $this->rules, $response->rules
-        );
+        foreach ($response->rules as $key => $rule) {
+            $this->rules[$key] = array_merge($this->rules[$key] ?? [], $rule);
+        }
 
         $this->implicitAttributes = array_merge(
             $this->implicitAttributes, $response->implicitAttributes

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5090,6 +5090,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testNumericKeys()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['3' => 'aslsdlks'], [3 => 'required']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testMergeRules()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asl', 'a' => [1, 4]], ['x' => ['alpha', ['min', 3]], 'a.*' => 'integer']);
+        $v->addRules(['x' => ['required', ['max', 10]], 'a.1' => 'digits:1']);
+        $this->assertEquals(
+            [
+                'x' => ['alpha', ['min', 3], 'required', ['max', 10]],
+                'a.0' => ['integer'],
+                'a.1' => ['integer', 'digits:1'],
+            ],
+            $v->getRules()
+        );
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateAlpha()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Fixes #51499 without changing the merge behavior (see `testMergeRules` in the PR that #39368 wouldn't have passed), simply preserve all the keys passed to the validator rules

### Bug description

Running the following in a tinker session
```php
Validator::validate(['foo' => 'baz', 4 => 'foo', 8 => 'baz'], ['foo' => 'required', 4 => 'required', 8 => 'required']);
```

Results in
```
   Illuminate\Validation\ValidationException  The 0 field is required. (and 1 more error).
```

Because array_merge_recursive rekeys any numeric keys it encounters
```php
array_merge_recursive([], ['foo' => 'required', 4 => 'required', 8 => 'required']);
= [
    "foo" => "required",
    0 => "required",
    1 => "required",
  ]
```
