### PR TITLE
[12.x] Add missing `through()` to pagination contracts

### DIFF
--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -58,14 +58,6 @@ interface CursorPaginator
     public function items();
 
     /**
-     * Transform each item in the slice of items using a callback.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function through(callable $callback);
-
-    /**
      * Get the "cursor" of the previous set of items.
      *
      * @return \Illuminate\Pagination\Cursor|null
@@ -78,6 +70,14 @@ interface CursorPaginator
      * @return \Illuminate\Pagination\Cursor|null
      */
     public function nextCursor();
+
+    /**
+     * Transform each item in the slice of items using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function through(callable $callback);
 
     /**
      * Determine how many items are being shown per page.

--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -58,6 +58,14 @@ interface CursorPaginator
     public function items();
 
     /**
+     * Transform each item in the slice of items using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function through(callable $callback);
+
+    /**
      * Get the "cursor" of the previous set of items.
      *
      * @return \Illuminate\Pagination\Cursor|null

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -65,6 +65,14 @@ interface Paginator
     public function lastItem();
 
     /**
+     * Transform each item in the slice of items using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function through(callable $callback);
+
+    /**
      * Determine how many items are being shown per page.
      *
      * @return int


### PR DESCRIPTION
Hello,

Although the current state will not produce any runtime errors, I want to stop our IDE from complaining about the `Undefined method 'through'` on Pagination. This will also allow us to jump to the function description.

Related issue:
- https://github.com/laravel/framework/issues/51165