### PR TITLE
[11.x] Fixes exception rendering

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
@@ -30,7 +30,7 @@ class Listener
     {
         $events->listen(QueryExecuted::class, [$this, 'onQueryExecuted']);
 
-        $events->listen([JobProcessing::class, JobProcessed::class], function ($event) {
+        $events->listen([JobProcessing::class, JobProcessed::class], function () {
             $this->queries = [];
         });
 

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
@@ -4,6 +4,8 @@ namespace Illuminate\Foundation\Exceptions\Renderer;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
 use Laravel\Octane\Events\RequestReceived;
 use Laravel\Octane\Events\RequestTerminated;
 use Laravel\Octane\Events\TaskReceived;
@@ -27,6 +29,10 @@ class Listener
     public function registerListeners(Dispatcher $events)
     {
         $events->listen(QueryExecuted::class, [$this, 'onQueryExecuted']);
+
+        $events->listen([JobProcessing::class, JobProcessed::class], function ($event) {
+            $this->queries = [];
+        });
 
         if (isset($_SERVER['LARAVEL_OCTANE'])) {
             $events->listen([RequestReceived::class, TaskReceived::class, TickReceived::class, RequestTerminated::class], function () {

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php
@@ -38,6 +38,12 @@
         hljs.initLineNumbersOnLoad()
 
         window.addEventListener('load', function() {
+            document.querySelectorAll('.renderer').forEach(function(element, index) {
+                if (index > 0) {
+                    element.remove();
+                }
+            });
+
             document.querySelector('.default-highlightable-code').style.display = 'block';
 
             document.querySelectorAll('.highlightable-code').forEach(function(element) {

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/theme-swicher.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/theme-swicher.blade.php
@@ -1,31 +1,34 @@
 <script>
-    const darkStyles = document.querySelector('style[data-theme="dark"]')?.textContent
-    const lightStyles = document.querySelector('style[data-theme="light"]')?.textContent
 
-    const removeStyles = () => {
-        document.querySelector('style[data-theme="dark"]')?.remove()
-        document.querySelector('style[data-theme="light"]')?.remove()
-    }
+    (function () {
+        const darkStyles = document.querySelector('style[data-theme="dark"]')?.textContent
+        const lightStyles = document.querySelector('style[data-theme="light"]')?.textContent
 
-    removeStyles()
+        const removeStyles = () => {
+            document.querySelector('style[data-theme="dark"]')?.remove()
+            document.querySelector('style[data-theme="light"]')?.remove()
+        }
 
-    setDarkClass = () => {
         removeStyles()
 
-        const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        setDarkClass = () => {
+            removeStyles()
 
-        isDark ? document.documentElement.classList.add('dark') : document.documentElement.classList.remove('dark')
+            const isDark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
-        if (isDark) {
-            document.head.insertAdjacentHTML('beforeend', `<style data-theme="dark">${darkStyles}</style>`)
-        } else {
-            document.head.insertAdjacentHTML('beforeend', `<style data-theme="light">${lightStyles}</style>`)
+            isDark ? document.documentElement.classList.add('dark') : document.documentElement.classList.remove('dark')
+
+            if (isDark) {
+                document.head.insertAdjacentHTML('beforeend', `<style data-theme="dark">${darkStyles}</style>`)
+            } else {
+                document.head.insertAdjacentHTML('beforeend', `<style data-theme="light">${lightStyles}</style>`)
+            }
         }
-    }
 
-    setDarkClass()
+        setDarkClass()
 
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', setDarkClass)
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', setDarkClass)
+    })();
 </script>
 
 <div

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
@@ -1,5 +1,5 @@
 <x-laravel-exceptions-renderer::layout :$exception>
-    <div class="container mx-auto lg:px-8">
+    <div class="renderer container mx-auto lg:px-8">
         <x-laravel-exceptions-renderer::navigation :$exception />
 
         <main class="px-6 pb-12 pt-6">


### PR DESCRIPTION
This pull request addresses two things on https://github.com/laravel/framework/pull/51261:

- Clears the queries context when jobs are starting and processed;
- Fixes double rendering, when sometimes, there more than one exception being renderered: like on the controller + on terminable middleware.