### PR TITLE
[11.x] Add transpose to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -257,7 +257,7 @@ class Arr
         $transposed = [];
 
         foreach ($array as $subArray) {
-            if(! is_array($subArray)) {
+            if (! is_array($subArray)) {
                 throw new InvalidArgumentException('The array must be a multi-dimensional array.');
             }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -247,6 +247,25 @@ class Arr
     }
 
     /**
+     * Transpose a multi-dimensional array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function transpose($array)
+    {
+        $transposed = [];
+
+        foreach ($array as $subArray) {
+            foreach (array_values($subArray) as $key => $value) {
+                $transposed[$key][] = $value;
+            }
+        }
+
+        return $transposed;
+    }
+
+    /**
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  iterable  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -257,6 +257,10 @@ class Arr
         $transposed = [];
 
         foreach ($array as $subArray) {
+            if(! is_array($subArray)) {
+                throw new InvalidArgumentException('The array must be a multi-dimensional array.');
+            }
+
             foreach (array_values($subArray) as $key => $value) {
                 $transposed[$key][] = $value;
             }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1153,7 +1153,7 @@ class SupportArrTest extends TestCase
 
     public function testTranspose()
     {
-        $transposed = Arr::transpose([
+        $transposedBalanced = Arr::transpose([
             ['John', 'Jane', 'Joe'],
             ['Admin', 'Support', 'Customer'],
             [true, false, null],
@@ -1163,7 +1163,19 @@ class SupportArrTest extends TestCase
             ['John', 'Admin', true],
             ['Jane', 'Support', false],
             ['Joe', 'Customer', null],
-        ], $transposed);
+        ], $transposedBalanced);
+
+        $transposedImbalanced = Arr::transpose([
+            ['John', 'Jane', 'Joe'],
+            ['laravel', 'laravel', 'laravel'],
+            ['livewire', 'inertiajs']
+        ]);
+
+        $this->assertSame([
+            ['John', 'laravel', 'livewire'],
+            ['Jane', 'laravel', 'inertiajs'],
+            ['Joe', 'laravel'],
+        ], $transposedImbalanced);
     }
 
     public function testWhere()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1151,6 +1151,21 @@ class SupportArrTest extends TestCase
         $this->assertSame('font-weight: bold; margin-top: 4px; margin-left: 2px;', $styles);
     }
 
+    public function testTranspose()
+    {
+        $transposed = Arr::transpose([
+            ['John', 'Jane', 'Joe'],
+            ['Admin', 'Support', 'Customer'],
+            [true, false, null],
+        ]);
+
+        $this->assertSame([
+            ['John', 'Admin', true],
+            ['Jane', 'Support', false],
+            ['Joe', 'Customer', null],
+        ], $transposed);
+    }
+
     public function testWhere()
     {
         $array = [100, '200', 300, '400', 500];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1168,7 +1168,7 @@ class SupportArrTest extends TestCase
         $transposedImbalanced = Arr::transpose([
             ['John', 'Jane', 'Joe'],
             ['laravel', 'laravel', 'laravel'],
-            ['livewire', 'inertiajs']
+            ['livewire', 'inertiajs'],
         ]);
 
         $this->assertSame([

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1181,7 +1181,7 @@ class SupportArrTest extends TestCase
         $this->expectExceptionMessage('The array must be a multi-dimensional array.');
 
         Arr::transpose([
-            "not an array inside an array",
+            'not an array inside an array',
         ]);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1176,6 +1176,13 @@ class SupportArrTest extends TestCase
             ['Jane', 'laravel', 'inertiajs'],
             ['Joe', 'laravel'],
         ], $transposedImbalanced);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The array must be a multi-dimensional array.');
+
+        Arr::transpose([
+            "not an array inside an array",
+        ]);
     }
 
     public function testWhere()


### PR DESCRIPTION
I'm pretty sure many are transforming data for analytics or for csv import/export. Transposing an array is one of those functions that seems small but can take a few hours to figure out every time we encounter it. I hope we can add it to the framework.

Example:
```php
$data = [
  ['John', 'Jane', 'Joe'],
  ['Admin', 'Support', 'Customer'],
  ['UTC', 'PDT', 'EDT']
];

$transposed = Arr::transpose($data);
// [ ['John', 'Admin', 'UTC'], ['Jane', 'Support', 'PDT'], ['Joe', 'Customer', 'EDT'] ]