### PR TITLE
[11.x] Add merge to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -658,7 +658,7 @@ class Arr
     }
 
     /**
-     * Merge arrays deeply
+     * Merge arrays deeply.
      *
      * @param  array|true  $array  `true` to preserve the numeric keys
      * @param  array[]  $arrays

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -658,6 +658,48 @@ class Arr
     }
 
     /**
+     * Merge arrays deeply
+     *
+     * @param  array|true  $array `true` to preserve the numeric keys
+     * @param  array[]  $arrays
+     */
+    public static function merge(array|bool $array, array ...$arrays): array
+    {
+        $preserveNumericKeys = false;
+        if ($array === true) {
+            $preserveNumericKeys = true;
+        } elseif ($array !== false) {
+            $arrays = [$array, ...$arrays];
+        }
+
+        $result = array_shift($arrays);
+        while (! empty($arrays)) {
+            $array = array_shift($arrays);
+            foreach ($array as $key => $value) {
+                // key does not present in the previous array, just set it
+                if (! array_key_exists($key, $result)) {
+                    $result[$key] = $value;
+                } elseif (! $preserveNumericKeys && is_int($key)) {
+                    // does not preserve numeric keys
+                    $result[] = $value;
+                } elseif (is_array($value) && is_array($result[$key])) {
+                    // merge two arrays deeply
+                    $result[$key] = static::merge(
+                        $preserveNumericKeys,
+                        $result[$key],
+                        $value
+                    );
+                } else {
+                    // override the key value
+                    $result[$key] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -660,7 +660,7 @@ class Arr
     /**
      * Merge arrays deeply
      *
-     * @param  array|true  $array `true` to preserve the numeric keys
+     * @param  array|true  $array  `true` to preserve the numeric keys
      * @param  array[]  $arrays
      */
     public static function merge(array|bool $array, array ...$arrays): array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -780,6 +780,59 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
     }
 
+    public function testMerge()
+    {
+        $a = [
+            'db' => [
+                'connections' => [
+                    'default' => [
+                        'host' => 'localhost',
+                        'username' => 'root',
+                        'password' => '',
+                    ],
+                ],
+            ],
+            1 => [
+                'one',
+                'two',
+            ],
+        ];
+
+        $b = [
+            'db' => [
+                'connections' => [
+                    'default' => [
+                        'host' => '127.0.0.1',
+                        'password' => 'root',
+                    ],
+                    'slave' => [
+                        'host' => 'slave host',
+                    ],
+                ],
+            ],
+            1 => [
+                'three',
+            ],
+        ];
+        // simple
+        $array = Arr::merge([], $a);
+        $this->assertSame($a, $array);
+
+        $array = Arr::merge($a, $b, ['more' => 'more']);
+        $this->assertSame('127.0.0.1', $array['db']['connections']['default']['host']);
+        $this->assertSame('root', $array['db']['connections']['default']['password']);
+        $this->assertSame('slave host', $array['db']['connections']['slave']['host']);
+        $this->assertSame('more', $array['more']);
+
+        // numeric key
+        $this->assertSame('three', $array[2][0]);
+
+        // preserve numeric keys
+        $array = Arr::merge(true, $a, $b);
+        $this->assertSame('three', $array[1][0]);
+        $this->assertFalse(isset($array[2]));
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');


### PR DESCRIPTION
`array_merge_recursive` does indeed merge arrays, but it converts values with duplicate keys to arrays rather than overwriting the value in the first array with the duplicate value in the second array, as `array_merge` does.

This PR add method `merge` to `Arr`, `Arr::merge` merge arrays deeply.

### Example(default) 
```php 
$arr1 = [
    'color' => [
        'favorite' => 'red'
    ], 
    5 => 5
];
$arr2 = [
    'color' => [
        'favorite' => 'green'
    ], 
    'blue',
    5 => 'five'
];
$result = Arr::merge($arr1, $arr2, ['fruit' => ['favorite' => 'apple']]);

$result = [
    'color' => [
        'favorite' => 'green'
    ],
    'fruit' => [
        'favorite' => 'apple'
    ] ,
    5 => 5
    0 => 'blue',
    6 => 'five',
];
```


### Example(preserve numeric keys)
```php
$result = Arr::merge(true, $arr1, $arr2);

$result = [
    'color' => [
        'favorite' => 'green'
    ], 
    5 => 'five',
    0 => 'blue',
];
```
> numeric keys will not be renumbered
