### PR TITLE
[11.x] Add `get`, `write` and `forget` cache events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheGet.php
+++ b/src/Illuminate/Cache/Events/CacheGet.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheGet extends CacheEvent
+{
+    //
+}

--- a/src/Illuminate/Cache/Events/CacheGetMany.php
+++ b/src/Illuminate/Cache/Events/CacheGetMany.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheGetMany extends CacheEvent
+{
+    /**
+     * The keys that are retrieved.
+     *
+     * @var array
+     */
+    public $keys;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @param  array  $keys
+     * @param  array  $tags
+     * @return void
+     */
+    public function __construct($storeName, $keys, array $tags = [])
+    {
+        parent::__construct($storeName, $keys[0] ?? '', $tags);
+
+        $this->keys = $keys;
+    }
+}

--- a/src/Illuminate/Cache/Events/KeyForget.php
+++ b/src/Illuminate/Cache/Events/KeyForget.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class KeyForget extends CacheEvent
+{
+    //
+}

--- a/src/Illuminate/Cache/Events/KeyForgetFailed.php
+++ b/src/Illuminate/Cache/Events/KeyForgetFailed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class KeyForgetFailed extends KeyForgotten
+{
+    //
+}

--- a/src/Illuminate/Cache/Events/KeyWrite.php
+++ b/src/Illuminate/Cache/Events/KeyWrite.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class KeyWrite extends CacheEvent
+{
+    /**
+     * The value that was written.
+     *
+     * @var mixed
+     */
+    public $value;
+
+    /**
+     * The number of seconds the key should be valid.
+     *
+     * @var int|null
+     */
+    public $seconds;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int|null  $seconds
+     * @param  array  $tags
+     * @return void
+     */
+    public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
+    {
+        parent::__construct($storeName, $key, $tags);
+
+        $this->value = $value;
+        $this->seconds = $seconds;
+    }
+}

--- a/src/Illuminate/Cache/Events/KeyWriteFailed.php
+++ b/src/Illuminate/Cache/Events/KeyWriteFailed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class KeyWriteFailed extends KeyWritten
+{
+    //
+}

--- a/src/Illuminate/Cache/Events/KeyWriteMany.php
+++ b/src/Illuminate/Cache/Events/KeyWriteMany.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class KeyWriteMany extends CacheEvent
+{
+    /**
+     * The keys that are writing.
+     *
+     * @var mixed
+     */
+    public $keys;
+
+    /**
+     * The value that are writing.
+     *
+     * @var mixed
+     */
+    public $values;
+
+    /**
+     * The number of seconds the keys should be valid.
+     *
+     * @var int|null
+     */
+    public $seconds;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @param  array  $keys
+     * @param  array  $values
+     * @param  int|null  $seconds
+     * @param  array  $tags
+     * @return void
+     */
+    public function __construct($storeName, $keys, $values, $seconds = null, $tags = [])
+    {
+        parent::__construct($storeName, $keys[0], $tags);
+
+        $this->keys = $keys;
+        $this->values = $values;
+        $this->seconds = $seconds;
+    }
+}

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -6,9 +6,16 @@ use ArrayAccess;
 use BadMethodCallException;
 use Closure;
 use DateTimeInterface;
+use Illuminate\Cache\Events\CacheGet;
+use Illuminate\Cache\Events\CacheGetMany;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Cache\Events\KeyForget;
+use Illuminate\Cache\Events\KeyForgetFailed;
 use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Cache\Events\KeyWrite;
+use Illuminate\Cache\Events\KeyWriteFailed;
+use Illuminate\Cache\Events\KeyWriteMany;
 use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Cache\Store;
@@ -104,6 +111,8 @@ class Repository implements ArrayAccess, CacheContract
             return $this->many($key);
         }
 
+        $this->event(new CacheGet($this->getName(), $key));
+
         $value = $this->store->get($this->itemKey($key));
 
         // If we could not find the cache value, we will fire the missed event and get
@@ -130,6 +139,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function many(array $keys)
     {
+        $this->event(new CacheGetMany($this->getName(), $keys));
+
         $values = $this->store->many(collect($keys)->map(function ($value, $key) {
             return is_string($key) ? $key : $value;
         })->values()->all());
@@ -222,10 +233,14 @@ class Repository implements ArrayAccess, CacheContract
             return $this->forget($key);
         }
 
+        $this->event(new KeyWrite($this->getName(), $key, $value, $seconds));
+
         $result = $this->store->put($this->itemKey($key), $value, $seconds);
 
         if ($result) {
             $this->event(new KeyWritten($this->getName(), $key, $value, $seconds));
+        } else {
+            $this->event(new KeyWriteFailed($this->getName(), $key, $value, $seconds));
         }
 
         return $result;
@@ -260,11 +275,15 @@ class Repository implements ArrayAccess, CacheContract
             return $this->deleteMultiple(array_keys($values));
         }
 
+        $this->event(new KeyWriteMany($this->getName(), array_keys($values), array_values($values), $seconds));
+
         $result = $this->store->putMany($values, $seconds);
 
