### PR TITLE
[11.x] Add filled and blank blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -233,6 +233,48 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the if-filled statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileFilled($expression)
+    {
+        return "<?php if(filled{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-filled statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndFilled()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the if-blank statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileBlank($expression)
+    {
+        return "<?php if(blank{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-blank statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndBlank()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the switch statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeIfBlankStatementsTest.php
+++ b/tests/View/Blade/BladeIfBlankStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfBlankStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@blank ($test)
+breeze
+@endblank';
+        $expected = '<?php if(blank($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeIfFilledStatementsTest.php
+++ b/tests/View/Blade/BladeIfFilledStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfFilledStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@filled ($test)
+breeze
+@endfilled';
+        $expected = '<?php if(filled($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Lately I found myself doing a bunch of `@if(filled($var))` in my project. I feel like Laravel's handy `filled` and `blank` helpers deserve corresponding blade directives. What do you think?

Example:
```php
@filled($city->ai_summary)
    <h1>Summary</h1>
    <p>{{ $city->formattedSummary() }} </p>
@endfilled