### PR TITLE
[11.x] Rename test function to match prohibit action

### DIFF
--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -73,7 +73,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $this->runCommand($command, ['--step' => 2]);
     }
 
-    public function testRefreshCommandExitsWhenPrevented()
+    public function testRefreshCommandExitsWhenProhibited()
     {
         $command = new RefreshCommand;
 

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -53,7 +53,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
 
-    public function testRefreshCommandExitsWhenPrevented()
+    public function testRefreshCommandExitsWhenProhibited()
     {
         $command = new ResetCommand($migrator = m::mock(Migrator::class));
 


### PR DESCRIPTION
Since the action is `prohibit()`  I have renamed the test to match it.