### PR TITLE
[11.x] renamed left `has` to `contains`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -501,7 +501,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate an attribute has a list of values.
+     * Validate an attribute contains a list of values.
      *
      * @param  string  $attribute
      * @param  mixed  $value


### PR DESCRIPTION
While renaming `has` to `contains` in this commit https://github.com/laravel/framework/commit/04f52a55ec75ac8004b93888466e142c2eea31e0, it seems that this instance was missed. If this is the case, then this PR addresses the missing change.