### PR TITLE
[11.x] Improve Precognition

### DIFF
--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -9,17 +9,17 @@ trait CanBePrecognitive
     /**
      * Filter the given array of rules into an array of rules that are included in precognitive headers.
      *
-     * @param  array  $rules
+     * @param array $rules
      * @return array
      */
-    public function filterPrecognitiveRules($rules)
+    public function filterPrecognitiveRules(array $rules): array
     {
         if (! $this->headers->has('Precognition-Validate-Only')) {
             return $rules;
         }
 
         return Collection::make($rules)
-            ->only(explode(',', $this->header('Precognition-Validate-Only')))
+            ->only($this->getPrecognitionValidate())
             ->all();
     }
 
@@ -28,7 +28,7 @@ trait CanBePrecognitive
      *
      * @return bool
      */
-    public function isAttemptingPrecognition()
+    public function isAttemptingPrecognition(): bool
     {
         return $this->header('Precognition') === 'true';
     }
@@ -41,5 +41,15 @@ trait CanBePrecognitive
     public function isPrecognitive()
     {
         return $this->attributes->get('precognitive', false);
+    }
+
+    /**
+     * Return Precognition-Validate-Only header data as an array.
+     *
+     * @return array
+     */
+    public function getPrecognitionValidate(): array
+    {
+        return explode(',', $this->header('Precognition-Validate-Only'));
     }
 }

--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -9,7 +9,7 @@ trait CanBePrecognitive
     /**
      * Filter the given array of rules into an array of rules that are included in precognitive headers.
      *
-     * @param array $rules
+     * @param  array  $rules
      * @return array
      */
     public function filterPrecognitiveRules(array $rules): array

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -121,6 +121,7 @@ namespace Illuminate\Support\Facades;
  * @method static array filterPrecognitiveRules(array $rules)
  * @method static bool isAttemptingPrecognition()
  * @method static bool isPrecognitive()
+ * @method static array getPrecognitionValidate()
  * @method static bool isJson()
  * @method static bool expectsJson()
  * @method static bool wantsJson()

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -113,6 +113,7 @@ class PrecognitionTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+        $response->assertHeader('Precognition', 'true');
         $response->assertHeaderMissing('Precognition-Success');
         $response->assertJsonPath('errors', [
             'required_integer' => [
@@ -132,6 +133,7 @@ class PrecognitionTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+        $response->assertHeaderMissing('Precognition');
         $response->assertHeaderMissing('Precognition-Success');
         $response->assertJsonPath('errors', [
             'required_integer' => [
@@ -158,6 +160,7 @@ class PrecognitionTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+        $response->assertHeader('Precognition', 'true');
         $response->assertHeaderMissing('Precognition-Success');
         $response->assertJsonPath('errors', [
             'optional_integer_1' => [
@@ -185,6 +188,7 @@ class PrecognitionTest extends TestCase
         ]);
 
         $response->assertNoContent();
+        $response->assertHeader('Precognition', 'true');
         $response->assertHeader('Precognition-Success', 'true');
     }
 
@@ -249,6 +253,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertOk();
         $response->assertHeaderMissing('Precognition-Success');
+        $response->assertHeaderMissing('Precognition');
         $response->assertExactJson([
             'first' => 'expected',
             'second' => 'values',


### PR DESCRIPTION
It seems the code `CanBePrecognitive` trait needed a method to get `Precognition-Validate-Only` header data in a proper way. It would be useful for debugging purposes. In addition, `PrecognitionTest` file doesn't have some asserts with `Precognition` header in some actions.