### PR TITLE
[10.x] Fix View Component resolve data kebab-case

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -90,6 +90,10 @@ abstract class Component
      */
     public static function resolve($data)
     {
+        $data = collect($data)->mapWithKeys(function ($item, $key) {
+            return [\Illuminate\Support\Str::camel($key) => $item];
+        })->toArray();
+
         if (static::$componentsResolver) {
             return call_user_func(static::$componentsResolver, static::class, $data);
         }


### PR DESCRIPTION
> [Component constructor arguments should be specified using camelCase, while kebab-case should be used when referencing the argument names in your HTML attributes.](https://laravel.com/docs/11.x/blade#casing)

This PR fixes view component `kebab-case` arguments not resolving to subcomponents.

Without this PR, the `Container` function `hasParameterOverride` returns `false` if the attribute written in "kebab-case".

https://github.com/laravel/framework/blob/c66290f9656cfca2bea9e7646605fc8e3924b988/src/Illuminate/Container/Container.php#L971-L975
