### PR TITLE
Fix permitting mysql/mariadb connection through Named Pipe on Windows systems

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -136,7 +136,8 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getSocketDsn(array $config)
     {
-        return "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+        // PDO for Mysql, on Windows requires "host=." to enable connection through Named Pipes
+        return "mysql:host=.;unix_socket={$config['unix_socket']};dbname={$config['database']}";
     }
 
     /**

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -50,7 +50,7 @@ class DatabaseConnectorTest extends TestCase
         return [
             ['mysql:host=foo;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
             ['mysql:host=foo;port=111;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:unix_socket=baz;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:host=.;unix_socket=baz;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
         ];
     }
 


### PR DESCRIPTION
# Description of the issue

On windows, when connecting to MySQL/MariaDB via Name Pipe, the connection fails with the following error:

`Illuminate\Database\QueryException
SQLSTATE[HY000] [2002] (...)  at vendor\laravel\framework\src\Illuminate\Database\Connection.php:813`

1  vendor\laravel\framework\src\Illuminate\Database\Connectors\Connector.php:65 PDOException::("SQLSTATE[HY000] [2002] Aucune connexion n’a pu être établie car l’ordinateur cible l’a expressément refusée")
2   vendor\laravel\framework\src\Illuminate\Database\Connectors\Connector.php:65 PDO::__construct("mysql:unix_socket=\\.\pipe\MYSQL;dbname=laravel", "root", Object(SensitiveParameterValue), [])
`

# Reproducing the issue

## Enable Named Pipes on MySQL/MariaDB

Modify `my.ini`

`[mysqld]`
`socket="MYSQL"`
`enable-named-pipe`

## Configure Laravel Application to use Name Pipes instead of TCP/IP

Modify `.env`

`DB_CONNECTION=mariadb`
`DB_HOST=.`
`DB_PORT=3306`
`DB_SOCKET=\\.\pipe\MYSQL`
`DB_DATABASE=laravel`
`DB_USERNAME=root`
`DB_PASSWORD=password`

## Test the connection

`php artisan migrate`

### Result:

Illuminate\Database\QueryException
SQLSTATE[HY000] [2002] (...)  at vendor\laravel\framework\src\Illuminate\Database\Connection.php:813
1  vendor\laravel\framework\src\Illuminate\Database\Connectors\Connector.php:65 PDOException::("SQLSTATE[HY000] [2002] Aucune connexion n’a pu être établie car l’ordinateur cible l’a expressément refusée")
2   vendor\laravel\framework\src\Illuminate\Database\Connectors\Connector.php:65 PDO::__construct("mysql:unix_socket=\\.\pipe\MYSQL;dbname=laravel", "root", Object(SensitiveParameterValue), [])

### Remarks
* Using `DB_HOST=localhost` or `DB_HOST=127.0.0.1` both result in a different error, due to the fact that, in that case, TCP is used instead of Name Pipe to connect to the database.
The value MUST be set to `DB_HOST=.` to really enable named pipe connection.
* The correct value for `DB_SOCKET` is `\\.\pipe\{name-of-the-pipe}` (the `\\.\pipe\` bit is required).
* The value of `DB_PORT` is ignored for named pipe connection

# Solving the problem

## Notes
* The documentation of this case is pretty poor in php.net.
* I have made some test with bare php, using mysqli::new() and PDO::new(). 
And came up with the conclusion that the parameter `host=.` is required to instruct PDO to connect using a Named Pipe.

## Implementation
* Laravel already detects properly that the user wants to use Named Pipe, by inspecting the value of the DB_HOST environment value.
* Named pipes are meant for *local* connections (same host) only. It is therefore useless to let the user configure the value of  `host` . The only acceptable value in that case is `.`
* Adding the missing `host=.;` in the PDO Dsn is sufficient to address the issue, it is done in src/Illuminate/Database/Connectors/MySqlConnector.php > getSocketDsn()

## Testing
* After adding the string in Illuminate\Database\Connectors\MySqlConnector::getSocketDsn(), the command `php artisan migrate` succeeds.

## Compatibility
* This fix address an issue on Windows systems only
* It is visible that the chapter on Unix Sockets & Named Pipe in the php documentation for mysqli and PDO drivers was written with Linux only in mind. That documentation states that `host=.` is an appropriate value. 
* Therefore the change should have no impact on Linux systems.
