### PR TITLE
[11.x] Allow setting Resend api key in mailer specific config

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -303,7 +303,7 @@ class MailManager implements FactoryContract
     protected function createResendTransport(array $config)
     {
         return new ResendTransport(
-            Resend::client($this->app['config']->get('services.resend.key')),
+            Resend::client($config['key'] ?? $this->app['config']->get('services.resend.key')),
         );
     }
 


### PR DESCRIPTION
Like other mailer configurations which allows setting the key inside the configuration instead of just in the services config.

This is useful for when you have multiple mailers from the same transport, but for different accounts or with different api keys.
