### PR TITLE
[11.x] Add generic PHPDoc to relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -11,9 +11,10 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 /**
- * @template T of \Illuminate\Database\Eloquent\Model
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TChildModel of \Illuminate\Database\Eloquent\Model
  *
- * @extends Relation<T>
+ * @extends Relation<TRelatedModel>
  */
 class BelongsTo extends Relation
 {
@@ -24,7 +25,7 @@ class BelongsTo extends Relation
     /**
      * The child model instance of the relation.
      *
-     * @var T
+     * @var TChildModel
      */
     protected $child;
 
@@ -200,8 +201,8 @@ class BelongsTo extends Relation
     /**
      * Associate the model instance to the given parent.
      *
-     * @param  T|int|string|null  $model
-     * @return T
+     * @param  TRelatedModel|int|string|null  $model
+     * @return TChildModel
      */
     public function associate($model)
     {
@@ -221,7 +222,7 @@ class BelongsTo extends Relation
     /**
      * Dissociate previously associated model from the given parent.
      *
-     * @return T
+     * @return TChildModel
      */
     public function dissociate()
     {
@@ -233,7 +234,7 @@ class BelongsTo extends Relation
     /**
      * Alias of "dissociate" method.
      *
-     * @return T
+     * @return TChildModel
      */
     public function disassociate()
     {
@@ -295,7 +296,7 @@ class BelongsTo extends Relation
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return T
+     * @return TRelatedModel
      */
     protected function newRelatedInstanceFor(Model $parent)
     {
@@ -305,7 +306,7 @@ class BelongsTo extends Relation
     /**
      * Get the child of the relationship.
      *
-     * @return T
+     * @return TChildModel
      */
     public function getChild()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends Relation<T>
  */
 class BelongsTo extends Relation

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -10,6 +10,10 @@ use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends Relation<T>
+ */
 class BelongsTo extends Relation
 {
     use ComparesRelatedModels,
@@ -19,7 +23,7 @@ class BelongsTo extends Relation
     /**
      * The child model instance of the relation.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var T
      */
     protected $child;
 
@@ -195,8 +199,8 @@ class BelongsTo extends Relation
     /**
      * Associate the model instance to the given parent.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|int|string|null  $model
-     * @return \Illuminate\Database\Eloquent\Model
+     * @param  T|int|string|null  $model
+     * @return T
      */
     public function associate($model)
     {
@@ -216,7 +220,7 @@ class BelongsTo extends Relation
     /**
      * Dissociate previously associated model from the given parent.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function dissociate()
     {
@@ -228,7 +232,7 @@ class BelongsTo extends Relation
     /**
      * Alias of "dissociate" method.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function disassociate()
     {
@@ -290,7 +294,7 @@ class BelongsTo extends Relation
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     protected function newRelatedInstanceFor(Model $parent)
     {
@@ -300,7 +304,7 @@ class BelongsTo extends Relation
     /**
      * Get the child of the relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function getChild()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends Relation<T>
  */
 class BelongsToMany extends Relation

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -16,6 +16,10 @@ use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends Relation<T>
+ */
 class BelongsToMany extends Relation
 {
     use InteractsWithDictionary, InteractsWithPivotTable;
@@ -583,7 +587,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Support\Collection<mixed, T>|T
      */
     public function findOrNew($id, $columns = ['*'])
     {
@@ -599,7 +603,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
@@ -617,7 +621,7 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
@@ -643,7 +647,7 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function createOrFirst(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
@@ -669,7 +673,7 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
@@ -687,7 +691,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
+     * @return T|\Illuminate\Database\Eloquent\Collection<mixed, T>|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -705,7 +709,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function findMany($ids, $columns = ['*'])
     {
@@ -725,7 +729,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return T|\Illuminate\Database\Eloquent\Collection<mixed, T>
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
      */
@@ -752,7 +756,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $id
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
+     * @return T|\Illuminate\Database\Eloquent\Collection<mixed, T>|mixed
      */
     public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
@@ -784,7 +788,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static|null
+     * @return T|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -795,7 +799,7 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static|null
+     * @return T|static|null
      */
     public function first($columns = ['*'])
     {
@@ -808,9 +812,9 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return T|static
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<T>
      */
     public function firstOrFail($columns = ['*'])
     {
@@ -826,7 +830,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     * @return T|static|mixed
      */
     public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
@@ -859,7 +863,7 @@ class BelongsToMany extends Relation
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function get($columns = ['*'])
     {
@@ -1284,7 +1288,7 @@ class BelongsToMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array  $pivotAttributes
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function save(Model $model, array $pivotAttributes = [], $touch = true)
     {
@@ -1301,7 +1305,7 @@ class BelongsToMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array  $pivotAttributes
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function saveQuietly(Model $model, array $pivotAttributes = [], $touch = true)
     {
@@ -1313,7 +1317,7 @@ class BelongsToMany extends Relation
     /**
      * Save an array of new models and attach them to the parent model.
      *
-     * @param  \Illuminate\Support\Collection|array  $models
+     * @param  \Illuminate\Support\Collection<mixed, T>|array  $models
      * @param  array  $pivotAttributes
      * @return array
      */
@@ -1331,7 +1335,7 @@ class BelongsToMany extends Relation
     /**
      * Save an array of new models without raising any events and attach them to the parent model.
      *
-     * @param  \Illuminate\Support\Collection|array  $models
+     * @param  \Illuminate\Support\Collection<mixed, T>|array  $models
      * @param  array  $pivotAttributes
      * @return array
      */
@@ -1348,7 +1352,7 @@ class BelongsToMany extends Relation
      * @param  array  $attributes
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function create(array $attributes = [], array $joining = [], $touch = true)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -4,12 +4,16 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 
+/**
+ * @template T
+ * @extends HasOneOrMany<T>
+ */
 class HasMany extends HasOneOrMany
 {
     /**
      * Convert the relationship to a "has one" relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne<T>
      */
     public function one()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @template T
+ *
  * @extends HasOneOrMany<T>
  */
 class HasMany extends HasOneOrMany

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -13,6 +13,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends Relation<T>
+ */
 class HasManyThrough extends Relation
 {
     use InteractsWithDictionary;
@@ -254,7 +258,7 @@ class HasManyThrough extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
@@ -270,7 +274,7 @@ class HasManyThrough extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
@@ -286,7 +290,7 @@ class HasManyThrough extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function createOrFirst(array $attributes = [], array $values = [])
     {
@@ -302,7 +306,7 @@ class HasManyThrough extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
@@ -320,7 +324,7 @@ class HasManyThrough extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static|null
+     * @return T|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -331,7 +335,7 @@ class HasManyThrough extends Relation
      * Execute the query and get the first related model.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static|null
+     * @return T|static|null
      */
     public function first($columns = ['*'])
     {
@@ -344,9 +348,9 @@ class HasManyThrough extends Relation
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return T|static
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<T>
      */
     public function firstOrFail($columns = ['*'])
     {
@@ -362,7 +366,7 @@ class HasManyThrough extends Relation
      *
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     * @return T|static|mixed
      */
     public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
@@ -384,7 +388,7 @@ class HasManyThrough extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
+     * @return T|\Illuminate\Database\Eloquent\Collection<mixed, T>|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -402,7 +406,7 @@ class HasManyThrough extends Relation
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function findMany($ids, $columns = ['*'])
     {
@@ -422,9 +426,9 @@ class HasManyThrough extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return T|\Illuminate\Database\Eloquent\Collection<mixed, T>
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<T>
      */
     public function findOrFail($id, $columns = ['*'])
     {
@@ -449,7 +453,7 @@ class HasManyThrough extends Relation
      * @param  mixed  $id
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
+     * @return T|\Illuminate\Database\Eloquent\Collection<mixed, T>|mixed
      */
     public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
@@ -490,7 +494,7 @@ class HasManyThrough extends Relation
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function get($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -15,6 +15,7 @@ use Illuminate\Database\UniqueConstraintViolationException;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends Relation<T>
  */
 class HasManyThrough extends Relation

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -11,6 +11,10 @@ use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use Illuminate\Database\Query\JoinClause;
 
+/**
+ * @template T
+ * @extends HasOneOrMany<T>
+ */
 class HasOne extends HasOneOrMany implements SupportsPartialRelations
 {
     use ComparesRelatedModels, CanBeOneOfMany, SupportsDefaultModels;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\JoinClause;
 
 /**
  * @template T
+ *
  * @extends HasOneOrMany<T>
  */
 class HasOne extends HasOneOrMany implements SupportsPartialRelations

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -10,6 +10,7 @@ use Illuminate\Database\UniqueConstraintViolationException;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends Relation<T>
  */
 abstract class HasOneOrMany extends Relation

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\UniqueConstraintViolationException;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends Relation<T>
+ */
 abstract class HasOneOrMany extends Relation
 {
     use InteractsWithDictionary;
@@ -47,7 +51,7 @@ abstract class HasOneOrMany extends Relation
      * Create and return an un-saved instance of the related model.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function make(array $attributes = [])
     {
@@ -60,7 +64,7 @@ abstract class HasOneOrMany extends Relation
      * Create and return an un-saved instance of the related models.
      *
      * @param  iterable  $records
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function makeMany($records)
     {
@@ -195,7 +199,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Support\Collection<mixed, T>|T
      */
     public function findOrNew($id, $columns = ['*'])
     {
@@ -213,7 +217,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
@@ -231,7 +235,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
@@ -247,7 +251,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function createOrFirst(array $attributes = [], array $values = [])
     {
@@ -263,7 +267,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
@@ -278,7 +282,7 @@ abstract class HasOneOrMany extends Relation
      * Attach a model instance to the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|false
+     * @return T|false
      */
     public function save(Model $model)
     {
@@ -291,7 +295,7 @@ abstract class HasOneOrMany extends Relation
      * Attach a model instance without raising any events to the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|false
+     * @return T|false
      */
     public function saveQuietly(Model $model)
     {
@@ -332,7 +336,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function create(array $attributes = [])
     {
@@ -347,7 +351,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model without raising any events to the parent model.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function createQuietly(array $attributes = [])
     {
@@ -358,7 +362,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function forceCreate(array $attributes = [])
     {
@@ -371,7 +375,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model with mass assignment without raising model events.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function forceCreateQuietly(array $attributes = [])
     {
@@ -382,7 +386,7 @@ abstract class HasOneOrMany extends Relation
      * Create a Collection of new instances of the related model.
      *
      * @param  iterable  $records
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function createMany(iterable $records)
     {
@@ -399,7 +403,7 @@ abstract class HasOneOrMany extends Relation
      * Create a Collection of new instances of the related model without raising any events to the parent model.
      *
      * @param  iterable  $records
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function createManyQuietly(iterable $records)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends HasManyThrough<T>
+ */
 class HasOneThrough extends HasManyThrough
 {
     use InteractsWithDictionary, SupportsDefaultModels;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends HasManyThrough<T>
  */
 class HasOneThrough extends HasManyThrough

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -5,12 +5,16 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends MorphOneOrMany<T>
+ */
 class MorphMany extends MorphOneOrMany
 {
     /**
      * Convert the relationship to a "morph one" relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOne<T>
      */
     public function one()
     {
@@ -68,7 +72,7 @@ class MorphMany extends MorphOneOrMany
      * Create a new instance of the related model. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function forceCreate(array $attributes = [])
     {
@@ -81,7 +85,7 @@ class MorphMany extends MorphOneOrMany
      * Create a new instance of the related model with mass assignment without raising model events.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function forceCreateQuietly(array $attributes = [])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends MorphOneOrMany<T>
  */
 class MorphMany extends MorphOneOrMany

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\JoinClause;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends MorphOneOrMany<T>
  */
 class MorphOne extends MorphOneOrMany implements SupportsPartialRelations

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -11,6 +11,10 @@ use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use Illuminate\Database\Query\JoinClause;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends MorphOneOrMany<T>
+ */
 class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
 {
     use CanBeOneOfMany, ComparesRelatedModels, SupportsDefaultModels;
@@ -115,7 +119,7 @@ class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function newRelatedInstanceFor(Model $parent)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -5,6 +5,10 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends MorphOneOrMany<T>
+ */
 abstract class MorphOneOrMany extends HasOneOrMany
 {
     /**
@@ -71,7 +75,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * Create a new instance of the related model. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function forceCreate(array $attributes = [])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -7,7 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
- * @extends MorphOneOrMany<T>
+ *
+ * @extends HasOneOrMany<T>
  */
 abstract class MorphOneOrMany extends HasOneOrMany
 {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -9,9 +9,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 /**
- * @template T of \Illuminate\Database\Eloquent\Model
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TChildModel of \Illuminate\Database\Eloquent\Model
  *
- * @extends BelongsTo<T>
+ * @extends BelongsTo<TRelatedModel, TChildModel>
  */
 class MorphTo extends BelongsTo
 {
@@ -133,7 +134,7 @@ class MorphTo extends BelongsTo
      * Get all of the relation results for a type.
      *
      * @param  string  $type
-     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, TRelatedModel>
      */
     protected function getResultsByType($type)
     {
@@ -182,7 +183,7 @@ class MorphTo extends BelongsTo
      * Create a new model instance by type.
      *
      * @param  string  $type
-     * @return T
+     * @return TRelatedModel
      */
     public function createModelByType($type)
     {
@@ -232,7 +233,7 @@ class MorphTo extends BelongsTo
      * Associate the model instance to the given parent.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $model
-     * @return T
+     * @return TRelatedModel
      */
     public function associate($model)
     {
@@ -256,7 +257,7 @@ class MorphTo extends BelongsTo
     /**
      * Dissociate previously associated model from the given parent.
      *
-     * @return T
+     * @return TRelatedModel
      */
     public function dissociate()
     {
@@ -283,7 +284,7 @@ class MorphTo extends BelongsTo
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return T
+     * @return TRelatedModel
      */
     protected function newRelatedInstanceFor(Model $parent)
     {
@@ -314,7 +315,7 @@ class MorphTo extends BelongsTo
      * Specify which relations to load for a given morph type.
      *
      * @param  array  $with
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<T>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel>
      */
     public function morphWith(array $with)
     {
@@ -329,7 +330,7 @@ class MorphTo extends BelongsTo
      * Specify which relationship counts to load for a given morph type.
      *
      * @param  array  $withCount
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<T>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel>
      */
     public function morphWithCount(array $withCount)
     {
@@ -344,7 +345,7 @@ class MorphTo extends BelongsTo
      * Specify constraints on the query for a given morph type.
      *
      * @param  array  $callbacks
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<T>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel>
      */
     public function constrain(array $callbacks)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends BelongsTo<T>
+ */
 class MorphTo extends BelongsTo
 {
     use InteractsWithDictionary;
@@ -128,7 +132,7 @@ class MorphTo extends BelongsTo
      * Get all of the relation results for a type.
      *
      * @param  string  $type
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     protected function getResultsByType($type)
     {
@@ -177,7 +181,7 @@ class MorphTo extends BelongsTo
      * Create a new model instance by type.
      *
      * @param  string  $type
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function createModelByType($type)
     {
@@ -227,7 +231,7 @@ class MorphTo extends BelongsTo
      * Associate the model instance to the given parent.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $model
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function associate($model)
     {
@@ -251,7 +255,7 @@ class MorphTo extends BelongsTo
     /**
      * Dissociate previously associated model from the given parent.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function dissociate()
     {
@@ -278,7 +282,7 @@ class MorphTo extends BelongsTo
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     protected function newRelatedInstanceFor(Model $parent)
     {
@@ -309,7 +313,7 @@ class MorphTo extends BelongsTo
      * Specify which relations to load for a given morph type.
      *
      * @param  array  $with
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<T>
      */
     public function morphWith(array $with)
     {
@@ -324,7 +328,7 @@ class MorphTo extends BelongsTo
      * Specify which relationship counts to load for a given morph type.
      *
      * @param  array  $withCount
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<T>
      */
     public function morphWithCount(array $withCount)
     {
@@ -339,7 +343,7 @@ class MorphTo extends BelongsTo
      * Specify constraints on the query for a given morph type.
      *
      * @param  array  $callbacks
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<T>
      */
     public function constrain(array $callbacks)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends BelongsTo<T>
  */
 class MorphTo extends BelongsTo

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ * @extends BelongsToMany<T>
+ */
 class MorphToMany extends BelongsToMany
 {
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 
 /**
  * @template T of \Illuminate\Database\Eloquent\Model
+ *
  * @extends BelongsToMany<T>
  */
 class MorphToMany extends BelongsToMany

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -13,6 +13,9 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ */
 abstract class Relation implements BuilderContract
 {
     use ForwardsCalls, Macroable {
@@ -157,7 +160,7 @@ abstract class Relation implements BuilderContract
     /**
      * Get the relationship for eager loading.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function getEager()
     {
@@ -170,7 +173,7 @@ abstract class Relation implements BuilderContract
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
      * @throws \Illuminate\Database\MultipleRecordsFoundException
@@ -196,7 +199,7 @@ abstract class Relation implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<mixed, T>
      */
     public function get($columns = ['*'])
     {
@@ -349,7 +352,7 @@ abstract class Relation implements BuilderContract
     /**
      * Get the related model of the relation.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return T
      */
     public function getRelated()
     {


### PR DESCRIPTION
These changes add support to generic types for model relations.

Now, we can write types like this:
```php
class User extends Model {
    /**
     * @return HasMany<Post>
     */
    public function posts(): HasMany {
        return $this->hasMany(Post::class);
    }
}
```
And we will get

`$user->posts()->get()` - Collection of Post
`$user->posts()->make()` - Model of Post

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
