### PR TITLE
[11.x] Allow aliases for `withMiddleware` and `withoutMiddleware` in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Http\Request;
+use Illuminate\Routing\MiddlewareNameResolver;
 use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
@@ -172,7 +173,15 @@ trait MakesHttpRequests
             return $this;
         }
 
-        foreach ((array) $middleware as $abstract) {
+        $router = $this->app->make('router');
+
+        foreach ((array) $middleware as $resolvableMiddleware) {
+            $abstract = MiddlewareNameResolver::resolve(
+                $resolvableMiddleware,
+                $router->getMiddleware(),
+                $router->getMiddlewareGroups()
+            );
+
             $this->app->instance($abstract, new class
             {
                 public function handle($request, $next)
@@ -199,7 +208,15 @@ trait MakesHttpRequests
             return $this;
         }
 
-        foreach ((array) $middleware as $abstract) {
+        $router = $this->app->make('router');
+
+        foreach ((array) $middleware as $resolvableMiddleware) {
+            $abstract = MiddlewareNameResolver::resolve(
+                $resolvableMiddleware,
+                $router->getMiddleware(),
+                $router->getMiddlewareGroups()
+            );
+
             unset($this->app[$abstract]);
         }
 

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -105,6 +105,31 @@ class MakesHttpRequestsTest extends TestCase
         );
     }
 
+    public function testWithoutAndWithMiddlewareAliasWithParameter()
+    {
+        $next = function ($request) {
+            return $request;
+        };
+
+        $router = $this->app->make(Registrar::class);
+
+        $router->aliasMiddleware('my-middleware', MyMiddleware::class);
+
+        $this->withoutMiddleware('my-middleware');
+        $this->assertTrue($this->app->has(MyMiddleware::class));
+        $this->assertSame(
+            'foo',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+
+        $this->withMiddleware('my-middleware');
+        $this->assertFalse($this->app->has(MyMiddleware::class));
+        $this->assertSame(
+            'fooWithMiddleware',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+    }
+
     public function testWithCookieSetCookie()
     {
         $this->withCookie('foo', 'bar');


### PR DESCRIPTION
This PR allows the use of middleware aliases in `withMiddleware` and `withoutMiddleware`.