### PR TITLE
[11.x] Fixes missing route context

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -164,7 +164,7 @@ class Exception
     /**
      * Get the application's route context.
      *
-     * @return array<string, string>|null
+     * @return array<string, string>
      */
     public function applicationRouteContext()
     {
@@ -174,7 +174,7 @@ class Exception
             'controller' => $route->getActionName(),
             'route name' => $route->getName() ?: null,
             'middleware' => implode(', ', $route->gatherMiddleware()),
-        ]) : null;
+        ]) : [];
     }
 
     /**
@@ -184,7 +184,7 @@ class Exception
      */
     public function applicationRouteParametersContext()
     {
-        $parameters = $this->request()->route()->parameters();
+        $parameters = $this->request()->route()?->parameters();
 
         return $parameters ? json_encode(array_map(
             fn ($value) => $value instanceof Model ? $value->withoutRelations() : $value,


### PR DESCRIPTION
This pull request fixes an issue that may happen when an exception is found and displayed before the "route" was be binded to the current request instance.