### PR TITLE
Fixes explicit route binding with `BackedEnum`

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -86,7 +86,9 @@ class ImplicitRouteBinding
 
             $backedEnumClass = $parameter->getType()?->getName();
 
-            $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);
+            $backedEnum = $parameterValue instanceof $backedEnumClass
+                ? $parameterValue
+                : $backedEnumClass::tryFrom((string) $parameterValue);
 
             if (is_null($backedEnum)) {
                 throw new BackedEnumCaseNotFoundException($backedEnumClass, $parameterValue);

--- a/tests/Integration/Routing/CategoryBackedEnum.php
+++ b/tests/Integration/Routing/CategoryBackedEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+enum CategoryBackedEnum: string
+{
+    case People = 'people';
+    case Fruits = 'fruits';
+
+    public static function fromCode(string $code)
+    {
+        return match ($code) {
+            'c01' => self::People,
+            'c02' => self::Fruits,
+            default => null,
+        };
+    }
+}

--- a/tests/Integration/Routing/Enums.php
+++ b/tests/Integration/Routing/Enums.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Illuminate\Tests\Integration\Routing;
-
-enum CategoryBackedEnum: string
-{
-    case People = 'people';
-    case Fruits = 'fruits';
-}

--- a/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
@@ -5,8 +5,6 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-include_once 'Enums.php';
-
 class ImplicitBackedEnumRouteBindingTest extends TestCase
 {
     protected function defineEnvironment($app): void
@@ -61,6 +59,12 @@ PHP);
             return $category->value;
         })->middleware('web');
 
+        Route::bind('categoryCode', fn (string $categoryCode) => CategoryBackedEnum::fromCode($categoryCode) ?? abort(404));
+
+        Route::post('/categories-code/{categoryCode}', function (CategoryBackedEnum $categoryCode) {
+            return $categoryCode->value;
+        })->middleware(['web']);
+
         $response = $this->post('/categories/fruits');
         $response->assertSee('fruits');
 
@@ -68,7 +72,7 @@ PHP);
         $response->assertSee('people');
 
         $response = $this->post('/categories/cars');
-        $response->assertNotFound(404);
+        $response->assertNotFound();
 
         $response = $this->post('/categories-default/');
         $response->assertSee('fruits');
@@ -78,5 +82,14 @@ PHP);
 
         $response = $this->post('/categories-default/fruits');
         $response->assertSee('fruits');
+
+        $response = $this->post('/categories-code/c01');
+        $response->assertSee('people');
+
+        $response = $this->post('/categories-code/c02');
+        $response->assertSee('fruits');
+
+        $response = $this->post('/categories-code/00');
+        $response->assertNotFound();
     }
 }


### PR DESCRIPTION
Port a078b1a97e (Fixes explicit route binding with `BackedEnum` (#51525), 2024-05-21 crynobone) to 10.x (from 11.x).

fixes #51583
refs #51514