### PR TITLE
[11.x] Add  --only to stub publish command

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -17,14 +17,15 @@ class StubPublishCommand extends Command
      */
     protected $signature = 'stub:publish
                     {--existing : Publish and overwrite only the files that have already been published}
-                    {--force : Overwrite any existing files}';
+                    {--force : Overwrite any existing files}
+                    {--only=* : Stub categories to publish (e.g. migration,controller)}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Publish all stubs that are available for customization';
+    protected $description = 'Publish stubs that are available for customization';
 
     /**
      * Execute the console command.
@@ -37,60 +38,120 @@ class StubPublishCommand extends Command
             (new Filesystem)->makeDirectory($stubsPath);
         }
 
-        $stubs = [
-            __DIR__.'/stubs/cast.inbound.stub' => 'cast.inbound.stub',
-            __DIR__.'/stubs/cast.stub' => 'cast.stub',
-            __DIR__.'/stubs/class.stub' => 'class.stub',
-            __DIR__.'/stubs/class.invokable.stub' => 'class.invokable.stub',
-            __DIR__.'/stubs/console.stub' => 'console.stub',
-            __DIR__.'/stubs/enum.stub' => 'enum.stub',
-            __DIR__.'/stubs/enum.backed.stub' => 'enum.backed.stub',
-            __DIR__.'/stubs/event.stub' => 'event.stub',
-            __DIR__.'/stubs/job.queued.stub' => 'job.queued.stub',
-            __DIR__.'/stubs/job.stub' => 'job.stub',
-            __DIR__.'/stubs/listener.typed.queued.stub' => 'listener.typed.queued.stub',
-            __DIR__.'/stubs/listener.queued.stub' => 'listener.queued.stub',
-            __DIR__.'/stubs/listener.typed.stub' => 'listener.typed.stub',
-            __DIR__.'/stubs/listener.stub' => 'listener.stub',
-            __DIR__.'/stubs/mail.stub' => 'mail.stub',
-            __DIR__.'/stubs/markdown-mail.stub' => 'markdown-mail.stub',
-            __DIR__.'/stubs/markdown-notification.stub' => 'markdown-notification.stub',
-            __DIR__.'/stubs/model.pivot.stub' => 'model.pivot.stub',
-            __DIR__.'/stubs/model.stub' => 'model.stub',
-            __DIR__.'/stubs/notification.stub' => 'notification.stub',
-            __DIR__.'/stubs/observer.plain.stub' => 'observer.plain.stub',
-            __DIR__.'/stubs/observer.stub' => 'observer.stub',
-            __DIR__.'/stubs/policy.plain.stub' => 'policy.plain.stub',
-            __DIR__.'/stubs/policy.stub' => 'policy.stub',
-            __DIR__.'/stubs/provider.stub' => 'provider.stub',
-            __DIR__.'/stubs/request.stub' => 'request.stub',
-            __DIR__.'/stubs/resource.stub' => 'resource.stub',
-            __DIR__.'/stubs/resource-collection.stub' => 'resource-collection.stub',
-            __DIR__.'/stubs/rule.stub' => 'rule.stub',
-            __DIR__.'/stubs/scope.stub' => 'scope.stub',
-            __DIR__.'/stubs/test.stub' => 'test.stub',
-            __DIR__.'/stubs/test.unit.stub' => 'test.unit.stub',
-            __DIR__.'/stubs/trait.stub' => 'trait.stub',
-            __DIR__.'/stubs/view-component.stub' => 'view-component.stub',
-            realpath(__DIR__.'/../../Database/Console/Factories/stubs/factory.stub') => 'factory.stub',
-            realpath(__DIR__.'/../../Database/Console/Seeds/stubs/seeder.stub') => 'seeder.stub',
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => 'migration.create.stub',
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => 'migration.stub',
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => 'migration.update.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => 'controller.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => 'controller.invokable.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => 'controller.model.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.stub') => 'controller.model.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.api.stub') => 'controller.nested.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.singleton.api.stub') => 'controller.nested.singleton.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.singleton.stub') => 'controller.nested.singleton.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => 'controller.nested.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => 'controller.plain.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.singleton.api.stub') => 'controller.singleton.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.singleton.stub') => 'controller.singleton.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => 'controller.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => 'middleware.stub',
+        $stubCategories = [
+            'cast' => [
+                __DIR__.'/stubs/cast.inbound.stub' => 'cast.inbound.stub',
+                __DIR__.'/stubs/cast.stub' => 'cast.stub',
+            ],
+            'class' => [
+                __DIR__.'/stubs/class.stub' => 'class.stub',
+                __DIR__.'/stubs/class.invokable.stub' => 'class.invokable.stub',
+            ],
+            'console' => [
+                __DIR__.'/stubs/console.stub' => 'console.stub',
+            ],
+            'enum' => [
+                __DIR__.'/stubs/enum.stub' => 'enum.stub',
+                __DIR__.'/stubs/enum.backed.stub' => 'enum.backed.stub',
+            ],
+            'event' => [
+                __DIR__.'/stubs/event.stub' => 'event.stub',
+            ],
+            'job' => [
+                __DIR__.'/stubs/job.queued.stub' => 'job.queued.stub',
+                __DIR__.'/stubs/job.stub' => 'job.stub',
+            ],
+            'listener' => [
+                __DIR__.'/stubs/listener.typed.queued.stub' => 'listener.typed.queued.stub',
+                __DIR__.'/stubs/listener.queued.stub' => 'listener.queued.stub',
+                __DIR__.'/stubs/listener.typed.stub' => 'listener.typed.stub',
+                __DIR__.'/stubs/listener.stub' => 'listener.stub',
+            ],
+            'mail' => [
+                __DIR__.'/stubs/mail.stub' => 'mail.stub',
+                __DIR__.'/stubs/markdown-mail.stub' => 'markdown-mail.stub',
+            ],
+            'notification' => [
+                __DIR__.'/stubs/notification.stub' => 'notification.stub',
+                __DIR__.'/stubs/markdown-notification.stub' => 'markdown-notification.stub',
+            ],
+            'model' => [
+                __DIR__.'/stubs/model.pivot.stub' => 'model.pivot.stub',
+                __DIR__.'/stubs/model.stub' => 'model.stub',
+            ],
+            'observer' => [
+                __DIR__.'/stubs/observer.plain.stub' => 'observer.plain.stub',
+                __DIR__.'/stubs/observer.stub' => 'observer.stub',
+            ],
+            'policy' => [
+                __DIR__.'/stubs/policy.plain.stub' => 'policy.plain.stub',
+                __DIR__.'/stubs/policy.stub' => 'policy.stub',
+            ],
+            'provider' => [
+                __DIR__.'/stubs/provider.stub' => 'provider.stub',
+            ],
+            'request' => [
+                __DIR__.'/stubs/request.stub' => 'request.stub',
+            ],
+            'resource' => [
+                __DIR__.'/stubs/resource.stub' => 'resource.stub',
+                __DIR__.'/stubs/resource-collection.stub' => 'resource-collection.stub',
+            ],
+            'rule' => [
+                __DIR__.'/stubs/rule.stub' => 'rule.stub',
+            ],
+            'scope' => [
+                __DIR__.'/stubs/scope.stub' => 'scope.stub',
+            ],
+            'test' => [
+                __DIR__.'/stubs/test.stub' => 'test.stub',
+                __DIR__.'/stubs/test.unit.stub' => 'test.unit.stub',
+            ],
+            'trait' => [
+                __DIR__.'/stubs/trait.stub' => 'trait.stub',
+            ],
+            'view-component' => [
+                __DIR__.'/stubs/view-component.stub' => 'view-component.stub',
+            ],
+            'factory' => [
+                realpath(__DIR__.'/../../Database/Console/Factories/stubs/factory.stub') => 'factory.stub',
+            ],
+            'seeder' => [
+                realpath(__DIR__.'/../../Database/Console/Seeds/stubs/seeder.stub') => 'seeder.stub',
+            ],
+            'migration' => [
+                realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => 'migration.create.stub',
+                realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => 'migration.stub',
+                realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => 'migration.update.stub',
+            ],
+            'controller' => [
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => 'controller.api.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => 'controller.invokable.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => 'controller.model.api.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.stub') => 'controller.model.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.api.stub') => 'controller.nested.api.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.singleton.api.stub') => 'controller.nested.singleton.api.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.singleton.stub') => 'controller.nested.singleton.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => 'controller.nested.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => 'controller.plain.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.singleton.api.stub') => 'controller.singleton.api.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.singleton.stub') => 'controller.singleton.stub',
+                realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => 'controller.stub',
+            ],
+            'middleware' => [
+                realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => 'middleware.stub',
+            ],
         ];
+
+        $only = $this->option('only') ? explode(',', $this->option('only')) : null;
+
+        $stubs = collect($stubCategories);
+        if (! is_null($only)) {
+            $stubs = $stubs->filter(function ($value, $key) use ($only) {
+                return in_array($key, $only);
+            })
+        }
+        $stubs = $stubs->flatten(1)->toArray();
 
         $this->laravel['events']->dispatch($event = new PublishingStubs($stubs));
 

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -18,7 +18,7 @@ class StubPublishCommand extends Command
     protected $signature = 'stub:publish
                     {--existing : Publish and overwrite only the files that have already been published}
                     {--force : Overwrite any existing files}
-                    {--only=* : Stub categories to publish (e.g. migration,controller)}';
+                    {--only= : Stub categories to publish (e.g. migration,controller)}';
 
     /**
      * The console command description.
@@ -147,11 +147,9 @@ class StubPublishCommand extends Command
 
         $stubs = collect($stubCategories);
         if (! is_null($only)) {
-            $stubs = $stubs->filter(function ($value, $key) use ($only) {
-                return in_array($key, $only);
-            });
+            $stubs = $stubs->filter(fn ($value, $key) => in_array($key, $only));
         }
-        $stubs = $stubs->flatten(1)->toArray();
+        $stubs = $stubs->flatMap(fn ($value) => $value)->toArray();
 
         $this->laravel['events']->dispatch($event = new PublishingStubs($stubs));
 

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -149,7 +149,7 @@ class StubPublishCommand extends Command
         if (! is_null($only)) {
             $stubs = $stubs->filter(function ($value, $key) use ($only) {
                 return in_array($key, $only);
-            })
+            });
         }
         $stubs = $stubs->flatten(1)->toArray();
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

it adds `--only` option to `stub:publish` command
user can pass a list of comma-separated categories
 - cast
 - class
- console
- enum
- event
- job
- listener
- mail
- notification
- model
- observer
- policy
- provider
- request
- resource
- rule
- scope
- test
- trait
- view
- factory
- seeder
- migration
- controller
- middleware

# Example
```bash
php artisan stub:publish --only=model,controller
```
if `--only` was given no value then it will be ignored and all stubs will be published

# Would need help with
Where to place the categories? should it be in the option description for example?