### PR TITLE
[11.x] Add Vite auto refresh to error page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -133,6 +133,6 @@ class Renderer
 
         return '<script type="text/javascript">'
             .file_get_contents(static::DIST.'scripts.js')
-            .'</script>' . $viteJsAutoRefresh;
+            .'</script>'.$viteJsAutoRefresh;
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -123,8 +123,16 @@ class Renderer
      */
     public static function js()
     {
+        $viteJsAutoRefresh = '';
+
+        $vite = app(\Illuminate\Foundation\Vite::class);
+
+        if (is_file($vite->hotFile())) {
+            $viteJsAutoRefresh = $vite->__invoke([]);
+        }
+
         return '<script type="text/javascript">'
             .file_get_contents(static::DIST.'scripts.js')
-            .'</script>';
+            .'</script>' . $viteJsAutoRefresh;
     }
 }


### PR DESCRIPTION
This adds Vite hot reloading to the error page

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
