### PR TITLE
Add option to override route name

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -875,10 +875,17 @@ class Route
      * Add or change the route name.
      *
      * @param  string  $name
+     * @param  bool  $override
      * @return $this
      */
-    public function name($name)
+    public function name($name, $override = false)
     {
+        if($override){
+            $this->action['as'] = $name;
+
+            return $this;
+        }
+
         $this->action['as'] = isset($this->action['as']) ? $this->action['as'].$name : $name;
 
         return $this;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1113,6 +1113,28 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanNotOverrideRouteName()
+    {
+        $this->router->group([ 'as' => 'users.' ],function ($router) {
+            $this->router->get('users', function () {
+                return 'all-users';
+            })->name('index');
+        });
+
+        $this->assertSame('users.index', $this->getRoute()->getName());
+    }
+
+    public function testCanOverrideRouteName()
+    {
+        $this->router->group([ 'as' => 'users.' ],function ($router) {
+            $this->router->get('users', function () {
+                return 'all-users';
+            })->name('override', true);
+        });
+
+        $this->assertSame('override', $this->getRoute()->getName());
+    }
+
     public function testPushMiddlewareToGroup()
     {
         $this->router->middlewareGroup('web', []);


### PR DESCRIPTION
Currently it is not possible to create a named route without it inheriting the name of its parent group.

This PR adds an option to override the route name belonging to a group.

Ex:
```php
Route::group([
    'prefix' => 'admin',
    'as' => 'admin.',
    ], function(){
    
    Route::get('not-override-route-name')
            ->name(name: 'not-override-name'); 
    # result name: admin.not-override-name
    
    Route::get('override-route-name')
        ->name(name: 'override-name',override: true); 
    # result name: override-name
});
```
