### PR TITLE
[11.x] Preload base options for missing config files

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -63,6 +63,10 @@ class LoadConfiguration
 
         $base = $this->getBaseConfiguration();
 
+        foreach (array_diff(array_keys($base), array_keys($files)) as $name => $config) {
+            $repository->set($name, $config);
+        }
+
         foreach ($files as $name => $path) {
             $base = $this->loadConfigurationFile($repository, $name, $path, $base);
         }

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Bootstrap;
 
-use Exception;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
@@ -61,10 +60,6 @@ class LoadConfiguration
     protected function loadConfigurationFiles(Application $app, RepositoryContract $repository)
     {
         $files = $this->getConfigurationFiles($app);
-
-        // if (! isset($files['app'])) {
-        //     throw new Exception('Unable to load the "app" configuration file.');
-        // }
 
         $base = $this->getBaseConfiguration();
 


### PR DESCRIPTION
Laravel 11 allows you to remove configuration files to keep your application slim and easier to maintain. However, Dries recently brought to my attention some issues which may arise when configuration files are removed.

After digging into the code, the issue occurs when a config file references another value from a missing (removed) config file. From [one of the issues](https://github.com/laravel/sanctum/issues/503), Sanctum referencing `app.url` when `config/app.php` has been removed.

This is because the application configuration files are loaded and merged with the base options, **then** any remaining base options are loaded.

This PR solves this issue by first loading the base options from any missing core configuration file first (i.e. app, broadcasting, view, etc). It is safe to preload these options as they do not exist and therefore do not need to be merged with user customizations.

There is no additional complexity as it loads the same amount of config files. It simply loops over any missing config files first to avoid invalid references. Furthermore, config may be cached, so this additional loop only runs once.

I did attempt to add a test for this, but it was pretty hacky as I needed to remove config files from the TestBench skeleton app for proper setup. Since that skeleton would also need to be maintained, it's not really worth it. If Orchestra ever adds a hook for swapping config files, I'll gladly backfill a test.