### PR TITLE
Use streams for disk attachments

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -491,7 +491,7 @@ class Mailable implements MailableContract, Renderable
             )->disk($attachment['disk']);
 
             $message->attachData(
-                $storage->get($attachment['path']),
+                $storage->readStream($attachment['path']),
                 $attachment['name'] ?? basename($attachment['path']),
                 array_merge(['mime' => $storage->mimeType($attachment['path'])], $attachment['options'])
             );


### PR DESCRIPTION
`attachData` supports `resource|string` so rather than pull the whole file into memory we should pass the `resource` to Symfony which should improve memory performance.
