### PR TITLE
[11.x] Optimize container by caching reflection data

### DIFF
--- a/src/Illuminate/Container/ClassDefinition/ClassDefinition.php
+++ b/src/Illuminate/Container/ClassDefinition/ClassDefinition.php
@@ -7,7 +7,7 @@ namespace Illuminate\Container\ClassDefinition;
 final readonly class ClassDefinition
 {
     /**
-     * @param Parameter[] $parameters
+     * @param  Parameter[]  $parameters
      */
     public function __construct(
         public string $class,

--- a/src/Illuminate/Container/ClassDefinition/ClassDefinition.php
+++ b/src/Illuminate/Container/ClassDefinition/ClassDefinition.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Container\ClassDefinition;
+
+final readonly class ClassDefinition
+{
+    /**
+     * @param Parameter[] $parameters
+     */
+    public function __construct(
+        public string $class,
+        public bool $isInstantiable,
+        public bool $isConstructorDefined,
+        public array $parameters,
+    ) {
+    }
+}

--- a/src/Illuminate/Container/ClassDefinition/ClassDefinitionProvider.php
+++ b/src/Illuminate/Container/ClassDefinition/ClassDefinitionProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Container\ClassDefinition;
+
+use Illuminate\Container\Util;
+use ReflectionClass;
+use ReflectionParameter;
+
+final class ClassDefinitionProvider
+{
+    /**
+     * @var array<string, ClassDefinition>
+     */
+    private array $definitions = [];
+
+    public function get(string $className): ClassDefinition
+    {
+        if (isset($this->definitions[$className])) {
+            return $this->definitions[$className];
+        }
+
+        $reflection = new ReflectionClass($className);
+        $definition = new ClassDefinition(
+            class: $className,
+            isInstantiable: $reflection->isInstantiable(),
+            isConstructorDefined: !is_null($reflection->getConstructor()),
+            parameters: array_map(
+                fn (ReflectionParameter $parameter) => new Parameter(
+                    name: $parameter->getName(),
+                    className: Util::getParameterClassName($parameter),
+                    isVariadic: $parameter->isVariadic(),
+                    isDefaultValueAvailable: $parameter->isDefaultValueAvailable(),
+                    defaultValue: $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
+                    declaringClassName: $parameter->getDeclaringClass()->getName(),
+                    asString: (string) $parameter,
+                ),
+                $reflection->getConstructor()?->getParameters() ?? [],
+            ),
+        );
+
+        $this->definitions[$className] = $definition;
+
+        return $definition;
+    }
+}

--- a/src/Illuminate/Container/ClassDefinition/ClassDefinitionProvider.php
+++ b/src/Illuminate/Container/ClassDefinition/ClassDefinitionProvider.php
@@ -6,6 +6,7 @@ namespace Illuminate\Container\ClassDefinition;
 
 use Illuminate\Container\Util;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionParameter;
 
 final class ClassDefinitionProvider
@@ -15,6 +16,9 @@ final class ClassDefinitionProvider
      */
     private array $definitions = [];
 
+    /**
+     * @throws ReflectionException
+     */
     public function get(string $className): ClassDefinition
     {
         if (isset($this->definitions[$className])) {
@@ -25,7 +29,7 @@ final class ClassDefinitionProvider
         $definition = new ClassDefinition(
             class: $className,
             isInstantiable: $reflection->isInstantiable(),
-            isConstructorDefined: !is_null($reflection->getConstructor()),
+            isConstructorDefined: ! is_null($reflection->getConstructor()),
             parameters: array_map(
                 fn (ReflectionParameter $parameter) => new Parameter(
                     name: $parameter->getName(),

--- a/src/Illuminate/Container/ClassDefinition/ClassDefinitionProvider.php
+++ b/src/Illuminate/Container/ClassDefinition/ClassDefinitionProvider.php
@@ -9,20 +9,20 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
 
-final class ClassDefinitionProvider
+class ClassDefinitionProvider
 {
     /**
      * @var array<string, ClassDefinition>
      */
-    private array $definitions = [];
+    private static array $definitions = [];
 
     /**
      * @throws ReflectionException
      */
     public function get(string $className): ClassDefinition
     {
-        if (isset($this->definitions[$className])) {
-            return $this->definitions[$className];
+        if (isset(self::$definitions[$className])) {
+            return self::$definitions[$className];
         }
 
         $reflection = new ReflectionClass($className);
@@ -44,7 +44,7 @@ final class ClassDefinitionProvider
             ),
         );
 
-        $this->definitions[$className] = $definition;
+        self::$definitions[$className] = $definition;
 
         return $definition;
     }

--- a/src/Illuminate/Container/ClassDefinition/Parameter.php
+++ b/src/Illuminate/Container/ClassDefinition/Parameter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Container\ClassDefinition;
+
+final readonly class Parameter
+{
+    public function __construct(
+        public string $name,
+        public ?string $className,
+        public bool $isVariadic,
+        public bool $isDefaultValueAvailable,
+        public mixed $defaultValue,
+        public string $declaringClassName,
+        public string $asString,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->asString;
+    }
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -216,6 +216,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function __construct($basePath = null)
     {
+        parent::__construct();
+
         if ($basePath) {
             $this->setBasePath($basePath);
         }

--- a/tests/Container/ClassDefinition/ClassDefinitionProviderTest.php
+++ b/tests/Container/ClassDefinition/ClassDefinitionProviderTest.php
@@ -78,7 +78,8 @@ final class ClassDefinitionProviderTest extends TestCase
     }
 }
 
-class Service {
+class Service
+{
     public function __construct(
         private Service1 $service1,
         private Service2 $service2,
@@ -87,10 +88,12 @@ class Service {
     }
 }
 
-class Service1 {
+class Service1
+{
 }
 
-class Service2 {
+class Service2
+{
 }
 
 class ServiceVariadicParameters
@@ -101,4 +104,6 @@ class ServiceVariadicParameters
     }
 }
 
-class Param {}
+class Param
+{
+}

--- a/tests/Container/ClassDefinition/ClassDefinitionProviderTest.php
+++ b/tests/Container/ClassDefinition/ClassDefinitionProviderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Container\ClassDefinition;
+
+use Illuminate\Container\ClassDefinition\ClassDefinition;
+use Illuminate\Container\ClassDefinition\ClassDefinitionProvider;
+use Illuminate\Container\ClassDefinition\Parameter;
+use PHPUnit\Framework\TestCase;
+
+final class ClassDefinitionProviderTest extends TestCase
+{
+    public function testReturnsAProperDefinitionOfABasicClass(): void
+    {
+        $sut = new ClassDefinitionProvider();
+
+        $definition = $sut->get(Service::class);
+
+        $this->assertEquals(new ClassDefinition(
+            class: Service::class,
+            isInstantiable: true,
+            isConstructorDefined: true,
+            parameters: [
+                new Parameter(
+                    name: 'service1',
+                    className: Service1::class,
+                    isVariadic: false,
+                    isDefaultValueAvailable: false,
+                    defaultValue: null,
+                    declaringClassName: Service::class,
+                    asString: 'Parameter #0 [ <required> Illuminate\Tests\Container\ClassDefinition\Service1 $service1 ]',
+                ),
+                new Parameter(
+                    name: 'service2',
+                    className: Service2::class,
+                    isVariadic: false,
+                    isDefaultValueAvailable: false,
+                    defaultValue: null,
+                    declaringClassName: Service::class,
+                    asString: 'Parameter #1 [ <required> Illuminate\Tests\Container\ClassDefinition\Service2 $service2 ]',
+                ),
+                new Parameter(
+                    name: 'primitive',
+                    className: null,
+                    isVariadic: false,
+                    isDefaultValueAvailable: false,
+                    defaultValue: null,
+                    declaringClassName: Service::class,
+                    asString: 'Parameter #2 [ <required> string $primitive ]',
+                ),
+            ],
+        ), $definition);
+    }
+
+    public function testReturnsAProperDefinitionOfAClassWithVariadicParameters(): void
+    {
+        $sut = new ClassDefinitionProvider();
+
+        $definition = $sut->get(ServiceVariadicParameters::class);
+
+        $this->assertEquals(new ClassDefinition(
+            class: ServiceVariadicParameters::class,
+            isInstantiable: true,
+            isConstructorDefined: true,
+            parameters: [
+                new Parameter(
+                    name: 'params',
+                    className: Param::class,
+                    isVariadic: true,
+                    isDefaultValueAvailable: false,
+                    defaultValue: null,
+                    declaringClassName: ServiceVariadicParameters::class,
+                    asString: 'Parameter #0 [ <optional> Illuminate\Tests\Container\ClassDefinition\Param ...$params ]',
+                ),
+            ],
+        ), $definition);
+    }
+}
+
+class Service {
+    public function __construct(
+        private Service1 $service1,
+        private Service2 $service2,
+        private string $primitive,
+    ) {
+    }
+}
+
+class Service1 {
+}
+
+class Service2 {
+}
+
+class ServiceVariadicParameters
+{
+    public function __construct(
+        Param ...$params,
+    ) {
+    }
+}
+
+class Param {}

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -150,6 +150,8 @@ class ApplicationDatabaseMigrationStub extends Application
 {
     public function __construct(array $data = [])
     {
+        parent::__construct();
+
         $mutex = m::mock(CommandMutex::class);
         $mutex->shouldReceive('create')->andReturn(true);
         $mutex->shouldReceive('release')->andReturn(true);

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -121,6 +121,8 @@ class ApplicationDatabaseRefreshStub extends Application
 {
     public function __construct(array $data = [])
     {
+        parent::__construct();
+
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -80,6 +80,8 @@ class ApplicationDatabaseResetStub extends Application
 {
     public function __construct(array $data = [])
     {
+        parent::__construct();
+
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -91,6 +91,8 @@ class ApplicationDatabaseRollbackStub extends Application
 {
     public function __construct(array $data = [])
     {
+        parent::__construct();
+
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }


### PR DESCRIPTION
It's another slight improvement for large applications with many dependencies. In Laravel we can define services with interfaces as scoped or singleton to force single creation. But for services without an interface (or those declared by using the bind method), there is no need to use scoped or singleton, so every time the service is needed a new instance needs to be created, and in the case of complex applications it could be quite slow. As the first improvement, we can cache data retrieved by using reflection to make those new instances a little bit faster. For a small number of services, it isn't a big optimization, but for a larger number of services, it could mean a few milliseconds per request, which could be a nice optimization. 

**Benchmarks**

It was tested on the example application with a few nested dependencies similar to the following structure: 
.Service1
..Service11
....ServiceA
....ServiceB
....ServiceC
....ServiceD
..Service12
....ServiceA
....ServiceB
....ServiceC
....ServiceD
..Service13
....ServiceA
....ServiceB
....ServiceC
....ServiceD
..Service14
....ServiceA
....ServiceB
....ServiceC
....ServiceD
..Service15
....ServiceA
....ServiceB
....ServiceC
....ServiceD

**BEFORE**
```
ab -n 1000 -c 1 http://127.0.0.1:8080/
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 127.0.0.1 (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        nginx/1.25.5
Server Hostname:        127.0.0.1
Server Port:            8080

Document Path:          /
Document Length:        2 bytes

Concurrency Level:      1
Time taken for tests:   44.335 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      1128000 bytes
HTML transferred:       2000 bytes
Requests per second:    22.56 [#/sec] (mean)
Time per request:       44.335 [ms] (mean)
Time per request:       44.335 [ms] (mean, across all concurrent requests)
Transfer rate:          24.85 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.3      0       8
Processing:    34   44   9.8     41     133
Waiting:       34   44   9.8     41     133
Total:         35   44   9.8     41     133

Percentage of the requests served within a certain time (ms)
  50%     41
  66%     43
  75%     45
  80%     47
  90%     55
  95%     65
  98%     73
  99%     81
 100%    133 (longest request)
```
<img width="1916" alt="Screenshot 2024-06-13 at 15 40 06" src="https://github.com/laravel/framework/assets/6762480/47dabea5-2c2f-4a4f-8a8c-49dfecee9104">


**AFTER**

```
ab -n 1000 -c 1 http://127.0.0.1:8080/
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 127.0.0.1 (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        nginx/1.25.5
Server Hostname:        127.0.0.1
Server Port:            8080

Document Path:          /
Document Length:        2 bytes

Concurrency Level:      1
Time taken for tests:   35.608 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      1128000 bytes
HTML transferred:       2000 bytes
Requests per second:    28.08 [#/sec] (mean)
Time per request:       35.608 [ms] (mean)
Time per request:       35.608 [ms] (mean, across all concurrent requests)
Transfer rate:          30.94 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.2      0       4
Processing:    29   35   7.9     33     110
Waiting:       29   35   7.9     33     110
Total:         29   35   7.9     33     110

Percentage of the requests served within a certain time (ms)
  50%     33
  66%     34
  75%     36
  80%     37
  90%     41
  95%     51
  98%     59
  99%     72
 100%    110 (longest request)
```

<img width="1923" alt="Screenshot 2024-06-13 at 15 40 16" src="https://github.com/laravel/framework/assets/6762480/0307202a-be70-4aa3-b5e2-42d25f7773fd">
