### PR TITLE
[11.x] Extract common logic in `join` method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -543,8 +543,6 @@ class Builder implements BuilderContract
             $first($join);
 
             $this->joins[] = $join;
-
-            $this->addBinding($join->getBindings(), 'join');
         }
 
         // If the column is simply a string, we can assume the join simply has a basic
@@ -554,9 +552,9 @@ class Builder implements BuilderContract
             $method = $where ? 'where' : 'on';
 
             $this->joins[] = $join->$method($first, $operator, $second);
-
-            $this->addBinding($join->getBindings(), 'join');
         }
+
+        $this->addBinding($join->getBindings(), 'join');
 
         return $this;
     }


### PR DESCRIPTION
Moved the common binding addition logic outside the conditional blocks.