### PR TITLE
[11.x] Filter environment variables in ServeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -142,12 +142,12 @@ class ServeCommand extends Command
      */
     protected function startProcess($hasEnvironment)
     {
-        $process = new Process($this->serverCommand(), public_path(), collect($_ENV)->mapWithKeys(function ($value, $key) use ($hasEnvironment) {
+        $process = new Process($this->serverCommand(), public_path(), collect($_ENV)->filter(function ($value, $key) use ($hasEnvironment) {
             if ($this->option('no-reload') || ! $hasEnvironment) {
-                return [$key => $value];
+                return true;
             }
 
-            return in_array($key, static::$passthroughVariables) ? [$key => $value] : [$key => false];
+            return in_array($key, static::$passthroughVariables);
         })->all());
 
         $this->trap(fn () => [SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT], function ($signal) use ($process) {


### PR DESCRIPTION
This PR fixes an old outstanding issue that previously required a `php.ini` adjustment. (https://github.com/laravel/framework/issues/34229) 

At the moment, the `ServeCommand` does not really filter environment variables that are being passed to the PHP process, but instead it sets them to `false`.
This can lead to issues if the variable is being used by the system and is then set to `false`.

Instead of passing the variables as `false`, this PR now filters the env variables and only passes those to the process that are passthrough variables - or all in case `--no-reload` is specified.