### PR TITLE
[11.x] Fix LazilyRefreshDatabase when using Laravel BrowserKit Testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -24,7 +24,7 @@ trait LazilyRefreshDatabase
 
             RefreshDatabaseState::$lazilyRefreshed = true;
 
-            if (property_exists($this, 'mockConsoleOutput')){
+            if (property_exists($this, 'mockConsoleOutput')) {
                 $shouldMockOutput = $this->mockConsoleOutput;
     
                 $this->mockConsoleOutput = false;
@@ -32,7 +32,7 @@ trait LazilyRefreshDatabase
 
             $this->baseRefreshDatabase();
 
-            if (property_exists($this, 'mockConsoleOutput')){
+            if (property_exists($this, 'mockConsoleOutput')) {
                 $this->mockConsoleOutput = $shouldMockOutput;
             }
         };

--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -24,7 +24,7 @@ trait LazilyRefreshDatabase
 
             RefreshDatabaseState::$lazilyRefreshed = true;
 
-            if(property_exists($this, 'mockConsoleOutput')){
+            if (property_exists($this, 'mockConsoleOutput')){
                 $shouldMockOutput = $this->mockConsoleOutput;
     
                 $this->mockConsoleOutput = false;

--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -24,13 +24,17 @@ trait LazilyRefreshDatabase
 
             RefreshDatabaseState::$lazilyRefreshed = true;
 
-            $shouldMockOutput = $this->mockConsoleOutput;
-
-            $this->mockConsoleOutput = false;
+            if(property_exists($this, 'mockConsoleOutput')){
+                $shouldMockOutput = $this->mockConsoleOutput;
+    
+                $this->mockConsoleOutput = false;
+            }
 
             $this->baseRefreshDatabase();
 
-            $this->mockConsoleOutput = $shouldMockOutput;
+            if(property_exists($this, 'mockConsoleOutput')){
+                $this->mockConsoleOutput = $shouldMockOutput;
+            }
         };
 
         $database->beforeStartingTransaction($callback);

--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -32,7 +32,7 @@ trait LazilyRefreshDatabase
 
             $this->baseRefreshDatabase();
 
-            if(property_exists($this, 'mockConsoleOutput')){
+            if (property_exists($this, 'mockConsoleOutput')){
                 $this->mockConsoleOutput = $shouldMockOutput;
             }
         };


### PR DESCRIPTION
This PR https://github.com/laravel/framework/pull/49914 introduced an issue where if you are using https://github.com/laravel/browser-kit-testing it will error when you run tests that use LazilyRefreshDatabase.

This is because PR 49914 added the use of the `mockConsoleOutput` property. 
The `InteractsWithConsole` trait in Laravel has this property set. https://github.com/laravel/framework/blob/e59372a464fb4b43b9c981db11cc7ecef8cf19d3/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php#L16
But the `InteractsWithConsole` in BrowserKit Testing does not 
https://github.com/laravel/browser-kit-testing/blob/7.x/src/Concerns/InteractsWithConsole.php 

When running tests we get the following error.
`ErrorException: Undefined property MyClassIntegrationTest::$mockConsoleOutput`

I added the conditional check for the `mockConsoleOutput` property into the `InteractsWithConsole` trait here because the `InteractsWithConsole` in BrowserKit Testing has not been edited in 8 years so has diverged greatly from the Frameworks current `InteractsWithConsole` trait. So I thought it would make sense to add it here instead of the package.