### PR TITLE
[12.x] Additionally pass `$uuid` to `failed()` method in Job

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -260,7 +260,7 @@ class CallQueuedHandler
         $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);
 
         if (method_exists($command, 'failed')) {
-            $command->failed($e);
+            $command->failed($uuid, $e);
         }
     }
 


### PR DESCRIPTION
Currently when a batched job fails, we have the ability to pass the exception, along with the job UUID to `recordFailedJob`. But for non-batched jobs, we do not have access to the `uuid` of the job in the `failed` method.

Breaking change: which matches the order of `$e` with the rest of methods