### PR TITLE
Add new test for InvalidArgumentException in databaseSeederTest

### DIFF
--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -5,11 +5,11 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
 use Illuminate\Database\Seeder;
+use InvalidArgumentException;
 use Mockery as m;
 use Mockery\Mock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
-use InvalidArgumentException;
 
 class TestSeeder extends Seeder
 {

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 use Mockery\Mock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
+use InvalidArgumentException;
 
 class TestSeeder extends Seeder
 {
@@ -24,6 +25,10 @@ class TestDepsSeeder extends Seeder
     {
         //
     }
+}
+
+class TestDepsWithoutRunSeeder extends Seeder
+{
 }
 
 class DatabaseSeederTest extends TestCase
@@ -88,5 +93,16 @@ class DatabaseSeederTest extends TestCase
         $seeder->__invoke(['test1', 'test2']);
 
         $container->shouldHaveReceived('call')->once()->with([$seeder, 'run'], ['test1', 'test2']);
+    }
+
+    public function testInvalidArgumentException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+
+        $seeder = new TestDepsWithoutRunSeeder;
+        $seeder->setContainer($container);
+        $seeder->__invoke(['test1', 'test2']);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`DatabaseSeederTest` needed a test to check the existence of the `run` method in the seeder class.