### PR TITLE
[12.x] Streamline functionality and performance increase on custom pivot models attach, update, and detach

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -430,7 +430,6 @@ trait InteractsWithPivotTable
     public function detach($ids = null, $touch = true)
     {
         if ($this->using && ! empty($ids)) {
-
             $results = $this->detachUsingCustomClass($ids);
         } else {
             $query = $this->newPivotQuery();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -491,9 +491,9 @@ trait InteractsWithPivotTable
     }
 
     /**
-     * Get the current pivot model instance for a given related pivot key
+     * Get the current pivot model instance for a given related pivot key.
      *
-     * @param mixed $id
+     * @param  mixed  $id
      * @return \Illuminate\Database\Eloquent\Relations\Pivot|null
      */
     protected function getCurrentlyAttachedPivot($id)
@@ -507,8 +507,9 @@ trait InteractsWithPivotTable
     }
 
     /**
-     * Hydrate the raw pivot record to a pivot model instance
-     * @param object $record
+     * Hydrate the raw pivot record to a pivot model instance.
+     * 
+     * @param  object  $record
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     protected function hydrateRecordAsPivotModel($record)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -508,7 +508,7 @@ trait InteractsWithPivotTable
 
     /**
      * Hydrate the raw pivot record to a pivot model instance.
-     * 
+     *
      * @param  object  $record
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -471,7 +471,7 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        foreach ($ids as $id) {
+        foreach ($this->parseIds($ids) as $id) {
             $results += $this->getCurrentlyAttachedPivot($id)?->delete() ?? 0;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -498,8 +498,7 @@ trait InteractsWithPivotTable
     protected function getCurrentlyAttachedPivot($id)
     {
         $record = $this->newPivotQuery()
-            ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
-            ->where($this->relatedPivotKey, $this->parseId($id))
+            ->where($this->getQualifiedRelatedPivotKeyName(), $this->parseId($id))
             ->first();
 
         return $record ? $this->hydrateRecordAsPivotModel($record) : null;

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -111,6 +111,7 @@ class EloquentPivotEventsTest extends DatabaseTestCase
                 'project_id' => '1',
                 'permissions' => '["foo","bar"]',
                 'role' => 'Lead Developer',
+                'urgent' => 0,
             ],
             $_SERVER['pivot_attributes']
         );
@@ -188,9 +189,7 @@ class PivotEventsTestUser extends Model
 
     public function urgentProjects()
     {
-        return $this->belongsToMany(PivotEventsTestProject::class, 'project_users', 'user_id', 'project_id')
-            ->using(PivotEventsTestCollaborator::class)
-            ->wherePivot('urgent', true);
+        return $this->projects()->wherePivot('urgent', true);
     }
 }
 

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -161,19 +161,19 @@ class EloquentPivotEventsTest extends DatabaseTestCase
         $project = PivotEventsTestProject::forceCreate(['name' => 'Test Project']);
 
         $user->projects()->attach($project, ['urgent' => false]);
-        $this->assertEquals(['saving', 'creating', 'created', 'saved'], PivotEventsTestModelEquipment::$eventsCalled);
+        $this->assertEquals(['saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
 
-        PivotEventsTestModelEquipment::$eventsCalled = [];
+        PivotEventsTestCollaborator::$eventsCalled = [];
         $user->projects()->updateExistingPivot($project, ['urgent' => true]);
-        $this->assertEquals(['saving', 'updating', 'updated', 'saved'], PivotEventsTestModelEquipment::$eventsCalled);
+        $this->assertEquals(['saving', 'updating', 'updated', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
 
-        PivotEventsTestModelEquipment::$eventsCalled = [];
+        PivotEventsTestCollaborator::$eventsCalled = [];
         $user->urgentProjects()->updateExistingPivot($project, ['role' => 'High Priority']);
-        $this->assertEquals(['saving', 'updating', 'updated', 'saved'], PivotEventsTestModelEquipment::$eventsCalled);
+        $this->assertEquals(['saving', 'updating', 'updated', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
 
-        PivotEventsTestModelEquipment::$eventsCalled = [];
+        PivotEventsTestCollaborator::$eventsCalled = [];
         $user->urgentProjects()->detach($project);
-        $this->assertEquals(['deleting', 'deleted'], PivotEventsTestModelEquipment::$eventsCalled);
+        $this->assertEquals(['deleting', 'deleted'], PivotEventsTestCollaborator::$eventsCalled);
     }
 }
 


### PR DESCRIPTION
This merge  request is a follow up to this rejected simpler pull request  https://github.com/laravel/framework/pull/51776. This pull request is targetting 12.x as Taylor mentioned on the other rejected PR that that update wouldn't be a good idea as a patch release.

This larger pull request does 3 things as described below.

- Performance boost when doing pivot record updates and using a custom pivot model class
- Consistent data provided to model events when doing attach, update, and detach
- Consistent use of `where` constraints defined on relationships whether doing raw queries or using a custom pivot model class.

## Pivot record update performance fix when using a custom pivot model class
Currently for every record updated using a custom class, the code is unnecessarily doing a `get()` to load all pivot records and hydrating them to then only attempt to grab the specific record needed, tossing the rest aside. 

This is a performance issue that compounds exponentially as more pivot records exist, regardless of how many need to be updated. For example, if 5 matching records exist and 3 need to be updated, it will load and hydrate those 5 records 3 times unnecessarily loading and hydrating 15 records overall instead of just 3. 

In my situation, any user could currently have up to 260 pivot records for a certain relationship. If all 260 records needed to be updated in a single request (extremely rare by the way), it would load and hydrate 67,600 records.

See use of `getCurrentlyAttachedPivots` below:

![image](https://github.com/laravel/framework/assets/1899636/a9d863a0-e121-4f95-aa1f-f8fcc3c433fc)

![image](https://github.com/laravel/framework/assets/1899636/2d7aaa6c-3b0a-40d5-9ee0-bc9e1c3758f3)

This pull request fixes that performance issue to only grab the wanted record so that it only loads and hydrates the equal number of records being updated. See use of `getCurrentlyAttachedPivot` below:

![image](https://github.com/laravel/framework/assets/1899636/5ae03329-e2ef-42cb-8ec1-f9bcb3001661)

![image](https://github.com/laravel/framework/assets/1899636/42d2b11a-fbd0-4d77-b6c3-0e88bc62a719)

Same 1-to-1 functionality for detaching

![image](https://github.com/laravel/framework/assets/1899636/d4eb7821-96b6-4967-8c06-0057226d0a56)

## Consistency between data loaded for pivot update and pivot detach
This pull request consistently loads the entire pivot record for update and detach so that the entire record is available for model events. Previously only pivot update loaded the entire record while detach only made the foreign keys available.

Update loads the full record from the DB and passing that in `updating` and `updated` events

![image](https://github.com/laravel/framework/assets/1899636/c13bf7f7-c05c-4d23-884c-5e03c608c702)

Detach creates a new pivot record only with foreign keys, leaving out the rest of the data available in `deleting` or `deleted` events

![image](https://github.com/laravel/framework/assets/1899636/83a40b6e-0c3a-4af3-90cc-4fd5c99b2c44)

For my personal situation, I wanted to audit deleted events but only received the foreign keys instead of the full record so that I could record what the entire pivot record looked like when it was deleted.

This pull request loads the full record from the db in both update and detach making the full record available consistent in all model events.

## Consistent use of `where` clauses when using custom pivot model class or doing raw queries
Lastly, the [original implementation of pivot model events](https://github.com/laravel/framework/pull/27571) did not consider `where` clause constraints placed on relationships. As described in [this previous pull request](https://github.com/laravel/framework/pull/27997) and also patched in [this other commit by Taylor](https://github.com/laravel/framework/commit/cadea88cc2007cedb825b5d86a0fb184dcd76ab4), it led to inconsistent functionality between using custom pivot models and using raw queries.

The fix was to ignore using custom pivot model classes if where clause constraints existed on the relationship.

![image](https://github.com/laravel/framework/assets/1899636/d27455bf-8c29-4a4d-95e1-577eb2593154)

![image](https://github.com/laravel/framework/assets/1899636/d59ddf6a-fd3c-4bbd-a2f2-fc9ff1ad8b9f)

Those fixes created a situation where you could only use custom pivot models if your relationship did not have any `where` clauses, which is not documented and also a weird limitation.

This pull request sets up both update and detach to use the `newPivotQuery` method to find existing pivot records when using a custom pivot model class, which do consider `where` clauses defined on the model relationship.

This method is used by update and detach to find existing pivot record considering `where` constraints
![image](https://github.com/laravel/framework/assets/1899636/3d00b40f-fa95-4efe-bdda-9be8b7fddb9a)

The `newPivotQuery` adds `where` constraints
![image](https://github.com/laravel/framework/assets/1899636/23e09ae0-94ff-4805-af52-413ffa628e8e)

The `newPivotQuery` method is also used on raw queries that do not use custom pivot models to respect those constraints when updating and detaching pivot records. So this change streamlines functionality to be the same whether using a custom pivot model or not.

This  now allows the use of custom pivot classes alongside having `where` constraints on relationships. 

Previously, you had to choose between using a custom pivot model class or having `where` constraints on a relationship definition. And since it wasn't documented, you kind of just had to stumble into this and track down why it's ignoring a defined custom pivot model.

### Final thoughts
Overall, this pull request streamlines functionality between the raw queries and using custom pivot models .

Thanks again for your consideration!

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
