### PR TITLE
[11x] Fixes test tracing by adding the exception message to the status message

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -170,7 +170,19 @@ class TestResponse implements ArrayAccess
      */
     protected function statusMessageWithDetails($expected, $actual)
     {
-        return "Expected response status code [{$expected}] but received {$actual}.";
+        $message = "Expected response status code [{$expected}] but received {$actual}.";
+        if ($actual === 500 && $lastException = $this->exceptions->last()) {
+            $message .= <<<"EOF"
+            The following exception occurred during the last request:
+
+            $lastException
+
+            ----------------------------------------------------------------------------------
+
+            {$lastException->getMessage()}
+            EOF;
+        }
+        return $message;
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -174,6 +174,8 @@ class TestResponse implements ArrayAccess
 
         if ($actual === 500 && $lastException = $this->exceptions->last()) {
             $message .= <<<"EOF"
+
+
             The following exception occurred during the last request:
 
             $lastException
@@ -181,6 +183,7 @@ class TestResponse implements ArrayAccess
             ----------------------------------------------------------------------------------
 
             {$lastException->getMessage()}
+
             EOF;
         }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -171,6 +171,7 @@ class TestResponse implements ArrayAccess
     protected function statusMessageWithDetails($expected, $actual)
     {
         $message = "Expected response status code [{$expected}] but received {$actual}.";
+
         if ($actual === 500 && $lastException = $this->exceptions->last()) {
             $message .= <<<"EOF"
             The following exception occurred during the last request:

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -182,6 +182,7 @@ class TestResponse implements ArrayAccess
             {$lastException->getMessage()}
             EOF;
         }
+
         return $message;
     }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -24,6 +24,7 @@ use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
 use LogicException;
+use PHPUnit\Event\Code\ThrowableBuilder;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionProperty;
 use Symfony\Component\HttpFoundation\Cookie;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -173,17 +173,17 @@ class TestResponse implements ArrayAccess
         $message = "Expected response status code [{$expected}] but received {$actual}.";
 
         if ($actual === 500 && $lastException = $this->exceptions->last()) {
-            $message .= <<<"EOF"
+            $exception = ThrowableBuilder::from($lastException);
 
+            $message .= <<<"EOF"
 
             The following exception occurred during the last request:
 
-            $lastException
+            {$exception->asString()}
 
             ----------------------------------------------------------------------------------
 
             {$lastException->getMessage()}
-
             EOF;
         }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2460,6 +2460,21 @@ class TestResponseTest extends TestCase
         $this->assertEquals($cookieValue, $cookie->getValue());
     }
 
+    public function testErrorMessageFromResponseIsVisibleInErrorMessageFromStatusAssertion()
+    {
+        $response = TestResponse::fromBaseResponse(
+            new Response('', 500)
+        );
+        $exceptionMessage = "This error was thrown during the request";
+        $response->withExceptions(collect([new \Exception($exceptionMessage)]));
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessageMatches("*$exceptionMessage*");
+
+        $response->assertOk();
+    }
+
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2465,7 +2465,7 @@ class TestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(
             new Response('', 500)
         );
-        $exceptionMessage = "This error was thrown during the request";
+        $exceptionMessage = 'This error was thrown during the request';
         $response->withExceptions(collect([new \Exception($exceptionMessage)]));
 
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
This pull request seeks to fix the broken test tracing discussed [here](https://github.com/laravel/framework/discussions/51154).

The Problem is basically that PHPUnit made their `runTest()` method final. The PR in #48733 fixes this incompatibility by using PHPUnit's `transformException()` method instead. The Problem with `transformException()` is that it's only called if an actual Exception occurs during the test and not if the assertion fails (see [PhpUnit's TestCase](https://github.com/sebastianbergmann/phpunit/blob/main/src/Framework/TestCase.php)).

This has led to not being able to trace down the exceptions that occurred during a `TestResponse`, aka with `$this->get(...)` `$this->post(...)` in a Feature Test. To fix test tracing again this PR adds the exception message of the last exception to the assertion message of the status code.

This works because if an error was thrown, the status code will be 500 and if we expected a 500 status code, the assertion message will not be displayed anyways.
