### PR TITLE
[11.x] Allow override non public method

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -86,6 +86,10 @@ trait Macroable
     public static function __callStatic($method, $parameters)
     {
         if (! static::hasMacro($method)) {
+            if (method_exists(static::class, '__'.$method)) {
+                return static::{'__'.$method}(...$parameters);
+            }
+
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));
@@ -112,6 +116,10 @@ trait Macroable
     public function __call($method, $parameters)
     {
         if (! static::hasMacro($method)) {
+            if (method_exists($this, '__'.$method)) {
+                return $this->{'__'.$method}(...$parameters);
+            }
+            
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -119,7 +119,7 @@ trait Macroable
             if (method_exists($this, '__'.$method)) {
                 return $this->{'__'.$method}(...$parameters);
             }
-            
+
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -159,6 +159,21 @@ class SupportMacroableTest extends TestCase
 
         $this->assertSame('newMethod', $this->macroable::existingMethod());
     }
+
+    public function testOverride()
+    {
+        $this->assertFalse((new TestMacroable())->override());
+
+        TestMacroable::macro('override', fn () => 'override');
+        $this->assertSame('override', (new TestMacroable())->override());
+
+        // static
+        $this->assertFalse(TestMacroable::overrideStatic());
+
+        TestMacroable::macro('overrideStatic', fn () => 'static');
+        $this->assertSame('static', TestMacroable::overrideStatic());
+
+    }
 }
 
 class EmptyMacroable
@@ -175,6 +190,16 @@ class TestMacroable
     protected static function getProtectedStatic()
     {
         return 'static';
+    }
+
+    protected function __override()
+    {
+        return false;
+    }
+
+    protected static function __overrideStatic()
+    {
+        return false;
     }
 }
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -172,7 +172,6 @@ class SupportMacroableTest extends TestCase
 
         TestMacroable::macro('overrideStatic', fn () => 'static');
         $this->assertSame('static', TestMacroable::overrideStatic());
-
     }
 }
 


### PR DESCRIPTION
This PR allow override non public methods in a macroable class,
for expamle, rewrite `Str::random`:

some changes:
```php
/**
 * @method static string random(int $length = 16)
 */
class Str
{
    protected static __random(int $length = 16): string
    {
        // default random string code
    }
}
```

override:
```php
    use Illuminate\Support\Str;

    Str::macro('random', function (int $length = 16) {
        // my random string code
    });
``` 

and more classes/methods like this.