### PR TITLE
Fix validator wildcard custom attributes when using NestedRules

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -285,7 +285,7 @@ trait FormatsMessages
             }
         }
 
-        // If no attribute is found using the expected attributes, loop through the 
+        // If no attribute is found using the expected attributes, loop through the
         // list of custom attributes and look for attributes with wildcards. Return
         // the first value that matches the custom attribute's pattern.
         foreach ($this->customAttributes as $key => $value) {

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -285,9 +285,9 @@ trait FormatsMessages
             }
         }
 
-        // If no attribute is found using the expected attributes, loop through the
-        // list of custom attributes and look for attributes with wildcards. Return
-        // the first value that matches the custom attribute's pattern.
+        // If no custom attribute is found using the expected attributes, loop through the
+        // list of custom attributes and look for attribute keys with wildcards. Return
+        // the first value that matches the custom attribute key's pattern.
         foreach ($this->customAttributes as $key => $value) {
             if (Str::contains($key, '*') && Str::is($key, $attribute)) {
                 return $value;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -285,6 +285,15 @@ trait FormatsMessages
             }
         }
 
+        // If no attribute is found using the expected attributes, loop through the 
+        // list of custom attributes and look for attributes with wildcards. Return
+        // the first value that matches the custom attribute's pattern.
+        foreach ($this->customAttributes as $key => $value) {
+            if (Str::contains($key, '*') && Str::is($key, $attribute)) {
+                return $value;
+            }
+        }
+
         // When no language line has been specified for the attribute and it is also
         // an implicit attribute we will display the raw attribute's name and not
         // modify it with any of these replacements before we display the name.


### PR DESCRIPTION
Resolves an issue where wildcard custom attributes aren't matched when using `NestedRules`. See issue #51784.

The underlying cause of this issue is that `NestedRules` doesn't correctly generate the relevant `implicitAttributes`, meaning custom attributes cannot be connected with their explicit attributes. There doesn't seem to be a good way to fix this underlying problem without major refactoring and breaking changes.

This PR resolves this issue by iterating over the custom attributes and pattern matching their keys with the given attribute. This is consistent with the way custom messages are already resolved and therefore has some precedence.