### PR TITLE
Run authorization before preparing to validate in FormRequest

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -16,11 +16,11 @@ trait ValidatesWhenResolvedTrait
      */
     public function validateResolved()
     {
-        $this->prepareForValidation();
-
         if (! $this->passesAuthorization()) {
             $this->failedAuthorization();
         }
+
+        $this->prepareForValidation();
 
         $instance = $this->getValidatorInstance();
 


### PR DESCRIPTION
In this small change we first authorize and only then do validation steps

`prepareForValidation()` can sometimes be a bit more complex and may run business logic (even though the docs shows the use case of formatting input) before merging in data. 

I think it makes more sense to authorize before running any sort of validation steps.

Is there a reason why you would want to prepare validation data and then authorize after? why would authorization depend on user input from a form?