### PR TITLE
[11.x] Add tests for `Arr::divide`

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -105,11 +105,32 @@ class SupportArrTest extends TestCase
         $this->assertSame([[]], Arr::crossJoin());
     }
 
-    public function testDivide()
+    public function testDivide(): void
     {
+        // Test dividing an empty array
+        [$keys, $values] = Arr::divide([]);
+        $this->assertEquals([],$keys);
+        $this->assertEquals([],$values);
+
+        // Test dividing an array with a single key-value pair
         [$keys, $values] = Arr::divide(['name' => 'Desk']);
         $this->assertEquals(['name'], $keys);
         $this->assertEquals(['Desk'], $values);
+
+        // Test dividing an array with multiple key-value pairs
+        [$keys, $values] = Arr::divide(['name' => 'Desk', 'price' => 100, 'available' => true]);
+        $this->assertEquals(['name', 'price', 'available'], $keys);
+        $this->assertEquals(['Desk', 100, true], $values);
+
+        // Test dividing an array with numeric keys
+        [$keys, $values] = Arr::divide([0 => 'first', 1 => 'second']);
+        $this->assertEquals([0, 1], $keys);
+        $this->assertEquals(['first', 'second'], $values);
+
+        // Test dividing an array with null key
+        [$keys, $values] = Arr::divide([null => 'Null', 1 => 'one']);
+        $this->assertEquals([null, 1], $keys);
+        $this->assertEquals(['Null', 'one'], $values);
     }
 
     public function testDot()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -131,6 +131,16 @@ class SupportArrTest extends TestCase
         [$keys, $values] = Arr::divide([null => 'Null', 1 => 'one']);
         $this->assertEquals([null, 1], $keys);
         $this->assertEquals(['Null', 'one'], $values);
+
+        // Test dividing an array with array key
+        [$keys, $values] = Arr::divide([['one' => 1, 2 => 'second'], 1 => 'one']);
+        $this->assertEquals([0, 1], $keys);
+        $this->assertEquals([['one' => 1, 2 => 'second'], 'one'], $values);
+
+        // Test dividing an array with array value
+        [$keys, $values] = Arr::divide([null => ['one' => 1, 2 => 'second'], 1 => 'one']);
+        $this->assertEquals([null, 1], $keys);
+        $this->assertEquals([['one' => 1, 2 => 'second'], 'one'], $values);
     }
 
     public function testDot()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -132,12 +132,12 @@ class SupportArrTest extends TestCase
         $this->assertEquals([null, 1], $keys);
         $this->assertEquals(['Null', 'one'], $values);
 
-        // Test dividing an array with array key
+        // Test dividing an array where the keys are arrays
         [$keys, $values] = Arr::divide([['one' => 1, 2 => 'second'], 1 => 'one']);
         $this->assertEquals([0, 1], $keys);
         $this->assertEquals([['one' => 1, 2 => 'second'], 'one'], $values);
 
-        // Test dividing an array with array value
+        // Test dividing an array where the values are arrays
         [$keys, $values] = Arr::divide([null => ['one' => 1, 2 => 'second'], 1 => 'one']);
         $this->assertEquals([null, 1], $keys);
         $this->assertEquals([['one' => 1, 2 => 'second'], 'one'], $values);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -109,8 +109,8 @@ class SupportArrTest extends TestCase
     {
         // Test dividing an empty array
         [$keys, $values] = Arr::divide([]);
-        $this->assertEquals([],$keys);
-        $this->assertEquals([],$values);
+        $this->assertEquals([], $keys);
+        $this->assertEquals([], $values);
 
         // Test dividing an array with a single key-value pair
         [$keys, $values] = Arr::divide(['name' => 'Desk']);


### PR DESCRIPTION
This PR, addes tests for `Arr::divide`

### Changes:

- Test dividing an empty array
- Test dividing an array with a single key-value pair
- Test dividing an array with multiple key-value pairs
- Test dividing an array with numeric keys
- Test dividing an array with null key
- Test dividing an array where the keys are arrays
- Test dividing an array where the values are arrays