### PR TITLE
[11.x] Add `linesChunk` method to the `FileSystem` class

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -162,19 +162,34 @@ class Filesystem
      */
     public function lines($path)
     {
+        return $this->linesChunk($path);
+    }
+
+    /**
+     * Get a portion of a file one line at a time.
+     *
+     * @param  string  $path
+     * @param  int  $startFrom
+     * @return \Illuminate\Support\LazyCollection
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function linesChunk($path, $startFrom = 0)
+    {
         if (! $this->isFile($path)) {
             throw new FileNotFoundException(
                 "File does not exist at path {$path}."
             );
         }
 
-        return LazyCollection::make(function () use ($path) {
+        return LazyCollection::make(function () use ($path, $startFrom) {
             $file = new SplFileObject($path);
 
             $file->setFlags(SplFileObject::DROP_NEW_LINE);
+            $file->seek($startFrom);
 
             while (! $file->eof()) {
-                yield $file->fgets();
+                yield $file->key() => $file->fgets();
             }
         });
     }


### PR DESCRIPTION
The added method `linesChunk` in this PR is a slightly more advanced version of the `lines` method to enable us to jump and start from a particular line in the middle of a file. This is particularly useful when we want to only process newly appended files to large log files and continue on from where we last left off. The main problem with the `lines` method in such cases is that it read all the lines one by one (which involves a lot of "disk IO") and feeds them into the next step of lazy collection to get filtered out but with `linesChunck` start from

```php
    //Create a sample ~100MB log file, with 1 million lines, 100 chars in each line.
    if (filesize(__DIR__.'/file.txt') < 10) {
            for ($i = 0; $i < 1_000_000; $i++) {
              
                file_put_contents(__DIR__.'/file.txt', '123456789|123456789|123456789|123456789|123456789|'.
                 '123456789|123456789|123456789|123456789|123456789|', FILE_APPEND);
            }
        }

        $files = new Filesystem;

        $t = microtime(true);
        $files->lines(__DIR__.'/file.txt')->skipWhile(function ($content, $number) {
            return $number < (1_000_000 - 10);
        })->all();
        echo (microtime(true) - $t);

        echo PHP_EOL;

        $t = microtime(true);
        $files->linesChunk(__DIR__.'/file.txt', 1_000_000 - 10)->all();
        echo (microtime(true) - $t);
```

The performance difference depends on the file size and hardware, and etc. 
This is the result for me running on Windows 11 and an NVME drive as file storage.

![image](https://github.com/laravel/framework/assets/6961695/92954b1f-f516-4347-9d07-ebe3ef800f4d)

## Backward-compatibility:
To be fully Backward-compatible with class extenders that have overridden the `lines` method, I created a brand new method and did not tamper with the signature of the `lines` method. The `lines` method can now reuse the added functionality.