### PR TITLE
[10.x] Fix SQL Server detection in database store

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -158,9 +158,7 @@ class DatabaseStore implements LockProvider, Store
         $value = $this->serialize($value);
         $expiration = $this->getTime() + $seconds;
 
-        $doesntSupportInsertOrIgnore = [SqlServerConnection::class];
-
-        if (! in_array(get_class($this->getConnection()), $doesntSupportInsertOrIgnore)) {
+        if (! $this->getConnection() instanceof SqlServerConnection) {
             return $this->table()->insertOrIgnore(compact('key', 'value', 'expiration')) > 0;
         }
 


### PR DESCRIPTION
Laravel doesn't have an `insertOrIgnore()` implementation for SQL Server and so the database store checks the connection class to see if the method can be used. However, the current detection logic doesn't work when the app uses a custom connection class that extends `SqlServerConnection` (e.g. when a package overrides it). By using `instanceof`, we also support theses cases.