### PR TITLE
[11.x] Add `before` and `after` methods to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1128,16 +1128,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return null;
         }
 
-        // Find the key position to cater for the case when the collection is an associative array.
         $position = $this->keys()->search($key);
 
         if ($position === 0) {
             return null;
         }
 
-        $previousKey = $this->keys()->get($position - 1);
-
-        return $this->get($previousKey);
+        return $this->get($this->keys()->get($position - 1));
     }
 
     /**
@@ -1155,16 +1152,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return null;
         }
 
-        // Find the key position to cater for the case when the collection is an associative array.
         $position = $this->keys()->search($key);
 
         if ($position === $this->keys()->count() - 1) {
             return null;
         }
 
-        $nextKey = $this->keys()->get($position + 1);
-
-        return $this->get($nextKey);
+        return $this->get($this->keys()->get($position + 1));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1131,7 +1131,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         // Find the key position to cater for the case when the collection is an associative array.
         $position = $this->keys()->search($key);
 
-        if ($position === false || $position === 0) {
+        if ($position === 0) {
             return null;
         }
 
@@ -1158,7 +1158,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         // Find the key position to cater for the case when the collection is an associative array.
         $position = $this->keys()->search($key);
 
-        if ($position === false || $position === $this->keys()->count() - 1) {
+        if ($position === $this->keys()->count() - 1) {
             return null;
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1122,7 +1122,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function before($value, $strict = false)
     {
-        // $key can be an array index or an associative array key which is a string.
         $key = $this->search($value, $strict);
 
         if ($key === false) {
@@ -1139,6 +1138,33 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $previousKey = $this->keys()->get($position - 1);
 
         return $this->get($previousKey);
+    }
+
+    /**
+     * Get the item after the given item.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function after($value, $strict = false)
+    {
+        $key = $this->search($value, $strict);
+
+        if ($key === false) {
+            return null;
+        }
+
+        // Find the key position to cater for the case when the collection is an associative array.
+        $position = $this->keys()->search($key);
+
+        if ($position === false || $position === $this->keys()->count() - 1) {
+            return null;
+        }
+
+        $nextKey = $this->keys()->get($position + 1);
+
+        return $this->get($nextKey);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1114,6 +1114,34 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the item before the given item.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function before($value, $strict = false)
+    {
+        // $key can be an array index or an associative array key which is a string.
+        $key = $this->search($value, $strict);
+
+        if ($key === false) {
+            return null;
+        }
+
+        // Find the key position to cater for the case when the collection is an associative array.
+        $position = $this->keys()->search($key);
+
+        if ($position === false || $position === 0) {
+            return null;
+        }
+
+        $previousKey = $this->keys()->get($position - 1);
+
+        return $this->get($previousKey);
+    }
+
+    /**
      * Get and remove the first N items from the collection.
      *
      * @param  int  $count

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -899,6 +899,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function before($value, $strict = false);
 
     /**
+     * Get the item after the given item.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function after($value, $strict = false);
+
+    /**
      * Shuffle the items in the collection.
      *
      * @return static

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -890,6 +890,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function search($value, $strict = false);
 
     /**
+     * Get the item before the given item.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function before($value, $strict = false);
+
+    /**
      * Shuffle the items in the collection.
      *
      * @return static

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1085,8 +1085,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the item before the given item.
      *
-     * @param TValue|(callable(TValue,TKey): bool) $value
-     * @param bool $strict
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  bool  $strict
      * @return TValue|null
      */
     public function before($value, $strict = false)
@@ -1114,8 +1114,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the item after the given item.
      *
