### PR TITLE
[10.x] Turn `Enumerable unless()`  $callback parameter optional

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -342,7 +342,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable($this): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType
      */
-    public function unless($value, callable $callback = null, callable $default = null);
+    public function unless($value, ?callable $callback = null, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is empty.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -338,11 +338,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TUnlessReturnType
      *
      * @param  bool  $value
-     * @param  (callable($this): TUnlessReturnType)  $callback
+     * @param  (callable($this): TUnlessReturnType)|null  $callback
      * @param  (callable($this): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType
      */
-    public function unless($value, callable $callback, callable $default = null);
+    public function unless($value, callable $callback = null, callable $default = null);
 
     /**
      * Apply the callback unless the collection is empty.


### PR DESCRIPTION
Helloo 👋🏻 

This screenshot is an example among others from laravel/framework codebase where `unless()` is used with only one argument. implementing `Enumerable` this makes the intelephense complains about it expecting two arguments.

https://github.com/laravel/framework/blob/a84c4f41d3fb1c57684bb417b1f0858300e769d0/src/Illuminate/Collections/LazyCollection.php#L1242

https://github.com/laravel/framework/blob/a84c4f41d3fb1c57684bb417b1f0858300e769d0/src/Illuminate/Collections/LazyCollection.php#L1266

![Screenshot from 2024-06-04 00-05-16](https://github.com/laravel/framework/assets/60013703/a133243a-d597-44b6-b59d-a9cd5cec223b)

