### PR TITLE
[11.x] Add Arr::mergeIf() array helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -640,6 +640,20 @@ class Arr
     }
 
     /**
+     * Conditionally merges several arrays into a single array
+     *
+     * Returns the first array if condition is false
+     *
+     * @param  bool  $condition
+     * @param  array  $array
+     * @return array
+     */
+    public static function mergeIf(bool $condition, array ...$array)
+    {
+        return ($condition) ? array_merge(...$array) : $array[0];
+    }
+
+    /**
      * Run a map over each nested chunk of items.
      *
      * @template TMapSpreadValue

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -640,6 +640,20 @@ class Arr
     }
 
     /**
+     * Conditionally merges several arrays into a single array.
+     *
+     * Returns the first array if condition is false.
+     *
+     * @param  bool  $condition
+     * @param  array  $array
+     * @return array
+     */
+    public static function mergeIf(bool $condition, array ...$array)
+    {
+        return ($condition) ? array_merge(...$array) : $array[0];
+    }
+
+    /**
      * Run a map over each nested chunk of items.
      *
      * @template TMapSpreadValue

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -729,6 +729,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals([], $mapped);
     }
 
+    public function testMergeIfTrue()
+    {
+        $merged = Arr::mergeIf(true, ['first' => 'Taylor'], ['last' => 'Otwell']);
+        $this->assertEquals(['first' => 'Taylor', 'last' => 'Otwell'], $merged);
+    }
+
+    public function testMergeIfFalse()
+    {
+        $first = Arr::mergeIf(false, ['first' => 'Taylor'], ['last' => 'Otwell']);
+        $this->assertEquals(['first' => 'Taylor'], $first);
+    }
+
     public function testMapNullValues()
     {
         $data = ['first' => 'taylor', 'last' => null];


### PR DESCRIPTION
Merge two or more arrays into a single array, when a condition is met or returns the first array if the condition is not met.

@taylorotwell Useful when composing huge payloads...and more data is added based on certain conditions. Ex. In Shipping, pickup address if pickup is requested or Export Declaration if it's required.