### PR TITLE
[11.x] Add `withoutDelay()` to the `Queueable` trait

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -141,7 +141,7 @@ trait Queueable
     }
 
     /**
-     * Set the delay for the job to zero, meaning no delay.
+     * Set the delay for the job to zero seconds.
      *
      * @return $this
      */

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -141,6 +141,18 @@ trait Queueable
     }
 
     /**
+     * Set the delay for the job to zero, meaning no delay.
+     *
+     * @return $this
+     */
+    public function withoutDelay()
+    {
+        $this->delay = 0;
+
+        return $this;
+    }
+
+    /**
      * Indicate that the job should be dispatched after all database transactions have committed.
      *
      * @return $this

--- a/tests/Queue/QueueDelayTest.php
+++ b/tests/Queue/QueueDelayTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Queue;
+use Orchestra\Testbench\TestCase;
+
+class QueueDelayTest extends TestCase
+{
+    public function test_queue_delay()
+    {
+        Queue::fake();
+
+        $job = new TestJob;
+
+        dispatch($job);
+
+        $this->assertEquals(60, $job->delay);
+    }
+
+    public function test_queue_without_delay()
+    {
+        Queue::fake();
+
+        $job = new TestJob;
+
+        dispatch($job->withoutDelay());
+
+        $this->assertEquals(0, $job->delay);
+    }
+}
+
+class TestJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->delay(60);
+    }
+}


### PR DESCRIPTION
Some of my jobs have a default delay, but on some specific occasions, I need to dispatch them without delay. So, I find myself doing this a lot:

```php
dispatch((new MyJob($data))->delay(0));
```
So, I thought about having a shortcut for this:

```php
dispatch((new MyJob($data))->withoutDelay());
```

I mean, this is just for UX. I'm fine with doing `delay(0)`, but I prefer `withoutDelay()`. =)