### PR TITLE
[10.x] Enhance enum validation

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -4,7 +4,6 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use TypeError;
 
@@ -85,7 +84,10 @@ class Enum implements Rule, ValidatorAwareRule
      */
     public function only($values)
     {
-        $this->only = Arr::wrap($values);
+        $this->only = [
+            ...$this->only,
+            ...(is_array($values) ? $values : func_get_args()),
+        ];
 
         return $this;
     }
@@ -98,7 +100,10 @@ class Enum implements Rule, ValidatorAwareRule
      */
     public function except($values)
     {
-        $this->except = Arr::wrap($values);
+        $this->except = [
+            ...$this->except,
+            ...(is_array($values) ? $values : func_get_args()),
+        ];
 
         return $this;
     }


### PR DESCRIPTION
This PR adds:
- Supports varidic functions for `only` and `expects`
- Chainable `only` and `expects`

Usage:
```php
(new Enum(IntegerStatus::class))
    ->only(IntegerStatus::pending, IntegerStatus::done);
(new Enum(IntegerStatus::class))
    ->except(IntegerStatus::pending, IntegerStatus::done);

(new Enum(IntegerStatus::class))
    ->only(IntegerStatus::pending)
    ->when($condition, fn ($validator) => $validator->only(IntegerStatus::done))
(new Enum(IntegerStatus::class))
    ->except(IntegerStatus::pending)
    ->when($condition, fn ($validator) => $validator->except(IntegerStatus::done))
```