### PR TITLE
[11.x] Enhance relationLoaded Method to Check Nested Relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -837,7 +837,7 @@ trait HasRelationships
      */
     public function relationLoaded($key)
     {
-        return array_key_exists($key, $this->relations);
+        return Arr::has($this->relations, $key);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -266,7 +266,7 @@ trait ConditionallyLoadsAttributes
             return value($default);
         }
 
-        $loadedValue = data_get($this->resource, $relationship, $default);
+        $loadedValue = data_get($this->resource, $relationship);
 
         if (func_num_args() === 1) {
             return $loadedValue;

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -266,7 +266,7 @@ trait ConditionallyLoadsAttributes
             return value($default);
         }
 
-        $loadedValue = $this->resource->{$relationship};
+        $loadedValue = data_get($this->resource, $relationship, $default);
 
         if (func_num_args() === 1) {
             return $loadedValue;


### PR DESCRIPTION
This pull request enhances the relationLoaded method within the Eloquent Model to support checking nested relations. Currently, the relationLoaded method only verifies direct relations, which limits its utility when working with complex relationships. This improvement aims to provide a more robust and flexible way to ascertain the loading status of nested relationships.

```
// Assuming $user has a nested relation 'posts.comments' loaded
if ($user->relationLoaded('posts.comments')) {
    // Perform actions knowing the 'posts.comments' relation is loaded
}
```

Thank you for considering this enhancement. I look forward to your feedback.

UPDATE::
The purpose of this pull request is to enhance the whenLoaded method in JSON resources to check if nested relations are loaded. Currently, whenLoaded only supports direct relations, which limits its utility when dealing with more complex, nested relationships.

