### PR TITLE
[11.x] Fix the chunk method to an integer type in the splitIn method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1254,7 +1254,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function splitIn($numberOfGroups)
     {
-        return $this->chunk(ceil($this->count() / $numberOfGroups));
+        return $this->chunk((int) ceil($this->count() / $numberOfGroups));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1317,7 +1317,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function splitIn($numberOfGroups)
     {
-        return $this->chunk(ceil($this->count() / $numberOfGroups));
+        return $this->chunk((int) ceil($this->count() / $numberOfGroups));
     }
 
     /**


### PR DESCRIPTION
Fixed a bug in the framework by converting the argument passed to the chunk method to an integer type in the splitIn method. 

the chunk method requires an integer, but this method does pass a float type。This change ensures that the method operates correctly by rounding up the count of elements divided by the specified number of groups to the nearest integer。

![image](https://github.com/laravel/framework/assets/162444894/2428d630-d7ba-49a5-a5a8-1e84f5dd6295)
