### PR TITLE
[11.x] Fix nested rules custom attribute names

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -285,7 +285,7 @@ trait FormatsMessages
             }
         }
 
-        // If no attribute is found using the expected attributes, loop through the 
+        // If no attribute is found using the expected attributes, loop through the
         // list of custom attributes and look for attributes with wildcards. Return
         // the first value that matches the custom attribute's pattern.
         foreach ($this->customAttributes as $key => $value) {

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -332,6 +332,7 @@ trait FormatsMessages
     protected function getAttributeFromTranslations($name)
     {
         $translations = Arr::dot((array) $this->translator->get('validation.attributes'));
+        
         return $this->getAttributeFromLocalArray($name, $translations);
     }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -298,6 +298,19 @@ trait FormatsMessages
     }
 
     /**
+     * Get the given attribute from the attribute translations.
+     *
+     * @param  string  $name
+     * @return string|null
+     */
+    protected function getAttributeFromTranslations($name)
+    {
+        return $this->getAttributeFromLocalArray(
+            $name, Arr::dot((array) $this->translator->get('validation.attributes'))
+        );
+    }
+
+    /**
      * Get the custom name for an attribute if it exists in the given array.
      *
      * @param  string  $attribute
@@ -321,19 +334,6 @@ trait FormatsMessages
                 }
             }
         }
-    }
-
-    /**
-     * Get the given attribute from the attribute translations.
-     *
-     * @param  string  $name
-     * @return string|null
-     */
-    protected function getAttributeFromTranslations($name)
-    {
-        $translations = Arr::dot((array) $this->translator->get('validation.attributes'));
-
-        return $this->getAttributeFromLocalArray($name, $translations);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -285,9 +285,9 @@ trait FormatsMessages
             }
         }
 
