### PR TITLE
[11.x] Fix typo in `VendorPublishCommand`

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -394,7 +394,7 @@ class VendorPublishCommand extends Command
     }
 
     /**
-     * Intruct the command to not update the dates on migrations when publishing.
+     * Instruct the command to not update the dates on migrations when publishing.
      *
      * @return void
      */


### PR DESCRIPTION
Fixes `Intruct` -> `Instruct`