### PR TITLE
[11.x] Replace all backed enums with values when building URLs

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -525,12 +525,17 @@ class UrlGenerator implements UrlGeneratorContract
     public function toRoute($route, $parameters, $absolute)
     {
         $parameters = collect(Arr::wrap($parameters))->map(function ($value, $key) use ($route) {
-            $value = $value instanceof UrlRoutable && $route->bindingFieldFor($key)
+            return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}
                     : $value;
-
-            return $value instanceof BackedEnum ? $value->value : $value;
         })->all();
+
+        // Recursively replace backed enums with their values
+        array_walk_recursive($parameters, function (&$item) {
+            if ($item instanceof BackedEnum) {
+                $item = $item->value;
+            }
+        });
 
         return $this->routeUrl()->to(
             $route, $this->formatParameters($parameters), $absolute

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -530,7 +530,6 @@ class UrlGenerator implements UrlGeneratorContract
                     : $value;
         })->all();
 
-        // Recursively replace backed enums with their values
         array_walk_recursive($parameters, function (&$item) {
             if ($item instanceof BackedEnum) {
                 $item = $item->value;

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -887,6 +887,22 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/fruits', $url->route('foo.bar', CategoryBackedEnum::Fruits));
     }
 
+    public function testRouteGenerationWithNestedBackedEnums()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $namedRoute = new Route(['GET'], '/foo', ['as' => 'foo']);
+        $routes->add($namedRoute);
+
+        $this->assertSame(
+            'http://www.foo.com/foo?filter%5B0%5D=people&filter%5B1%5D=fruits',
+            $url->route('foo', ['filter' => [CategoryBackedEnum::People, CategoryBackedEnum::Fruits]]),
+        );
+    }
+
     public function testSignedUrlWithKeyResolver()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
When building a URL, the `UrlGenerator` takes each parameter that is a backed enum instance, and replaces it with its underlying value. This PR lets the UrlGenerator also replace backed enums that are nested more deeply in the `$parameters` array. This is useful when passing an array of enums as one of the parameters, for example when adding a filter query parameter.

### Example:
```
route('foo', ['filters' => [MyEnum::One, MyEnum::Two]])
= http://example.com/foo?filters%5B0%5D=one&filters%5B1%5D=two
```

### Previous behavior:
You'd get this URL from the above command, which includes the name and value of each enum instance separately:
```
= http://example.com/foo?filters%5B0%5D%5Bname%5D=One&filters%5B0%5D%5Bvalue%5D=one&filters%5B1%5D%5Bname%5D=Two&filters%5B1%5D%5Bvalue%5D=two
```

In order to get the shorter URL you'd have to add `->value` to each enum instance.

### Breaking changes
None as far as I can tell, unless you were using arrays of enum instances as parameter values as in the above example. I don't assume anyone did, looking at the format of the above URL, but maybe I'm missing something.
