### PR TITLE
[11.x] Allow using hashed index names in schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1604,9 +1604,15 @@ class Blueprint
             ? substr_replace($this->table, '.'.$this->prefix, strrpos($this->table, '.'), 1)
             : $this->prefix.$this->table;
 
-        $index = strtolower($table.'_'.implode('_', $columns).'_'.$type);
+        $indexSegment = str_replace(
+            ['-', '.'], '_', strtolower($table.'_'.implode('_', $columns))
+        );
 
-        return str_replace(['-', '.'], '_', $index);
+        $type = strtolower($type);
+
+        return Builder::$useHashedDefaultIndexNames
+            ? $type.'_'.md5($indexSegment)
+            : $indexSegment.'_'.$type;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -49,6 +49,13 @@ class Builder
     public static $defaultMorphKeyType = 'int';
 
     /**
+     * The flag to indicate that generated indexes should be hashed.
+     *
+     * @var bool
+     */
+    public static $useHashedDefaultIndexNames = false;
+
+    /**
      * Create a new database Schema manager.
      *
      * @param  \Illuminate\Database\Connection  $connection
@@ -106,6 +113,26 @@ class Builder
     public static function morphUsingUlids()
     {
         return static::defaultMorphKeyType('ulid');
+    }
+
+    /**
+     * Indicate that hash should be used for generated indexes.
+     *
+     * @return void
+     */
+    public static function useHashedDefaultIndexNames()
+    {
+        static::$useHashedDefaultIndexNames = true;
+    }
+
+    /**
+     * Indicates that plain names should be used for generated indexes.
+     *
+     * @return void
+     */
+    public static function usePlainDefaultIndexNames()
+    {
+        static::$useHashedDefaultIndexNames = false;
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -19,6 +19,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
     {
         m::close();
         Builder::$defaultMorphKeyType = 'int';
+        Builder::$useHashedDefaultIndexNames = false;
     }
 
     public function testToSqlRunsCommandsFromBlueprint()
@@ -69,6 +70,46 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertSame('prefix_geo_coordinates_spatialindex', $commands[0]->index);
     }
 
+    public function testHashedIndexDefaultNames()
+    {
+        Builder::useHashedDefaultIndexNames();
+
+        $blueprint = new Blueprint('users');
+        $blueprint->unique(['foo', 'bar']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('unique_73b4eae4eaf368bb4273fe6a72781ec0', $commands[0]->index);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->index('foo');
+        $commands = $blueprint->getCommands();
+        $this->assertSame('index_fe4dc6f046ca6fdb056baf72b1daf3f6', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
+        $commands = $blueprint->getCommands();
+        $this->assertSame('spatialindex_5d3776dbc01157dca4ed6396e9e3d140', $commands[0]->index);
+    }
+
+    public function testHashedIndexDefaultNamesWhenPrefixSupplied()
+    {
+        Builder::useHashedDefaultIndexNames();
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->unique(['foo', 'bar']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('unique_ef725794d0b5afca65529e90099367e8', $commands[0]->index);
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->index('foo');
+        $commands = $blueprint->getCommands();
+        $this->assertSame('index_07653c2433f97f90795907969ba0bc90', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo', null, 'prefix_');
+        $blueprint->spatialIndex('coordinates');
+        $commands = $blueprint->getCommands();
+        $this->assertSame('spatialindex_1a38d6f13d00a4abed526c1cb8d370bb', $commands[0]->index);
+    }
+
     public function testDropIndexDefaultNames()
     {
         $blueprint = new Blueprint('users');
@@ -103,6 +144,46 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->dropSpatialIndex(['coordinates']);
         $commands = $blueprint->getCommands();
         $this->assertSame('prefix_geo_coordinates_spatialindex', $commands[0]->index);
+    }
+
+    public function testDropHashedIndexDefaultNames()
+    {
+        Builder::useHashedDefaultIndexNames();
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dropUnique(['foo', 'bar']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('unique_73b4eae4eaf368bb4273fe6a72781ec0', $commands[0]->index);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIndex(['foo']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('index_fe4dc6f046ca6fdb056baf72b1daf3f6', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('spatialindex_5d3776dbc01157dca4ed6396e9e3d140', $commands[0]->index);
+    }
+
+    public function testDropHashedIndexDefaultNamesWhenPrefixSupplied()
+    {
+        Builder::useHashedDefaultIndexNames();
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->dropUnique(['foo', 'bar']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('unique_ef725794d0b5afca65529e90099367e8', $commands[0]->index);
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->dropIndex(['foo']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('index_07653c2433f97f90795907969ba0bc90', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo', null, 'prefix_');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('spatialindex_1a38d6f13d00a4abed526c1cb8d370bb', $commands[0]->index);
     }
 
     public function testDefaultCurrentDateTime()


### PR DESCRIPTION
Hello,

The current index name generation is based on table, columns, and index type. This is fine in most cases, but when multiple columns build up the indexes, the name for that index can get very large. Databases have a limited number of characters for storing index names:
- MySQL: 64
- PostgreSQL: 63
- MSSQL: 128

This PR proposes a solution that hashes the table and column names and prefixes it with the index type. For example:
- `unique_9a495ca8d66df444bf4a2feab1a44f98`
- `foreign_5c59867eab5e61f82dd21674fb7e4349`

The solution is an **opt-in** one, so **no breaking changes** are introduced.
It can be activated using the `Schema` facade:
```php
Schema::useHashedDefaultIndexNames();
```

and can be deactivated by:
```php
Schema::usePlainDefaultIndexNames();
```

Other ORM tools, such as **TypeORM** inspired this.

Issues and ideas from the past:
- https://github.com/laravel/framework/issues/44947
- https://github.com/laravel/framework/issues/13512
- https://github.com/laravel/ideas/issues/814

Thanks,
Otto