### PR TITLE
[11.x] Fix `join_paths` issue with segment '0'

### DIFF
--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -13,7 +13,7 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
     function join_paths($basePath, ...$paths)
     {
         foreach ($paths as $index => $path) {
-            if (empty($path)) {
+            if (empty($path) && $path !== '0') {
                 unset($paths[$index]);
             } else {
                 $paths[$index] = DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR);

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -23,13 +23,21 @@ class JoinPathsHelperTest extends TestCase
         yield ['segments/get/ltrimed/by_directory/separator.php', join_paths('segments', '/get/ltrimed', '/by_directory/separator.php')];
         yield ['only/\\os_separator\\/\\get_ltrimmed.php', join_paths('only', '\\os_separator\\', '\\get_ltrimmed.php')];
         yield ['/base_path//does_not/get_trimmed.php', join_paths('/base_path/', '/does_not', '/get_trimmed.php')];
-        yield ['Empty/1/Segments/00/Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
+        yield ['Empty/0/1/Segments/00/Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
+        yield ['1/2/3', join_paths(1, 0, 2, 3)];
         yield ['app/objecty', join_paths('app', new class()
         {
             public function __toString()
             {
                 return 'objecty';
+            }
+        })];
+        yield ['app/0', join_paths('app', new class()
+        {
+            public function __toString()
+            {
+                return '0';
             }
         })];
     }
@@ -47,13 +55,21 @@ class JoinPathsHelperTest extends TestCase
         yield ['segments\get\ltrimed\by_directory\separator.php', join_paths('segments', '\get\ltrimed', '\by_directory\separator.php')];
         yield ['only\\/os_separator/\\/get_ltrimmed.php', join_paths('only', '/os_separator/', '/get_ltrimmed.php')];
         yield ['\base_path\\\\does_not\get_trimmed.php', join_paths('\\base_path\\', '\does_not', '\get_trimmed.php')];
-        yield ['Empty\1\Segments\00\Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
+        yield ['Empty\0\1\Segments\00\Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
+        yield ['1\2\3', join_paths(1, 2, 3)];
         yield ['app\\objecty', join_paths('app', new class()
         {
             public function __toString()
             {
                 return 'objecty';
+            }
+        })];
+        yield ['app\\0', join_paths('app', new class()
+        {
+            public function __toString()
+            {
+                return '0';
             }
         })];
     }


### PR DESCRIPTION
since the join_paths() function internally uses the `empty` function to filter out empty strings and prevent double slashes in the end result, it also filters out a perfectly valid path segment with the value of '0'.   
`empty('0');`  // true
`empty('');`   // true

a folder with the name "0" is perfectly valid in Windows and UNIX, so there is no reason to delete 0 from segments while joining them.

![image](https://github.com/laravel/framework/assets/6961695/5839ddf6-2d83-444b-b52f-81ffe05f41b4)

Backward compatibility:

This is not in theory backward compatible but statistically very rare to happen and very rare for an application to rely on this flaw to work correctly.
