### PR TITLE
[11.x] Fix Edge cases in Illuminate\Translation\Translator's get() method

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -176,7 +176,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
+        return $this->makeReplacements(is_null($line) ? $key : $line, $replace);
     }
 
     /**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -66,6 +66,17 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testGetMethodProperlyRetrievesItemWithFalsyStringKey()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['empty' => '', 'zero' => '0']);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['empty' => '', 'zero' => '0']);
+        $this->assertSame('', $t->get('foo::bar.empty'));
+        $this->assertSame('0', $t->get('foo::bar.zero'));
+        $this->assertSame('', $t->get('empty'));
+        $this->assertSame('0', $t->get('zero'));
+    }
+
     public function testGetMethodForNonExistingReturnsSameKey()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
This PR proposes a fix for the main issue described in https://github.com/laravel/framework/issues/51703 .

An explicit null check is used instead of an implicit one (via the short ternary), so that values like `""` or `"0"` would not make the [`get()`](https://github.com/laravel/framework/blob/a84c4f41d3fb1c57684bb417b1f0858300e769d0/src/Illuminate/Translation/Translator.php#L179) method erroneously return the key instead of the defined translation.

An appropriate test was also added to ensure the fix works as intended and to any future prevent regressions.

Thank you.