### PR TITLE
[12.x] Add Seeding events

### DIFF
--- a/src/Illuminate/Database/Console/Events/SeedingFailed.php
+++ b/src/Illuminate/Database/Console/Events/SeedingFailed.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Console\Events;
+
+use Throwable;
+
+class SeedingFailed
+{
+    protected Throwable $exception;
+
+    public function __construct(Throwable $exception)
+    {
+        $this->exception = $exception;
+    }
+
+    public function exception(): Throwable
+    {
+        return $this->exception;
+    }
+}

--- a/src/Illuminate/Database/Console/Events/SeedingFinished.php
+++ b/src/Illuminate/Database/Console/Events/SeedingFinished.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Console\Events;
+
+class SeedingFinished
+{
+    //
+}

--- a/src/Illuminate/Database/Console/Events/SeedingStarted.php
+++ b/src/Illuminate/Database/Console/Events/SeedingStarted.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Console\Events;
+
+class SeedingStarted
+{
+    //
+}

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -69,6 +69,7 @@ class SeedCommand extends Command
      * Execute the console command.
      *
      * @return int
+     *
      * @throws Throwable
      */
     public function handle()
@@ -114,7 +115,7 @@ class SeedCommand extends Command
         $class = $this->input->getArgument('class') ?? $this->input->getOption('class');
 
         if (! str_contains($class, '\\')) {
-            $class = 'Database\\Seeders\\' . $class;
+            $class = 'Database\\Seeders\\'.$class;
         }
 
         if ($class === 'Database\\Seeders\\DatabaseSeeder' &&
@@ -123,8 +124,8 @@ class SeedCommand extends Command
         }
 
         return $this->laravel->make($class)
-            ->setContainer($this->laravel)
-            ->setCommand($this);
+                        ->setContainer($this->laravel)
+                        ->setCommand($this);
     }
 
     /**
@@ -159,10 +160,7 @@ class SeedCommand extends Command
     protected function getOptions()
     {
         return [
-            [
-                'class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder',
-                'Database\\Seeders\\DatabaseSeeder'
-            ],
+            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -846,7 +846,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerSeedCommand()
     {
         $this->app->singleton(SeedCommand::class, function ($app) {
-            return new SeedCommand($app['db']);
+            return new SeedCommand($app['db'], $app['events']);
         });
     }
 

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -27,7 +27,7 @@ class SeedCommandTest extends TestCase
     public function testHandle()
     {
         $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
-        $output = new NullOutput();
+        $output = new NullOutput;
         $outputStyle = new OutputStyle($input, $output);
 
         $seeder = m::mock(Seeder::class);
@@ -73,7 +73,7 @@ class SeedCommandTest extends TestCase
             '--database' => 'sqlite',
             '--class' => UserWithoutModelEventsSeeder::class,
         ]);
-        $output = new NullOutput();
+        $output = new NullOutput;
         $outputStyle = new OutputStyle($input, $output);
 
         $instance = new UserWithoutModelEventsSeeder();
@@ -124,7 +124,7 @@ class SeedCommandTest extends TestCase
             '--database' => 'sqlite',
             '--class' => FailingSeeder::class,
         ]);
-        $output = new NullOutput();
+        $output = new NullOutput;
         $outputStyle = new OutputStyle($input, $output);
 
         $instance = new FailingSeeder();


### PR DESCRIPTION
**Description**

This PR introduces 3 new events when running the `db:seed` command.

Currently, there is no simple way to run code before database seeds, after database seeds and if the seeder fails.
There is also no way to know, whether a piece of code is being executed during seeding (where we might, for example, want to skip logging, or sending e-mails).

Therefore, the newly introduced `SeedingStarted`, `SeedingFinished` & `SeedingFailed` events are introduced in this PR.

**Breaking change**

This is a breaking change, as the constructor of the `SeedCommand` has been updated. Although, I'd consider using the `Event` Facade which would allow this feature to target the `11.x` branch, which would be my preference.
Open to suggestions on this.