### PR TITLE
Added filename match type to download assertion 

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -331,9 +331,10 @@ class TestResponse implements ArrayAccess
      * Assert that the response offers a file download.
      *
      * @param  string|null  $filename
+     * @param  string  $matchType
      * @return $this
      */
-    public function assertDownload($filename = null)
+    public function assertDownload($filename = null, $matchType = 'exact')
     {
         $contentDisposition = explode(';', $this->headers->get('content-disposition', ''));
 
@@ -358,13 +359,23 @@ class TestResponse implements ArrayAccess
             if (! isset($contentDisposition[1])) {
                 PHPUnit::fail($message);
             } else {
-                PHPUnit::assertSame(
-                    $filename,
-                    isset(explode('=', $contentDisposition[1])[1])
-                        ? trim(explode('=', $contentDisposition[1])[1], " \"'")
-                        : '',
-                    $message
-                );
+                $actual = isset(explode('=', $contentDisposition[1])[1])
+                    ? trim(explode('=', $contentDisposition[1])[1], " \"'")
+                    : '';
+
+                switch($matchType) {
+                    case 'exact':
+                        PHPUnit::assertSame($filename, $actual, $message);
+                        break;
+                    case 'startsWith':
+                        PHPUnit::assertStringStartsWith($filename, $actual, $message);
+                        break;
+                    case 'endsWith':
+                        PHPUnit::assertStringEndsWith($filename, $actual, $message);
+                        break;
+                    default:
+                        throw new \InvalidArgumentException('Invalid match type: ' . $matchType);
+                }
 
                 return $this;
             }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -374,7 +374,7 @@ class TestResponse implements ArrayAccess
                         PHPUnit::assertStringEndsWith($filename, $actual, $message);
                         break;
                     default:
-                        throw new \InvalidArgumentException('Invalid match type: ' . $matchType);
+                        throw new \InvalidArgumentException('Invalid match type: '.$matchType);
                 }
 
                 return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2055,6 +2055,36 @@ class TestResponseTest extends TestCase
         $files->deleteDirectory($tempDir);
     }
 
+    public function testAssertDownloadOfferedWithAFileNamePrefix()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file_example.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            $files->get($tempDir.'/file_example.txt'), 200, [
+                'Content-Disposition' => 'attachment; filename = file_example.txt',
+            ]
+        ));
+        $testResponse->assertDownload('file_', 'startsWith');
+        $files->deleteDirectory($tempDir);
+    }
+
+    public function testAssertDownloadOfferedWithAFileNameSuffix()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file_example.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            $files->get($tempDir.'/file_example.txt'), 200, [
+                'Content-Disposition' => 'attachment; filename = file_example.txt',
+            ]
+        ));
+        $testResponse->assertDownload('.txt', 'endsWith');
+        $files->deleteDirectory($tempDir);
+    }
+
     public function testAssertDownloadOfferedWorksWithBinaryFileResponse()
     {
         $files = new Filesystem;


### PR DESCRIPTION
I was currently testing downloads for my application and I thought it was a good idea to test the name of the downloaded file as well. The `assertDownload` function however just checks whether the filename is exactle the same as expected. However, there might be functionality to lock to a given time but that's weird testing in my opinion.

In my case, I'm generating file names containing a username and the current date and time like `someuser_2024-05-28_20-51-16.json`. If a test for some reason takes a bit longer than expected, the exact check of a filename doesn't work anymore if the current time second had changed.

For this reason, and there may others, I've added a functionality to check whether the filename starts or ends with a given string. The original `exact` check is still present.

There're three checks by default:
`exact`: As before and default value
`startsWith`: To check whether the filename starts with the given string
`endsWith`: To check whether the filename ends with the given string

Example with filename `someuser_2024-05-28_20-51-16.json` and current time of `2024-05-28 20:51:16`:
`->assertDownload('someuser_');` = `false`
`->assertDownload('someuser_', 'startsWith');` = `true`
`->assertDownload('someuser_', 'endsWith');` = `false`

Example with filename `someuser_2024-05-28_20-51-16.json` and current time of `2024-05-28 20:51:17`:
`->assertDownload('someuser_');` = `false`
`->assertDownload('someuser_', 'startsWith');` = `true`
`->assertDownload('.json', 'endsWith');` = `true`