### PR TITLE
[12.x] Add JSON response to the heath endpoint

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -206,7 +206,13 @@ class ApplicationBuilder
                 Route::middleware('web')->get($health, function () {
                     Event::dispatch(new DiagnosingHealth);
 
-                    return View::file(__DIR__.'/../resources/health-up.blade.php');
+                    return request()->wantsJson()
+                        ? response()->json([
+                                'app' => config('app.name', 'Laravel'),
+                                'status' => 'up',
+                                'response_time' => defined('LARAVEL_START') ? round((microtime(true) - LARAVEL_START) * 1000) : null,
+                            ])
+                        : View::file(__DIR__ . '/../resources/health-up.blade.php');
                 });
             }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When requesting the health endpoint with the `Accept: application/json` header, respond with the app name, status and response time in JSON format:

```json
{
  "app": "Laravel",
  "status": "up",
  "response_time": 12
}
```

This is useful for headless systems that are checking the status and response time of the application.
