### PR TITLE
[11.x] Read XSRF-TOKEN Directly from Cookie

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -159,6 +159,10 @@ class VerifyCsrfToken
             }
         }
 
+        if (! $token && $request->cookie('XSRF-TOKEN')) {
+            $token = $request->cookie('XSRF-TOKEN');
+        }
+
         return $token;
     }
 


### PR DESCRIPTION
### Description:

I propose enhancing the XSRF token retrieval process to also read the XSRF-TOKEN directly from the cookie if the input or header does not contain the token.

### Rationale:

There are numerous cases where users encounter errors related to missing XSRF tokens because they don't understand the current mechanism. Even if the header is set, the cookie contains the same data. By reading the XSRF-TOKEN directly from the cookie, we simplify the process and reduce potential errors.

### Benefits:

- Improved Reliability: Ensures the token is always retrieved, reducing the chance of missing token errors.
- Simplicity: Cookies are already decrypted at this point, eliminating the need to pass the token through a decryptor (as it's done for header).
- Tested Solution: I have tested this approach on two projects, and it works seamlessly.