### PR TITLE
[12.x] feat: use database default datetime precision

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1103,7 +1103,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function dateTime($column, $precision = 0)
+    public function dateTime($column, $precision = null)
     {
         return $this->addColumn('dateTime', $column, compact('precision'));
     }
@@ -1115,7 +1115,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function dateTimeTz($column, $precision = 0)
+    public function dateTimeTz($column, $precision = null)
     {
         return $this->addColumn('dateTimeTz', $column, compact('precision'));
     }
@@ -1127,7 +1127,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function time($column, $precision = 0)
+    public function time($column, $precision = null)
     {
         return $this->addColumn('time', $column, compact('precision'));
     }
@@ -1139,7 +1139,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function timeTz($column, $precision = 0)
+    public function timeTz($column, $precision = null)
     {
         return $this->addColumn('timeTz', $column, compact('precision'));
     }
@@ -1151,7 +1151,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function timestamp($column, $precision = 0)
+    public function timestamp($column, $precision = null)
     {
         return $this->addColumn('timestamp', $column, compact('precision'));
     }
@@ -1163,7 +1163,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function timestampTz($column, $precision = 0)
+    public function timestampTz($column, $precision = null)
     {
         return $this->addColumn('timestampTz', $column, compact('precision'));
     }
@@ -1174,7 +1174,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function timestamps($precision = 0)
+    public function timestamps($precision = null)
     {
         $this->timestamp('created_at', $precision)->nullable();
 
@@ -1189,7 +1189,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function nullableTimestamps($precision = 0)
+    public function nullableTimestamps($precision = null)
     {
         $this->timestamps($precision);
     }
@@ -1200,7 +1200,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function timestampsTz($precision = 0)
+    public function timestampsTz($precision = null)
     {
         $this->timestampTz('created_at', $precision)->nullable();
 
@@ -1213,7 +1213,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function datetimes($precision = 0)
+    public function datetimes($precision = null)
     {
         $this->datetime('created_at', $precision)->nullable();
 
@@ -1227,7 +1227,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletes($column = 'deleted_at', $precision = 0)
+    public function softDeletes($column = 'deleted_at', $precision = null)
     {
         return $this->timestamp($column, $precision)->nullable();
     }
@@ -1239,7 +1239,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletesTz($column = 'deleted_at', $precision = 0)
+    public function softDeletesTz($column = 'deleted_at', $precision = null)
     {
         return $this->timestampTz($column, $precision)->nullable();
     }
@@ -1251,7 +1251,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletesDatetime($column = 'deleted_at', $precision = 0)
+    public function softDeletesDatetime($column = 'deleted_at', $precision = null)
     {
         return $this->datetime($column, $precision)->nullable();
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -698,7 +698,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp without time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -725,7 +725,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp with time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -752,7 +752,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time without time zone not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -779,7 +779,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time with time zone not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -806,7 +806,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp without time zone not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -833,7 +833,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp with time zone not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -860,7 +860,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp without time zone null, add column "updated_at" timestamp without time zone null', $statements[0]);
     }
 
     public function testAddingTimestampsTz()
@@ -869,7 +869,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp with time zone null, add column "updated_at" timestamp with time zone null', $statements[0]);
     }
 
     public function testAddingBinary()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -117,7 +117,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp without time zone not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SQLiteGrammar));
@@ -138,7 +138,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` timestamp not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp without time zone not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SQLiteGrammar));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR updates the default datetime precision to `null` which in turn uses the database default precision instead of defaulting to `0` across the board.

As I mentioned in https://github.com/laravel/framework/pull/51363 (specifically for Postgres), rounding issues can occur when using a non-default precision for that database. These rounding issues are eliminated when using the database default precision. For example, when using a precision of 0, Postgres will round `2000-01-01 23:59:59.999999` up to the next day (`2000-01-02 00:00:00`) whereas no rounding will occur when using the default precision (6). At least in Postgres' case, using a lower precision does not have any storage benefits---a timestamp takes up [8 bytes](https://www.postgresql.org/docs/current/datatype-datetime.html) regardless of the precision (however, this may not be the case for all databases).

Note, that if we want more control in the application over the default precision on a per database level, then we could always create `getDatetimePrecision` methods (similar to `getDateFormat`) on the schema grammars.

Thanks!