### PR TITLE
[11.x] Display test creation messages

### DIFF
--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -36,7 +36,7 @@ trait CreatesMatchingTest
             return false;
         }
 
-        return $this->callSilent('make:test', [
+        return $this->call('make:test', [
             'name' => Str::of($path)->after($this->laravel['path'])->beforeLast('.php')->append('Test')->replace('\\', '/'),
             '--pest' => $this->option('pest'),
             '--phpunit' => $this->option('phpunit'),

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -183,9 +183,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         $info = $this->type;
 
         if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
-            if ($this->handleTestCreation($path)) {
-                $info .= ' and test';
-            }
+            $this->handleTestCreation($path);
         }
 
         if (windows_os()) {


### PR DESCRIPTION
When creating test files with a controller, etc., the test file creation messages are omitted.
IMHO there's no need to omit them.
One advantage of showing them is that if you use vscode's terminal, you can Ctrl/Cmd + click and open files in the editor.

## Before
![2024-05-22_21h14_15](https://github.com/laravel/framework/assets/14008307/c6bc7570-caec-49ca-8298-fa920b73c359)

## After
![2024-05-22_21h14_40](https://github.com/laravel/framework/assets/14008307/0acc4f56-5080-4df1-951e-88700751fc71)

This was originally the case, but was changed when a new look was introduced.
https://github.com/laravel/framework/pull/43065/files#diff-ac95f44c26b05e25b5037e16808aaff5e97b022fd518b1f069133588e76e5eb6L39
