### PR TITLE
[11.x] Give session ID retrieval the Laravel treatment

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -648,6 +648,16 @@ class Store implements Session
      *
      * @return string
      */
+    public function id()
+    {
+        return $this->getId();
+    }
+
+    /**
+     * Get the current session ID.
+     *
+     * @return string
+     */
     public function getId()
     {
         return $this->id;

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -50,6 +50,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool isStarted()
  * @method static string getName()
  * @method static void setName(string $name)
+ * @method static string id()
  * @method static string getId()
  * @method static void setId(string|null $id)
  * @method static bool isValidId(string|null $id)


### PR DESCRIPTION
```diff
use Illuminate\Support\Facades\Session;

- Session::getId();
+ Session::id();
```

That's it. That's the PR.