### PR TITLE
[11.x] Fix altering a table that has a column with `default 0` on SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -272,7 +272,7 @@ class SQLiteGrammar extends Grammar
                             'change' => true,
                             'type' => $column['type_name'],
                             'nullable' => $column['nullable'],
-                            'default' => $column['default'] ? new Expression($column['default']) : null,
+                            'default' => is_null($column['default']) ? null : new Expression($column['default']),
                             'autoIncrement' => $column['auto_increment'],
                             'collation' => $column['collation'],
                             'comment' => $column['comment'],


### PR DESCRIPTION
Fixes #51747 

Modifying a column on a table that has another column with `default 0` was causing the default expression to be dropped, this PR fixes that.

This happens only when the table has a column with `default 0` as `->default(new Expression('0'))` and not `->default(0)` that compiles as `default '0'`.