### PR TITLE
[11.x] Add `File::maxServerSize()` validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -204,6 +204,37 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Indicate that the uploaded file should be no more than value specified by php.ini.
+     *
+     * @return $this
+     */
+    public function maxServerSize()
+    {
+        $uploadMaxSize = ini_parse_quantity($this->getPhpIniValue('upload_max_filesize'));
+        if ($uploadMaxSize > 0) {
+            return $this->max($uploadMaxSize);
+        }
+
+        $postMaxSize = ini_parse_quantity($this->getPhpIniValue('post_max_size'));
+        if ($postMaxSize > 0) {
+            return $this->max($postMaxSize);
+        }
+
+        return $this;
+    }
+
+    /**
+     * This method is here in order to mock calls to `ini_get` when testing.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function getPhpIniValue(string $key)
+    {
+        return ini_get($key);
+    }
+
+    /**
      * Convert a potentially human-friendly file size to kilobytes.
      *
      * @param  string|int  $size

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -11,7 +11,6 @@ use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
-use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class ValidationFileRuleTest extends TestCase


### PR DESCRIPTION
Hello!

This PR introduces a `maxServerSize` file validation rule. 

On a few projects I've worked on, I noticed, that quite often we want to allow the max file size to be the same as our setting inside `php.ini`. Over time the value inside `php.ini` might change due to different requirements, but the validation rules usually stay the same until some user hits the rule and it prevents them from proceeding. 

Thanks to this rule the max file size is automatically loaded based on the current `php.ini` setting hence it stays in sync.

## Usage
```php
Validator::make(['file', $file], [Rule::file()->maxServerSize()]);
```

This is my first ever PR to Laravel, so in case I missed something I will happily fix it. Also, I'm open to any suggestions.

Thank you for your time looking at this PR,
Tony