### PR TITLE
[11.x] Using null coalescing assignment aperator (??= operator)

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -257,9 +257,7 @@ trait ConfiguresPrompts
                 ? ['None', ...$options]
                 : ['' => 'None'] + $options;
 
-            if ($default === null) {
-                $default = 'None';
-            }
+            $default ??= 'None';
         }
 
         $answers = $this->components->choice($label, $options, $default, null, true);

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -558,9 +558,7 @@ trait QueriesRelationships
             throw new InvalidArgumentException('Collection given to whereBelongsTo method may not be empty.');
         }
 
-        if ($relationshipName === null) {
-            $relationshipName = Str::camel(class_basename($related));
-        }
+        $relationshipName ??= Str::camel(class_basename($related));
 
         try {
             $relationship = $this->model->{$relationshipName}();


### PR DESCRIPTION
In this PR,  using `??=` in some cases. 

We have used the `??=` operator in many places in Laravel, which reduces the number of lines and improves readability. For example, in CacheManager:

```php
public function store($name = null)
{
    $name = $name ?: $this->getDefaultDriver();

    return $this->stores[$name] ??= $this->resolve($name);
}
```

In these two places where I made changes, we can also use the `??=` operator to reduce the number of lines.