### PR TITLE
[11.x] Avoid using Laravel new error page if `app.debug` changes to `true` at runtime

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -833,9 +833,11 @@ class Handler implements ExceptionHandlerContract
     {
         try {
             if (config('app.debug')) {
-                return app()->has(ExceptionRenderer::class)
-                    ? $this->renderExceptionWithCustomRenderer($e)
-                    : $this->container->make(Renderer::class)->render(request(), $e);
+                if (app()->has(ExceptionRenderer::class)) {
+                    return $this->renderExceptionWithCustomRenderer($e);
+                } elseif ($this->container->bound(Renderer::class)) {
+                    return $this->container->make(Renderer::class)->render(request(), $e);
+                }
             }
 
             return $this->renderExceptionWithSymfony($e, config('app.debug'));

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Renderer\Renderer;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\TestCase;
+use RuntimeException;
+
+class RendererTest extends TestCase
+{
+    protected function defineRoutes($router)
+    {
+        $router->get('failed', fn () => throw new RuntimeException('Bad route!'));
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItCanRenderExceptionPage()
+    {
+        $this->assertTrue($this->app->bound(Renderer::class));
+
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertSee('RuntimeException')
+            ->assertSee('Bad route!');
+    }
+
+    public function testItCanRenderExceptionPageUsingSymfonyIfRendererIsNotDefined()
+    {
+        config(['app.debug' => true]);
+
+        $this->assertFalse($this->app->bound(Renderer::class));
+
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertSee('RuntimeException')
+            ->assertSee('Bad route!');
+    }
+}

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -25,6 +25,7 @@ class RendererTest extends TestCase
             ->assertSee('Bad route!');
     }
 
+    #[WithConfig('app.debug', false)]
     public function testItCanRenderExceptionPageUsingSymfonyIfRendererIsNotDefined()
     {
         config(['app.debug' => true]);


### PR DESCRIPTION
Laravel only register `Renderer` instance when the application is booted with `app.debug` as `true`. This would cause an error (mainly during development) if the configuration were changed to `true` before an exception occurred.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
