### PR TITLE
[11.x] Support third-party relations in `model:show` command

### DIFF
--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionNamedType;
 use SplFileObject;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -196,8 +197,14 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 fn (ReflectionMethod $method) => $method->isStatic()
                     || $method->isAbstract()
                     || $method->getDeclaringClass()->getName() === Model::class
+                    || $method->getNumberOfParameters() > 0
             )
             ->filter(function (ReflectionMethod $method) {
+                if ($method->getReturnType() instanceof ReflectionNamedType
+                    && is_subclass_of($method->getReturnType()->getName(), Relation::class)) {
+                    return true;
+                }
+
                 $file = new SplFileObject($method->getFileName());
                 $file->seek($method->getStartLine() - 1);
                 $code = '';


### PR DESCRIPTION
The `model:show` command finds a model's relations by analyzing the code of its methods and looking for `$this->hasMany(` etc. This doesn't detect third-party relations (like [`eloquent-has-many-deep`](https://github.com/staudenmeir/eloquent-has-many-deep)). We could build a whole system for packages to hook into, but that would be overkill, IMO.

Instead, we can check the method's return type and see if it's a subclass of the base `Relation` class. Not everybody uses return types, but I hope that most do nowadays.

I also added a check to skip methods with parameters. That's necessary to ignore some internal methods of third-party packages. Since relations shouldn't have parameters, I don't consider this a breaking change.

The command doesn't have any tests.