### PR TITLE
[11.x] cache `HasAttributes::getAttributeValue` result

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2388,6 +2388,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->classCastCache = [];
         $this->attributeCastCache = [];
+        $this->castedAttributeCache = [];
 
         return array_keys(get_object_vars($this));
     }

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -78,9 +78,11 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->seedData();
 
         $like = TestLikeWithSingleWith::first();
+        $testComment = TestComment::first();
+        $testComment->id;
 
         $this->assertTrue($like->relationLoaded('likeable'));
-        $this->assertEquals(TestComment::first(), $like->likeable);
+        $this->assertEquals($testComment, $like->likeable);
     }
 
     public function testItLoadsChainedRelationshipsAutomatically()
@@ -88,9 +90,11 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->seedData();
 
         $like = TestLikeWithSingleWith::first();
+        $testPost = TestPost::first();
+        $testPost->id;
 
         $this->assertTrue($like->likeable->relationLoaded('commentable'));
-        $this->assertEquals(TestPost::first(), $like->likeable->commentable);
+        $this->assertEquals($testPost, $like->likeable->commentable);
     }
 
     public function testItLoadsNestedRelationshipsAutomatically()
@@ -102,7 +106,10 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertTrue($like->relationLoaded('likeable'));
         $this->assertTrue($like->likeable->relationLoaded('owner'));
 
-        $this->assertEquals(TestUser::first(), $like->likeable->owner);
+        $testUser = TestUser::first();
+        $testUser->id;
+
+        $this->assertEquals($testUser, $like->likeable->owner);
     }
 
     public function testItLoadsNestedRelationshipsOnDemand()
@@ -114,7 +121,10 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertTrue($like->relationLoaded('likeable'));
         $this->assertTrue($like->likeable->relationLoaded('owner'));
 
-        $this->assertEquals(TestUser::first(), $like->likeable->owner);
+        $testUser = TestUser::first();
+        $testUser->id;
+
+        $this->assertEquals($testUser, $like->likeable->owner);
     }
 
     public function testItLoadsNestedMorphRelationshipsOnDemand()

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -141,7 +141,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('{"key1":"value1"}', false)
             ->andReturn('encrypted-secret-object-string');
         $this->encrypter->expects('decrypt')
-            ->twice()
+            ->once()
             ->with('encrypted-secret-object-string', false)
             ->andReturn('{"key1":"value1"}');
 
@@ -164,7 +164,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('{"key1":"value1"}', false)
             ->andReturn('encrypted-secret-collection-string');
         $this->encrypter->expects('decrypt')
-            ->twice()
+            ->once()
             ->with('encrypted-secret-collection-string', false)
             ->andReturn('{"key1":"value1"}');
 


### PR DESCRIPTION
### Problem

Filtering a collection with a casted property results in casting the property of each instance in the collection. Doing this numerous times on the same collection, looking for different instances, can become incredibly inefficient.

#### Example

Imagine two tables connected with a hasMany relationship; User and UserActivity.

A user may have 100 activities, and during a certain request we want to find the date a few of these activities occurred. So we would have something like:

```
$user = User::find(1);
$activities = $user->activities;

function getActivity(Collection $activities, string $activityName): ?UserActivity {
    return $activities->where('is_active', 1)->where('activity', $activityName)->first();
}

$last_logged_in_date = getActivity($activities, 'last_login')?->created_at;
```

This will iterate over the entire user activities collection for this user, casting `is_active` to an integer and `activity` to a string. Since this user has 100 activities, we're casting each one separately. The problem with this occurs when we start looking for multiple activities like:

```
$i = 0;
while ($i < 50) {
   $i++;
   getActivity('test_' . $i);
}
```

This PR reduces the number of calls to `HasAttributes::getAttributeValue()` significantly because it caches the result and reuses it unless the value changes.

### Callgrind Comparison

#### [11.x]:

![Screenshot 2024-05-29 at 11 34 31 AM](https://github.com/laravel/framework/assets/753951/e7c0fa75-4841-4515-b88d-30c0e2aff54c)

#### [This Branch]:

![Screenshot 2024-05-29 at 5 01 11 PM](https://github.com/laravel/framework/assets/753951/7d6b71cd-38c0-40d5-83e4-b09c2f9f255c)

