### PR TITLE
[11.x] Fixed pop on default Beankstalkd queue when not specifically added

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -168,15 +168,16 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function pop($queue = null)
     {
-        $queue = $this->getQueue($queue);
-        $newTube = new TubeName($queue);
-        $this->pheanstalk->watch($newTube);
-        $watched = $this->pheanstalk->listTubesWatched();
-        foreach ($watched as $w){
-            if($w->value !== $newTube->value){
-                $this->pheanstalk->ignore($w);
+        $this->pheanstalk->watch(
+            $tube = new TubeName($queue = $this->getQueue($queue))
+        );
+
+        foreach ($this->pheanstalk->listTubesWatched() as $watched) {
+            if ($watched->value !== $tube->value) {
+                $this->pheanstalk->ignore($watched);
             }
         }
+
         $job = $this->pheanstalk->reserveWithTimeout($this->blockFor);
 
         if ($job instanceof JobIdInterface) {

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -169,9 +169,14 @@ class BeanstalkdQueue extends Queue implements QueueContract
     public function pop($queue = null)
     {
         $queue = $this->getQueue($queue);
-
-        $this->pheanstalk->watch(new TubeName($queue));
-
+        $newTube = new TubeName($queue);
+        $this->pheanstalk->watch($newTube);
+        $watched = $this->pheanstalk->listTubesWatched();
+        foreach ($watched as $w){
+            if($w->value !== $newTube->value){
+                $this->pheanstalk->ignore($w);
+            }
+        }
         $job = $this->pheanstalk->reserveWithTimeout($this->blockFor);
 
         if ($job instanceof JobIdInterface) {

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -7,7 +7,6 @@ use Illuminate\Queue\BeanstalkdQueue;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 use Illuminate\Support\Str;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
 use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\PheanstalkManagerInterface;
 use Pheanstalk\Contract\PheanstalkPublisherInterface;
@@ -16,6 +15,7 @@ use Pheanstalk\Pheanstalk;
 use Pheanstalk\Values\Job;
 use Pheanstalk\Values\TubeList;
 use Pheanstalk\Values\TubeName;
+use PHPUnit\Framework\TestCase;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -7,14 +7,15 @@ use Illuminate\Queue\BeanstalkdQueue;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 use Illuminate\Support\Str;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\PheanstalkManagerInterface;
 use Pheanstalk\Contract\PheanstalkPublisherInterface;
 use Pheanstalk\Contract\PheanstalkSubscriberInterface;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\Values\Job;
+use Pheanstalk\Values\TubeList;
 use Pheanstalk\Values\TubeName;
-use PHPUnit\Framework\TestCase;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
@@ -80,9 +81,12 @@ class QueueBeanstalkdQueueTest extends TestCase
     public function testPopProperlyPopsJobOffOfBeanstalkd()
     {
         $this->setQueue('default', 60);
+        $tube = new TubeName('default');
 
         $pheanstalk = $this->queue->getPheanstalk();
-        $pheanstalk->shouldReceive('watch')->once()->with(m::type(TubeName::class));
+        $pheanstalk->shouldReceive('watch')->once()->with(m::type(TubeName::class))
+            ->shouldReceive('listTubesWatched')->once()->andReturn(new TubeList($tube));
+
         $jobId = m::mock(JobIdInterface::class);
         $jobId->shouldReceive('getId')->once();
         $job = new Job($jobId, '');
@@ -96,9 +100,12 @@ class QueueBeanstalkdQueueTest extends TestCase
     public function testBlockingPopProperlyPopsJobOffOfBeanstalkd()
     {
         $this->setQueue('default', 60, 60);
+        $tube = new TubeName('default');
 
         $pheanstalk = $this->queue->getPheanstalk();
-        $pheanstalk->shouldReceive('watch')->once()->with(m::type(TubeName::class));
+        $pheanstalk->shouldReceive('watch')->once()->with(m::type(TubeName::class))
+            ->shouldReceive('listTubesWatched')->once()->andReturn(new TubeList($tube));
+
         $jobId = m::mock(JobIdInterface::class);
         $jobId->shouldReceive('getId')->once();
         $job = new Job($jobId, '');


### PR DESCRIPTION
This pull request addresses a change in behavior observed when migrating from Laravel 10 to Laravel 11. The pop method in the queue implementation has been enhanced to ensure that it only watches the specified queue and ignores any previously watched queues, effectively restoring the behavior from Laravel 10.

Problem Statement
In Laravel 11, when launching a worker on a specific queue using the artisan command php artisan queue:work --queue=one, the worker listens to both the specified queue (one) and the default queue of Beanstalkd. This results in the worker popping jobs from both queues, which can lead to unintended job processing and potential job loss from queues meant to be handled by separate workers.