### PR TITLE
[11.x] Add `Relation::getMorphAlias()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -502,6 +502,23 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Get the alias associated with a custom polymorphic class.
+     *
+     * @param  string  $className
+     * @return int|string|null
+     */
+    public static function getMorphAlias(string $className)
+    {
+        foreach (static::$morphMap as $alias => $morphedClass) {
+            if ($morphedClass === $className) {
+                return $alias;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -509,13 +509,7 @@ abstract class Relation implements BuilderContract
      */
     public static function getMorphAlias(string $className)
     {
-        foreach (static::$morphMap as $alias => $morphedClass) {
-            if ($morphedClass === $className) {
-                return $alias;
-            }
-        }
-
-        return null;
+        return array_flip(static::$morphMap)[$className] ?? null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -235,6 +235,14 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
+    public function testGetMorphAlias()
+    {
+        Relation::morphMap(['user' => 'App\User']);
+
+        $this->assertEquals('user', Relation::getMorphAlias('App\User'));
+        $this->assertNull(Relation::getMorphAlias('Does\Not\Exist'));
+    }
+
     public function testWithoutRelations()
     {
         $original = new EloquentNoTouchingModelStub;


### PR DESCRIPTION
Since there is a `Relation::getMorphedModel()` I think it would be beneficial to add the reverse `getMorphAlias`.

This addition is particularly beneficial for testing, as it simplifies assertions with ﻿$this->assertDatabaseHas. Developers no longer need to recall the morph alias used:

```php
$this->assertDatabaseHas('taskables', [
   'taskable_type' => Relation::getMorphAlias(Document::class),
   'taskable_id' => $mitigation->id,
   'task_id' => $taskB->id
]);
```

A similar PR with a broader scope was previously submitted:
https://github.com/laravel/framework/pull/43487