### PR TITLE
[11.x] Add unprocessableContent and update unprocessableEntity

### DIFF
--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -146,13 +146,23 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response was a 422 "Unprocessable Content" response.
+     *
+     * @return bool
+     */
+    public function unprocessableContent()
+    {
+        return $this->status() === 422;
+    }
+
+    /**
      * Determine if the response was a 422 "Unprocessable Entity" response.
      *
      * @return bool
      */
     public function unprocessableEntity()
     {
-        return $this->status() === 422;
+        return $this->unprocessableContent();
     }
 
     /**

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -156,7 +156,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a 422 "Unprocessable Entity" response.
+     * Determine if the response was a 422 "Unprocessable Content" response.
      *
      * @return bool
      */

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -212,7 +212,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a 422 "Unprocessable Entity" status code.
+     * Assert that the response has a 422 "Unprocessable Content" status code.
      *
      * @return $this
      */

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -206,6 +206,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->conflict());
     }
 
+    public function testUnprocessableContentRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_UNPROCESSABLE_ENTITY),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->unprocessableContent());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->unprocessableContent());
+    }
+
     public function testUnprocessableEntityRequest()
     {
         $this->factory->fake([


### PR DESCRIPTION
I know you've mentioned on other PRs that you aren't accepting more of these status helpers, but this is a little different because it reflects a change made to HTTP.

It appears that [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-422-unprocessable-content) from June 2022 renamed HTTP 422 from `Unprocessable Entity` to `Unprocessable Content`, and this change is also [reflected in the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422).

For this reason I've added `unprocessableContent` as a new status helper and updated `unprocessableEntity` to point it.

---

Another option you might prefer (for consistency) is to instead add just `unprocessable`. The reason for this is that it would match [`assertUnprocessable`](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php#L219). Happy to update the PR if you'd prefer that.