### PR TITLE
[11.x] Add `expectsSearch()` assertion for testing prompts that use `search()` and `multisearch()` functions

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -270,7 +270,6 @@ trait ConfiguresPrompts
         }
 
         if ($required === false) {
-            $answers = Arr::wrap($answers);
             return array_is_list($options)
                 ? array_values(array_filter($answers, fn ($value) => $value !== 'None'))
                 : array_filter($answers, fn ($value) => $value !== '');

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Console\Concerns;
 
 use Illuminate\Console\PromptValidationException;
-use Illuminate\Support\Arr;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Concerns;
 
 use Illuminate\Console\PromptValidationException;
+use Illuminate\Support\Arr;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
@@ -269,6 +270,7 @@ trait ConfiguresPrompts
         }
 
         if ($required === false) {
+            $answers = Arr::wrap($answers);
             return array_is_list($options)
                 ? array_values(array_filter($answers, fn ($value) => $value !== 'None'))
                 : array_filter($answers, fn ($value) => $value !== '');

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -135,6 +135,22 @@ class PendingCommand
     }
 
     /**
+     * Specify an expected search question with an expected search string, followed by an expected choice question with expected answers.
+     *
+     * @param  string  $question
+     * @param  string|array  $answer
+     * @param  string  $search
+     * @param  array  $answers
+     * @return $this
+     */
+    public function expectsSearch($question, $answer, $search, $answers)
+    {
+        return $this
+            ->expectsQuestion($question, $search)
+            ->expectsChoice($question, $answer, $answers);
+    }
+
+    /**
      * Specify output that should be printed when the command runs.
      *
      * @param  string|null  $output

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -139,41 +139,6 @@ class PromptsAssertionTest extends TestCase
             ->expectsOutput('Your name is Jane.');
     }
 
-    public function testAssertionForSelectPromptFollowedByMultisearchPrompt()
-    {
-        $this->app[Kernel::class]->registerCommand(
-            new class extends Command
-            {
-                protected $signature = 'test:select';
-
-                public function handle()
-                {
-                    $name = select(
-                        label: 'What is your name?',
-                        options: ['John', 'Jane']
-                    );
-
-                    $titles = collect(['Mr', 'Mrs', 'Ms', 'Dr']);
-                    $title = multisearch(
-                        label: 'What is your title?',
-                        options: fn (string $value) => strlen($value) > 0
-                            ? $titles->filter(fn ($title) => str_contains($title, $value))->values()->toArray()
-                            : []
-                    );
-
-                    $this->line('I will refer to you '.$title[0].' '.$name.'.');
-                }
-            }
-        );
-
-        $this
-            ->artisan('test:select')
-            ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
-            ->expectsQuestion('What is your title?', 'D')
-            ->expectsChoice('What is your title?', ['Dr'], ['Dr'])
-            ->expectsOutput('I will refer to you Dr Jane.');
-    }
-
     public function testAssertionForRequiredMultiselectPrompt()
     {
         $this->app[Kernel::class]->registerCommand(
@@ -302,5 +267,40 @@ class PromptsAssertionTest extends TestCase
             ->expectsQuestion('Which names do you like?', 'J')
             ->expectsChoice('Which names do you like?', ['None'], ['John', 'Jane', 'Jack'])
             ->expectsOutput('You like nobody.');
+    }
+
+    public function testAssertionForSelectPromptFollowedByMultisearchPrompt()
+    {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:select';
+
+                public function handle()
+                {
+                    $name = select(
+                        label: 'What is your name?',
+                        options: ['John', 'Jane']
+                    );
+
+                    $titles = collect(['Mr', 'Mrs', 'Ms', 'Dr']);
+                    $title = multisearch(
+                        label: 'What is your title?',
+                        options: fn (string $value) => strlen($value) > 0
+                            ? $titles->filter(fn ($title) => str_contains($title, $value))->values()->toArray()
+                            : []
+                    );
+
+                    $this->line('I will refer to you '.$title[0].' '.$name.'.');
+                }
+            }
+        );
+
+        $this
+            ->artisan('test:select')
+            ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
+            ->expectsQuestion('What is your title?', 'D')
+            ->expectsChoice('What is your title?', ['Dr'], ['Dr'])
+            ->expectsOutput('I will refer to you Dr Jane.');
     }
 }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Orchestra\Testbench\TestCase;
 
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multisearch;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -224,8 +224,7 @@ class PromptsAssertionTest extends TestCase
 
         $this
             ->artisan('test:search')
-            ->expectsQuestion('What is your name?', 'J')
-            ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane', 'Jack'])
+            ->expectsSearch('What is your name?', 'Jane', 'J', ['John', 'Jane', 'Jack'])
             ->expectsOutput('Your name is Jane.');
     }
 
@@ -258,14 +257,12 @@ class PromptsAssertionTest extends TestCase
 
         $this
             ->artisan('test:multisearch')
-            ->expectsQuestion('Which names do you like?', 'J')
-            ->expectsChoice('Which names do you like?', ['John', 'Jane'], ['John', 'Jane', 'Jack'])
+            ->expectsSearch('Which names do you like?', ['John', 'Jane'], 'J', ['John', 'Jane', 'Jack'])
             ->expectsOutput('You like John, Jane.');
 
         $this
             ->artisan('test:multisearch')
-            ->expectsQuestion('Which names do you like?', 'J')
-            ->expectsChoice('Which names do you like?', ['None'], ['John', 'Jane', 'Jack'])
+            ->expectsSearch('Which names do you like?', [], 'J', ['John', 'Jane', 'Jack'])
             ->expectsOutput('You like nobody.');
     }
 
@@ -299,8 +296,7 @@ class PromptsAssertionTest extends TestCase
         $this
             ->artisan('test:select')
             ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
-            ->expectsQuestion('What is your title?', 'D')
-            ->expectsChoice('What is your title?', ['Dr'], ['Dr'])
+            ->expectsSearch('What is your title?', ['Dr'], 'D', ['Dr'])
             ->expectsOutput('I will refer to you Dr Jane.');
     }
 }


### PR DESCRIPTION
### ~~This is just a failing test, hoping for some help to figure out a fix~~

I have been trying to test a command that first prompts with a basic `select` then immediately after prompts with a `multisearch`.

Im not quite sure what is going on, but it seems the assertions get polluted which each others options, which causes the assertion to fail.

As a side note, to even get to this point, I had to add the following line in `ConfiguresPrompts`...
https://github.com/laravel/framework/blob/2f33b4aabb6936d6ddd3795e79007a6ea76c2d4d/src/Illuminate/Console/Concerns/ConfiguresPrompts.php#L273

otherwise, `array_filter` errors here....

https://github.com/laravel/framework/blob/2f33b4aabb6936d6ddd3795e79007a6ea76c2d4d/src/Illuminate/Console/Concerns/ConfiguresPrompts.php#L275

@jessarcher I was hoping you may be able to shed some light on all of this as I think I have traced this as far as I can for now and its all getting a bit over my head :confused:

Here is the PHPUnit output when running this test, why is the `What is you name?` assertion seeing the option of `Dr` as that is an option from the next prompt?

<img width="843" alt="Screenshot 2024-05-31 at 15 42 05" src="https://github.com/laravel/framework/assets/340752/2ababeef-d34f-42eb-9188-f0b9d8f5f79c">