### PR TITLE
Update commandClassFromFile to work inside Phars and on Windows

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -384,11 +384,13 @@ class Kernel implements KernelContract
      */
     protected function commandClassFromFile(SplFileInfo $file, string $namespace): string
     {
-        return $namespace.str_replace(
-            ['/', '.php'],
-            ['\\', ''],
-            Str::after($file->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
-        );
+        return $namespace . Str::after(str_replace(
+                    ['/', '.php'],
+                    ['\\', ''],
+                    $file->getRealPath() ?: $file->getPathname(),
+                ),
+                str_replace('/', '\\', (realpath(app_path()) ?: app_path()) . '\\'),
+            );
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -384,13 +384,13 @@ class Kernel implements KernelContract
      */
     protected function commandClassFromFile(SplFileInfo $file, string $namespace): string
     {
-        return $namespace . Str::after(str_replace(
-                    ['/', '.php'],
-                    ['\\', ''],
-                    $file->getRealPath() ?: $file->getPathname(),
-                ),
-                str_replace('/', '\\', (realpath(app_path()) ?: app_path()) . '\\'),
-            );
+        return $namespace.Str::after(str_replace(
+            ['/', '.php'],
+            ['\\', ''],
+            $file->getRealPath() ?: $file->getPathname(),
+        ),
+            str_replace('/', '\\', (realpath(app_path()) ?: app_path()).'\\'),
+        );
     }
 
     /**


### PR DESCRIPTION
When attempting to package a Laravel application inside of a phar the artisan commands did not work.

Problem 1: realpath() returns false when pointing at a file inside a phar (the path for these files starts with phar://)

Problem 2: Using DIRECTORY_SEPARATOR results in \ windows which breaks the Str::after call since the paths inside the phar use the path separator /.

I could work around the issue by explicitly adding the commands.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
