### PR TITLE
[11.x] Remove extra double quote in the error page

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/card.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/card.blade.php
@@ -1,5 +1,5 @@
 <section
-    {{ $attributes->merge(['class' => "@container flex flex-col p-6 sm:p-12 bg-white dark:bg-gray-900/80 text-gray-900 dark:text-gray-100 rounded-lg default:col-span-full default:lg:col-span-6 default:row-span-1 dark:ring-1 dark:ring-gray-800 shadow-xl"]) }}"
+    {{ $attributes->merge(['class' => "@container flex flex-col p-6 sm:p-12 bg-white dark:bg-gray-900/80 text-gray-900 dark:text-gray-100 rounded-lg default:col-span-full default:lg:col-span-6 default:row-span-1 dark:ring-1 dark:ring-gray-800 shadow-xl"]) }}
 >
     {{ $slot }}
 </section>


### PR DESCRIPTION
Pretty sure this is a typo, it was making the output HTML invalid.