### PR TITLE
[11.x] Update detachUsingCustomClass to trigger delete event with full model record

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -481,10 +481,11 @@ trait InteractsWithPivotTable
         $results = 0;
 
         foreach ($this->parseIds($ids) as $id) {
-            $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->{$this->parentKey},
-                $this->relatedPivotKey => $id,
-            ], true)->delete();
+            $results += $this->getCurrentlyAttachedPivots()
+                ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
+                ->where($this->relatedPivotKey, $this->parseId($id))
+                ->first()
+                ?->delete() ?? 0;
         }
 
         return $results;


### PR DESCRIPTION
**TLDR**: This update allows the any listener to the delete event on a pivot model record to receive the full set of columns (including the PK) instead of just the foreign keys.

Fully compatible with 10.x branch as well.

**Long Description**: I am working on a feature to audit pivot column changes. Attach and detach work fine to create audits. However, detach (the delete event) failed to create an audit record because my audits table does not allow null values for auditable primary key value. The issue is that the detach section was creating a new pivot record only with the foreign keys leaving out all other columns from the delete event.

While debugging I dug into the history of Laravel supporting pivot records triggering events and this change brings the framework more in line with how the `updateExistingPivot` method works when using a pivot model in the `updateExistingPivotUsingCustomClass` method. 

![image](https://github.com/laravel/framework/assets/1899636/87b3b554-d8e7-4826-830f-a2caf6b4d2c1)

I also made the delete null safe in case the record has already been deleted by another process it doesn't throw a "call to member function delete() on null"  as was fixed on this pull request for the pivot update section -> https://github.com/laravel/framework/pull/29362

Relevant links to other PRs or commits related to this change:

- Original PR for pivot model events -> https://github.com/laravel/framework/pull/27571
- Commit to use `getCurrentlyAttachedPivots` method in `updateExistingPivotUsingCustomClass` -> https://github.com/laravel/framework/commit/e31d13111da02fed6bd2ce7a6393431a4b34f924

Happy to add necessary test but generally speaking this change should match all existing tests.

Thank you for your consideration!

Abraham
