### PR TITLE
[11.x] Add assertCsvContentHasRowsInOrder to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1468,6 +1468,37 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the CSV content has the rows in given order.
+     * Each row should be an array of values in order as expected in the CSV.
+     * The number of asserted rows must match the CSV content row count.
+     *
+     * @param string $content
+     * @param array<array<int,string>> $rows
+     * @param bool $withHeaderRow
+     * @param string $csvDelimiter
+     * @return $this
+     */
+    public function assertCsvContentHasRowsInOrder($content, $rows, $withHeaderRow = false, $csvDelimiter = ';')
+    {
+        $temp = tmpfile();
+        fwrite($temp, $content);
+        rewind($temp);
+        if(!$withHeaderRow) fgetcsv($temp, 0, $csvDelimiter); // skip header row
+        foreach ($rows as $expectedRow) {
+            $csvRow = fgetcsv($temp, 0, $csvDelimiter);
+            PHPUnit::assertTrue($csvRow !== FALSE, 'CSV content has less lines then expected');
+            $colIdx = 0;
+            foreach ($expectedRow as $expectedValue) {
+                PHPUnit::assertEquals($expectedValue, $csvRow[$colIdx]);
+                $colIdx++;
+            }
+        }
+        PHPUnit::assertFalse(fgetcsv($temp, 0, $csvDelimiter) !== FALSE, 'CSV content has more lines then expected');
+        fclose($temp);
+        return $this;
+    }
+
+    /**
      * Get the current session store.
      *
      * @return \Illuminate\Session\Store

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2435,6 +2435,50 @@ class TestResponseTest extends TestCase
         });
     }
 
+    public function testAssertCsvContentHasRowsInOrder()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertCsvContentHasRowsInOrder('id;name\n1;test1\n2;test2', [
+            [1, 'test1'],
+            [2, 'test2'],
+        ]);
+    }
+
+    public function testAssertCsvContentHasRowsInOrderHasNotMatchingRows()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertCsvContentHasRowsInOrder('id;name\n1;test1\n2;test2', [
+            [1, 'test3'],
+            [2, 'test3'],
+        ]);
+    }
+
+    public function testAssertCsvContentHasRowsInOrderHasLessRows()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertCsvContentHasRowsInOrder('id;name\n1;test1\n2;test2', [
+            [1, 'test1'],
+        ]);
+    }
+
+    public function testAssertCsvContentHasRowsInOrderHasTooManyRows()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertCsvContentHasRowsInOrder('id;name\n1;test1\n2;test2', [
+            [1, 'test1'],
+            [1, 'test1'],
+            [1, 'test1'],
+        ]);
+    }
+
     public function testGetEncryptedCookie()
     {
         $container = Container::getInstance();


### PR DESCRIPTION
This PR attempts to add a new method to `TestResponse` called `assertCsvContentHasRowsInOrder`. The method should be able to parse the string as CSV and assert rows in the CSV match the expected matrix provided as the second argument. You can also configure whether to skip the header row (by default will skip) and what character to use as the CSV delimiter (by default set to `;`).

- The assertion fails if the expected matrix has more rows then the CSV content
- The assertion fails if the expected matrix has less rows then the CSV content
- The assertion fails if the CSV columns of row at index `i` do not match the columns of expected matrix at row at index `i` in order

Else, the assertion passes.

Benefit can be seen when writing role-based API endpoints which do some sort of export to CSV file. Some roles may have access to more records then others. In this case, we want to assert how the output will look when different roles try calling the API. This helps assert the security and can prevent accidental data leaks through CSV exports.

The same benefit applies to filtered result set (i.e. show only this months records). We could make sure that the filter was at least applied.

