### PR TITLE
[11.x] Add tests to improve test coverage for `Arr::whereNotNull`

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -213,10 +213,22 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
-    public function testWhereNotNull()
+    public function testWhereNotNull(): void
     {
         $array = array_values(Arr::whereNotNull([null, 0, false, '', null, []]));
         $this->assertEquals([0, false, '', []], $array);
+
+        $array = array_values(Arr::whereNotNull([1, 2, 3]));
+        $this->assertEquals([1, 2, 3], $array);
+
+        $array = array_values(Arr::whereNotNull([null, null, null]));
+        $this->assertEquals([], $array);
+
+        $array = array_values(Arr::whereNotNull(['a', null, 'b', null, 'c']));
+        $this->assertEquals(['a', 'b', 'c'], $array);
+
+        $array = array_values(Arr::whereNotNull([null, 1, 'string', 0.0, false, [], new stdClass(), function () {}]));
+        $this->assertEquals([1, 'string', 0.0, false, [], new stdClass(), function () {}], $array);
     }
 
     public function testFirst()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -227,8 +227,8 @@ class SupportArrTest extends TestCase
         $array = array_values(Arr::whereNotNull(['a', null, 'b', null, 'c']));
         $this->assertEquals(['a', 'b', 'c'], $array);
 
-        $array = array_values(Arr::whereNotNull([null, 1, 'string', 0.0, false, [], new stdClass(), function () {}]));
-        $this->assertEquals([1, 'string', 0.0, false, [], new stdClass(), function () {}], $array);
+        $array = array_values(Arr::whereNotNull([null, 1, 'string', 0.0, false, [], new stdClass(), fn () => null]));
+        $this->assertEquals([1, 'string', 0.0, false, [], new stdClass(), fn () => null], $array);
     }
 
     public function testFirst()


### PR DESCRIPTION
This PR, adds tests to improve the test coverage of `Arr::whereNotNull`.

### The array contains only numeric items
```php
$array = array_values(Arr::whereNotNull([1, 2, 3]));
$this->assertEquals([1, 2, 3], $array);
```

### The array contains only null values
```php
$array = array_values(Arr::whereNotNull([null, null, null]));
$this->assertEquals([], $array);
```

### An array consisting of a mix of characters and null values.
```php
$array = array_values(Arr::whereNotNull(['a', null, 'b', null, 'c']));
$this->assertEquals(['a', 'b', 'c'], $array);
```

### An array containing various data types.
```php
$array = array_values(Arr::whereNotNull([null, 1, 'string', 0.0, false, [], new stdClass(), function () {}]));
$this->assertEquals([1, 'string', 0.0, false, [], new stdClass(), function () {}], $array);
```