### PR TITLE
Add deleteOrCreate Method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1340,6 +1340,24 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Delete or create a record matching the attributes.
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function deleteOrCreate(array $attributes, array $values = [])
+    {
+        return tap($this->firstOrNew($attributes), function ($instance) use ($attributes, $values) {
+            if ($instance->exists) {
+                $instance->delete();
+            } else {
+                $instance->fill(array_merge($attributes, $values))->save();
+            }
+        });
+    }
+
+    /**
      * Determine if the given model has a scope.
      *
      * @param  string  $scope


### PR DESCRIPTION
### Introduction

This PR introduces a new method `deleteOrCreate` to the `Eloquent\Builder` class. This method allows developers to either delete an existing record based on specified attributes or create a new one if the record does not exist.

### Motivation

In many scenarios, developers need a convenient way to delete a record if it exists or create a new one if it doesn't. This functionality is similar to the existing `updateOrCreate` method but focuses on deletion and creation. This method simplifies the logic and reduces boilerplate code for such operations.

### Scenario: User Hearting a Gift
Consider a scenario where a user can react to a gift with a "heart". If the user has already reacted to the gift with a heart, this reaction should be deleted. If the user hasn't reacted yet, a new reaction should be created.

### Implementation

The `deleteOrCreate` method attempts to find the first record matching the given attributes using `firstOrNew`. If the record exists, it is deleted. If the record does not exist, a new one is created with the specified attributes and values.

### Method Signature

```php
public function deleteOrCreate(array $attributes, array $values = [])
{
    return tap($this->firstOrNew($attributes), function ($instance) use ($attributes, $values) {
        if ($instance->exists) {
            $instance->delete();
        } else {
            $instance->fill(array_merge($attributes, $values))->save();
        }
    });
}


###Conclusion
This method enhances the Eloquent ORM by providing a straightforward way to handle delete-or-create operations, making the code more concise and readable.

