### PR TITLE
[11.x] Remove Arr::sortRecursiveDesc() method to avoid redundency in codebase. 

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -856,18 +856,6 @@ class Arr
     }
 
     /**
-     * Recursively sort an array by keys and values in descending order.
-     *
-     * @param  array  $array
-     * @param  int  $options
-     * @return array
-     */
-    public static function sortRecursiveDesc($array, $options = SORT_REGULAR)
-    {
-        return static::sortRecursive($array, $options, true);
-    }
-
-    /**
      * Conditionally compile classes from an array into a CSS class list.
      *
      * @param  array  $array


### PR DESCRIPTION
**Description:**
This pull request removes the `Arr::sortRecursiveDesc()` method from the codebase. The `Arr::sortRecursive()` method already supports sorting in descending order through its `$descending` parameter, making the `sortRecursiveDesc` method redundant.

**Changes:**
- Removed `Arr::sortRecursiveDesc()` method from the `Arr` class.

**Rationale:**
- Reduces redundancy in the codebase.
- Simplifies the `Arr` class by utilizing the existing `sortRecursive` method with the `$descending` parameter set to `true` for descending order sorting.
- `Arr::sortRecursiveDesc()` is not used anywhere in the framework.

This change helps maintain a cleaner and more maintainable codebase by eliminating unnecessary methods.
