### PR TITLE
[11.x] Add `Macroable` to `PendingCommand`

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -20,6 +21,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 class PendingCommand
 {
     use Conditionable;
+    use Macroable;
 
     /**
      * The test being run.


### PR DESCRIPTION
I would like to add some custom assertions for our console tests, but there is currently no way to extend the `PendingCommand` (used for testing). By adding the `Macroable` trait, it will be possible to write custom assertions like:

```php
PendingCommand::macro('expectsOutputToBeFoo', function () {
    $this->expectsOutput('foo');

    return $this;
});

$this->artisan('foo')->expectsOutputToBeFoo();
```

