### PR TITLE
Negatable options in fluent command signatures

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -112,11 +112,14 @@ class Parser
             $token = $matches[1];
         }
 
+
         switch (true) {
             case str_ends_with($token, '='):
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
             case str_ends_with($token, '=*'):
                 return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
+            case str_ends_with($token, '=~'):
+                return new InputOption(trim($token, '=~'), null, InputOption::VALUE_NEGATABLE, $description);
             case preg_match('/(.+)\=\*(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
             case preg_match('/(.+)\=(.+)/', $token, $matches):

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -112,7 +112,6 @@ class Parser
             $token = $matches[1];
         }
 
-
         switch (true) {
             case str_ends_with($token, '='):
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
@@ -122,6 +121,8 @@ class Parser
                 return new InputOption(trim($token, '=~'), null, InputOption::VALUE_NEGATABLE, $description);
             case preg_match('/(.+)\=\*(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
+            case preg_match('/(.+)\=\~(.+)/', $token, $matches):
+                return new InputOption($matches[1], null, InputOption::VALUE_NEGATABLE, $description, filter_var($matches[2], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
             case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
             default:

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -117,11 +117,11 @@ class Parser
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
             case str_ends_with($token, '=*'):
                 return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
-            case str_ends_with($token, '=~'):
-                return new InputOption(trim($token, '=~'), null, InputOption::VALUE_NEGATABLE, $description);
+            case str_ends_with($token, '=!'):
+                return new InputOption(trim($token, '=!'), null, InputOption::VALUE_NEGATABLE, $description);
             case preg_match('/(.+)\=\*(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)\=\~(.+)/', $token, $matches):
+            case preg_match('/(.+)\=!(.+)/', $token, $matches):
                 return new InputOption($matches[1], null, InputOption::VALUE_NEGATABLE, $description, filter_var($matches[2], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
             case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -126,6 +126,59 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->isArray());
     }
 
+    public function testNegatableDefaultValue()
+    {
+        $results = Parser::parse('command:name {--option=~}');
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertNull($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~true}');
+
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertTrue($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~false}');
+
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertFalse($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~true : Enable/disable option.}');
+
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('Enable/disable option.', $results[2][0]->getDescription());
+        $this->assertTrue($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~invalid}');
+
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertNull($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~FALSE}');
+
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertFalse($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~TRUE}');
+        $this->assertTrue($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+
+        $results = Parser::parse('command:name {--option=~tRuE}');
+        $this->assertTrue($results[2][0]->getDefault());
+        $this->assertTrue($results[2][0]->isNegatable());
+    }
+
     public function testShortcutsAreIgnoredWithNegatableOptions()
     {
         $results = Parser::parse('command:name {--o|option=~}');

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -108,6 +108,7 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->isArray());
 
         $results = Parser::parse('command:name {--o|option=* : The option description.}');
+
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('o', $results[2][0]->getShortcut());
         $this->assertSame('option', $results[2][0]->getName());

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -40,7 +40,7 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
 
-        $results = Parser::parse('command:name {argument?*} {--option=~}');
+        $results = Parser::parse('command:name {argument?*} {--option=!}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('argument', $results[1][0]->getName());
@@ -78,7 +78,7 @@ class ConsoleParserTest extends TestCase
 
         $results = Parser::parse('command:name
             {argument?* : The argument description.}
-            {--option=~ : Enable/Disable description.}');
+            {--option=! : Enable/Disable description.}');
 
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertSame('Enable/Disable description.', $results[2][0]->getDescription());
@@ -128,27 +128,27 @@ class ConsoleParserTest extends TestCase
 
     public function testNegatableDefaultValue()
     {
-        $results = Parser::parse('command:name {--option=~}');
+        $results = Parser::parse('command:name {--option=!}');
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertNull($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~true}');
+        $results = Parser::parse('command:name {--option=!true}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertTrue($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~false}');
+        $results = Parser::parse('command:name {--option=!false}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertFalse($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~true : Enable/disable option.}');
+        $results = Parser::parse('command:name {--option=!true : Enable/disable option.}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
@@ -156,39 +156,39 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~invalid}');
+        $results = Parser::parse('command:name {--option=!invalid}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertNull($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~FALSE}');
+        $results = Parser::parse('command:name {--option=!FALSE}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertFalse($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~TRUE}');
+        $results = Parser::parse('command:name {--option=!TRUE}');
         $this->assertTrue($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--option=~tRuE}');
+        $results = Parser::parse('command:name {--option=!tRuE}');
         $this->assertTrue($results[2][0]->getDefault());
         $this->assertTrue($results[2][0]->isNegatable());
     }
 
     public function testShortcutsAreIgnoredWithNegatableOptions()
     {
-        $results = Parser::parse('command:name {--o|option=~}');
+        $results = Parser::parse('command:name {--o|option=!}');
 
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertNull($results[2][0]->getShortcut(), 'Shortcuts are ignored with negatable options.');
         $this->assertTrue($results[2][0]->isNegatable());
 
-        $results = Parser::parse('command:name {--o|option=~ : Enable/Disable description.}');
+        $results = Parser::parse('command:name {--o|option=! : Enable/Disable description.}');
         $this->assertSame('command:name', $results[0]);
         $this->assertSame('option', $results[2][0]->getName());
         $this->assertSame('Enable/Disable description.', $results[2][0]->getDescription());


### PR DESCRIPTION
I was reaching for [negatable options](https://symfony.com/blog/new-in-symfony-5-3-negatable-command-options) on an existing command and thought I'd propose a way to use them with the fluent signature:

```
php artisan my:command --notify
php artisan my:command --no-notify
```

Here's the simplest example:

```php
use Illuminate\Console\Command;

class MyCommand extends Command
{
    protected $signature = 'my:command {--cache=!}';
}
```

Negatable options can have one of three states: `null`, `false`, and `true`. Running `my:command` without `--cache|--no-cache`, the default option value will be `null`. This is useful if you'd like to prompt the user of their preference if they don't pass an option:

```
# Prompts the user
$ php artisan my:command
> Would you like the cache the result?
...

# Skips prompt
$ php artisan my:command --cache
$ php artisan my:command --no-cache
```

You can also get both variants of the option:

```php
// my:command
$this->option('cache'); // null
$this->option('no-cache'); // null

// my:command --cache
$this->option('cache'); // true
$this->option('no-cache'); // false

// my:command --no-cache
$this->option('cache'); // false
$this->option('no-cache'); // true
```

I like negatable options to unify toggling a boolean value on/off:
<img width="1015" alt="image" src="https://github.com/laravel/framework/assets/177773/d7449059-2de6-4a4c-95b3-bde7a2edf5e2">


Using fluent signatures, you can also choose to define the default value as `true` or `false` when the user doesn't pass an option if you'd like:

```php
protected $signature = 'my:command {--cache=!true : Enable/Disable cache (default true).}';
protected $signature = 'my:command {--cache=!false : Enable/Disable cache (default false).}';
```

### Handling an Invalid Default
Developers could misconfigure the fluent syntax. This implementation chooses to fall back to the default value of `null` when `filter_var()` fails to filter a Boolean:

```php
// (true) fails using `filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)`
protected $signature = 'my:command {--cache=!(true) : Enable/Disable cache.}';

// Running `my:command`
$this->option('cache'); // null

// Running `my:command --cache` 
$this->option('cache'); // true

// Running `my:command --no-cache` 
$this->option('cache'); // false
```

### Programmatically Calling Commands

You still need to pass `true` or `false` when using negatable options programmatically. However, you can use both flags:

```php
use Illuminate\Support\Facades\Artisan;

Artisan::call('my:command', ['--cache' => true]); // cache=true
Artisan::call('my:command', ['--cache' => false]); // cache=false

// Slightly confusing, using the `--no-*` version always sets the option to `false`:
Artisan::call('my:command', ['--no-cache' => false]); // cache=false
Artisan::call('my:command', ['--no-cache' => true]); // cache=false
```

---

### Possible B/C Issues?

The syntax could be whatever is desired if this PR is merged. The syntax I chose in this PR is the `!` character (I also considered `~`). I did a quick Google search and found that `~` and `¬` are commonly used to represent negation. Although edge-case, my concern with `~` is a higher possibility that user-land signatures use `~` as the first character of a default value for the home folder on Unix systems:

```php
protected $signature = 'my:command {--dir=~}';
```

The above would be broken by this implementation, which would convert the option to a negatable option. That being said, there's a possibility that `!` breaks user-land code too, but seems edge-case and odd that someone would start a default value with `!`:

```php
protected $signature = 'my:command {--message=!This is a warning : The message to send.}';
```

Fluent command signatures already support the `*` symbol for arrays, so to me, the `!` doesn't feel too far a stretch for fluent negatable options:

```php
protected $signature = 'my:command
    {--option=* : Some array option}
    {--cache=! : Enable/Disable cache.}';
```

##  Reasons to Not Merge / Current Options using Fluent Signature

Without merging this PR, a developer can use a boolean "switch" by using only one of two options depending on what the desired default should be:

```php
protected $signature = 'my:command {--cache}'

// Prompt the user if they want to cache or not:
// my:command
$this->option('cache'); // false

// my:command --cache
// They passed the option, cache it.
$this->option('cache'); // true
```

You could also define both flags, but it's possible that both flags are passed and both would be `true`:

```php
protected $signature = 'my:command {--cache} {--no-cache}'
```

I still prefer the DX of having separate flags to toggle a boolean—with the option of `null` by default when omitted.

Another approach outside of this PR is _not_ using the fluent syntax and instead defining command options using `configure()`:

```php
protected function configure(): void
{        
    $this
        ->setName('my:command')
        // ...
        ->addOption('cache', null, InputOption::VALUE_NEGATABLE, "Cache/Don't cache result.", true);
}
```
