### PR TITLE
[11.x] Use Powershell on Windows Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,14 +140,16 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/psr7:~2.4 --no-interaction --no-update
+          command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
+          shell: powershell
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require phpunit/phpunit:~${{ matrix.phpunit }} --dev --no-interaction --no-update
+          command: composer require phpunit/phpunit:^${{ matrix.phpunit }} --dev --no-interaction --no-update
+          shell: powershell
 
       - name: Install dependencies
         uses: nick-fields/retry@v3


### PR DESCRIPTION
Trying out the `^` symbol in `powershell`, because it is only an escape character for the `cmd` tool.