### PR TITLE
[11.x] Replace while loop with array_walk

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1151,13 +1151,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     protected function fireAppCallbacks(array &$callbacks)
     {
-        $index = 0;
-
-        while ($index < count($callbacks)) {
-            $callbacks[$index]($this);
-
-            $index++;
-        }
+        array_walk(
+            $callbacks, fn($callback) => $callback($this)
+        );
     }
 
     /**
@@ -1409,13 +1405,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function terminate()
     {
-        $index = 0;
-
-        while ($index < count($this->terminatingCallbacks)) {
-            $this->call($this->terminatingCallbacks[$index]);
-
-            $index++;
-        }
+        array_walk(
+            $this->terminatingCallbacks, fn ($callback) => $this->call($callback)
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1152,7 +1152,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected function fireAppCallbacks(array &$callbacks)
     {
         array_walk(
-            $callbacks, fn($callback) => $callback($this)
+            $callbacks, fn ($callback) => $callback($this)
         );
     }
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -104,13 +104,9 @@ abstract class ServiceProvider
      */
     public function callBootingCallbacks()
     {
-        $index = 0;
-
-        while ($index < count($this->bootingCallbacks)) {
-            $this->app->call($this->bootingCallbacks[$index]);
-
-            $index++;
-        }
+        array_walk(
+            $this->bootingCallbacks, fn ($callback) => $this->app->call($callback)
+        );
     }
 
     /**
@@ -120,13 +116,9 @@ abstract class ServiceProvider
      */
     public function callBootedCallbacks()
     {
-        $index = 0;
-
-        while ($index < count($this->bootedCallbacks)) {
-            $this->app->call($this->bootedCallbacks[$index]);
-
-            $index++;
-        }
+        array_walk(
+            $this->bootedCallbacks, fn($callback) => $this->app->call($callback)
+        );
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -117,7 +117,7 @@ abstract class ServiceProvider
     public function callBootedCallbacks()
     {
         array_walk(
-            $this->bootedCallbacks, fn($callback) => $this->app->call($callback)
+            $this->bootedCallbacks, fn ($callback) => $this->app->call($callback)
         );
     }
 

--- a/tests/Support/ServiceProviderTest.php
+++ b/tests/Support/ServiceProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+use PHPUnit\Framework\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    public function testItFiresBootingCallbacksSequentially ()
+    {
+        $provider = new StuffServiceProvider(
+            new Application()
+        );
+
+        $values = [];
+
+        $provider->booting(function () use (&$values) {
+            $values[] = 1;
+        });
+
+        $provider->booting(function () use (&$values) {
+            $values[] = 2;
+        });
+
+        $provider->booting(function () use (&$values) {
+            $values[] = 3;
+        });
+
+        $provider->callBootingCallbacks();
+
+        $this->assertSame([1, 2, 3], $values);
+    }
+
+    public function testItFiresBootedCallbacksSequentially ()
+    {
+        $provider = new StuffServiceProvider(
+            new Application()
+        );
+
+        $values = [];
+
+        $provider->booted(function () use (&$values) {
+            $values[] = 1;
+        });
+
+        $provider->booted(function () use (&$values) {
+            $values[] = 2;
+        });
+
+        $provider->booted(function () use (&$values) {
+            $values[] = 3;
+        });
+
+        $provider->callBootedCallbacks();
+
+        $this->assertSame([1, 2, 3], $values);
+    }
+}
+
+class StuffServiceProvider extends ServiceProvider
+{
+    //
+}

--- a/tests/Support/ServiceProviderTest.php
+++ b/tests/Support/ServiceProviderTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class ServiceProviderTest extends TestCase
 {
-    public function testItFiresBootingCallbacksSequentially ()
+    public function testItFiresBootingCallbacksSequentially()
     {
         $provider = new StuffServiceProvider(
             new Application()
@@ -33,7 +33,7 @@ class ServiceProviderTest extends TestCase
         $this->assertSame([1, 2, 3], $values);
     }
 
-    public function testItFiresBootedCallbacksSequentially ()
+    public function testItFiresBootedCallbacksSequentially()
     {
         $provider = new StuffServiceProvider(
             new Application()


### PR DESCRIPTION
Inside Foundation\Application and Support\ServiceProvider classes, there is code that executes callbacks sequentially like this:

```php
protected function fireAppCallbacks(array &$callbacks)
{
    $index = 0;

    while ($index < count($callbacks)) { // count function is called on every callback.
        $callbacks[$index]($this);

        $index++;
    }
}
```

The while loop can be replaced with array_walk like code below. Then, no need to initialize and increase $index variable, unnecessary count calls are removed.

```php
protected function fireAppCallbacks(array &$callbacks)
{
    array_walk(
        $callbacks, fn($callback) => $callback($this)
    );
}
```

Plus: I add tests to ensure booting/booted callbacks are executed sequentially.