### PR TITLE
[10.x] Do not use `app()` Foundation helper on `ViewServiceProvider`

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View;
 
+use Illuminate\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
@@ -135,7 +136,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerFileEngine($resolver)
     {
         $resolver->register('file', function () {
-            return new FileEngine(app()->make('files'));
+            return new FileEngine(Container::getInstance()->make('files'));
         });
     }
 
@@ -148,7 +149,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerPhpEngine($resolver)
     {
         $resolver->register('php', function () {
-            return new PhpEngine(app()->make('files'));
+            return new PhpEngine(Container::getInstance()->make('files'));
         });
     }
 
@@ -161,7 +162,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            $app = app();
+            $app = Container::getInstance();
 
             $compiler = new CompilerEngine(
                 $app->make('blade.compiler'),


### PR DESCRIPTION
PR #51450 makes use of the `app()` helper to solve the view engine resolvers leaking memory issue.

The `app()` is provided by the Foundation component, while the fix was made into the View component.

Currently, the Foundation component is not a dependency of the View component.

This PR

- Replaces the `app()` calls with `Container::getInstance()` calls where appropriate

Note that the View component already requires the Container component, and that the `app()` helper code basically delegates to `Container::getInstance()`:

https://github.com/laravel/framework/blob/21e6d31b39b007adefa36eb399329503f6afabde/src/Illuminate/Foundation/helpers.php#L116-L123

No tests were added.