### PR TITLE
[10.x] Test abort behavior

### DIFF
--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -11,6 +11,8 @@ use Illuminate\Support\ServiceProvider;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class FoundationApplicationTest extends TestCase
 {
@@ -523,6 +525,35 @@ class FoundationApplicationTest extends TestCase
         $app->bootstrapWith([\Illuminate\Foundation\Bootstrap\LoadConfiguration::class]);
 
         $this->assertSame('bar', $app->make('config')->get('app.foo'));
+    }
+
+    public function testAbortThrowsNotFoundHttpException()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Page was not found');
+
+        $app = new Application();
+        $app->abort(404, 'Page was not found');
+    }
+
+    public function testAbortThrowsHttpException()
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Request is bad');
+
+        $app = new Application();
+        $app->abort(400, 'Request is bad');
+    }
+
+    public function testAbortAcceptsHeaders()
+    {
+        try {
+            $app = new Application();
+            $app->abort(400, 'Bad request', ['X-FOO' => 'BAR']);
+            $this->fail(sprintf('abort must throw an %s.', HttpException::class));
+        } catch (HttpException $exception) {
+            $this->assertSame(['X-FOO' => 'BAR'], $exception->getHeaders());
+        }
     }
 }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,13 +3,18 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class FoundationHelpersTest extends TestCase
 {
@@ -239,5 +244,54 @@ class FoundationHelpersTest extends TestCase
         });
 
         $this->assertSame('expected', mix('asset.png'));
+    }
+
+    public function testAbortReceivesCodeAsSymfonyResponseInstance()
+    {
+        try {
+            abort($code = new SymfonyResponse());
+
+            $this->fail(
+                sprintf('abort function must throw %s when receiving code as Symfony Response instance.', HttpResponseException::class)
+            );
+        } catch (HttpResponseException $ex) {
+            $this->assertSame($code, $ex->getResponse());
+        }
+    }
+
+    public function testAbortReceivesCodeAsResponableImplementation()
+    {
+        app()->instance('request', $request = Request::create('/'));
+
+        try {
+            abort($code = new class implements Responsable {
+                public $request;
+
+                public function toResponse($request)
+                {
+                    $this->request = $request;
+
+                    return new SymfonyResponse();
+                }
+            });
+
+            $this->fail(
+                sprintf('abort function must throw %s when receiving code as Responable implementation.', HttpResponseException::class)
+            );
+        } catch (HttpResponseException $ex) {
+            $this->assertSame($request, $code->request);
+        }
+    }
+
+    public function testAbortReceivesCodeAsInteger()
+    {
+        $app = m::mock(Application::class);
+        $app->shouldReceive('abort')
+            ->with($code = 400, $message = 'Bad request', $headers = ['X-FOO' => 'BAR'])
+            ->once();
+
+        Container::setInstance($app);
+
+        abort($code, $message, $headers);
     }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -264,7 +264,8 @@ class FoundationHelpersTest extends TestCase
         app()->instance('request', $request = Request::create('/'));
 
         try {
-            abort($code = new class implements Responsable {
+            abort($code = new class implements Responsable
+            {
                 public $request;
 
                 public function toResponse($request)


### PR DESCRIPTION
I add some tests for abort behavior:

- Application::abort() method throws NotFoundHttpException if code is 404.
- Application::abort() method throws HttpException if code is not 404.
- Application::abort() method accepts headers as an array.
- abort() function receives code as a Symfony Response instance.
- abort() function receives code as a Responable implementation.
- abort() function forwards call to Application::abort() if code is not a Symfony Response instance or a Responable implementation.
