### PR TITLE
[11.x] Container shares fixed values/initialized instances instead of singleton closure resolutions

### DIFF
--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -43,9 +43,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
 
-        $this->container->singleton(Registrar::class, function () {
-            return $this->router;
-        });
+        $this->container->instance(Registrar::class, $this->router);
     }
 
     protected function tearDown(): void
@@ -318,14 +316,8 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $request = m::mock(Request::class);
 
-        $nextParam = null;
-
-        $next = function ($param) use (&$nextParam) {
-            $nextParam = $param;
-        };
-
         (new Authorize($this->gate()))
-            ->handle($request, $next, 'success', $instance);
+            ->handle($request, function () {}, 'success', $instance);
     }
 
     /**

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -316,8 +316,12 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $request = m::mock(Request::class);
 
+        $next = function () {
+            //
+        };
+
         (new Authorize($this->gate()))
-            ->handle($request, function () {}, 'success', $instance);
+            ->handle($request, $next, 'success', $instance);
     }
 
     /**

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -212,7 +212,7 @@ class PruneCommandTest extends TestCase
         });
         $dispatcher->shouldReceive('forget')->once()->with(ModelsPruned::class);
 
-        Application::getInstance()->singleton(DispatcherContract::class, fn () => $dispatcher);
+        Application::getInstance()->instance(DispatcherContract::class, $dispatcher);
 
         $this->artisan(['--model' => PrunableTestModelWithPrunableRecords::class]);
     }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -23,11 +23,7 @@ class HandleExceptionsTest extends TestCase
     {
         $this->app = m::mock(Application::setInstance(new Application));
 
-        $this->config = new Config();
-
-        $this->app->singleton('config', function () {
-            return $this->config;
-        });
+        $this->app->instance('config', $this->config = new Config());
     }
 
     protected function handleExceptions()

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -48,9 +48,7 @@ class RouteListCommandTest extends TestCase
 
         $kernel->prependToMiddlewarePriority('Middleware 5');
 
-        $laravel->singleton(Kernel::class, function () use ($kernel) {
-            return $kernel;
-        });
+        $laravel->instance(Kernel::class, $kernel);
 
         $router->get('/example', function () {
             return 'Hello World';

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -66,9 +66,7 @@ class MailableQueuedTest extends TestCase
         $filesystemFactory = $this->getMockBuilder(FilesystemManager::class)
             ->setConstructorArgs([$app])
             ->getMock();
-        $container->singleton('filesystem', function () use ($filesystemFactory) {
-            return $filesystemFactory;
-        });
+        $container->instance('filesystem', $filesystemFactory);
         $queueFake = new QueueFake($app);
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -492,9 +492,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
 
         $container->bind(RoutingTestUserModel::class, function () {
         });
@@ -1099,9 +1097,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
         $container->bind(RouteModelInterface::class, RouteModelBindingStub::class);
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
@@ -1598,9 +1594,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $router->get('foo/bar', function () {
             return '';
         });
@@ -1634,9 +1628,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router($events = new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
         $router->get('foo/bar', function () {
             return '';
@@ -1988,9 +1980,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
 
         $container->bind(RoutingTestUserModel::class, RoutingTestExtendedUserModel::class);
@@ -2067,17 +2057,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
-            return $request;
-        });
+        $container->instance(Request::class, $request);
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
-            return $urlGenerator;
-        });
+        $container->instance(UrlGenerator::class, $urlGenerator);
         $router->get('contact_us', function () {
             throw new Exception('Route should not be reachable.');
         });
@@ -2092,17 +2076,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
-            return $request;
-        });
+        $container->instance(Request::class, $request);
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
-            return $urlGenerator;
-        });
+        $container->instance(UrlGenerator::class, $urlGenerator);
         $router->get('contact_us', function () {
             throw new Exception('Route should not be reachable.');
         });
@@ -2117,17 +2095,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
-            return $request;
-        });
+        $container->instance(Request::class, $request);
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
-            return $urlGenerator;
-        });
+        $container->instance(UrlGenerator::class, $urlGenerator);
         $router->get('contact_us', function () {
             throw new Exception('Route should not be reachable.');
         });
@@ -2145,17 +2117,11 @@ class RoutingRouteTest extends TestCase
 
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $request = Request::create('users', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
-            return $request;
-        });
+        $container->instance(Request::class, $request);
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
-            return $urlGenerator;
-        });
+        $container->instance(UrlGenerator::class, $urlGenerator);
         $router->get('users', function () {
             throw new Exception('Route should not be reachable.');
         });
@@ -2168,17 +2134,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
-            return $request;
-        });
+        $container->instance(Request::class, $request);
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
-            return $urlGenerator;
-        });
+        $container->instance(UrlGenerator::class, $urlGenerator);
         $router->get('contact_us', function () {
             throw new Exception('Route should not be reachable.');
         });
@@ -2193,17 +2153,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
-            return $request;
-        });
+        $container->instance(Request::class, $request);
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
-            return $urlGenerator;
-        });
+        $container->instance(UrlGenerator::class, $urlGenerator);
         $router->get('contact_us', function () {
             throw new Exception('Route should not be reachable.');
         });
@@ -2272,9 +2226,7 @@ class RoutingRouteTest extends TestCase
 
         $router = new Router($container->make(Dispatcher::class), $container);
 
-        $container->singleton(Registrar::class, function () use ($router) {
-            return $router;
-        });
+        $container->instance(Registrar::class, $router);
 
         $container->bind(ControllerDispatcherContract::class, fn ($app) => new ControllerDispatcher($app));
         $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2199,9 +2199,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton('encrypter', function () use ($encrypter) {
-            return $encrypter;
-        });
+        $container->instance('encrypter', $encrypter);
 
         $cookieName = 'cookie-name';
         $cookieValue = 'cookie-value';
@@ -2442,9 +2440,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton('encrypter', function () use ($encrypter) {
-            return $encrypter;
-        });
+        $container->instance('encrypter', $encrypter);
 
         $cookieName = 'cookie-name';
         $cookieValue = 'cookie-value';

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -60,9 +60,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
             throw new Exception('The fluent object has been successfully handled!');
         });
 
-        app()->singleton('blade.compiler', function () {
-            return $this->compiler;
-        });
+        app()->instance('blade.compiler', $this->compiler);
 
         $exampleObject = new Fluent();
 
@@ -84,9 +82,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     {
         $this->compiler->stringable('iterable', $closure);
 
-        app()->singleton('blade.compiler', function () {
-            return $this->compiler;
-        });
+        app()->instance('blade.compiler', $this->compiler);
 
         ob_start();
         eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
@@ -108,9 +104,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     #[DataProvider('nonStringableDataProvider')]
     public function testHandlerWorksWithNonStringables($blade, $expectedOutput)
     {
-        app()->singleton('blade.compiler', function () {
-            return $this->compiler;
-        });
+        app()->instance('blade.compiler', $this->compiler);
 
         ob_start();
         eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));


### PR DESCRIPTION
Inside tests, there are a few fixed values/initialized instances that can be shared instead of being resolved via callbacks. Eg:

```php
$this->container->singleton(Registrar::class, function () {
    return $this->router;
});

// container->make() will return same instance like the code above.
$this->container->instance(Registrar::class, $this->router);
```