### PR TITLE
[11.x] Execute `then` Callback Before Loading `web` Routes in ApplicationBuilder

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -210,6 +210,10 @@ class ApplicationBuilder
                 });
             }
 
+            if (is_callable($then)) {
+                $then($this->app);
+            }
+
             if (is_string($web) || is_array($web)) {
                 if (is_array($web)) {
                     foreach ($web as $webRoute) {
@@ -228,9 +232,6 @@ class ApplicationBuilder
                 Folio::route($pages, middleware: $this->pageMiddleware);
             }
 
-            if (is_callable($then)) {
-                $then($this->app);
-            }
         };
     }
 


### PR DESCRIPTION
### Summary

This pull request ensures that the `then` callback is executed before loading the `web` routes in the `ApplicationBuilder`. This change is necessary to prevent domain-specific routes from being overridden by the main `web` routes.

### Rationale

In applications with domain-specific routing requirements, it is crucial that domain-specific routes are loaded before the general `web` routes to avoid conflicts. Executing the `then` callback before loading the `web` routes ensures that domain-specific routing logic is prioritized, improving maintainability and scalability.

### Changes

- The `then` callback is now executed before loading the `web` routes in the `ApplicationBuilder::buildRoutingCallback` method.

### Testing

This change has been tested to ensure that domain-specific routes are correctly applied and that no existing functionality is broken. The following scenarios have been verified:
- Domain-specific routes are loaded correctly.
- General `web` routes are loaded correctly after domain-specific routes.
- No conflicts or overrides occur between domain-specific and general routes.

### Additional Notes

This change does not affect existing applications that do not use domain-specific routing. It enhances flexibility for those who do, adhering to Laravel's best practices for routing.
