### PR TITLE
[11.x] Prevent BcryptHasher to fail if hashedValue is null or empty string

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -67,6 +67,10 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      */
     public function check($value, $hashedValue, array $options = [])
     {
+        if ($hashedValue === null || $hashedValue === '') {
+            return false;
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }


### PR DESCRIPTION
Hi!

I suggest this little change to avoid login attempt crashing when the user has a null password in the database making the `BcryptHasher` returning `false` instead of a `RuntimeException`.

I think this would be useful for applications where, for example, an administrator creates a user and  this receives an email to set the password.

Thanks a lot!