### PR TITLE
[11.x] Consistent behavior using eloquents with method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -678,19 +678,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Begin querying a model with eager loading.
-     *
-     * @param  array|string  $relations
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public static function with($relations)
-    {
-        return static::query()->with(
-            is_string($relations) ? func_get_args() : $relations
-        );
-    }
-
-    /**
      * Eager load relations on the model.
      *
      * @param  array|string  $relations


### PR DESCRIPTION
When introducing support for closures to eloquent's _instanced_ `with` method ([here](https://github.com/laravel/framework/pull/32924)), I failed to include support for the static `with` method. This caused inconsistent behavior and has led to developer confusion ([here](https://github.com/laravel/framework/issues/46111)).

It was pointed out ([here](https://github.com/laravel/framework/issues/46111#issuecomment-1430760403)) that the static method could be dropped and we can instead rely on the static call being forwarded to the instanced method. So I've done exactly that.

This should not only keep the behavior consistent but reduce the maintenance burden in the future going from two methods to support to one.