### PR TITLE
Add `abbreviate` method to both Str and Stringable classes to abbreviate strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -78,7 +78,7 @@ class Str
 
     /**
      * Abbreviates a given string using the delimiter and glue.
-+    *
+     * 
      * @param  string  $subject
      * @param  string  $delimiter
      * @param  string  $glue

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -77,8 +77,8 @@ class Str
     }
 
     /**
-     * Abbreviates a given string using the delimiter and glue
-     * 
+     * Abbreviates a given string using the delimiter and glue.
++    *
      * @param  string  $subject
      * @param  string  $delimiter
      * @param  string  $glue

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -78,7 +78,7 @@ class Str
 
     /**
      * Abbreviates a given string using the delimiter and glue.
-     * 
+     *
      * @param  string  $subject
      * @param  string  $delimiter
      * @param  string  $glue

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -77,6 +77,27 @@ class Str
     }
 
     /**
+     * Abbreviates a given string using the delimiter and glue
+     * 
+     * @param  string  $subject
+     * @param  string  $delimiter
+     * @param  string  $glue
+     * @return string
+     */
+    public static function abbreviate($subject, $delimiter = ' ', $glue = ''): string
+    {
+        $subject = (string) $subject;
+
+        $subject = static::upper($subject);
+
+        $parts = explode($delimiter, $subject);
+
+        $parts = array_map(fn ($word) => static::substr($word, 0, 1), $parts);
+
+        return implode($glue, $parts);
+    }
+
+    /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $subject

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -35,6 +35,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Abbreviates a given string using the delimiter and glue
+     *
+     * @param  string  $delimiter
+     * @param  string  $glue
+     * @return static
+     */
+    public function abbreviate($delimiter = ' ', $glue = '')
+    {
+        return new static(Str::abbreviate($this->value, $delimiter, $glue));
+    }
+
+    /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -36,7 +36,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
 
     /**
      * Abbreviates a given string using the delimiter and glue.
-     * 
+     *
      * @param  string  $delimiter
      * @param  string  $glue
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -36,7 +36,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
 
     /**
      * Abbreviates a given string using the delimiter and glue.
-+    *
+     * 
      * @param  string  $delimiter
      * @param  string  $glue
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -35,8 +35,8 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Abbreviates a given string using the delimiter and glue
-     *
+     * Abbreviates a given string using the delimiter and glue.
++    *
      * @param  string  $delimiter
      * @param  string  $glue
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1531,7 +1531,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('FBM', Str::abbreviate('Foo Bar Moo'));
         $this->assertSame('FBM', Str::abbreviate('Foo-Bar-Moo', '-'));
-        $this->assertSame('F-B-M', Str::abbreviate('Foo Bar Moo',' ', '-'));
+        $this->assertSame('F-B-M', Str::abbreviate('Foo Bar Moo', ' ', '-'));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1526,6 +1526,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::fromBase64(base64_encode('foo')));
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
+
+    public function testItCanAbbreviate()
+    {
+        $this->assertSame('FBM', Str::abbreviate('Foo Bar Moo'));
+        $this->assertSame('FBM', Str::abbreviate('Foo-Bar-Moo', '-'));
+        $this->assertSame('F-B-M', Str::abbreviate('Foo Bar Moo',' ', '-'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1324,8 +1324,8 @@ class SupportStringableTest extends TestCase
 
     public function testItCanAbbreviate()
     {
-        $this->assertSame('FBM', $this->stringable('Foo Bar Moo')->abbreviate());
-        $this->assertSame('FBM', $this->stringable('Foo-Bar-Moo')->abbreviate('-'));
-        $this->assertSame('F-B-M', $this->stringable('Foo Bar Moo')->abbreviate(' ', '-'));
+        $this->assertSame('FBM', (string) $this->stringable('Foo Bar Moo')->abbreviate());
+        $this->assertSame('FBM', (string) $this->stringable('Foo-Bar-Moo')->abbreviate('-'));
+        $this->assertSame('F-B-M', (string) $this->stringable('Foo Bar Moo')->abbreviate(' ', '-'));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1321,4 +1321,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
+
+    public function testItCanAbbreviate()
+    {
+        $this->assertSame('FBM', $this->stringable('Foo Bar Moo')->abbreviate());
+        $this->assertSame('FBM', $this->stringable('Foo-Bar-Moo')->abbreviate('-'));
+        $this->assertSame('F-B-M', $this->stringable('Foo Bar Moo')->abbreviate(' ', '-'));
+    }
 }


### PR DESCRIPTION
A new method called "abbreviate" has been added to the `Stringable` and `Str` classes in this PR:

When you need to generate codes or abbreviated representations of lengthy strings, this approach does a great job. Additionally, these utility methods facilitate work inside the context of a `Stringable` object.


Example Usage:
```php
$abbreviatedString = Str::abbreviate('Very important person'); //should return VIP
$abbreviatedString = Str::abbreviate('Automatic teller machine',' ', '.'); //should return A.T.M
```

The current method for implementing this with the built-in 'Str' or 'Stringable' classes is as follows:
```php
Str::of('Very important person')
    ->upper()
    ->explode(' ')
    ->map(fn ($word) => Str::of($word)->substr(0, 1))
    ->join('');
```