### PR TITLE
[11.x] Short-Hand for setting a Scheduled Job's timezone

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -650,6 +650,19 @@ trait ManagesFrequencies
     }
 
     /**
+     * A shorthand to set the timezone the date should be evaluated on.
+     *
+     * @param  \DateTimeZone|string  $timezone
+     * @return $this
+     */
+    public function tz($timezone)
+    {
+        $this->timezone($timezone);
+
+        return $this;
+    }
+
+    /**
      * Splice the given value into the given position of the expression.
      *
      * @param  int  $position


### PR DESCRIPTION
Hello Everyone! 

(please go easy on me here, after being a Laravel developer for about 5 years, this is my first small attempt at contributing back to the project 😁)

### Why?

- In my own work, I've made the mistake of calling `->tz(...)` (like Carbon's shorthand for setting a timezone) on an instance of a command, rather than `->timezone(...)`. I thought maybe some others may have made the same mistake or could find this little shorthand helpful.



### What Changed?

- This PR adds a function to the ManagesFrequencies trait for setting the timezone a job should run. 
- This new function is just a short hand version of the already-existing timezone setting functionality.


### Example Implementation

```php
protected function schedule(Schedule $schedule)
{
    $schedule->command('inspire')->tz('America/New_York')->hourly();
}
```

Thanks all for reading!