### PR TITLE
Use Guzzle to resolve the URL against the base URL

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -886,10 +886,6 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        if (! Str::startsWith($url, ['http://', 'https://'])) {
-            $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
-        }
-
         $url = $this->expandUrlParameters($url);
 
         $options = $this->parseHttpOptions($options);
@@ -966,6 +962,10 @@ class PendingRequest
      */
     protected function parseHttpOptions(array $options)
     {
+        if ($this->baseUrl && ! isset($options['base_uri'])) {
+            $options['base_uri'] = $this->baseUrl;
+        }
+
         if (isset($options[$this->bodyFormat])) {
             if ($this->bodyFormat === 'multipart') {
                 $options[$this->bodyFormat] = $this->parseMultipartBodyFormat($options[$this->bodyFormat]);


### PR DESCRIPTION
Hello Reviewers :wave: 

This work extends the support for [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2) from Guzzle Client to the Http Client. 

Previously @JaZo tried to implement this but it was partially addressed by https://github.com/laravel/framework/pull/41307 in version 9 and not merged for version 10 https://github.com/laravel/framework/pull/41289.

The [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2) that Guzzle implements allows us to do something that currently isn't possible because this code:
https://github.com/laravel/framework/blob/741560fc1405dd2ee7b319cb2a9305728e52d969/src/Illuminate/Http/Client/PendingRequest.php#L887-L891

:red_circle:  **First: overriding the base path** (initial slash of URI)
```
Http::baseUrl('http://foo.com/foo')->get('/bar')
// should call -> http://foo.com/bar
// but now     -> http://foo.com/foo/bar
// same as Http::baseUrl('http://foo.com/foo')->get('bar')
```
this is really helpful when you have special routes (baseUri: http://foo.com/api/v1 but you would like to call http://foo.com/health-check)

:red_circle: **Second: overriding the last part of the path** (no trailing slash in baseURI)
```
Http::baseUrl('http://foo.com/foo/bar')->get('baz')
// should call -> http://foo.com/foo/baz
// but now     -> http://foo.com/foo/bar/baz
// same as Http::baseUrl('http://foo.com/foo/bar')->get('/baz')
```

:bulb: **Solution**

If it is set, pass the `PendingRequest:baseUrl` into the options for the Guzzle client and delegate to it the resolution of the final URI . If the `base_uri` is explicitly set in the `$options` for a request, this takes precedence over the `PendingRequest:baseUrl`. By doing this, we also have support for `idn_conversion` and the addition of the schema if it's missing thanks to [Guzzle's Client::buildUrl(...)](https://github.com/guzzle/guzzle/blob/429cb6702659329819fb40c9487eac3132bdd80b/src/Client.php#L212-L224)

This is the table taken from [Guzzle doc](https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client) :

| baseUri | URI  | Expected by RFC| Current result | Compliant |
| --- | --- | --- | --- | --- |
| http://foo.com |	/bar  |	http://foo.com/bar|	http://foo.com/bar |:heavy_check_mark: |
| http://foo.com/foo |	/bar  |	http://foo.com/bar|	 http://foo.com/foo/bar | :x:  |
| http://foo.com/foo |	bar |	http://foo.com/bar|	http://foo.com/foo/bar  | :x:  |
| http://foo.com/foo/ |	bar |	http://foo.com/foo/bar|	http://foo.com/foo/bar  |:heavy_check_mark: |
| http://foo.com/ |	http://baz.com/  |	http://baz.com/|	http://baz.com/ | :heavy_check_mark: |
| http://foo.com/?bar |	bar   |	   http://foo.com/bar|	http://foo.com/?bar/bar | :x:  |

:green_circle: Adopting an RFC and having consistency with the underlying Guzzle client, I think, will help future developers.

:bangbang: This introduces **breaking changes** potentially affecting all those who have _incorrectly_ used the baseUri/URI combination. 
For this reason, I have targeted the PR to master and not to 11.x or 10.x, but if it can considered a bugfix I'm happy to cherry-pick this commit.
