### PR TITLE
[10.x] Fix collection shift less than one item

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1131,7 +1131,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function shift($count = 1)
     {
         if ($count < 0) {
-            throw new InvalidArgumentException('can not shift less than 0.');
+            throw new InvalidArgumentException('Number of shifted items may not be less than zero.');
         }
 
         if ($count === 0 || $this->isEmpty()) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use stdClass;
 use Traversable;
 
@@ -1124,15 +1125,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $count
      * @return static<int, TValue>|TValue|null
+     *
+     * @throws \InvalidArgumentException
      */
     public function shift($count = 1)
     {
-        if ($count === 1) {
-            return array_shift($this->items);
+        if ($count === 0 || $this->isEmpty()) {
+            return new static;
         }
 
-        if ($this->isEmpty()) {
-            return new static;
+        if ($count < 0) {
+            throw new InvalidArgumentException('can not shift less than 0.');
+        }
+
+        if ($count === 1) {
+            return array_shift($this->items);
         }
 
         $results = [];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1130,12 +1130,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function shift($count = 1)
     {
-        if ($count === 0 || $this->isEmpty()) {
-            return new static;
-        }
-
         if ($count < 0) {
             throw new InvalidArgumentException('can not shift less than 0.');
+        }
+
+        if ($count === 0 || $this->isEmpty()) {
+            return new static;
         }
 
         if ($count === 1) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -391,6 +391,17 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('baz', $data->first());
 
         $this->assertEquals(new Collection(['foo', 'bar', 'baz']), (new Collection(['foo', 'bar', 'baz']))->shift(6));
+
+        $data = new Collection(['foo', 'bar', 'baz']);
+
+        $this->assertEquals(new Collection([]), $data->shift(0));
+        $this->assertEquals(collect(['foo', 'bar', 'baz']), $data);
+
+        $this->expectException('InvalidArgumentException');
+        (new Collection(['foo', 'bar', 'baz']))->shift(-1);
+
+        $this->expectException('InvalidArgumentException');
+        (new Collection(['foo', 'bar', 'baz']))->shift(-2);
     }
 
     /**


### PR DESCRIPTION
Helloo 👋🏻 

In this PR I have fixed the `collection shift()` behaviour when trying to shift less than one item.

Fixes #51684

----
### $count = 0
#### Current
```php
$collection = new Collection(['foo', 'bar', 'baz']);
echo $collection->shift(0); // ['foo', 'bar']
echo $collection; // ['baz']
````

#### Expected
```php
$collection = new Collection(['foo', 'bar', 'baz']);
echo $collection->shift(0); // []
echo $collection; // ['foo', 'bar', 'baz']
````
----
### $count < 0
#### Current
```php
$collection = new Collection(['foo', 'bar', 'baz']);
echo $collection->shift(-1); // ['foo', 'bar', 'baz']
echo $collection; // []
````

#### Expected
```php
$collection = new Collection(['foo', 'bar', 'baz']);
echo $collection->shift(-1); // InvalidArgumentException
```