-        // If no attribute is found using the expected attributes, loop through the
-        // list of custom attributes and look for attributes with wildcards. Return
-        // the first value that matches the custom attribute's pattern.
+        // If no custom attribute is found using the expected attributes, loop through the
+        // list of custom attributes and look for attribute keys with wildcards. Return
+        // the first value that matches the custom attribute key's pattern.
         foreach ($this->customAttributes as $key => $value) {
             if (Str::contains($key, '*') && Str::is($key, $attribute)) {
                 return $value;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -273,7 +273,7 @@ trait FormatsMessages
             // The developer may dynamically specify the array of custom attributes on this
             // validator instance. If the attribute exists in this array it is used over
             // the other ways of pulling the attribute name for this given attributes.
-            if($inlineAttribute = $this->getAttributeFromLocalArray($name)) {
+            if ($inlineAttribute = $this->getAttributeFromLocalArray($name)) {
                 return $inlineAttribute;
             }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -273,24 +273,15 @@ trait FormatsMessages
             // The developer may dynamically specify the array of custom attributes on this
             // validator instance. If the attribute exists in this array it is used over
             // the other ways of pulling the attribute name for this given attributes.
-            if (isset($this->customAttributes[$name])) {
-                return $this->customAttributes[$name];
+            if($inlineAttribute = $this->getAttributeFromLocalArray($name)) {
+                return $inlineAttribute;
             }
 
             // We allow for a developer to specify language lines for any attribute in this
             // application, which allows flexibility for displaying a unique displayable
             // version of the attribute name instead of the name used in an HTTP POST.
-            if ($line = $this->getAttributeFromTranslations($name)) {
-                return $line;
-            }
-        }
-
-        // If no custom attribute is found using the expected attributes, loop through the
-        // list of custom attributes and look for attribute keys with wildcards. Return
-        // the first value that matches the custom attribute key's pattern.
-        foreach ($this->customAttributes as $key => $value) {
-            if (Str::contains($key, '*') && Str::is($key, $attribute)) {
-                return $value;
+            if ($translatedAttribute = $this->getAttributeFromTranslations($name)) {
+                return $translatedAttribute;
             }
         }
 
@@ -307,14 +298,41 @@ trait FormatsMessages
     }
 
     /**
+     * Get the custom name for an attribute if it exists in the given array.
+     *
+     * @param  string  $attribute
+     * @param  array|null  $source
+     * @return string|null
+     */
+    protected function getAttributeFromLocalArray($attribute, $source = null)
+    {
+        $source = $source ?: $this->customAttributes;
+
+        if (isset($source[$attribute])) {
+            return $source[$attribute];
+        }
+
+        foreach (array_keys($source) as $sourceKey) {
+            if (str_contains($sourceKey, '*')) {
+                $pattern = str_replace('\*', '([^.]*)', preg_quote($sourceKey, '#'));
+
+                if (preg_match('#^'.$pattern.'\z#u', $attribute) === 1) {
+                    return $source[$sourceKey];
+                }
+            }
+        }
+    }
+
+    /**
      * Get the given attribute from the attribute translations.
      *
      * @param  string  $name
-     * @return string
+     * @return string|null
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->get('validation.attributes'), $name);
+        $translations = Arr::dot((array) $this->translator->get('validation.attributes'));
+        return $this->getAttributeFromLocalArray($name, $translations);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -285,6 +285,15 @@ trait FormatsMessages
             }
         }
 
+        // If no attribute is found using the expected attributes, loop through the 
+        // list of custom attributes and look for attributes with wildcards. Return
+        // the first value that matches the custom attribute's pattern.
+        foreach ($this->customAttributes as $key => $value) {
+            if (Str::contains($key, '*') && Str::is($key, $attribute)) {
+                return $value;
+            }
+        }
+
         // When no language line has been specified for the attribute and it is also
         // an implicit attribute we will display the raw attribute's name and not
         // modify it with any of these replacements before we display the name.

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -332,7 +332,7 @@ trait FormatsMessages
     protected function getAttributeFromTranslations($name)
     {
         $translations = Arr::dot((array) $this->translator->get('validation.attributes'));
-        
+
         return $this->getAttributeFromLocalArray($name, $translations);
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Stringable;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\DatabasePresenceVerifierInterface;
+use Illuminate\Validation\Rule as ValidationRule;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\Unique;
@@ -556,6 +557,16 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['names' => [null, 'name']], ['names.*' => 'Required']);
         $v->messages()->setFormat(':message');
         $this->assertSame('First name is required!', $v->messages()->first('names.0'));
+    }
+
+    public function testAttributeNamesAreReplacedInArraysFromNestedRules()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
+        $v = new Validator($trans, ['users' => [['name' => 'Taylor']]], ['users.*' => ValidationRule::forEach(fn () => ['id' => 'required'])], [], ['users.*' => 'User ID']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('User ID is required!', $v->messages()->first('users.0.id'));
     }
 
     public function testInputIsReplaced()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -564,11 +564,11 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $v = new Validator($trans, [
-            'users' => [['name' => 'Taylor']]
+            'users' => [['name' => 'Taylor']],
         ], [
-            'users.*' => ValidationRule::forEach(fn () => ['id' => 'required'])
+            'users.*' => ValidationRule::forEach(fn () => ['id' => 'required']),
         ], [], [
-            'users.*.id' => 'User ID'
+            'users.*.id' => 'User ID',
         ]);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -583,9 +583,9 @@ class ValidationValidatorTest extends TestCase
             'validation.attributes' => ['users.*.id' => 'User ID'],
         ], 'en');
         $v = new Validator($trans, [
-            'users' => [['name' => 'Taylor']]
+            'users' => [['name' => 'Taylor']],
         ], [
-            'users.*' => ValidationRule::forEach(fn () => ['id' => 'required'])
+            'users.*' => ValidationRule::forEach(fn () => ['id' => 'required']),
         ]);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');


### PR DESCRIPTION
## Updated PR
Reopening previously closed PR #51785 — now with tests and refactored to support the same functionality in both inline custom attributes and translated custom attributes. A new common method `getAttributeFromLocalArray` is used to ensure equivalent functionality when pulling from either source. This PR has been crafted to match the existing functionality of custom messages where applicable as I believe this is the expected developer experience.

Check [these action results](https://github.com/owenandrews/laravel-framework/actions/runs/9510170795/job/26214224628?pr=1#step:9:203) to see these tests failing against the current 11.x branch.

## Original PR
Resolves an issue where wildcard custom attributes aren't matched when using NestedRules. See issue #51784.

The underlying cause of this issue is that NestedRules doesn't correctly generate the relevant `implicitAttributes`, meaning custom attributes cannot be connected with their explicit attributes. There doesn't seem to be a good way to fix this underlying problem without major refactoring and breaking changes.

This PR resolves this issue by iterating over the custom attributes and pattern matching their keys with the given attribute. This is consistent with the way custom messages are already resolved and therefore has some precedence.