### PR TITLE
[11.x] Add Str::isCase() Method for Checking String Case Types

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use JsonException;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
@@ -1903,5 +1904,31 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
+    }
+
+    /**
+     * @param string $value
+     * @param string $case
+     * @return bool
+     */
+    public static function isCase($value, $case){
+        $caseToMethodMap = [
+            'upper' => 'upper',
+            'lower' => 'lower',
+            'title' => 'title',
+            'kebab' => 'kebab',
+            'snake' => 'snake',
+            'camel' => 'camel',
+            'studly' => 'studly',
+        ];
+        
+        $case = static::lower($case);
+
+        if (!array_key_exists($case, $caseToMethodMap)){
+            throw new InvalidArgumentException("Invalid case type: $case");
+        }
+
+        $toCaseValue = call_user_func([self::class, $caseToMethodMap[$case]], $value);
+        return $toCaseValue === $value;
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1907,8 +1907,8 @@ class Str
     }
 
     /**
-     * @param string $value
-     * @param string $case
+     * @param  string  $value
+     * @param  string  $case
      * @return bool
      */
     public static function isCase($value, $case){

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1526,6 +1526,31 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::fromBase64(base64_encode('foo')));
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
+
+    public function testIsCase()
+    {
+        $this->assertTrue(Str::isCase("HELLOWORLD", "upper"));
+        $this->assertFalse(Str::isCase("HelloWorld", "upper"));
+        $this->assertFalse(Str::isCase("HelloWorld", "UPPER"));
+
+        $this->assertTrue(Str::isCase("helloworld", "lower"));
+        $this->assertFalse(Str::isCase("HelloWorld", "lower"));
+
+        $this->assertTrue(Str::isCase("hello-world", "kebab"));
+        $this->assertFalse(Str::isCase("helloWorld", "kebab"));
+
+        $this->assertTrue(Str::isCase("hello_world", "snake"));
+        $this->assertFalse(Str::isCase("helloWorld", "snake"));
+
+        $this->assertTrue(Str::isCase("Hello World", "title"));
+        $this->assertFalse(Str::isCase("hello world", "title"));
+
+        $this->assertTrue(Str::isCase("helloWorld", "camel"));
+        $this->assertFalse(Str::isCase("hello_world", "camel"));
+
+        $this->assertTrue(Str::isCase("HelloWorld", "studly"));
+        $this->assertFalse(Str::isCase("hello_world", "studly"));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Exception;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
@@ -1550,6 +1551,11 @@ class SupportStrTest extends TestCase
 
         $this->assertTrue(Str::isCase("HelloWorld", "studly"));
         $this->assertFalse(Str::isCase("hello_world", "studly"));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid case type: camell");
+
+        Str::isCase("HelloWorld", "camell");
     }
 }
 


### PR DESCRIPTION
This pull request introduces the `Str::isCase()` method to check if a string matches a specified case type (e.g., upper, lower, title, kebab, snake, camel, studly). The method maps case names to corresponding static methods for clean and maintainable code. Comprehensive tests are included to ensure correctness.