-     * @param TValue|(callable(TValue,TKey): bool) $value
-     * @param bool $strict
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  bool  $strict
      * @return TValue|null
      */
     public function after($value, $strict = false)

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1112,6 +1112,37 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the item after the given item.
+     *
+     * @param TValue|(callable(TValue,TKey): bool) $value
+     * @param bool $strict
+     * @return TValue|null
+     */
+    public function after($value, $strict = false)
+    {
+        $found = false;
+
+        /** @var (callable(TValue,TKey): bool) $predicate */
+        $predicate = $this->useAsCallable($value)
+            ? $value
+            : function ($item) use ($value, $strict) {
+                return $strict ? $item === $value : $item == $value;
+            };
+
+        foreach ($this as $key => $item) {
+            if ($found) {
+                return $item;
+            }
+
+            if ($predicate($item, $key)) {
+                $found = true;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Shuffle the items in the collection.
      *
      * @return static

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1083,6 +1083,35 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the item before the given item.
+     *
+     * @param TValue|(callable(TValue,TKey): bool) $value
+     * @param bool $strict
+     * @return TValue|null
+     */
+    public function before($value, $strict = false)
+    {
+        $previous = null;
+
+        /** @var (callable(TValue,TKey): bool) $predicate */
+        $predicate = $this->useAsCallable($value)
+            ? $value
+            : function ($item) use ($value, $strict) {
+                return $strict ? $item === $value : $item == $value;
+            };
+
+        foreach ($this as $key => $item) {
+            if ($predicate($item, $key)) {
+                return $previous;
+            }
+
+            $previous = $item;
+        }
+
+        return null;
+    }
+
+    /**
      * Shuffle the items in the collection.
      *
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3703,6 +3703,64 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testBeforeReturnsItemBeforeTheGivenItem($collection)
+    {
+        $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);
+
+        $this->assertEquals(1, $c->before(2));
+        $this->assertEquals(1, $c->before('2'));
+        $this->assertSame(5, $c->before('bar'));
+        $this->assertEquals(4, $c->before(function ($value) {
+            return $value > 4;
+        }));
+        $this->assertSame(5, $c->before(function ($value) {
+            return ! is_numeric($value);
+        }));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testBeforeInStrictMode($collection)
+    {
+        $c = new $collection([false, 0, 1, [], '']);
+        $this->assertNull($c->before('false', true));
+        $this->assertNull($c->before('1', true));
+        $this->assertNull($c->before(false, true));
+        $this->assertEquals(false, $c->before(0, true));
+        $this->assertEquals(0, $c->before(1, true));
+        $this->assertEquals(1, $c->before([], true));
+        $this->assertEquals([], $c->before('', true));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testBeforeReturnsNullWhenItemIsNotFound($collection)
+    {
+        $c = new $collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
+
+        $this->assertNull($c->before(6));
+        $this->assertNull($c->before('foo'));
+        $this->assertNull($c->before(function ($value) {
+            return $value < 1 && is_numeric($value);
+        }));
+        $this->assertNull($c->before(function ($value) {
+            return $value === 'nope';
+        }));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testBeforeReturnsNullWhenItemOnTheFirstitem($collection)
+    {
+        $c = new $collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
+
+        $this->assertNull($c->before(1));
+        $this->assertNull($c->before(function ($value) {
+            return $value < 2 && is_numeric($value);
+        }));
+
+        $c = new $collection(['foo' => 'bar', 1, 2, 3, 4, 5]);
+        $this->assertNull($c->before('foo'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testKeys($collection)
     {
         $c = new $collection(['name' => 'taylor', 'framework' => 'laravel']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3709,12 +3709,12 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(1, $c->before(2));
         $this->assertEquals(1, $c->before('2'));
-        $this->assertSame(5, $c->before('taylor'));
+        $this->assertEquals(5, $c->before('taylor'));
         $this->assertSame('taylor', $c->before('laravel'));
         $this->assertEquals(4, $c->before(function ($value) {
             return $value > 4;
         }));
-        $this->assertSame(5, $c->before(function ($value) {
+        $this->assertEquals(5, $c->before(function ($value) {
             return ! is_numeric($value);
         }));
     }
@@ -3759,6 +3759,68 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection(['foo' => 'bar', 1, 2, 3, 4, 5]);
         $this->assertNull($c->before('bar'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testAfterReturnsItemAfterTheGivenItem($collection)
+    {
+        $c = new $collection([1, 2, 3, 4, 2, 5, 'name' => 'taylor', 'framework' => 'laravel']);
+
+        $this->assertEquals(2, $c->after(1));
+        $this->assertEquals(3, $c->after(2));
+        $this->assertEquals(4, $c->after(3));
+        $this->assertEquals(2, $c->after(4));
+        $this->assertEquals('taylor', $c->after(5));
+        $this->assertEquals('laravel', $c->after('taylor'));
+
+        $this->assertEquals(4, $c->after(function ($value) {
+            return $value > 2;
+        }));
+        $this->assertEquals('laravel', $c->after(function ($value) {
+            return ! is_numeric($value);
+        }));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testAfterInStrictMode($collection)
+    {
+        $c = new $collection([false, 0, 1, [], '']);
+
+        $this->assertNull($c->after('false', true));
+        $this->assertNull($c->after('1', true));
+        $this->assertNull($c->after('', true));
+        $this->assertEquals(0, $c->after(false, true));
+        $this->assertEquals([], $c->after(1, true));
+        $this->assertEquals('', $c->after([], true));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testAfterReturnsNullWhenItemIsNotFound($collection)
+    {
+        $c = new $collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
+
+        $this->assertNull($c->after(6));
+        $this->assertNull($c->after('foo'));
+        $this->assertNull($c->after(function ($value) {
+            return $value < 1 && is_numeric($value);
+        }));
+        $this->assertNull($c->after(function ($value) {
+            return $value === 'nope';
+        }));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testAfterReturnsNullWhenItemOnTheLastItem($collection)
+    {
+        $c = new $collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
+
+        $this->assertNull($c->after('bar'));
+        $this->assertNull($c->after(function ($value) {
+            return $value > 4 && !is_numeric($value);
+        }));
+
+        $c = new $collection(['foo' => 'bar', 1, 2, 3, 4, 5]);
+        $this->assertNull($c->after(5));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3705,11 +3705,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testBeforeReturnsItemBeforeTheGivenItem($collection)
     {
-        $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);
+        $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'name' => 'taylor', 'framework' => 'laravel']);
 
         $this->assertEquals(1, $c->before(2));
         $this->assertEquals(1, $c->before('2'));
-        $this->assertSame(5, $c->before('bar'));
+        $this->assertSame(5, $c->before('taylor'));
+        $this->assertSame('taylor', $c->before('laravel'));
         $this->assertEquals(4, $c->before(function ($value) {
             return $value > 4;
         }));
@@ -3757,7 +3758,7 @@ class SupportCollectionTest extends TestCase
         }));
 
         $c = new $collection(['foo' => 'bar', 1, 2, 3, 4, 5]);
-        $this->assertNull($c->before('foo'));
+        $this->assertNull($c->before('bar'));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3816,7 +3816,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertNull($c->after('bar'));
         $this->assertNull($c->after(function ($value) {
-            return $value > 4 && !is_numeric($value);
+            return $value > 4 && ! is_numeric($value);
         }));
 
         $c = new $collection(['foo' => 'bar', 1, 2, 3, 4, 5]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR introduces two new methods to the `Collection` and `LazyCollection`.

### `before` method
The `before` method returns the item before the given item. It returns null if the given item is the first item or not found.

```php
$collection = collect([1, 2, 3, 4, 5, 'name' => 'taylor', 'framework' => 'laravel']);

$collection->before(2) // 1
$collection->before('taylor') // 5
$collection->before('laravel') // 'taylor'
$collection->before(fn ($value) => $value > 4) // 4
$collection->before(fn ($value) => ! is_numeric($value)) // 5
$collection->before(1) // null
$collection->before('not found') // null
```

### `after` method
The `after` method returns the item after the given item. It returns null if the given item is the last item or not found.

```php
$collection = collect([1, 2, 3, 4, 5, 'name' => 'taylor', 'framework' => 'laravel']);

$collection->after(1) // 2
$collection->after('taylor') // 'laravel'
$collection->after(fn ($value) => $value > 4) // 'taylor'
$collection->after(fn ($value) => ! is_numeric($value)) // 'laravel'
$collection->after('laravel') // null
$collection->after('not found') // null
```