### PR TITLE
[10.x] Fix typo in return comment of createSesTransport method

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -259,7 +259,7 @@ class MailManager implements FactoryContract
      * Create an instance of the Symfony Amazon SES V2 Transport driver.
      *
      * @param  array  $config
-     * @return \Illuminate\Mail\Transport\Se2VwTransport
+     * @return \Illuminate\Mail\Transport\SesV2Transport
      */
     protected function createSesV2Transport(array $config)
     {


### PR DESCRIPTION
I've noticed that in the MailManager class, the createSesTransport method has a typo in the return comment. The "SesV2Transport" was mistakenly spelled as "Se2VwTransport". This PR fixes the typo in the return parameter of the method.
