### PR TITLE
[11.x] Fix `loadCount` unwanted `retrieved` event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -88,8 +88,8 @@ class Collection extends BaseCollection implements QueueableCollection
         $models = $this->first()->newModelQuery()
             ->whereKey($this->modelKeys())
             ->select($this->first()->getKeyName())
-            ->withAggregate($relations, $column, $function)
-            ->get()
+            ->withAggregate($relations, $column, $function);
+        $models = Model::withoutEvents(fn () => $models->get())
             ->keyBy($this->first()->getKeyName());
 
         $attributes = Arr::except(

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -89,6 +89,7 @@ class Collection extends BaseCollection implements QueueableCollection
             ->whereKey($this->modelKeys())
             ->select($this->first()->getKeyName())
             ->withAggregate($relations, $column, $function);
+
         $models = Model::withoutEvents(fn () => $models->get())
             ->keyBy($this->first()->getKeyName());
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -66,6 +66,26 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $this->assertSame('2', (string) $posts[2]->comments_count);
     }
 
+    public function testLoadCountDoesNotFireAnyModelRelatedEvents()
+    {
+        // arrange:
+        $posts = Post::all()->push(Post::first());
+
+        $_SERVER['-'] = [];
+
+        $listener = function ($model) {
+            $_SERVER['-'][] = $model;
+        };
+
+        Post::getEventDispatcher()->listen('eloquent.*: '.Post::class, $listener);
+        // act:
+        $posts->loadCount('comments');
+
+        // assert:
+        $this->assertEquals([], $_SERVER['-']);
+        unset($_SERVER['-']);
+    }
+
     public function testLoadCountOnDeletedModels()
     {
         $posts = Post::all()->each->delete();

--- a/tests/Integration/Database/EloquentModelLoadMaxTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMaxTest.php
@@ -48,6 +48,24 @@ class EloquentModelLoadMaxTest extends DatabaseTestCase
         $this->assertEquals(11, $model->related1_max_number);
     }
 
+    public function testLoadMaxDoesNotFireEvent()
+    {
+        $model = BaseModel::first();
+
+        $_SERVER['-'] = [];
+        $listener = function ($model) {
+            $_SERVER['-'][] = $model;
+        };
+        BaseModel::getEventDispatcher()->listen('eloquent.*: '.BaseModel::class, $listener);
+
+        // act:
+        $model->loadMax('related1', 'number');
+
+        // assert:
+        $this->assertEquals([], $_SERVER['-']);
+        unset($_SERVER['-']);
+    }
+
     public function testLoadMaxMultipleRelations()
     {
         $model = BaseModel::first();

--- a/tests/Integration/Database/EloquentModelLoadMinTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMinTest.php
@@ -48,6 +48,24 @@ class EloquentModelLoadMinTest extends DatabaseTestCase
         $this->assertEquals(10, $model->related1_min_number);
     }
 
+    public function testLoadMinDoesNotFireEvent()
+    {
+        $model = BaseModel::first();
+
+        $_SERVER['-'] = [];
+        $listener = function ($model) {
+            $_SERVER['-'][] = $model;
+        };
+        BaseModel::getEventDispatcher()->listen('eloquent.*: '.BaseModel::class, $listener);
+
+        // act:
+        $model->loadMin('related1', 'number');
+
+        // assert:
+        $this->assertEquals([], $_SERVER['-']);
+        unset($_SERVER['-']);
+    }
+
     public function testLoadMinMultipleRelations()
     {
         $model = BaseModel::first();

--- a/tests/Integration/Database/EloquentModelLoadSumTest.php
+++ b/tests/Integration/Database/EloquentModelLoadSumTest.php
@@ -47,6 +47,24 @@ class EloquentModelLoadSumTest extends DatabaseTestCase
         $this->assertEquals(21, $model->related1_sum_number);
     }
 
+    public function testLoadSumDoesNotFireEvent()
+    {
+        $model = BaseModel::first();
+
+        $_SERVER['-'] = [];
+        $listener = function ($model) {
+            $_SERVER['-'][] = $model;
+        };
+        BaseModel::getEventDispatcher()->listen('eloquent.*: '.BaseModel::class, $listener);
+
+        // act:
+        $model->loadSum('related1', 'number');
+
+        // assert:
+        $this->assertEquals([], $_SERVER['-']);
+        unset($_SERVER['-']);
+    }
+
     public function testLoadSumMultipleRelations()
     {
         $model = BaseModel::first();


### PR DESCRIPTION
The  https://github.com/laravel/framework/issues/51276 issue mentions an extra model event fired when the `loadCount` is called. That is, in fact, relevant to all the load families of methods like `loadMax`, `loadMin` and etc that internally use `loadAggregate`.
The `retrieved` event is fired when the `->get()` is called on line 92 and the event can be suppressed by wrapping it around the `Model::withoutEvent`.

- This is not backward compatible if an app relies on this flaw. (I do not know if the same solution has been suggested before)
- The added tests will fail without this change, due to the fired event.