### PR TITLE
[11.x] Fix new exception renderer compatibility with closure middleware

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Exceptions\Renderer;
 
+use Closure;
 use Composer\Autoload\ClassLoader;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Http\Request;
@@ -173,7 +174,9 @@ class Exception
         return $route ? array_filter([
             'controller' => $route->getActionName(),
             'route name' => $route->getName() ?: null,
-            'middleware' => implode(', ', $route->gatherMiddleware()),
+            'middleware' => implode(', ', array_map(function ($middleware) {
+                return $middleware instanceof Closure ? 'Closure' : $middleware;
+            }, $route->gatherMiddleware())),
         ]) : [];
     }
 


### PR DESCRIPTION
In an application with a [closure/inline middleware in a controller](https://laravel.com/docs/11.x/controllers#controller-middleware:~:text=You%20may%20also%20define%20controller%20middleware%20as%20closures%2C%20which%20provides%20a%20convenient%20way%20to%20define%20an%20inline%20middleware%20without%20writing%20an%20entire%20middleware%20class%3A), the exception renderer fails with `Object of class Closure could not be converted to string`.

This was previously fixed in Debugbar for Laravel: https://github.com/barryvdh/laravel-debugbar/pull/1146.

The word "Closure" is now returned instead of failing:

<img width="760" alt="Screenshot 2024-05-29 at 13 42 07" src="https://github.com/laravel/framework/assets/708498/841b63bd-709f-4a3d-a8db-2289d187f2ad">

