### PR TITLE
[11.x] Fix Route::resource parameters registration

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -79,7 +79,8 @@ class ResourceRegistrar
      */
     public function register($name, $controller, array $options = [])
     {
-        if (isset($options['parameters']) && ! isset($this->parameters)) {
+        $this->parameters = null;
+        if (isset($options['parameters'])) {
             $this->parameters = $options['parameters'];
         }
 


### PR DESCRIPTION
Description:

This pull request fixes a bug where the Route::resource()->parameters() function wouldn't work if there were multiple Route::resource defined with different names, as only the first one would have the correct parameters set.
This was due to the $this->parameters variable being set and never being emptied, as the ResourceRegistrar object is never destroyed.