### PR TITLE
[11.x] Eloquent inverse relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -3,13 +3,14 @@
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
 
 trait SupportsInverseRelations
 {
     protected string|null $inverseRelationship = null;
 
     /**
-     * Gets the name of the inverse relationship
+     * Gets the name of the inverse relationship.
      *
      * @return string|null
      */
@@ -19,13 +20,17 @@ trait SupportsInverseRelations
     }
 
     /**
-     * Links the related models back to the parent after the query has run
+     * Links the related models back to the parent after the query has run.
      *
      * @param  string  $relation
      * @return $this
      */
     public function inverse(string $relation)
     {
+        if (! $this->getModel()->isRelation($relation)) {
+            throw RelationNotFoundException::make($this->getModel(), $relation);
+        }
+
         if ($this->inverseRelationship === null && $relation) {
             $this->query->afterQuery(function ($result) {
                 return $this->inverseRelationship
@@ -35,6 +40,18 @@ trait SupportsInverseRelations
         }
 
         $this->inverseRelationship = $relation;
+
+        return $this;
+    }
+
+    /**
+     * Removes the inverse relationship for this query.
+     *
+     * @return $this
+     */
+    public function withoutInverse()
+    {
+        $this->inverseRelationship = null;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -9,25 +9,33 @@ use Illuminate\Support\Str;
 
 trait SupportsInverseRelations
 {
+    /**
+     * The name of the inverse relationship.
+     *
+     * @var string|null
+     */
     protected string|null $inverseRelationship = null;
 
     /**
-     * Gets the name of the inverse relationship.
+     * Instruct Eloquent to link the related models back to the parent after the relationship query has run.
      *
-     * @return string|null
-     */
-    public function getInverseRelationship()
-    {
-        return $this->inverseRelationship;
-    }
-
-    /**
-     * Links the related models back to the parent after the query has run.
+     * Alias of "chaperone".
      *
      * @param  string|null  $relation
      * @return $this
      */
     public function inverse(?string $relation = null)
+    {
+        return $this->chaperone($relation);
+    }
+
+    /**
+     * Instruct Eloquent to link the related models back to the parent after the relationship query has run.
+     *
+     * @param  string|null  $relation
+     * @return $this
+     */
+    public function chaperone(?string $relation = null)
     {
         $relation ??= $this->guessInverseRelation();
 
@@ -49,19 +57,20 @@ trait SupportsInverseRelations
     }
 
     /**
-     * Removes the inverse relationship for this query.
+     * Guess the name of the inverse relationship.
      *
-     * @return $this
+     * @return string|null
      */
-    public function withoutInverse()
+    protected function guessInverseRelation(): string|null
     {
-        $this->inverseRelationship = null;
-
-        return $this;
+        return Arr::first(
+            $this->getPossibleInverseRelations(),
+            fn ($relation) => $relation && $this->getModel()->isRelation($relation)
+        );
     }
 
     /**
-     * Gets possible inverse relations for the parent model.
+     * Get the possible inverse relations for the parent model.
      *
      * @return array<non-empty-string>
      */
@@ -77,20 +86,7 @@ trait SupportsInverseRelations
     }
 
     /**
-     * Guesses the name of the inverse relationship.
-     *
-     * @return string|null
-     */
-    protected function guessInverseRelation(): string|null
-    {
-        return Arr::first(
-            $this->getPossibleInverseRelations(),
-            fn ($relation) => $relation && $this->getModel()->isRelation($relation)
-        );
-    }
-
-    /**
-     * Sets the inverse relation on all models in a collection.
+     * Set the inverse relation on all models in a collection.
      *
      * @param  \Illuminate\Database\Eloquent\Collection  $models
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
@@ -108,7 +104,7 @@ trait SupportsInverseRelations
     }
 
     /**
-     * Sets the inverse relation on a model.
+     * Set the inverse relation on a model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
@@ -123,5 +119,39 @@ trait SupportsInverseRelations
         }
 
         return $model;
+    }
+
+    /**
+     * Get the name of the inverse relationship.
+     *
+     * @return string|null
+     */
+    public function getInverseRelationship()
+    {
+        return $this->inverseRelationship;
+    }
+
+    /**
+     * Remove the chaperone / inverse relationship for this query.
+     *
+     * Alias of "withoutChaperone".
+     *
+     * @return $this
+     */
+    public function withoutInverse()
+    {
+        return $this->withoutChaperone();
+    }
+
+    /**
+     * Remove the chaperone / inverse relationship for this query.
+     *
+     * @return $this
+     */
+    public function withoutChaperone()
+    {
+        $this->inverseRelationship = null;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait SupportsInverseRelations
+{
+    protected string|null $inverseRelationship = null;
+
+    /**
+     * Gets the name of the inverse relationship
+     *
+     * @return string|null
+     */
+    public function getInverseRelationship()
+    {
+        return $this->inverseRelationship;
+    }
+
+    /**
+     * Links the related models back to the parent after the query has run
+     *
+     * @param  string  $relation
+     * @return $this
+     */
+    public function inverse(string $relation)
+    {
+        if ($this->inverseRelationship === null && $relation) {
+            $this->query->afterQuery(function ($result) {
+                return $this->inverseRelationship
+                    ? $this->applyInverseRelationToCollection($result, $this->getParent())
+                    : $result;
+            });
+        }
+
+        $this->inverseRelationship = $relation;
+
+        return $this;
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected function applyInverseRelationToCollection($models, ?Model $parent = null)
+    {
+        $parent ??= $this->getParent();
+
+        foreach ($models as $model) {
+            $this->applyInverseRelationToModel($model, $parent);
+        }
+
+        return $models;
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function applyInverseRelationToModel(Model $model, ?Model $parent = null)
+    {
+        if ($inverse = $this->getInverseRelationship()) {
+            $parent ??= $this->getParent();
+
+            $model->setRelation($inverse, $parent);
+        }
+
+        return $model;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,11 +13,18 @@ class HasMany extends HasOneOrMany
      */
     public function one()
     {
-        return HasOne::noConstraints(fn () => new HasOne(
-            $this->getQuery(),
-            $this->parent,
-            $this->foreignKey,
-            $this->localKey
+        return HasOne::noConstraints(fn () => tap(
+            new HasOne(
+                $this->getQuery(),
+                $this->parent,
+                $this->foreignKey,
+                $this->localKey
+            ),
+            function ($hasOne) {
+                if ($inverse = $this->getInverseRelationship()) {
+                    $hasOne->inverse($inverse);
+                }
+            }
         ));
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -119,9 +119,10 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
      */
     public function newRelatedInstanceFor(Model $parent)
     {
-        return $this->related->newInstance()->setAttribute(
-            $this->getForeignKeyName(), $parent->{$this->localKey}
-        );
+        return tap($this->related->newInstance(), function ($instance) use ($parent) {
+            $instance->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey});
+            $this->applyInverseRelationToModel($instance, $parent);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -6,11 +6,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Database\Eloquent\Relations\Concerns\SupportsInverseRelations;
 use Illuminate\Database\UniqueConstraintViolationException;
 
 abstract class HasOneOrMany extends Relation
 {
-    use InteractsWithDictionary;
+    use InteractsWithDictionary, SupportsInverseRelations;
 
     /**
      * The foreign key of the parent model.
@@ -53,6 +54,7 @@ abstract class HasOneOrMany extends Relation
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
+            $this->applyInverseRelationToModel($instance);
         });
     }
 
@@ -151,9 +153,13 @@ abstract class HasOneOrMany extends Relation
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
             if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
-                $model->setRelation(
-                    $relation, $this->getRelationValue($dictionary, $key, $type)
-                );
+                $related = $this->getRelationValue($dictionary, $key, $type);
+                $model->setRelation($relation, $related);
+
+                // Apply the inverse relation if we have one
+                $type === 'one'
+                    ? $this->applyInverseRelationToModel($related, $model)
+                    : $this->applyInverseRelationToCollection($related, $model);
             }
         }
 
@@ -340,6 +346,8 @@ abstract class HasOneOrMany extends Relation
             $this->setForeignAttributesForCreate($instance);
 
             $instance->save();
+
+            $this->applyInverseRelationToModel($instance);
         });
     }
 
@@ -364,7 +372,7 @@ abstract class HasOneOrMany extends Relation
     {
         $attributes[$this->getForeignKeyName()] = $this->getParentKey();
 
-        return $this->related->forceCreate($attributes);
+        return $this->applyInverseRelationToModel($this->related->forceCreate($attributes));
     }
 
     /**
@@ -415,6 +423,7 @@ abstract class HasOneOrMany extends Relation
     protected function setForeignAttributesForCreate(Model $model)
     {
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+        $this->applyInverseRelationToModel($model);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -156,7 +156,7 @@ abstract class HasOneOrMany extends Relation
                 $related = $this->getRelationValue($dictionary, $key, $type);
                 $model->setRelation($relation, $related);
 
-                // Apply the inverse relation if we have one
+                // Apply the inverse relation if we have one...
                 $type === 'one'
                     ? $this->applyInverseRelationToModel($related, $model)
                     : $this->applyInverseRelationToCollection($related, $model);
@@ -423,6 +423,7 @@ abstract class HasOneOrMany extends Relation
     protected function setForeignAttributesForCreate(Model $model)
     {
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+
         $this->applyInverseRelationToModel($model);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -14,12 +14,19 @@ class MorphMany extends MorphOneOrMany
      */
     public function one()
     {
-        return MorphOne::noConstraints(fn () => new MorphOne(
-            $this->getQuery(),
-            $this->getParent(),
-            $this->morphType,
-            $this->foreignKey,
-            $this->localKey
+        return MorphOne::noConstraints(fn () => tap(
+            new MorphOne(
+                $this->getQuery(),
+                $this->getParent(),
+                $this->morphType,
+                $this->foreignKey,
+                $this->localKey
+            ),
+            function ($morphOne) {
+                if ($inverse = $this->getInverseRelationship()) {
+                    $morphOne->inverse($inverse);
+                }
+            }
         ));
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -119,9 +119,12 @@ class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
      */
     public function newRelatedInstanceFor(Model $parent)
     {
-        return $this->related->newInstance()
-                    ->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey})
-                    ->setAttribute($this->getMorphType(), $this->morphClass);
+        return tap($this->related->newInstance(), function ($instance) use ($parent) {
+            $instance->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey})
+                ->setAttribute($this->getMorphType(), $this->morphClass);
+
+            $this->applyInverseRelationToModel($instance, $parent);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -78,7 +78,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $attributes[$this->getForeignKeyName()] = $this->getParentKey();
         $attributes[$this->getMorphType()] = $this->morphClass;
 
-        return $this->related->forceCreate($attributes);
+        return $this->applyInverseRelationToModel($this->related->forceCreate($attributes));
     }
 
     /**
@@ -92,6 +92,8 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getForeignKeyName()} = $this->getParentKey();
 
         $model->{$this->getMorphType()} = $this->morphClass;
+
+        $this->applyInverseRelationToModel($model);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 abstract class MorphOneOrMany extends HasOneOrMany
 {
@@ -139,5 +140,18 @@ abstract class MorphOneOrMany extends HasOneOrMany
     public function getMorphClass()
     {
         return $this->morphClass;
+    }
+
+    /**
+     * Gets possible inverse relations for the parent model.
+     *
+     * @return array<non-empty-string>
+     */
+    protected function getPossibleInverseRelations(): array
+    {
+        return array_unique([
+            Str::beforeLast($this->getMorphType(), '_type'),
+            ...parent::getPossibleInverseRelations(),
+        ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -143,7 +143,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Gets possible inverse relations for the parent model.
+     * Get the possible inverse relations for the parent model.
      *
      * @return array<non-empty-string>
      */

--- a/tests/Database/DatabaseEloquentInverseRelationHasManyTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationHasManyTest.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentInverseRelationHasManyTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('test_users', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('test_posts', function ($table) {
+            $table->increments('id');
+            $table->foreignId('user_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('test_users');
+        $this->schema()->drop('test_posts');
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        HasManyInverseUserModel::factory()->count(3)->withPosts()->create();
+        $users = HasManyInverseUserModel::all();
+
+        foreach ($users as $user) {
+            $this->assertFalse($user->relationLoaded('posts'));
+            foreach ($user->posts as $post) {
+                $this->assertTrue($post->relationLoaded('user'));
+                $this->assertSame($user, $post->user);
+            }
+        }
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        HasManyInverseUserModel::factory()->count(3)->withPosts()->create();
+        $users = HasManyInverseUserModel::with('posts')->get();
+
+        foreach ($users as $user) {
+            $posts = $user->getRelation('posts');
+
+            foreach ($posts as $post) {
+                $this->assertTrue($post->relationLoaded('user'));
+                $this->assertSame($user, $post->user);
+            }
+        }
+    }
+
+    public function testHasLatestOfManyInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        HasManyInverseUserModel::factory()->count(3)->withPosts()->create();
+        $users = HasManyInverseUserModel::all();
+
+        foreach ($users as $user) {
+            $this->assertFalse($user->relationLoaded('lastPost'));
+            $post = $user->lastPost;
+
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testHasLatestOfManyInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        HasManyInverseUserModel::factory()->count(3)->withPosts()->create();
+        $users = HasManyInverseUserModel::with('lastPost')->get();
+
+        foreach ($users as $user) {
+            $post = $user->getRelation('lastPost');
+
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testOneOfManyInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        HasManyInverseUserModel::factory()->count(3)->withPosts()->create();
+        $users = HasManyInverseUserModel::all();
+
+        foreach ($users as $user) {
+            $this->assertFalse($user->relationLoaded('firstPost'));
+            $post = $user->firstPost;
+
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testOneOfManyInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        HasManyInverseUserModel::factory()->count(3)->withPosts()->create();
+        $users = HasManyInverseUserModel::with('firstPost')->get();
+
+        foreach ($users as $user) {
+            $post = $user->getRelation('firstPost');
+
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenMakingMany()
+    {
+        $user = HasManyInverseUserModel::create();
+
+        $posts = $user->posts()->makeMany(array_fill(0, 3, []));
+
+        foreach ($posts as $post) {
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenCreatingMany()
+    {
+        $user = HasManyInverseUserModel::create();
+
+        $posts = $user->posts()->createMany(array_fill(0, 3, []));
+
+        foreach ($posts as $post) {
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenCreatingManyQuietly()
+    {
+        $user = HasManyInverseUserModel::create();
+
+        $posts = $user->posts()->createManyQuietly(array_fill(0, 3, []));
+
+        foreach ($posts as $post) {
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenSavingMany()
+    {
+        $user = HasManyInverseUserModel::create();
+
+        $posts = array_fill(0, 3, new HasManyInversePostModel);
+
+        $user->posts()->saveMany($posts);
+
+        foreach ($posts as $post) {
+            $this->assertTrue($post->relationLoaded('user'));
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    public function testHasManyInverseRelationIsProperlySetToParentWhenUpdatingMany()
+    {
+        $user = HasManyInverseUserModel::create();
+
+        $posts = HasManyInversePostModel::factory()->count(3)->create();
+
+        foreach ($posts as $post) {
+            $this->assertTrue($user->isNot($post->user));
+        }
+
+        $user->posts()->saveMany($posts);
+
+        foreach ($posts as $post) {
+            $this->assertSame($user, $post->user);
+        }
+    }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class HasManyInverseUserModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_users';
+    protected $fillable = ['id'];
+
+    protected static function newFactory()
+    {
+        return new HasManyInverseUserModelFactory();
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(HasManyInversePostModel::class, 'user_id')->inverse('user');
+    }
+
+    public function lastPost(): HasOne
+    {
+        return $this->hasOne(HasManyInversePostModel::class, 'user_id')->latestOfMany()->inverse('user');
+    }
+
+    public function firstPost(): HasOne
+    {
+        return $this->posts()->one();
+    }
+}
+
+class HasManyInverseUserModelFactory extends Factory
+{
+    protected $model = HasManyInverseUserModel::class;
+
+    public function definition()
+    {
+        return [];
+    }
+
+    public function withPosts(int $count = 3)
+    {
+        return $this->afterCreating(function (HasManyInverseUserModel $model) use ($count) {
+            HasManyInversePostModel::factory()->recycle($model)->count($count)->create();
+        });
+    }
+}
+
+class HasManyInversePostModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_posts';
+    protected $fillable = ['id', 'user_id'];
+
+    protected static function newFactory()
+    {
+        return new HasManyInversePostModelFactory();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(HasManyInverseUserModel::class, 'user_id');
+    }
+}
+
+class HasManyInversePostModelFactory extends Factory
+{
+    protected $model = HasManyInversePostModel::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => HasManyInverseUserModel::factory(),
+        ];
+    }
+}

--- a/tests/Database/DatabaseEloquentInverseRelationHasOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationHasOneTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentInverseRelationHasOneTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('test_parent', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('test_child', function ($table) {
+            $table->increments('id');
+            $table->foreignId('parent_id')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('test_parent');
+        $this->schema()->drop('test_child');
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        HasOneInverseChildModel::factory(5)->create();
+        $models = HasOneInverseParentModel::all();
+
+        foreach ($models as $parent) {
+            $this->assertFalse($parent->relationLoaded('child'));
+            $child = $parent->child;
+            $this->assertTrue($child->relationLoaded('parent'));
+            $this->assertSame($parent, $child->parent);
+        }
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        HasOneInverseChildModel::factory(5)->create();
+
+        $models = HasOneInverseParentModel::with('child')->get();
+
+        foreach ($models as $parent) {
+            $child = $parent->child;
+
+            $this->assertTrue($child->relationLoaded('parent'));
+            $this->assertSame($parent, $child->parent);
+        }
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenMaking()
+    {
+        $parent = HasOneInverseParentModel::create();
+
+        $child = $parent->child()->make();
+
+        $this->assertTrue($child->relationLoaded('parent'));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenCreating()
+    {
+        $parent = HasOneInverseParentModel::create();
+
+        $child = $parent->child()->create();
+
+        $this->assertTrue($child->relationLoaded('parent'));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenCreatingQuietly()
+    {
+        $parent = HasOneInverseParentModel::create();
+
+        $child = $parent->child()->createQuietly();
+
+        $this->assertTrue($child->relationLoaded('parent'));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenForceCreating()
+    {
+        $parent = HasOneInverseParentModel::create();
+
+        $child = $parent->child()->forceCreate();
+
+        $this->assertTrue($child->relationLoaded('parent'));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenSaving()
+    {
+        $parent = HasOneInverseParentModel::create();
+        $child = HasOneInverseChildModel::make();
+
+        $this->assertFalse($child->relationLoaded('parent'));
+        $parent->child()->save($child);
+
+        $this->assertTrue($child->relationLoaded('parent'));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenSavingQuietly()
+    {
+        $parent = HasOneInverseParentModel::create();
+        $child = HasOneInverseChildModel::make();
+
+        $this->assertFalse($child->relationLoaded('parent'));
+        $parent->child()->saveQuietly($child);
+
+        $this->assertTrue($child->relationLoaded('parent'));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    public function testHasOneInverseRelationIsProperlySetToParentWhenUpdating()
+    {
+        $parent = HasOneInverseParentModel::create();
+        $child = HasOneInverseChildModel::factory()->create();
+
+        $this->assertTrue($parent->isNot($child->parent));
+
+        $parent->child()->save($child);
+
+        $this->assertTrue($parent->is($child->parent));
+        $this->assertSame($parent, $child->parent);
+    }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class HasOneInverseParentModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_parent';
+
+    protected $fillable = ['id'];
+
+    protected static function newFactory()
+    {
+        return new HasOneInverseParentModelFactory();
+    }
+
+    public function child(): HasOne
+    {
+        return $this->hasOne(HasOneInverseChildModel::class, 'parent_id')->inverse('parent');
+    }
+}
+
+class HasOneInverseParentModelFactory extends Factory
+{
+    protected $model = HasOneInverseParentModel::class;
+
+    public function definition()
+    {
+        return [];
+    }
+}
+
+class HasOneInverseChildModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_child';
+    protected $fillable = ['id', 'parent_id'];
+
+    protected static function newFactory()
+    {
+        return new HasOneInverseChildModelFactory();
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(HasOneInverseParentModel::class, 'parent_id');
+    }
+}
+
+class HasOneInverseChildModelFactory extends Factory
+{
+    protected $model = HasOneInverseChildModel::class;
+
+    public function definition()
+    {
+        return [
+            'parent_id' => HasOneInverseParentModel::factory(),
+        ];
+    }
+}

--- a/tests/Database/DatabaseEloquentInverseRelationMorphManyTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationMorphManyTest.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentInverseRelationMorphManyTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('test_posts', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('test_comments', function ($table) {
+            $table->increments('id');
+            $table->morphs('commentable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('test_posts');
+        $this->schema()->drop('test_comments');
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        MorphManyInversePostModel::factory()->withComments()->count(3)->create();
+        $posts = MorphManyInversePostModel::all();
+
+        foreach ($posts as $post) {
+            $this->assertFalse($post->relationLoaded('comments'));
+            $comments = $post->comments;
+            foreach ($comments as $comment) {
+                $this->assertTrue($comment->relationLoaded('commentable'));
+                $this->assertSame($post, $comment->commentable);
+            }
+        }
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        MorphManyInversePostModel::factory()->withComments()->count(3)->create();
+        $posts = MorphManyInversePostModel::with('comments')->get();
+
+        foreach ($posts as $post) {
+            $comments = $post->getRelation('comments');
+
+            foreach ($comments as $comment) {
+                $this->assertTrue($comment->relationLoaded('commentable'));
+                $this->assertSame($post, $comment->commentable);
+            }
+        }
+    }
+
+    public function testMorphLatestOfManyInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        MorphManyInversePostModel::factory()->count(3)->withComments()->create();
+        $posts = MorphManyInversePostModel::all();
+
+        foreach ($posts as $post) {
+            $this->assertFalse($post->relationLoaded('lastComment'));
+            $comment = $post->lastComment;
+
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphLatestOfManyInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        MorphManyInversePostModel::factory()->count(3)->withComments()->create();
+        $posts = MorphManyInversePostModel::with('lastComment')->get();
+
+        foreach ($posts as $post) {
+            $comment = $post->getRelation('lastComment');
+
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphOneOfManyInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        MorphManyInversePostModel::factory()->count(3)->withComments()->create();
+        $posts = MorphManyInversePostModel::all();
+
+        foreach ($posts as $post) {
+            $this->assertFalse($post->relationLoaded('firstComment'));
+            $comment = $post->firstComment;
+
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphOneOfManyInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        MorphManyInversePostModel::factory()->count(3)->withComments()->create();
+        $posts = MorphManyInversePostModel::with('firstComment')->get();
+
+        foreach ($posts as $post) {
+            $comment = $post->getRelation('firstComment');
+
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenMakingMany()
+    {
+        $post = MorphManyInversePostModel::create();
+
+        $comments = $post->comments()->makeMany(array_fill(0, 3, []));
+
+        foreach ($comments as $comment) {
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenCreatingMany()
+    {
+        $post = MorphManyInversePostModel::create();
+
+        $comments = $post->comments()->createMany(array_fill(0, 3, []));
+
+        foreach ($comments as $comment) {
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenCreatingManyQuietly()
+    {
+        $post = MorphManyInversePostModel::create();
+
+        $comments = $post->comments()->createManyQuietly(array_fill(0, 3, []));
+
+        foreach ($comments as $comment) {
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenSavingMany()
+    {
+        $post = MorphManyInversePostModel::create();
+        $comments = array_fill(0, 3, new MorphManyInverseCommentModel);
+
+        $post->comments()->saveMany($comments);
+
+        foreach ($comments as $comment) {
+            $this->assertTrue($comment->relationLoaded('commentable'));
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    public function testMorphManyInverseRelationIsProperlySetToParentWhenUpdatingMany()
+    {
+        $post = MorphManyInversePostModel::create();
+        $comments = MorphManyInverseCommentModel::factory()->count(3)->create();
+
+        foreach ($comments as $comment) {
+            $this->assertTrue($post->isNot($comment->commentable));
+        }
+
+        $post->comments()->saveMany($comments);
+
+        foreach ($comments as $comment) {
+            $this->assertSame($post, $comment->commentable);
+        }
+    }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class MorphManyInversePostModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_posts';
+    protected $fillable = ['id'];
+
+    protected static function newFactory()
+    {
+        return new MorphManyInversePostModelFactory();
+    }
+
+    public function comments(): MorphMany
+    {
+        return $this->morphMany(MorphManyInverseCommentModel::class, 'commentable')->inverse('commentable');
+    }
+
+    public function lastComment(): MorphOne
+    {
+        return $this->morphOne(MorphManyInverseCommentModel::class, 'commentable')->latestOfMany()->inverse('commentable');
+    }
+
+    public function firstComment(): MorphOne
+    {
+        return $this->comments()->one();
+    }
+}
+
+class MorphManyInversePostModelFactory extends Factory
+{
+    protected $model = MorphManyInversePostModel::class;
+
+    public function definition()
+    {
+        return [];
+    }
+
+    public function withComments(int $count = 3)
+    {
+        return $this->afterCreating(function (MorphManyInversePostModel $model) use ($count) {
+            MorphManyInverseCommentModel::factory()->recycle($model)->count($count)->create();
+        });
+    }
+}
+
+class MorphManyInverseCommentModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_comments';
+    protected $fillable = ['id', 'commentable_type', 'commentable_id'];
+
+    protected static function newFactory()
+    {
+        return new MorphManyInverseCommentModelFactory();
+    }
+
+    public function commentable(): MorphTo
+    {
+        return $this->morphTo('commentable');
+    }
+}
+
+class MorphManyInverseCommentModelFactory extends Factory
+{
+    protected $model = MorphManyInverseCommentModel::class;
+
+    public function definition()
+    {
+        return [
+            'commentable_type' => MorphManyInversePostModel::class,
+            'commentable_id' => MorphManyInversePostModel::factory(),
+        ];
+    }
+}

--- a/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('test_posts', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('test_images', function ($table) {
+            $table->increments('id');
+            $table->morphs('imageable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('test_posts');
+        $this->schema()->drop('test_images');
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        MorphOneInverseImageModel::factory(6)->create();
+        $posts = MorphOneInversePostModel::all();
+
+        foreach ($posts as $post) {
+            $this->assertFalse($post->relationLoaded('image'));
+            $image = $post->image;
+            $this->assertTrue($image->relationLoaded('imageable'));
+            $this->assertSame($post, $image->imageable);
+        }
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        MorphOneInverseImageModel::factory(6)->create();
+        $posts = MorphOneInversePostModel::with('image')->get();
+
+        foreach ($posts as $post) {
+            $image = $post->getRelation('image');
+
+            $this->assertTrue($image->relationLoaded('imageable'));
+            $this->assertSame($post, $image->imageable);
+        }
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenMaking()
+    {
+        $post = MorphOneInversePostModel::create();
+
+        $image = $post->image()->make();
+
+        $this->assertTrue($image->relationLoaded('imageable'));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenCreating()
+    {
+        $post = MorphOneInversePostModel::create();
+
+        $image = $post->image()->create();
+
+        $this->assertTrue($image->relationLoaded('imageable'));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenCreatingQuietly()
+    {
+        $post = MorphOneInversePostModel::create();
+
+        $image = $post->image()->createQuietly();
+
+        $this->assertTrue($image->relationLoaded('imageable'));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenForceCreating()
+    {
+        $post = MorphOneInversePostModel::create();
+
+        $image = $post->image()->forceCreate();
+
+        $this->assertTrue($image->relationLoaded('imageable'));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenSaving()
+    {
+        $post = MorphOneInversePostModel::create();
+        $image = MorphOneInverseImageModel::make();
+
+        $this->assertFalse($image->relationLoaded('imageable'));
+        $post->image()->save($image);
+
+        $this->assertTrue($image->relationLoaded('imageable'));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenSavingQuietly()
+    {
+        $post = MorphOneInversePostModel::create();
+        $image = MorphOneInverseImageModel::make();
+
+        $this->assertFalse($image->relationLoaded('imageable'));
+        $post->image()->saveQuietly($image);
+
+        $this->assertTrue($image->relationLoaded('imageable'));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    public function testMorphOneInverseRelationIsProperlySetToParentWhenUpdating()
+    {
+        $post = MorphOneInversePostModel::create();
+        $image = MorphOneInverseImageModel::factory()->create();
+
+        $this->assertTrue($post->isNot($image->imageable));
+
+        $post->image()->save($image);
+
+        $this->assertTrue($post->is($image->imageable));
+        $this->assertSame($post, $image->imageable);
+    }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class MorphOneInversePostModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_posts';
+    protected $fillable = ['id'];
+
+    protected static function newFactory()
+    {
+        return new MorphOneInversePostModelFactory();
+    }
+
+    public function image(): MorphOne
+    {
+        return $this->morphOne(MorphOneInverseImageModel::class, 'imageable')->inverse('imageable');
+    }
+}
+
+class MorphOneInversePostModelFactory extends Factory
+{
+    protected $model = MorphOneInversePostModel::class;
+
+    public function definition()
+    {
+        return [];
+    }
+}
+
+class MorphOneInverseImageModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'test_images';
+    protected $fillable = ['id', 'imageable_type', 'imageable_id'];
+
+    protected static function newFactory()
+    {
+        return new MorphOneInverseImageModelFactory();
+    }
+
+    public function imageable(): MorphTo
+    {
+        return $this->morphTo('imageable');
+    }
+}
+
+class MorphOneInverseImageModelFactory extends Factory
+{
+    protected $model = MorphOneInverseImageModel::class;
+
+    public function definition()
+    {
+        return [
+            'imageable_type' => MorphOneInversePostModel::class,
+            'imageable_id' => MorphOneInversePostModel::factory(),
+        ];
+    }
+}

--- a/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
@@ -83,6 +83,32 @@ class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
         }
     }
 
+    public function testMorphOneGuessedInverseRelationIsProperlySetToParentWhenLazyLoaded()
+    {
+        MorphOneInverseImageModel::factory(6)->create();
+        $posts = MorphOneInversePostModel::all();
+
+        foreach ($posts as $post) {
+            $this->assertFalse($post->relationLoaded('guessedImage'));
+            $image = $post->guessedImage;
+            $this->assertTrue($image->relationLoaded('imageable'));
+            $this->assertSame($post, $image->imageable);
+        }
+    }
+
+    public function testMorphOneGuessedInverseRelationIsProperlySetToParentWhenEagerLoaded()
+    {
+        MorphOneInverseImageModel::factory(6)->create();
+        $posts = MorphOneInversePostModel::with('guessedImage')->get();
+
+        foreach ($posts as $post) {
+            $image = $post->getRelation('guessedImage');
+
+            $this->assertTrue($image->relationLoaded('imageable'));
+            $this->assertSame($post, $image->imageable);
+        }
+    }
+
     public function testMorphOneInverseRelationIsProperlySetToParentWhenMaking()
     {
         $post = MorphOneInversePostModel::create();
@@ -200,6 +226,11 @@ class MorphOneInversePostModel extends Model
     public function image(): MorphOne
     {
         return $this->morphOne(MorphOneInverseImageModel::class, 'imageable')->inverse('imageable');
+    }
+
+    public function guessedImage(): MorphOne
+    {
+        return $this->morphOne(MorphOneInverseImageModel::class, 'imageable')->inverse();
     }
 }
 

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsInverseRelations;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Mockery as m;
@@ -23,16 +25,46 @@ class DatabaseEloquentInverseRelationTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
         $builder->shouldReceive('afterQuery')->never();
 
-        new HasInverseRelationStub($builder, new HasInverseRelationParentStub(['id' => 1]));
+        new HasInverseRelationStub($builder, new HasInverseRelationParentStub());
     }
 
     public function testInverseRelationCallbackIsNotSetIfInverseRelationIsEmpty()
     {
         $builder = m::mock(Builder::class);
+
+        $this->expectException(RelationNotFoundException::class);
         $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
         $builder->shouldReceive('afterQuery')->never();
 
         (new HasInverseRelationStub($builder, new HasInverseRelationParentStub()))->inverse('');
+    }
+
+    public function testInverseRelationCallbackIsNotSetIfInverseRelationshipDoesNotExist()
+    {
+        $builder = m::mock(Builder::class);
+
+        $this->expectException(RelationNotFoundException::class);
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+        $builder->shouldReceive('afterQuery')->never();
+
+        (new HasInverseRelationStub($builder, new HasInverseRelationParentStub()))->inverse('foo');
+    }
+
+    public function testWithoutInverseMethodRemovesInverseRelation()
+    {
+        $builder = m::mock(Builder::class);
+
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+        $builder->shouldReceive('afterQuery')->once()->andReturnSelf();
+
+        $relation = (new HasInverseRelationStub($builder, new HasInverseRelationParentStub()));
+        $this->assertNull($relation->getInverseRelationship());
+
+        $relation->inverse('test');
+        $this->assertSame('test', $relation->getInverseRelationship());
+
+        $relation->withoutInverse();
+        $this->assertNull($relation->getInverseRelationship());
     }
 
     public function testBuilderCallbackIsAppliedWhenInverseRelationIsSet()
@@ -80,7 +112,7 @@ class DatabaseEloquentInverseRelationTest extends TestCase
         }
     }
 
-    public function testInverseRelationIsNotSetIfInverseRelationNameIsEmpty()
+    public function testInverseRelationIsNotSetIfInverseRelationIsUnset()
     {
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
@@ -93,10 +125,7 @@ class DatabaseEloquentInverseRelationTest extends TestCase
 
         $parent = new HasInverseRelationParentStub();
         $relation = (new HasInverseRelationStub($builder, $parent));
-        // Set the callback
         $relation->inverse('test');
-        // Override the relation name to be blank
-        $relation->inverse('');
 
         $results = new Collection(array_fill(0, 5, new HasInverseRelationRelatedStub()));
         foreach ($results as $model) {
@@ -104,17 +133,36 @@ class DatabaseEloquentInverseRelationTest extends TestCase
         }
         $results = $afterQuery($results);
         foreach ($results as $model) {
+            $this->assertNotEmpty($model->getRelations());
+            $this->assertSame($parent, $model->getRelation('test'));
+        }
+
+        // Reset the inverse relation
+        $relation->withoutInverse();
+
+        $results = new Collection(array_fill(0, 5, new HasInverseRelationRelatedStub()));
+        foreach ($results as $model) {
+            $this->assertEmpty($model->getRelations());
+        }
+        foreach ($results as $model) {
             $this->assertEmpty($model->getRelations());
         }
     }
 }
 
-class HasInverseRelationParentStub extends Model {
+class HasInverseRelationParentStub extends Model
+{
     protected static $unguarded = true;
 }
 
-class HasInverseRelationRelatedStub extends Model {
+class HasInverseRelationRelatedStub extends Model
+{
     protected static $unguarded = true;
+
+    public function test(): BelongsTo
+    {
+        return $this->belongsTo(HasInverseRelationParentStub::class);
+    }
 }
 
 class HasInverseRelationStub extends Relation
@@ -122,9 +170,28 @@ class HasInverseRelationStub extends Relation
     use SupportsInverseRelations;
 
     // None of these methods will actually be called - they're just needed to fill out `Relation`
-    public function match(array $models, Collection $results, $relation) {return $models;}
-    public function initRelation(array $models, $relation) {return $models;}
-    public function getResults(){return $this->query->get();}
-    public function addConstraints() {}
-    public function addEagerConstraints(array $models) {}
+    public function match(array $models, Collection $results, $relation)
+    {
+        return $models;
+    }
+
+    public function initRelation(array $models, $relation)
+    {
+        return $models;
+    }
+
+    public function getResults()
+    {
+        return $this->query->get();
+    }
+
+    public function addConstraints()
+    {
+        //
+    }
+
+    public function addEagerConstraints(array $models)
+    {
+        //
+    }
 }

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\SupportsInverseRelations;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentInverseRelationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testBuilderCallbackIsNotAppliedWhenInverseRelationIsNotSet()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+        $builder->shouldReceive('afterQuery')->never();
+
+        new HasInverseRelationStub($builder, new HasInverseRelationParentStub(['id' => 1]));
+    }
+
+    public function testInverseRelationCallbackIsNotSetIfInverseRelationIsEmpty()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+        $builder->shouldReceive('afterQuery')->never();
+
+        (new HasInverseRelationStub($builder, new HasInverseRelationParentStub()))->inverse('');
+    }
+
+    public function testBuilderCallbackIsAppliedWhenInverseRelationIsSet()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+
+        $parent = new HasInverseRelationParentStub();
+        $builder->shouldReceive('afterQuery')->withArgs(function (\Closure $callback) use ($parent) {
+            $relation = (new \ReflectionFunction($callback))->getClosureThis();
+
+            return $relation instanceof HasInverseRelationStub && $relation->getParent() === $parent;
+        })->once()->andReturnSelf();
+
+        (new HasInverseRelationStub($builder, $parent))->inverse('test');
+    }
+
+    public function testBuilderCallbackAppliesInverseRelationToAllModelsInResult()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+
+        // Capture the callback so that we can manually call it.
+        $afterQuery = null;
+        $builder->shouldReceive('afterQuery')->withArgs(function (\Closure $callback) use (&$afterQuery) {
+            return (bool) $afterQuery = $callback;
+        })->once()->andReturnSelf();
+
+        $parent = new HasInverseRelationParentStub();
+        (new HasInverseRelationStub($builder, $parent))->inverse('test');
+
+        $results = new Collection(array_fill(0, 5, new HasInverseRelationRelatedStub()));
+
+        foreach ($results as $model) {
+            $this->assertEmpty($model->getRelations());
+            $this->assertFalse($model->relationLoaded('test'));
+        }
+
+        $results = $afterQuery($results);
+
+        foreach ($results as $model) {
+            $this->assertNotEmpty($model->getRelations());
+            $this->assertTrue($model->relationLoaded('test'));
+            $this->assertSame($parent, $model->test);
+        }
+    }
+
+    public function testInverseRelationIsNotSetIfInverseRelationNameIsEmpty()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new HasInverseRelationRelatedStub());
+
+        // Capture the callback so that we can manually call it.
+        $afterQuery = null;
+        $builder->shouldReceive('afterQuery')->withArgs(function (\Closure $callback) use (&$afterQuery) {
+            return (bool) $afterQuery = $callback;
+        })->once()->andReturnSelf();
+
+        $parent = new HasInverseRelationParentStub();
+        $relation = (new HasInverseRelationStub($builder, $parent));
+        // Set the callback
+        $relation->inverse('test');
+        // Override the relation name to be blank
+        $relation->inverse('');
+
+        $results = new Collection(array_fill(0, 5, new HasInverseRelationRelatedStub()));
+        foreach ($results as $model) {
+            $this->assertEmpty($model->getRelations());
+        }
+        $results = $afterQuery($results);
+        foreach ($results as $model) {
+            $this->assertEmpty($model->getRelations());
+        }
+    }
+}
+
+class HasInverseRelationParentStub extends Model {
+    protected static $unguarded = true;
+}
+
+class HasInverseRelationRelatedStub extends Model {
+    protected static $unguarded = true;
+}
+
+class HasInverseRelationStub extends Relation
+{
+    use SupportsInverseRelations;
+
+    // None of these methods will actually be called - they're just needed to fill out `Relation`
+    public function match(array $models, Collection $results, $relation) {return $models;}
+    public function initRelation(array $models, $relation) {return $models;}
+    public function getResults(){return $this->query->get();}
+    public function addConstraints() {}
+    public function addEagerConstraints(array $models) {}
+}


### PR DESCRIPTION
How many times has this happened to you?

```html
@foreach($post->comments as $comment)
  <!-- comment content -->
  @can('promote', $comment)
    <a href="{{ route('posts.comments.promote', [$post, $comment]) }}">promote</a>
  @endcan
@endforeach
```
With the policy:
```php
public function promote(User $user, Comment $comment): bool
{
    return
        $comment->approved_at !== null
        && $comment->promoted === false
        && $user->can('update', $comment->post);
}
```
Only to find that you're now getting a new query for every single comment to pull the post back out of the database?

Obviously you could eager-load the post back onto the model, but even then that's creating a lot of extra busywork _and_ it might miss scopes that were added on the original query:
```php
// Ensure that the comments pull can access trashed posts
$posts = Post::withTrashed()->with(['comments' => ['post' => fn ($q) => $q->withTrashed() ]])->paginate();
```

Well it's happened to me. A lot. So I decided to do something about it.

### Introducing `inverse()`

`inverse()` is a modifier for `Has*` and `Morph*` relations that allows you to easily set the parent model in the correct relation on the child models:

```php
public function comments(): HasMany
{
    return $this->hasMany(Comment::class)->inverse('post');
}
```
Now you can do:
```php
$posts = Post::withTrashed()->with('comments')->paginate();
```
And each `Comment` model will have its `post` relation filled out with the _actual instance_ of the parent model, with no extra queries, or missed scopes.

Note that it injects the _actual instance_, instead of querying and pulling _another_ instance which could then get out of sync:
```php
$eager = $post->comments()->with('post')->first();
$inverse = $post->comments()->inverse('post')->first();
$post->delete();
$eager->post->trashed(); // false
$inverse->post->trashed(); // true
```

#### Optionally Skipping an Inverse Relationship

If you _don't_ want to incluide the inverse relationship for some reason, you can tack `->withoutInverse()` onto the query builder that you get from the relation:
```php
public function posts(): HasMany
{
    return $this->hasMany(Post::class)->inverse('user');
}

// ...

User::with(['posts' => fn ($q) => $q->withoutInverse()])->toArray();
```

#### Guessing the Inverse Relationship

If you don't define the inverse relationship it will attempt to guess the correct relationship based on the foreign key of the relation, the foriegn key of the parent, the name of the parent model, the name of a polymorphic relationship, or a couple of common relationship names such as `owner`.

```php
class Comment extends Model
{
    public function user(): BelongsTo;
}

class PageView extends Model
{
    public function person(): BelongsTo;
}

class Post extends Model
{
    public function author(): BelongsTo;
}

class PageView extends Model
{
    public function person(): BelongsTo;
}

class Licence extends Model
{
    public function owner(): BelongsTo;
}

class Report extends Model
{
    public function reportable(): MorphTo
}

class User extends Model
{
    public function getForeignKey()
    {
        return 'person_id';
    }

    public function comments(): HasMany
    {
        // guesses user() from User::class
        return $this->hasMany(Comment::class)->inverse();
    }

    public function pageViews(): HasMany
    {
        // guesses person() from User::getForeignKey()
        return $this->hasMany(PageView::class)->inverse();
    }

    public function posts(): HasMany
    {
        // guesses author() from passing author_id
        return $this->hasMany(Post::class, 'author_id')->inverse();
    }

    public function licence(): HasOne
    {
        // guesses owner() as a fallback
        return $this->hasOne(Licence::class)->inverse();
    }

    public function reports(): MorphMany
    {
        // guesses reportable from the relationship
        return $this->morphMany(Report::class, 'reportable')->inverse();
    }
}
```

If the parent is the same class as the child, it will also guess `parent`.

```php
class Category extends Model
{
    public function ancestor(): BelongsTo
    {
        return $this->belongsTo(Category::class, 'parent_id');
    }

    public function children(): HasMany
    {
        // guesses $category->ancestor
        return $this->hasMany(Category::class, 'parent_id')->inverse();
    }
}
```

#### Backwards Compatibility

There aren't really any backwards compatibility concerns - the new method is "opt-in", and the changes made to the existing relationships shouldn't have any affect if the new method isn't used.

#### Which Relationships Can Be Inverted?

Only the `HasOneOrMany` relationships make sense for `inverse()`. This means that it's available for `HasOne`, `HasMany`, `MorphOne`, and `MorphMany`. It also supports the `OneOfMany` modifiers.

None of the `BelongsTo*` relations really make sense to define an inverse relationship because the inverse will _probably_ be a collection.

#### Potential risks

As mentioned by @stayallive, there is a known issue with `getQueueableRelations()` and `relationsToArray()` when you have circular object references, leading to an infinite loop as it tries to dig down through the "tree" to discover relations. While this change isn't _introducing_ that issue (it already exists), it does increase the likelihood that developers will encounter it.

I don't think that trying to fix it in _this_ PR is wise, because that will increase the complexity of this change and, again, this change doesn't _create_ the issue - it just makes it more likely for developers to encounter it. I've personally encountered it in my own work when I was using `setRelation` to manually do what `inverse()` does.

I do have a mitigation in mind for it, but I think that I'll reserve that for a separate PR. In short, it could be mitigated by keeping track of the _objects_ that have been serialized, and don't keep digging down on ones that we have already seen - it shouldn't be particularly more memory hungry (it will involve _temporarily_ holding another array of references to objects), but it does need to get added in a number of places.