### PR TITLE
[11.x] Support soft deleted models when using explicit route model binding

### DIFF
--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 
 class RouteBinding
@@ -57,7 +58,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return function ($value, $route) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -67,7 +68,11 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            $routeBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
+                        ? 'resolveSoftDeletableRouteBinding'
+                        : 'resolveRouteBinding';
+
+            if ($model = $instance->{$routeBindingMethod}($value)) {
                 return $model;
             }
 
@@ -78,7 +83,7 @@ class RouteBinding
                 return $callback($value);
             }
 
-            throw (new ModelNotFoundException)->setModel($class);
+            throw (new ModelNotFoundException())->setModel($class);
         };
     }
 }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -83,7 +83,7 @@ class RouteBinding
                 return $callback($value);
             }
 
-            throw (new ModelNotFoundException())->setModel($class);
+            throw (new ModelNotFoundException)->setModel($class);
         };
     }
 }

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Routing\RouteBinding;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+
+class RouteBindingTest extends TestCase
+{
+    public function test_it_can_resolve_the_explicit_model_for_the_given_route()
+    {
+        $container = Container::getInstance();
+
+        $route = new Route('GET', '/users/{user}', function () {
+        });
+
+        $callback = RouteBinding::forModel($container, ExplicitRouteBindingUser::class);
+        $this->assertInstanceOf(ExplicitRouteBindingUser::class, $callback(1, $route));
+    }
+
+    public function test_it_cannot_resolve_the_explicit_soft_deleted_model_for_the_given_route()
+    {
+        $container = Container::getInstance();
+
+        $route = new Route('GET', '/users/{user}', function () {
+        });
+
+        $callback = RouteBinding::forModel($container, ExplicitRouteBindingSoftDeletableUser::class);
+
+        $this->expectException(ModelNotFoundException::class);
+        $callback(1, $route);
+    }
+
+    public function test_it_can_resolve_the_explicit_soft_deleted_model_for_the_given_route_with_trashed()
+    {
+        $container = Container::getInstance();
+
+        $route = (new Route('GET', '/users/{user}', function () {
+        }))->withTrashed();
+
+        $callback = RouteBinding::forModel($container, ExplicitRouteBindingSoftDeletableUser::class);
+        $this->assertInstanceOf(ExplicitRouteBindingSoftDeletableUser::class, $callback(1, $route));
+    }
+}
+
+class ExplicitRouteBindingUser extends Model
+{
+    public function resolveRouteBinding($value, $field = null)
+    {
+        return new self();
+    }
+}
+
+class ExplicitRouteBindingSoftDeletableUser extends Model
+{
+    use SoftDeletes;
+
+    public function resolveRouteBinding($value, $field = null)
+    {
+        return null;
+    }
+
+    public function resolveSoftDeletableRouteBinding($value, $field = null)
+    {
+        return new self();
+    }
+}

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -6,8 +6,8 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Routing\RouteBinding;
 use Illuminate\Routing\Route;
+use Illuminate\Routing\RouteBinding;
 use PHPUnit\Framework\TestCase;
 
 class RouteBindingTest extends TestCase


### PR DESCRIPTION
This PR allows the resolution of soft-deleted models when using Laravel's explicit route-model binding feature.

It allows developers to use explicit route-model binding without having to customise the resolution logic when dealing with soft-deleted models. To do so it uses the same `withTrashed()` method as implicit binding.

Before:

```
Route::get('/users/{user}', ...);

Route::bind('user', function (string $value) {
    return User::where('id', $value)->withTrashed()->firstOrFail();
});
````

After:

```
Route::get('/users/{user}', ...)->withTrashed();

Route::model('user', User::class);
````

This introduces no breaking changes, as `resolveSoftDeletableRouteBinding` is only being called when the route explicitly requests `withTrashed()` and the corresponding model uses the `SoftDeletes` trait.
