### PR TITLE
[11.x] Add `registerProviderProperties()` method to Application

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -867,22 +867,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         $provider->register();
 
-        // If there are bindings / singletons set as properties on the provider we
-        // will spin through them and register them with the application, which
-        // serves as a convenience layer while registering a lot of bindings.
-        if (property_exists($provider, 'bindings')) {
-            foreach ($provider->bindings as $key => $value) {
-                $this->bind($key, $value);
-            }
-        }
-
-        if (property_exists($provider, 'singletons')) {
-            foreach ($provider->singletons as $key => $value) {
-                $key = is_int($key) ? $value : $key;
-
-                $this->singleton($key, $value);
-            }
-        }
+        $this->registerProviderProperties($provider);
 
         $this->markAsRegistered($provider);
 
@@ -931,6 +916,32 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function resolveProvider($provider)
     {
         return new $provider($this);
+    }
+
+    /**
+     * Register the given provider properties.
+     *
+     * @param  \Illuminate\Support\ServiceProvider  $provider
+     * @return void
+     */
+    protected function registerProviderProperties($provider)
+    {
+        // If there are bindings / singletons set as properties on the provider we
+        // will spin through them and register them with the application, which
+        // serves as a convenience layer while registering a lot of bindings.
+        if (property_exists($provider, 'bindings')) {
+            foreach ($provider->bindings as $key => $value) {
+                $this->bind($key, $value);
+            }
+        }
+
+        if (property_exists($provider, 'singletons')) {
+            foreach ($provider->singletons as $key => $value) {
+                $key = is_int($key) ? $value : $key;
+
+                $this->singleton($key, $value);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds `registerProviderProperties()` to `Application`, which will allow expanding the pool of possible properties in service providers for automatic registration.

## Usage example

```php
class MyApplication extends Application
{
    protected function registerProviderProperties($provider)
    {
        parent::registerProviderProperties();

        if (property_exists($provider, 'policies')) {
            foreach ($provider->policies as $key => $value) {
                Gate::policy($key, $value);
            }
        }

        if (property_exists($provider, 'components')) {
            foreach ($provider->components as $key => $value) {
                Blade::component($key, $value);
            }
        }
    }
}
```