### PR TITLE
[11.x] Detect Cockroach DB connection loss

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -74,6 +74,8 @@ trait DetectsLostConnections
             'SQLSTATE[HY000]: General error: 3989',
             'went away',
             'No such file or directory',
+            'server is shutting down',
+            'failed to connect to'
         ]);
     }
 }

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -75,7 +75,7 @@ trait DetectsLostConnections
             'went away',
             'No such file or directory',
             'server is shutting down',
-            'failed to connect to'
+            'failed to connect to',
         ]);
     }
 }


### PR DESCRIPTION
This PR should cover catching the connection loss to a Cockroach DB. CockroachDB supports the PostgreSQL and is more and more used in cloud-native applications. Currently, the `causedByLostConnection` is not able to detect connection problems, since it's not catching the thrown error message.