### PR TITLE
[10.x] - Fix batch list loading in Horizon when serialization error

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -6,10 +6,10 @@ use Carbon\CarbonImmutable;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
+use Throwable;
 
 class DatabaseBatchRepository implements PrunableBatchRepository
 {
@@ -352,7 +352,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
 
         try {
             return unserialize($serialized);
-        } catch (ModelNotFoundException) {
+        } catch (Throwable) {
             return [];
         }
     }


### PR DESCRIPTION
When any of the batch options generate a serialization error, the entire list of batches is not loaded.

The current implementation only listens for `ModelNotFoundException`, this PR changes the type in the catch to `Throwable` so that any errors in the batches options do not compromise the loading of the entire batch list