### PR TITLE
[11.x] Add Blade `@notEmpty` and `@endNotEmpty` directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -233,6 +233,27 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the if-not-empty statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileNotEmpty($expression)
+    {
+        return "<?php if(!empty{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-not-empty statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndNotEmpty()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the switch statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeIfNotEmptyStatementsTest.php
+++ b/tests/View/Blade/BladeIfNotEmptyStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfNotEmptyStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@notEmpty ($test)
+breeze
+@endNotEmpty';
+        $expected = '<?php if(!empty($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `@notEmpty` Blade directive (as well as its complementary `@endNotEmpty` directive).

Implemented following the style of `@isset` for the functionality, and `@pushOnce` for the multiple-word naming.

## Benefits
* Cleaner code within Blade views
* Mirrors the `@empty` tag
* Can also easily be back-ported to older versions of Laravel

## Breaking changes

* Only if someone is using a custom `@notEmpty` (and `@endNotEmpty`) directive

## Usage

Before

```blade
@if(!empty($arr['key']))
  {{ $arr['key'] }}
@endif


@if(!empty($obj->property))
  {{ $obj->property }}
@endif
```

After

```blade
@notEmpty($arr['key'])
  {{ $arr['key'] }}
@endNotEmpty


@notEmpty($obj->property)
  {{ $obj->property }}
@endNotEmpty
```
