### PR TITLE
[12.x] fix: Str::snake with multibyte strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1410,11 +1410,8 @@ class Str
             return static::$snakeCache[$key][$delimiter];
         }
 
-        if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', ucwords($value));
-
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
-        }
+        $lowered = static::lower(implode(' ', static::ucsplit($value)));
+        $value = implode($delimiter, array_filter(explode(' ', $lowered)));
 
         return static::$snakeCache[$key][$delimiter] = $value;
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -622,7 +622,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
         $this->assertSame('laravel-php-framework', Str::kebab('Laravel Php Framework'));
-        $this->assertSame('laravel❤-php-framework', Str::kebab('Laravel ❤ Php Framework'));
+        $this->assertSame('laravel-❤-php-framework', Str::kebab('Laravel ❤ Php Framework'));
         $this->assertSame('', Str::kebab(''));
     }
 
@@ -855,7 +855,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo-bar', Str::snake('foo-bar'));
         $this->assertSame('foo-_bar', Str::snake('Foo-Bar'));
         $this->assertSame('foo__bar', Str::snake('Foo_Bar'));
-        $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
+
+        $this->assertSame('żółta_łódka', Str::snake('ŻółtaŁódka'));
+        $this->assertSame('öffentliche_überraschungen', Str::snake('ÖffentlicheÜberraschungen'));
     }
 
     public function testTrim()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -984,7 +984,9 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo-bar', (string) $this->stringable('foo-bar')->snake());
         $this->assertSame('foo-_bar', (string) $this->stringable('Foo-Bar')->snake());
         $this->assertSame('foo__bar', (string) $this->stringable('Foo_Bar')->snake());
-        $this->assertSame('żółtałódka', (string) $this->stringable('ŻółtaŁódka')->snake());
+
+        $this->assertSame('żółta_łódka', (string) $this->stringable('ŻółtaŁódka')->snake());
+        $this->assertSame('öffentliche_überraschungen', (string) $this->stringable('ÖffentlicheÜberraschungen')->snake());
     }
 
     public function testStudly()


### PR DESCRIPTION
Fix for #51624 

May be breaking if someone uses `snake` method for slug generation, so pushing to `master`