### PR TITLE
[11.x] Imporve tests in RepositoryTest

### DIFF
--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -36,6 +36,9 @@ class RepositoryTest extends TestCase
                 'aaa',
                 'zzz',
             ],
+            'multidimensional_array' => [
+                'a' => ['a', 'b']
+            ],
             'x' => [
                 'z' => 'zoo',
             ],
@@ -154,6 +157,9 @@ class RepositoryTest extends TestCase
     {
         $this->repository->set('key', 'value');
         $this->assertSame('value', $this->repository->get('key'));
+
+        $this->repository->set('key');
+        $this->assertSame(null, $this->repository->get('key'));
     }
 
     public function testSetArray()
@@ -175,6 +181,12 @@ class RepositoryTest extends TestCase
         $this->assertSame('bar', $this->repository->get('key4.foo'));
         $this->assertSame('bar', $this->repository->get('key4.bar.foo'));
         $this->assertNull($this->repository->get('key5'));
+
+        $this->repository->set(['key' => 'value'] , 'second_value');
+        $this->assertNotSame('second_value', $this->repository->get('key'));
+
+        $this->repository->set('key.key2', 'value');
+        $this->assertSame('value', $this->repository->get('key.key2'));
     }
 
     public function testPrepend()
@@ -188,6 +200,14 @@ class RepositoryTest extends TestCase
         $this->assertSame('zzz', $this->repository->get('array.2'));
         $this->assertNull($this->repository->get('array.3'));
         $this->assertCount(3, $this->repository->get('array'));
+
+        $this->repository->prepend('multidimensional_array.a', 'z');
+        $this->assertSame('z', $this->repository->get('multidimensional_array.a.0'));
+        $this->assertSame('a', $this->repository->get('multidimensional_array.a.1'));
+        $this->assertSame('b', $this->repository->get('multidimensional_array.a.2'));
+        $this->assertNull($this->repository->get('multidimensional_array.a.3'));
+        $this->assertCount(3, $this->repository->get('multidimensional_array.a'));
+
     }
 
     public function testPush()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -37,7 +37,7 @@ class RepositoryTest extends TestCase
                 'zzz',
             ],
             'multidimensional_array' => [
-                'a' => ['a', 'b']
+                'a' => ['a', 'b'],
             ],
             'x' => [
                 'z' => 'zoo',
@@ -182,7 +182,7 @@ class RepositoryTest extends TestCase
         $this->assertSame('bar', $this->repository->get('key4.bar.foo'));
         $this->assertNull($this->repository->get('key5'));
 
-        $this->repository->set(['key' => 'value'] , 'second_value');
+        $this->repository->set(['key' => 'value'], 'second_value');
         $this->assertNotSame('second_value', $this->repository->get('key'));
 
         $this->repository->set('key.key2', 'value');
@@ -207,7 +207,6 @@ class RepositoryTest extends TestCase
         $this->assertSame('b', $this->repository->get('multidimensional_array.a.2'));
         $this->assertNull($this->repository->get('multidimensional_array.a.3'));
         $this->assertCount(3, $this->repository->get('multidimensional_array.a'));
-
     }
 
     public function testPush()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I've added some assert tests for `RepositoryTest`.

@taylorotwell  In addition, the `prepend` method doesn't support associate arrays properly. It would be useful if we could pass an associated array to `prepend` and get an outcome like this :

```
 'a' => 'aaa',
 'x' => 'xxx',
 'y' => 'yyy',
```

instead of :

```
 0 => ['a' => 'aaa'],
 'x' => 'xxx',
 'y' => 'yyy',
```