### PR TITLE
[11.x] Write test for route stub cache file

### DIFF
--- a/tests/Routing/routes.stub
+++ b/tests/Routing/routes.stub
@@ -1,0 +1,10 @@
+<?php 
+
+namespace Illuminate\Tests\Routing;
+
+class RoutesCached
+{
+    function cachedRoute() {
+        return {{routes}};
+    }
+}


### PR DESCRIPTION
I added test for route.stub file.
It create a group route and then I add it to `RouteCollection` class and build cache file and checks data in the cache file
to equal with non-cache file.
The benefit of this it give idea to another that want to write test for cache.
Thanks