### PR TITLE
[11.x] Restored "apc" as supported driver and added default config

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -26,12 +26,16 @@ return [
     | well as their drivers. You may even define multiple stores for the
     | same cache driver to group types of items stored in your caches.
     |
-    | Supported drivers: "array", "database", "file", "memcached",
+    | Supported drivers: "apc", "array", "database", "file", "memcached",
     |                    "redis", "dynamodb", "octane", "null"
     |
     */
 
     'stores' => [
+
+        'apc' => [
+            'driver' => 'apc',
+        ],
 
         'array' => [
             'driver' => 'array',


### PR DESCRIPTION
Having this removed from the list of supported drivers within the comment is a tad misleading as it's still supported.

I've also added an entry into the array of stores for slimmer config, that way the `cache.php` config file does not need to be published in order to manually add the missing `apc` store.

This helps maintain a slim skeleton for new projects and existing projects alike.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
