### PR TITLE
[10.x] Fix collection items pop when count is 0 or less than 0.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -954,11 +954,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             throw new InvalidArgumentException('Number of popped items may not be less than zero.');
         }
 
-        if ($count === 0) {
-            return new static($this->items);
-        }
-
-        if ($this->isEmpty()) {
+        if ($count === 0 || $this->isEmpty()) {
             return new static;
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -954,7 +954,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             throw new InvalidArgumentException('Number of popped items may not be less than zero.');
         }
 
-        if ($count === 0 || $this->isEmpty()) {
+        if ($count === 0) {
+            return new static($this->items);
+        }
+
+        if ($this->isEmpty()) {
             return new static;
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -945,15 +945,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $count
      * @return static<int, TValue>|TValue|null
+     *
+     * @throws \InvalidArgumentException
      */
     public function pop($count = 1)
     {
-        if ($count === 1) {
-            return array_pop($this->items);
+        if ($count < 0) {
+            throw new InvalidArgumentException('Number of popped items may not be less than zero.');
         }
 
-        if ($this->isEmpty()) {
+        if ($count === 0 || $this->isEmpty()) {
             return new static;
+        }
+
+        if ($count === 1) {
+            return array_pop($this->items);
         }
 
         $results = [];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -371,6 +371,17 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $c->first());
 
         $this->assertEquals(new Collection(['baz', 'bar', 'foo']), (new Collection(['foo', 'bar', 'baz']))->pop(6));
+
+        $c = new Collection(['foo', 'bar', 'baz']);
+
+        $this->assertEquals(new Collection([]), $c->pop(0));
+        $this->assertEquals(collect(['foo', 'bar', 'baz']), $c);
+
+        $this->expectException('InvalidArgumentException');
+        (new Collection(['foo', 'bar', 'baz']))->pop(-1);
+
+        $this->expectException('InvalidArgumentException');
+        (new Collection(['foo', 'bar', 'baz']))->pop(-2);
     }
 
     public function testShiftReturnsAndRemovesFirstItemInCollection()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -372,9 +372,11 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(new Collection(['baz', 'bar', 'foo']), (new Collection(['foo', 'bar', 'baz']))->pop(6));
 
-        $c = new Collection(['foo', 'bar', 'baz']);
+        $c = new Collection([]);
+        $this->assertEquals(new Collection([]), $c->pop(0));
 
-        $this->assertEquals(new Collection(['foo', 'bar', 'baz']), $c->pop(0));
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $this->assertEquals(collect(['foo', 'bar', 'baz']), $c->pop(0));
 
         $this->expectException('InvalidArgumentException');
         (new Collection(['foo', 'bar', 'baz']))->pop(-1);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -376,7 +376,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(new Collection([]), $c->pop(0));
 
         $c = new Collection(['foo', 'bar', 'baz']);
-        $this->assertEquals(collect(['foo', 'bar', 'baz']), $c->pop(0));
+
+        $this->assertEquals(new Collection([]), $c->pop(0));
+        $this->assertEquals(collect(['foo', 'bar', 'baz']), $c);
 
         $this->expectException('InvalidArgumentException');
         (new Collection(['foo', 'bar', 'baz']))->pop(-1);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -374,8 +374,7 @@ class SupportCollectionTest extends TestCase
 
         $c = new Collection(['foo', 'bar', 'baz']);
 
-        $this->assertEquals(new Collection([]), $c->pop(0));
-        $this->assertEquals(collect(['foo', 'bar', 'baz']), $c);
+        $this->assertEquals(new Collection(['foo', 'bar', 'baz']), $c->pop(0));
 
         $this->expectException('InvalidArgumentException');
         (new Collection(['foo', 'bar', 'baz']))->pop(-1);


### PR DESCRIPTION
Hello

Building upon the improvements from Issue #51684 and in merged PR #51686; the ```pop``` method in Laravel's Collection class does not correctly handle cases where the ```$count``` parameter is zero or negative. 

This proposal seeks to refine the method's behavior to:

1. Return empty collection when ```$count``` is zero.
2. Throw an InvalidArgumentException when ```$count``` is less than zero.

___

**Current**

```php
$c = collect([10, 20, 30, 40]);
$c->pop(0); 
$c; // [10, 20]
```

```php
$c = collect([10, 20, 30, 40]);
$c->pop(-1); 
$c; // [10]
```

```php
$c = collect([10, 20, 30, 40]);
$c->pop(-2); 
$c; // []
```

**Expected**

```php
$c = collect([10, 20, 30, 40]);
$c->pop(0); 
$c; // []
```

```php
$c = collect([10, 20, 30, 40]);
$c->pop(-1);  // InvalidArgumentException('Number of popped items may not be less than zero.');
```

```php
$c = collect([10, 20, 30, 40]);
$c->pop(-2); // InvalidArgumentException('Number of popped items may not be less than zero.');
```

I hope you find this helpful.

Thank you