### PR TITLE
[11.x] Improve Queue::assertNothingPushed() error message

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -303,7 +303,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         $pushedJobs = implode("\n- ", array_keys($this->jobs));
 
-        PHPUnit::assertEmpty($this->jobs, "The following jobs were pushed unexpectedly:\n- $pushedJobs\n");
+        PHPUnit::assertEmpty($this->jobs, "The following jobs were pushed unexpectedly:\n\n- $pushedJobs\n");
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -301,7 +301,9 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function assertNothingPushed()
     {
-        PHPUnit::assertEmpty($this->jobs, 'Jobs were pushed unexpectedly.');
+        $pushedJobs = implode("\n- ", array_keys($this->jobs));
+
+        PHPUnit::assertEmpty($this->jobs, "The following jobs were pushed unexpectedly:\n- $pushedJobs\n");
     }
 
     /**

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Application;
+use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
@@ -194,11 +195,17 @@ class SupportTestingQueueFakeTest extends TestCase
 
         $this->fake->push($this->job);
 
+        $this->fake->push(function () {
+            //
+        });
+
         try {
             $this->fake->assertNothingPushed();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('Jobs were pushed unexpectedly.', $e->getMessage());
+            $this->assertStringContainsString('The following jobs were pushed unexpectedly', $e->getMessage());
+            $this->assertStringContainsString(get_class($this->job), $e->getMessage());
+            $this->assertStringContainsString(CallQueuedClosure::class, $e->getMessage());
         }
     }
 


### PR DESCRIPTION
`Queue::assertNothingPushed()` currently doesn't show a useful message when the assertion fails:

<img width="658" alt="image" src="https://github.com/laravel/framework/assets/7202674/d33c9863-e971-4b9e-829f-0484333e07fb">



This PR makes `Queue::assertNothingPushed()` show the names of the jobs that were unexpectedly pushed:

<img width="658" alt="image" src="https://github.com/laravel/framework/assets/7202674/0f9f9492-d608-46b6-842e-d82a26cd01ce">
