### PR TITLE
[11.x] Add dd_if and dd_unless conditional dump and die helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1040,3 +1040,19 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('dd_if')) {
+    /**
+     * Die and dump if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed  $vars
+     * @return void
+     */
+    function dd_if($boolean, ...$vars)
+    {
+        if ($boolean) {
+            dd($vars);
+        }
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1043,7 +1043,7 @@ if (! function_exists('view')) {
 
 if (! function_exists('dd_if')) {
     /**
-     * Die and dump if the given condition is true.
+     * Dump and die if the given condition is true.
      *
      * @param  bool  $boolean
      * @param  mixed  $vars

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1049,7 +1049,7 @@ if (! function_exists('dd_if')) {
      * @param  mixed  $vars
      * @return void
      */
-    function dd_if($boolean, ...$vars)
+    function dd_if(bool $boolean, mixed ...$vars): void
     {
         if ($boolean) {
             dd($vars);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1056,3 +1056,19 @@ if (! function_exists('dd_if')) {
         }
     }
 }
+
+if (! function_exists('dd_unless')) {
+    /**
+     * Dump and die unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed  $vars
+     * @return void
+     */
+    function dd_unless(bool $boolean, mixed ...$vars): void
+    {
+        if (! $boolean) {
+            dd($vars);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a helper function named `dd_if` and `dd_unless` to conditionally dump and die. This can be helpful when testing different code paths. This is a new addition, so no backwards breaking changes.

A quick example:
```php
dd_if(time() % 2 === 0, 'remainder of 2!')
```
The above code will only dump and die run when `time()` has a remainder of `2`

I don't believe there is currently a good way to write tests for code that runs `die`. If there is, please do let me know, I'd be happy to add them.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
