### PR TITLE
[11.x] Add an option to remove the original environment file after encrypting

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -21,7 +21,7 @@ class EnvironmentEncryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
-                    {--remove= : Remove the original file}
+                    {--prune= : Delete the original environment file}
                     {--force : Overwrite the existing encrypted environment file}';
 
     /**
@@ -99,7 +99,7 @@ class EnvironmentEncryptCommand extends Command
             return Command::FAILURE;
         }
 
-        if ($this->option('remove')) {
+        if ($this->option('prune')) {
             $this->files->delete($environmentFile);
         }
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -21,6 +21,7 @@ class EnvironmentEncryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
+                    {--remove= : Remove the original file}
                     {--force : Overwrite the existing encrypted environment file}';
 
     /**
@@ -96,6 +97,10 @@ class EnvironmentEncryptCommand extends Command
             $this->components->error($e->getMessage());
 
             return Command::FAILURE;
+        }
+
+        if ($this->option('remove')) {
+            $this->files->delete($environmentFile);
         }
 
         $this->components->info('Environment successfully encrypted.');

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -155,4 +155,24 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
     }
+
+    public function testItCanRemoveTheOriginalFile()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt', ['--remove' => true])
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env.encrypted'), m::any());
+
+        $this->filesystem->shouldHaveReceived('delete')
+            ->with(base_path('.env'));
+    }
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -165,7 +165,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->once()
             ->andReturn(false);
 
-        $this->artisan('env:encrypt', ['--remove' => true])
+        $this->artisan('env:encrypt', ['--prune' => true])
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
 


### PR DESCRIPTION
When managing environment files for multiple environments, it's useful to be able to remove the original file when encrypting to prevent outdated environment files from sticking around.

This adds an extra `--prune` option to the `php artisan env:encrypt` command that instantly removes the original environment file after encrypting.

```shell
php artisan env:encrypt --env=production --prune
```

Similar tools like git-secret remove the original file by default.