### PR TITLE
[11.x] Use str helper in layout stub locale formatting

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str(app()->getLocale())->replace('_', '-') }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This PR replaces the use of `str_replace()` for formatting the app locale in the `make:layout` command stub, with the `str` helper / strings API version.