-        if ($result) {
-            foreach ($values as $key => $value) {
+        foreach ($values as $key => $value) {
+            if ($result) {
                 $this->event(new KeyWritten($this->getName(), $key, $value, $seconds));
+            } else {
+                $this->event(new KeyWriteFailed($this->getName(), $key, $value, $seconds));
             }
         }
 
@@ -372,10 +391,14 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function forever($key, $value)
     {
+        $this->event(new KeyWrite($this->getName(), $key, $value));
+
         $result = $this->store->forever($this->itemKey($key), $value);
 
         if ($result) {
             $this->event(new KeyWritten($this->getName(), $key, $value));
+        } else {
+            $this->event(new KeyWriteFailed($this->getName(), $key, $value));
         }
 
         return $result;
@@ -456,9 +479,13 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function forget($key)
     {
+        $this->event(new KeyForget($this->getName(), $key));
+
         return tap($this->store->forget($this->itemKey($key)), function ($result) use ($key) {
             if ($result) {
                 $this->event(new KeyForgotten($this->getName(), $key));
+            } else {
+                $this->event(new KeyForgetFailed($this->getName(), $key));
             }
         });
     }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -3,9 +3,15 @@
 namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Events\CacheGet;
+use Illuminate\Cache\Events\CacheGetMany;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Cache\Events\KeyForget;
+use Illuminate\Cache\Events\KeyForgetFailed;
 use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Cache\Events\KeyWrite;
+use Illuminate\Cache\Events\KeyWriteMany;
 use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Store;
@@ -25,15 +31,19 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo']));
         $this->assertFalse($repository->has('foo'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux']));
         $this->assertTrue($repository->has('baz'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
         $this->assertFalse($repository->tags('taylor')->has('foo'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux', 'tags' => ['taylor']]));
         $this->assertTrue($repository->tags('taylor')->has('baz'));
     }
@@ -43,15 +53,24 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo']));
         $this->assertNull($repository->get('foo'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGetMany::class, ['storeName' => 'array', 'keys' => ['foo', 'bar']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo']));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'bar']));
+        $this->assertSame(['foo' => null, 'bar' => null], $repository->get(['foo', 'bar']));
+
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux']));
         $this->assertSame('qux', $repository->get('baz'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
         $this->assertNull($repository->tags('taylor')->get('foo'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux', 'tags' => ['taylor']]));
         $this->assertSame('qux', $repository->tags('taylor')->get('baz'));
     }
@@ -61,7 +80,9 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux']));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForget::class, ['storeName' => 'array', 'key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgotten::class, ['storeName' => 'array', 'key' => 'baz']));
         $this->assertSame('qux', $repository->pull('baz'));
     }
@@ -71,7 +92,9 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux', 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForget::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgotten::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $this->assertSame('qux', $repository->tags('taylor')->pull('baz'));
     }
@@ -81,9 +104,16 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $repository->put('foo', 'bar', 99);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWriteMany::class, ['storeName' => 'array', 'keys' => ['foo', 'baz'], 'values' => ['bar', 'qux'], 'seconds' => 99]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'baz', 'value' => 'qux', 'seconds' => 99]));
+        $repository->putMany(['foo' => 'bar', 'baz' => 'qux'], 99);
+
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $repository->tags('taylor')->put('foo', 'bar', 99);
     }
@@ -93,11 +123,15 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo']));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $this->assertTrue($repository->add('foo', 'bar', 99));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $this->assertTrue($repository->tags('taylor')->add('foo', 'bar', 99));
     }
@@ -107,9 +141,11 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null]));
         $repository->forever('foo', 'bar');
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
         $repository->tags('taylor')->forever('foo', 'bar');
     }
@@ -119,13 +155,17 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo']));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
         $this->assertSame('bar', $repository->remember('foo', 99, function () {
             return 'bar';
         }));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
         $this->assertSame('bar', $repository->tags('taylor')->remember('foo', 99, function () {
             return 'bar';
@@ -137,13 +177,17 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo']));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null]));
         $this->assertSame('bar', $repository->rememberForever('foo', function () {
             return 'bar';
         }));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheGet::class, ['storeName' => 'array', 'key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['storeName' => 'array', 'key' => 'foo', 'tags' => ['taylor']]));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWrite::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['storeName' => 'array', 'key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
         $this->assertSame('bar', $repository->tags('taylor')->rememberForever('foo', function () {
             return 'bar';
@@ -155,14 +199,16 @@ class CacheEventsTest extends TestCase
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForget::class, ['storeName' => 'array', 'key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgotten::class, ['storeName' => 'array', 'key' => 'baz']));
         $this->assertTrue($repository->forget('baz'));
 
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForget::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgotten::class, ['storeName' => 'array', 'key' => 'baz', 'tags' => ['taylor']]));
         $this->assertTrue($repository->tags('taylor')->forget('baz'));
     }
 
-    public function testForgetDoesNotTriggerEventOnFailure()
+    public function testForgetDoesTriggerFailedEventOnFailure()
     {
         $dispatcher = $this->getDispatcher();
         $store = m::mock(Store::class);
@@ -170,7 +216,8 @@ class CacheEventsTest extends TestCase
         $repository = new Repository($store);
         $repository->setEventDispatcher($dispatcher);
 
-        $dispatcher->shouldReceive('dispatch')->never();
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForget::class, ['key' => 'baz']));
+        $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgetFailed::class, ['key' => 'baz']));
         $this->assertFalse($repository->forget('baz'));
     }
 

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Events\CacheGet;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
@@ -75,13 +76,14 @@ class SupportFacadesEventTest extends TestCase
     {
         $arrayRepository = Cache::store('array');
 
-        $this->events->shouldReceive('dispatch')->once();
+        $this->events->shouldReceive('dispatch')->times(2);
         $arrayRepository->get('foo');
 
         Event::fake();
 
         $arrayRepository->get('bar');
 
+        Event::assertDispatched(CacheGet::class);
         Event::assertDispatched(CacheMissed::class);
     }
 


### PR DESCRIPTION
To allow tracing how long read/write cache operations take I've added events that fire before the already existing events that fired after calling the cache store. This makes it so that every cache operation has a "start" and "end" event that allows tracking the time between them. 

To make sure every cache operation has a matching start and end event there are also 2 new failed events. The `$result` could also be added to the current events but not sure if it's a BC change to do that so instead I opted for the new failed events.

_I believe the `composer update` updated phpstan which results in the static analysis failing in a place where the changes in the PR should not affect it._