### PR TITLE
Ensure files exist for `install:broadcasting`

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -115,7 +115,13 @@ class BroadcastingInstallCommand extends Command
      */
     protected function enableBroadcastServiceProvider()
     {
-        $config = ($filesystem = new Filesystem)->get(app()->configPath('app.php'));
+        $filesystem = new Filesystem;
+
+        if (! $filesystem->exists(app()->configPath('app.php')) || ! $filesystem->exists('app/Providers/BroadcastServiceProvider.php')) {
+            return;
+        }
+
+        $config = $filesystem->get(app()->configPath('app.php'));
 
         if (str_contains($config, '// App\Providers\BroadcastServiceProvider::class')) {
             $filesystem->replaceInFile(

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -117,7 +117,8 @@ class BroadcastingInstallCommand extends Command
     {
         $filesystem = new Filesystem;
 
-        if (! $filesystem->exists(app()->configPath('app.php')) || ! $filesystem->exists('app/Providers/BroadcastServiceProvider.php')) {
+        if (! $filesystem->exists(app()->configPath('app.php')) || 
+            ! $filesystem->exists('app/Providers/BroadcastServiceProvider.php')) {
             return;
         }
 


### PR DESCRIPTION
Although closed, this addresses [Issue #51157](https://github.com/laravel/framework/issues/51157). The `install:broadcasting` has some legacy code which assumes the existence of `config/app.php` and `app/Providers/BroadcastServiceProvider.php`. Neither may be true within a Laravel 11 application.

This PR simply checks for the existence of these files before attempting to read a presumably legacy `config/app.php` to uncomment the legacy reference to `BroadcastServiceProvider`.

Ideally, the `enableBroadcastServiceProvider` method would be removed as it is not needed within a modern Laravel 11 application. But I left it to maintain support for older, _unslimmed_ applications which are now running Laravel 11.