### PR TITLE
[11.x] Add pluralSmart

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -869,6 +869,21 @@ class Str
     }
 
     /**
+     * Detect count and get plural form (if needed) of an English word.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function pluralSmart($value)
+    {
+        if (! preg_match('/[\d]/', $value, $matches)) {
+            return $value;
+        }
+
+        return self::plural($value, $matches[0]);
+    }
+
+    /**
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -592,7 +592,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      *
      * @return static
      */
-    public static function pluralSmart()
+    public function pluralSmart()
     {
         return new static(Str::pluralSmart($this->value));
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -588,6 +588,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Detect count and get plural form (if needed) of an English word.
+     *
+     * @return static
+     */
+    public static function pluralSmart()
+    {
+        return new static(Str::pluralSmart($this->value));
+    }
+
+    /**
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  int|array|\Countable  $count

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -54,6 +54,12 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('tests', Str::plural('test', -2));
     }
 
+    public function testPluralSmart()
+    {
+        $this->assertSame('1 test', Str::pluralSmart('1 test'));
+        $this->assertSame('2 tests', Str::pluralSmart('2 test'));
+    }
+
     public function testPluralStudly()
     {
         $this->assertPluralStudly('RealHumans', 'RealHuman');


### PR DESCRIPTION
I absolutely love the `plural` string helper. One of my biggest quarrels with it though is that I need to provide the count twice, which is especially annoying when it's a long variable name or nested relationship.

This adds a `pluralSmart` helper that automatically detects the first number in the string and pluralizes from that. If the regex fails, it just returns the original string. I didn't want to touch the original plural helper since you aren't required to pass a count and potentially create a breaking change.

```
Str::of($customer->latestOrder->items->count() . ' Item')->plural($customer->latestOrder->items->count())
// 10 Items
```
becomes...
```
Str::of($customer->latestOrder->items->count() . ' Item')->pluralSmart()
// 10 Items
```