### PR TITLE
[11.x] Fix type tests

### DIFF
--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -42,7 +42,7 @@ assertType('int', with(new User(), function ($user): int {
     return 10;
 }));
 
-assertType('mixed', with(new User(), function ($user) {
+assertType('User', with(new User(), function ($user) {
     return $user;
 }));
 assertType('User', with(new User(), function ($user): User {


### PR DESCRIPTION
Latest `phpstan` got smarter and #51557 has broken tests because of it. This fixes the tests with the latest version of `phpstan`.

See: https://github.com/phpstan/phpstan/releases/tag/1.11.2