### PR TITLE
Updated phpdoc for Builder::from()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -467,7 +467,7 @@ class Builder implements BuilderContract
     /**
      * Set the table which the query is targeting.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $table
      * @param  string|null  $as
      * @return $this
      */


### PR DESCRIPTION
I just added `Illuminate\Contracts\Database\Query\Expression` to the phpdoc for `$table` in `Illuminate/Database/Query/Builder::from()` as its actually possible to pass in an expression.
