### PR TITLE
[11.x] Fix missing table name in `db:table` command

### DIFF
--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -49,7 +49,7 @@ class TableCommand extends DatabaseInspectionCommand
         $table = Arr::first($tables, fn ($table) => $table['name'] === $tableName);
 
         if (! $table) {
-            $this->components->warn("Table [{$table}] doesn't exist.");
+            $this->components->warn("Table [{$tableName}] doesn't exist.");
 
             return 1;
         }


### PR DESCRIPTION
This PR fixes a missing table name in the error message of `artisan db:table this_table_does_not_exist`

## Before
```bash
php artisan db:table this_table_does_not_exist

   WARN  Table [] doesn't exist.  

```

## After
```bash
php artisan db:table this_table_does_not_exist

   WARN  Table [this_table_does_not_exist] doesn't exist.  

```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
