### PR TITLE
Change scope for `afterCreating` and `afterMaking` callbacks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -694,7 +694,8 @@ abstract class Factory
     {
         $instances->each(function ($model) {
             $this->afterMaking->each(function ($callback) use ($model) {
-                $callback($model);
+                \Closure::fromCallable($callback)
+                    ->call($this, $model);
             });
         });
     }
@@ -710,7 +711,8 @@ abstract class Factory
     {
         $instances->each(function ($model) use ($parent) {
             $this->afterCreating->each(function ($callback) use ($model, $parent) {
-                $callback($model, $parent);
+                \Closure::fromCallable($callback)
+                    ->call($this, $model, $parent);
             });
         });
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

*Configuration variables/properties on factories can not be used in the `afterMaking` and `afterCreating` callbacks because they bind to the wrong scope/instance.*

Configuration methods like `has`, `for`, `state` and many more create new instances via the `newInstance` method. This means, that the `afterMaking` and `afterCreating` are called with the scope of a prior instance. In most cases this is no problem unless one wants to use the configuration parameters of the current instance. Any changes, to the factory configuration made after the `configure` call are trapped in later instances and thus not available in those callbacks.


```php
class MyModelFactory extends \Illuminate\Database\Eloquent\Factories\Factory
{
    public function __construct(
        $count = null,
        ?Collection $states = null,
        ?Collection $has = null,
        ?Collection $for = null,
        ?Collection $afterMaking = null,
        ?Collection $afterCreating = null,
        $connection = null,
        ?Collection $recycle = null,
        protected bool $withMyConfigFlag = false
    ) {
        parent::__construct(
            $count,
            $states,
            $has,
            $for,
            $afterMaking,
            $afterCreating,
            $connection,
            $recycle
        );
    }

    protected function newInstance(array $arguments = [])
    {
        $arguments = array_merge(
            $arguments,
            [
                'withMyConfigFlag' => array_key_exists('withMyConfigFlag', $arguments)
                    ? $arguments['withMyConfigFlag']
                    : $this->withMyConfigFlag,
            ],
        );

        return parent::newInstance($arguments);
    }

    public function withMyConfigFlag(bool $withMyConfigFlag = true): static
    {
        $this->withMyConfigFlag = $withMyConfigFlag;

        return $this->newInstance(['withMyConfigFlag' => $withMyConfigFlag]);
    }

    public function configure(): static
    {
        return $this->afterMaking(function (MyModel $myModel) {
            if ($this->withMyConfigFlag) { // will always be `false`
              // do something...
            }
        });
    }
}
```

This pull request shifts the scope to the current factory instance when calling the callbacks, thus making the configuration of the factory instance available where the `make` or `create` method was called.