### PR TITLE
[12.x] Adds missing streamJson() to ResponseFactory contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -67,7 +67,6 @@ interface ResponseFactory
      */
     public function stream($callback, $status = 200, array $headers = []);
 
-
     /**
      * Create a new streamed JSON response instance.
      *

--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -67,6 +67,18 @@ interface ResponseFactory
      */
     public function stream($callback, $status = 200, array $headers = []);
 
+
+    /**
+     * Create a new streamed JSON response instance.
+     *
+     * @param  array  $data
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  int  $encodingOptions
+     * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
+     */
+    public function streamJson($data, $status = 200, $headers = [], $encodingOptions = 15);
+
     /**
      * Create a new streamed response instance as a file download.
      *

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -131,7 +131,7 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
-     * Create a new streamed response instance.
+     * Create a new streamed JSON response instance.
      *
      * @param  array  $data
      * @param  int  $status


### PR DESCRIPTION
This PR adds the missing declaration of `streamJson()` to the ResponseFactory contract.

This PR targets `master`/`12.x` branch as it affects a contract and has breaking changes.