### PR TITLE
[12.x] feat: configure default datetime precision on per-grammar basis

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -17,6 +17,16 @@ class Blueprint
     use Macroable;
 
     /**
+     * The database connection instance.
+     */
+    protected Connection $connection;
+
+    /**
+     * The schema grammar instance.
+     */
+    protected Grammar $grammar;
+
+    /**
      * The table the blueprint describes.
      *
      * @var string
@@ -94,8 +104,10 @@ class Blueprint
      * @param  string  $prefix
      * @return void
      */
-    public function __construct($table, ?Closure $callback = null, $prefix = '')
+    public function __construct(Connection $connection, $table, ?Closure $callback = null, $prefix = '')
     {
+        $this->connection = $connection;
+        $this->grammar = $connection->getSchemaGrammar();
         $this->table = $table;
         $this->prefix = $prefix;
 
@@ -107,34 +119,30 @@ class Blueprint
     /**
      * Execute the blueprint against the database.
      *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    public function build(Connection $connection, Grammar $grammar)
+    public function build()
     {
-        foreach ($this->toSql($connection, $grammar) as $statement) {
-            $connection->statement($statement);
+        foreach ($this->toSql() as $statement) {
+            $this->connection->statement($statement);
         }
     }
 
     /**
      * Get the raw SQL statements for the blueprint.
      *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return array
      */
-    public function toSql(Connection $connection, Grammar $grammar)
+    public function toSql()
     {
-        $this->addImpliedCommands($connection, $grammar);
+        $this->addImpliedCommands();
 
         $statements = [];
 
         // Each type of command has a corresponding compiler function on the schema
         // grammar which is used to build the necessary SQL statements to build
         // the blueprint element, so we'll just call that compilers function.
-        $this->ensureCommandsAreValid($connection);
+        $this->ensureCommandsAreValid();
 
         foreach ($this->commands as $command) {
             if ($command->shouldBeSkipped) {
@@ -143,12 +151,12 @@ class Blueprint
 
             $method = 'compile'.ucfirst($command->name);
 
-            if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
+            if (method_exists($this->grammar, $method) || $this->grammar::hasMacro($method)) {
                 if ($this->hasState()) {
                     $this->state->update($command);
                 }
 
-                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
+                if (! is_null($sql = $this->grammar->$method($this, $command, $this->connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }
@@ -160,12 +168,11 @@ class Blueprint
     /**
      * Ensure the commands on the blueprint are valid for the connection type.
      *
-     * @param  \Illuminate\Database\Connection  $connection
      * @return void
      *
      * @throws \BadMethodCallException
      */
-    protected function ensureCommandsAreValid(Connection $connection)
+    protected function ensureCommandsAreValid()
     {
         //
     }
@@ -188,15 +195,12 @@ class Blueprint
     /**
      * Add the commands that are implied by the blueprint's state.
      *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    protected function addImpliedCommands(Connection $connection, Grammar $grammar)
+    protected function addImpliedCommands()
     {
-        $this->addFluentIndexes($connection, $grammar);
-
-        $this->addFluentCommands($connection, $grammar);
+        $this->addFluentIndexes();
+        $this->addFluentCommands();
 
         if (! $this->creating()) {
             $this->commands = array_map(
@@ -206,25 +210,23 @@ class Blueprint
                 $this->commands
             );
 
-            $this->addAlterCommands($connection, $grammar);
+            $this->addAlterCommands();
         }
     }
 
     /**
      * Add the index commands fluently specified on columns.
      *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    protected function addFluentIndexes(Connection $connection, Grammar $grammar)
+    protected function addFluentIndexes()
     {
         foreach ($this->columns as $column) {
             foreach (['primary', 'unique', 'index', 'fulltext', 'fullText', 'spatialIndex'] as $index) {
                 // If the column is supposed to be changed to an auto increment column and
                 // the specified index is primary, there is no need to add a command on
                 // MySQL, as it will be handled during the column definition instead.
-                if ($index === 'primary' && $column->autoIncrement && $column->change && $grammar instanceof MySqlGrammar) {
+                if ($index === 'primary' && $column->autoIncrement && $column->change && $this->grammar instanceof MySqlGrammar) {
                     continue 2;
                 }
 
@@ -264,14 +266,12 @@ class Blueprint
     /**
      * Add the fluent commands specified on any columns.
      *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    public function addFluentCommands(Connection $connection, Grammar $grammar)
+    public function addFluentCommands()
     {
         foreach ($this->columns as $column) {
-            foreach ($grammar->getFluentCommands() as $commandName) {
+            foreach ($this->grammar->getFluentCommands() as $commandName) {
                 $this->addCommand($commandName, compact('column'));
             }
         }
@@ -280,17 +280,15 @@ class Blueprint
     /**
      * Add the alter commands if whenever needed.
      *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    public function addAlterCommands(Connection $connection, Grammar $grammar)
+    public function addAlterCommands()
     {
-        if (! $grammar instanceof SQLiteGrammar) {
+        if (! $this->grammar instanceof SQLiteGrammar) {
             return;
         }
 
-        $alterCommands = $grammar->getAlterCommands($connection);
+        $alterCommands = $this->grammar->getAlterCommands($this->connection);
 
         [$commands, $lastCommandWasAlter, $hasAlterCommand] = [
             [], false, false,
@@ -313,7 +311,7 @@ class Blueprint
         }
 
         if ($hasAlterCommand) {
-            $this->state = new BlueprintState($this, $connection, $grammar);
+            $this->state = new BlueprintState($this, $this->connection, $this->grammar);
         }
 
         $this->commands = $commands;
@@ -1162,8 +1160,10 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function dateTime($column, $precision = 0)
+    public function dateTime($column, $precision = null)
     {
+        $precision ??= $this->defaultTimePrecision();
+
         return $this->addColumn('dateTime', $column, compact('precision'));
     }
 
@@ -1174,8 +1174,10 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function dateTimeTz($column, $precision = 0)
+    public function dateTimeTz($column, $precision = null)
     {
+        $precision ??= $this->defaultTimePrecision();
+
         return $this->addColumn('dateTimeTz', $column, compact('precision'));
     }
 
@@ -1186,8 +1188,10 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function time($column, $precision = 0)
+    public function time($column, $precision = null)
     {
+        $precision ??= $this->defaultTimePrecision();
+
         return $this->addColumn('time', $column, compact('precision'));
     }
 
@@ -1198,8 +1202,10 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function timeTz($column, $precision = 0)
+    public function timeTz($column, $precision = null)
     {
+        $precision ??= $this->defaultTimePrecision();
+
         return $this->addColumn('timeTz', $column, compact('precision'));
     }
 
@@ -1210,8 +1216,10 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function timestamp($column, $precision = 0)
+    public function timestamp($column, $precision = null)
     {
+        $precision ??= $this->defaultTimePrecision();
+
         return $this->addColumn('timestamp', $column, compact('precision'));
     }
 
@@ -1222,8 +1230,10 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function timestampTz($column, $precision = 0)
+    public function timestampTz($column, $precision = null)
     {
+        $precision ??= $this->defaultTimePrecision();
+
         return $this->addColumn('timestampTz', $column, compact('precision'));
     }
 
@@ -1233,7 +1243,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function timestamps($precision = 0)
+    public function timestamps($precision = null)
     {
         $this->timestamp('created_at', $precision)->nullable();
 
@@ -1248,7 +1258,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function nullableTimestamps($precision = 0)
+    public function nullableTimestamps($precision = null)
     {
         $this->timestamps($precision);
     }
@@ -1259,7 +1269,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function timestampsTz($precision = 0)
+    public function timestampsTz($precision = null)
     {
         $this->timestampTz('created_at', $precision)->nullable();
 
@@ -1272,7 +1282,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return void
      */
-    public function datetimes($precision = 0)
+    public function datetimes($precision = null)
     {
         $this->datetime('created_at', $precision)->nullable();
 
@@ -1286,7 +1296,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletes($column = 'deleted_at', $precision = 0)
+    public function softDeletes($column = 'deleted_at', $precision = null)
     {
         return $this->timestamp($column, $precision)->nullable();
     }
@@ -1298,7 +1308,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletesTz($column = 'deleted_at', $precision = 0)
+    public function softDeletesTz($column = 'deleted_at', $precision = null)
     {
         return $this->timestampTz($column, $precision)->nullable();
     }
@@ -1310,7 +1320,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletesDatetime($column = 'deleted_at', $precision = 0)
+    public function softDeletesDatetime($column = 'deleted_at', $precision = null)
     {
         return $this->datetime($column, $precision)->nullable();
     }
@@ -1852,5 +1862,13 @@ class Blueprint
         return array_filter($this->columns, function ($column) {
             return (bool) $column->change;
         });
+    }
+
+    /**
+     * Get the default time precision.
+     */
+    protected function defaultTimePrecision(): ?int
+    {
+        return $this->connection->getSchemaBuilder()::$defaultTimePrecision;
     }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -42,6 +42,11 @@ class Builder
     public static $defaultStringLength = 255;
 
     /**
+     * The default time precision for migrations.
+     */
+    public static ?int $defaultTimePrecision = 0;
+
+    /**
      * The default relationship morph key type.
      *
      * @var string
@@ -69,6 +74,14 @@ class Builder
     public static function defaultStringLength($length)
     {
         static::$defaultStringLength = $length;
+    }
+
+    /**
+     * Set the default time precision for migrations.
+     */
+    public static function defaultTimePrecision(?int $precision): void
+    {
+        static::$defaultTimePrecision = $precision;
     }
 
     /**
@@ -561,7 +574,7 @@ class Builder
      */
     protected function build(Blueprint $blueprint)
     {
-        $blueprint->build($this->connection, $this->grammar);
+        $blueprint->build();
     }
 
     /**
@@ -573,15 +586,15 @@ class Builder
      */
     protected function createBlueprint($table, ?Closure $callback = null)
     {
-        $prefix = $this->connection->getConfig('prefix_indexes')
-                    ? $this->connection->getConfig('prefix')
-                    : '';
+        $connection = $this->connection;
+
+        $prefix = $connection->getConfig('prefix_indexes') ? $connection->getConfig('prefix') : '';
 
         if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $table, $callback, $prefix);
+            return call_user_func($this->resolver, $connection, $table, $callback, $prefix);
         }
 
-        return Container::getInstance()->make(Blueprint::class, compact('table', 'callback', 'prefix'));
+        return Container::getInstance()->make(Blueprint::class, compact('connection', 'table', 'callback', 'prefix'));
     }
 
     /**

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MariaDbGrammar;
+use Illuminate\Database\Schema\MariaDbBuilder;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -20,29 +21,29 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
-        $blueprint = new Blueprint('users');
-        $blueprint->increments('id');
-        $blueprint->string('email');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame([
@@ -50,14 +51,14 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
             'alter table `users` add `email` varchar(255) not null',
         ], $statements);
 
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->uuid('id')->primary();
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->uuid('id')->primary();
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table `users` (`id` uuid not null, primary key (`id`))', $statements[0]);
@@ -65,17 +66,17 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id')->startingValue(1000);
-        $blueprint->string('email');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id')->startingValue(1000);
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
@@ -84,10 +85,10 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddColumnsWithMultipleAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id()->from(100);
         $blueprint->string('name')->from(200);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertEquals([
             'alter table `users` add `id` bigint unsigned not null auto_increment primary key',
@@ -98,32 +99,32 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testEngineCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->engine('InnoDB');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
-        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email');
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn('InnoDB');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
@@ -131,32 +132,32 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testCharsetCollationCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->charset('utf8mb4');
         $blueprint->collation('utf8mb4_unicode_ci');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci'", $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email')->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email')->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
@@ -164,17 +165,18 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTableWithPrefix()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email');
         $grammar = $this->getGrammar();
         $grammar->setTablePrefix('prefix_');
 
-        $conn = $this->getConnection();
+        $conn = $this->getConnection($grammar);
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $grammar);
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
@@ -182,16 +184,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testCreateTemporaryTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->temporary();
         $blueprint->increments('id');
         $blueprint->string('email');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
@@ -199,9 +201,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table `users`', $statements[0]);
@@ -209,9 +211,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table if exists `users`', $statements[0]);
@@ -219,23 +221,23 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `foo`', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
@@ -243,9 +245,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop primary key', $statements[0]);
@@ -253,9 +255,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
@@ -263,9 +265,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
@@ -273,9 +275,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
@@ -283,9 +285,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop foreign key `foo`', $statements[0]);
@@ -293,9 +295,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
@@ -303,9 +305,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
@@ -313,9 +315,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testDropMorphs()
     {
-        $blueprint = new Blueprint('photos');
+        $blueprint = new Blueprint($this->getConnection(), 'photos');
         $blueprint->dropMorphs('imageable');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
@@ -324,9 +326,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('rename table `users` to `foo`', $statements[0]);
@@ -334,9 +336,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testRenameIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->renameIndex('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` rename index `foo` to `bar`', $statements[0]);
@@ -344,9 +346,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add primary key (`foo`)', $statements[0]);
@@ -354,9 +356,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKeyWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add primary key using hash(`foo`)', $statements[0]);
@@ -364,9 +366,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
@@ -374,9 +376,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
@@ -384,9 +386,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingIndexWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
@@ -394,9 +396,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->fulltext('body');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add fulltext `users_body_fulltext`(`body`)', $statements[0]);
@@ -404,9 +406,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
@@ -414,9 +416,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingFluentSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point')->spatialIndex();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
@@ -424,9 +426,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingRawIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rawIndex('(function(column))', 'raw_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `raw_index`((function(column)))', $statements[0]);
@@ -434,23 +436,23 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingForeignKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders')->cascadeOnDelete();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on delete cascade', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders')->cascadeOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on update cascade', $statements[0]);
@@ -458,9 +460,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
@@ -468,9 +470,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
@@ -478,16 +480,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -495,14 +497,14 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingForeignID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignId = $blueprint->foreignId('foo');
         $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
@@ -520,9 +522,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertSame([
             'alter table `users` add `company_id` bigint unsigned not null',
             'alter table `users` add constraint `my_index` foreign key (`company_id`) references `companies` (`id`)',
@@ -531,9 +533,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -541,9 +543,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingColumnInTableFirst()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('name')->first();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `name` varchar(255) not null first', $statements[0]);
@@ -551,9 +553,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingColumnAfterAnotherColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('name')->after('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
@@ -561,13 +563,13 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMultipleColumnsAfterAnotherColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->after('foo', function ($blueprint) {
             $blueprint->string('one');
             $blueprint->string('two');
         });
         $blueprint->string('three');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(3, $statements);
         $this->assertSame([
             'alter table `users` add `one` varchar(255) not null after `foo`',
@@ -578,11 +580,11 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumn()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5');
         $blueprint->integer('discounted_stored')->storedAs('price - 5');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -591,11 +593,11 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
             'alter table `products` add `discounted_stored` int as (price - 5) stored',
         ], $statements);
 
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5')->nullable(false);
         $blueprint->integer('discounted_stored')->storedAs('price - 5')->nullable(false);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -607,11 +609,11 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumnWithCharset()
     {
-        $blueprint = new Blueprint('links');
+        $blueprint = new Blueprint($this->getConnection(), 'links');
         $blueprint->string('url', 2083)->charset('ascii');
         $blueprint->string('url_hash_virtual', 64)->virtualAs('sha2(url, 256)')->charset('ascii');
         $blueprint->string('url_hash_stored', 64)->storedAs('sha2(url, 256)')->charset('ascii');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -623,11 +625,11 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumnByExpression()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs(new Expression('price - 5'));
         $blueprint->integer('discounted_stored')->storedAs(new Expression('price - 5'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -639,9 +641,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingInvisibleColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('secret', 64)->nullable(false)->invisible();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `secret` varchar(64) not null invisible', $statements[0]);
@@ -649,37 +651,37 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default(new Expression('CURRENT TIMESTAMP'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default(Foo::BAR);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
@@ -687,9 +689,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` text not null', $statements[0]);
@@ -697,16 +699,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
@@ -714,16 +716,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
@@ -731,9 +733,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementsWithStartingValues()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id()->startingValue(1000);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -742,16 +744,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` mediumint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
@@ -759,16 +761,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
@@ -776,16 +778,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` tinyint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
@@ -793,9 +795,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` float(5) not null', $statements[0]);
@@ -803,9 +805,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` double not null', $statements[0]);
@@ -813,9 +815,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
@@ -823,9 +825,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
@@ -833,9 +835,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
@@ -843,9 +845,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingSet()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->set('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
@@ -853,9 +855,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
@@ -863,9 +865,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
@@ -873,9 +875,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` date not null', $statements[0]);
@@ -883,201 +885,201 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingYear()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->year('birth_year');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrent()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo')->useCurrent();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithOnUpdateCurrent()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo')->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null on update CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrentAndOnUpdateCurrent()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo')->useCurrent()->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrentOnUpdateCurrentAndPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo', 3)->useCurrent()->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime(3) not null default CURRENT_TIMESTAMP(3) on update CURRENT_TIMESTAMP(3)', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimestampWithDefault()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
     public function testAddingTimestampWithDefaultCurrentSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1)->useCurrent();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null default CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampWithOnUpdateCurrentSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1)->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null on update CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampWithDefaultCurrentAndOnUpdateCurrentSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1)->useCurrent()->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null default CURRENT_TIMESTAMP(1) on update CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTzWithDefault()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
     public function testAddingTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table `users` add `created_at` timestamp null',
@@ -1087,9 +1089,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table `users` add `created_at` timestamp null',
@@ -1099,9 +1101,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingRememberToken()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rememberToken();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
@@ -1109,9 +1111,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
@@ -1119,9 +1121,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` uuid not null', $statements[0]);
@@ -1129,9 +1131,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingUuidDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `uuid` uuid not null', $statements[0]);
@@ -1139,14 +1141,14 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingForeignUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignUuid = $blueprint->foreignUuid('foo');
         $blueprint->foreignUuid('company_id')->constrained();
         $blueprint->foreignUuid('laravel_idea_id')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
         $blueprint->foreignUuid('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
@@ -1164,9 +1166,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(45) not null', $statements[0]);
@@ -1174,9 +1176,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `ip_address` varchar(45) not null', $statements[0]);
@@ -1184,9 +1186,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(17) not null', $statements[0]);
@@ -1194,9 +1196,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `mac_address` varchar(17) not null', $statements[0]);
@@ -1204,9 +1206,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` geometry not null', $statements[0]);
@@ -1214,9 +1216,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingGeography()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geography('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` geometry ref_system_id=4326 not null', $statements[0]);
@@ -1224,9 +1226,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingPoint()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` point not null', $statements[0]);
@@ -1234,9 +1236,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingPointWithSrid()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point', 4326);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` point ref_system_id=4326 not null', $statements[0]);
@@ -1244,9 +1246,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingPointWithSridColumn()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point', 4326)->after('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` point ref_system_id=4326 not null after `id`', $statements[0]);
@@ -1254,9 +1256,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingLineString()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'linestring');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` linestring not null', $statements[0]);
@@ -1264,9 +1266,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingPolygon()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'polygon');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` polygon not null', $statements[0]);
@@ -1274,9 +1276,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingGeometryCollection()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'geometrycollection');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
@@ -1284,9 +1286,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMultiPoint()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multipoint');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
@@ -1294,9 +1296,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMultiLineString()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multilinestring');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
@@ -1304,9 +1306,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingMultiPolygon()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multipolygon');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
@@ -1314,9 +1316,9 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingComment()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo')->comment("Escape ' when using words like it's");
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
@@ -1354,38 +1356,38 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_column');
         $blueprint->string('my_other_column')->virtualAs('my_column');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_column` varchar(255) not null, `my_other_column` varchar(255) as (my_column)) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->virtualAsJson('my_json_column->some_attribute');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\"'))))", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->virtualAsJson('my_json_column->some_attribute->nested');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))))", $statements[0]);
@@ -1393,14 +1395,14 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithVirtualAsColumnWhenJsonColumnHasArrayKey()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"foo\"[0][1]'))))", $statements[0]);
@@ -1413,38 +1415,38 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_column');
         $blueprint->string('my_other_column')->storedAs('my_column');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_column` varchar(255) not null, `my_other_column` varchar(255) as (my_column) stored) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->storedAsJson('my_json_column->some_attribute');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\"'))) stored)", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->storedAsJson('my_json_column->some_attribute->nested');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))) stored)", $statements[0]);
@@ -1493,13 +1495,26 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertTrue($c);
     }
 
-    protected function getConnection()
-    {
-        return m::mock(Connection::class);
+    protected function getConnection(
+        ?MariaDbGrammar $grammar = null,
+        ?MariaDbBuilder $builder = null,
+    ) {
+        $grammar ??= $this->getGrammar();
+        $builder ??= $this->getBuilder();
+
+        return m::mock(Connection::class)
+            ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
+            ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->getMock();
     }
 
     public function getGrammar()
     {
         return new MariaDbGrammar;
+    }
+
+    public function getBuilder()
+    {
+        return mock(MariaDbBuilder::class);
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -20,29 +21,29 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
-        $blueprint = new Blueprint('users');
-        $blueprint->increments('id');
-        $blueprint->string('email');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame([
@@ -50,14 +51,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
             'alter table `users` add `email` varchar(255) not null',
         ], $statements);
 
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->uuid('id')->primary();
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->uuid('id')->primary();
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table `users` (`id` char(36) not null, primary key (`id`))', $statements[0]);
@@ -65,17 +66,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id')->startingValue(1000);
-        $blueprint->string('email');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id')->startingValue(1000);
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
@@ -84,10 +85,10 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddColumnsWithMultipleAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id()->from(100);
         $blueprint->string('name')->from(200);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertEquals([
             'alter table `users` add `id` bigint unsigned not null auto_increment primary key',
@@ -98,32 +99,32 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testEngineCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->engine('InnoDB');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
-        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email');
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn('InnoDB');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
@@ -131,32 +132,32 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testCharsetCollationCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->charset('utf8mb4');
         $blueprint->collation('utf8mb4_unicode_ci');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci'", $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email')->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email')->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
@@ -164,17 +165,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTableWithPrefix()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->increments('id');
-        $blueprint->string('email');
         $grammar = $this->getGrammar();
         $grammar->setTablePrefix('prefix_');
 
-        $conn = $this->getConnection();
+        $conn = $this->getConnection($grammar);
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $grammar);
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
@@ -182,16 +184,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testCreateTemporaryTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->temporary();
         $blueprint->increments('id');
         $blueprint->string('email');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
@@ -199,9 +201,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table `users`', $statements[0]);
@@ -209,9 +211,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table if exists `users`', $statements[0]);
@@ -219,23 +221,23 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `foo`', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
@@ -243,9 +245,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop primary key', $statements[0]);
@@ -253,9 +255,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
@@ -263,9 +265,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
@@ -273,9 +275,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
@@ -283,9 +285,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop foreign key `foo`', $statements[0]);
@@ -293,9 +295,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
@@ -303,9 +305,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
@@ -313,9 +315,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testDropMorphs()
     {
-        $blueprint = new Blueprint('photos');
+        $blueprint = new Blueprint($this->getConnection(), 'photos');
         $blueprint->dropMorphs('imageable');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
@@ -324,9 +326,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('rename table `users` to `foo`', $statements[0]);
@@ -334,9 +336,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testRenameIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->renameIndex('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` rename index `foo` to `bar`', $statements[0]);
@@ -344,9 +346,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add primary key (`foo`)', $statements[0]);
@@ -354,9 +356,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKeyWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add primary key using hash(`foo`)', $statements[0]);
@@ -364,9 +366,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
@@ -374,9 +376,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
@@ -384,9 +386,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingIndexWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
@@ -394,9 +396,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->fulltext('body');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add fulltext `users_body_fulltext`(`body`)', $statements[0]);
@@ -404,9 +406,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
@@ -414,9 +416,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingFluentSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point')->spatialIndex();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
@@ -424,9 +426,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingRawIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rawIndex('(function(column))', 'raw_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `raw_index`((function(column)))', $statements[0]);
@@ -434,23 +436,23 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingForeignKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders')->cascadeOnDelete();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on delete cascade', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders')->cascadeOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on update cascade', $statements[0]);
@@ -458,9 +460,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
@@ -468,9 +470,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
@@ -478,16 +480,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -495,14 +497,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingForeignID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignId = $blueprint->foreignId('foo');
         $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
@@ -520,9 +522,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertSame([
             'alter table `users` add `company_id` bigint unsigned not null',
             'alter table `users` add constraint `my_index` foreign key (`company_id`) references `companies` (`id`)',
@@ -531,9 +533,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -541,9 +543,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingColumnInTableFirst()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('name')->first();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `name` varchar(255) not null first', $statements[0]);
@@ -551,9 +553,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingColumnAfterAnotherColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('name')->after('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
@@ -561,13 +563,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMultipleColumnsAfterAnotherColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->after('foo', function ($blueprint) {
             $blueprint->string('one');
             $blueprint->string('two');
         });
         $blueprint->string('three');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(3, $statements);
         $this->assertSame([
             'alter table `users` add `one` varchar(255) not null after `foo`',
@@ -578,11 +580,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumn()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5');
         $blueprint->integer('discounted_stored')->storedAs('price - 5');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -591,11 +593,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
             'alter table `products` add `discounted_stored` int as (price - 5) stored',
         ], $statements);
 
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5')->nullable(false);
         $blueprint->integer('discounted_stored')->storedAs('price - 5')->nullable(false);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -607,11 +609,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumnWithCharset()
     {
-        $blueprint = new Blueprint('links');
+        $blueprint = new Blueprint($this->getConnection(), 'links');
         $blueprint->string('url', 2083)->charset('ascii');
         $blueprint->string('url_hash_virtual', 64)->virtualAs('sha2(url, 256)')->charset('ascii');
         $blueprint->string('url_hash_stored', 64)->storedAs('sha2(url, 256)')->charset('ascii');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -623,11 +625,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumnByExpression()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs(new Expression('price - 5'));
         $blueprint->integer('discounted_stored')->storedAs(new Expression('price - 5'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $this->assertSame([
@@ -639,9 +641,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingInvisibleColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('secret', 64)->nullable(false)->invisible();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `secret` varchar(64) not null invisible', $statements[0]);
@@ -649,37 +651,37 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default(new Expression('CURRENT TIMESTAMP'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default(Foo::BAR);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
@@ -687,9 +689,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` text not null', $statements[0]);
@@ -697,16 +699,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
@@ -714,16 +716,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
@@ -731,9 +733,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementsWithStartingValues()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id()->startingValue(1000);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -742,16 +744,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` mediumint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
@@ -759,16 +761,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
@@ -776,16 +778,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` tinyint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
@@ -793,9 +795,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` float(5) not null', $statements[0]);
@@ -803,9 +805,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` double not null', $statements[0]);
@@ -813,9 +815,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
@@ -823,9 +825,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
@@ -833,9 +835,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
@@ -843,9 +845,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingSet()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->set('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
@@ -853,9 +855,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
@@ -863,9 +865,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
@@ -873,9 +875,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` date not null', $statements[0]);
@@ -883,201 +885,201 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingYear()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->year('birth_year');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrent()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo')->useCurrent();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithOnUpdateCurrent()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo')->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null on update CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrentAndOnUpdateCurrent()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo')->useCurrent()->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrentOnUpdateCurrentAndPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo', 3)->useCurrent()->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime(3) not null default CURRENT_TIMESTAMP(3) on update CURRENT_TIMESTAMP(3)', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimestampWithDefault()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
     public function testAddingTimestampWithDefaultCurrentSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1)->useCurrent();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null default CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampWithOnUpdateCurrentSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1)->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null on update CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampWithDefaultCurrentAndOnUpdateCurrentSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1)->useCurrent()->useCurrentOnUpdate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null default CURRENT_TIMESTAMP(1) on update CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTzWithDefault()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
     public function testAddingTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table `users` add `created_at` timestamp null',
@@ -1087,9 +1089,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table `users` add `created_at` timestamp null',
@@ -1099,9 +1101,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingRememberToken()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rememberToken();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
@@ -1109,9 +1111,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
@@ -1119,9 +1121,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
@@ -1129,9 +1131,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingUuidDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `uuid` char(36) not null', $statements[0]);
@@ -1139,14 +1141,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingForeignUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignUuid = $blueprint->foreignUuid('foo');
         $blueprint->foreignUuid('company_id')->constrained();
         $blueprint->foreignUuid('laravel_idea_id')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
         $blueprint->foreignUuid('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
@@ -1164,9 +1166,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(45) not null', $statements[0]);
@@ -1174,9 +1176,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `ip_address` varchar(45) not null', $statements[0]);
@@ -1184,9 +1186,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(17) not null', $statements[0]);
@@ -1194,9 +1196,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `mac_address` varchar(17) not null', $statements[0]);
@@ -1204,9 +1206,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` geometry not null', $statements[0]);
@@ -1214,9 +1216,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeography()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geography('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` geometry srid 4326 not null', $statements[0]);
@@ -1224,9 +1226,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingPoint()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` point not null', $statements[0]);
@@ -1234,9 +1236,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingPointWithSrid()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point', 4326);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` point srid 4326 not null', $statements[0]);
@@ -1244,9 +1246,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingPointWithSridColumn()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point', 4326)->after('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` point srid 4326 not null after `id`', $statements[0]);
@@ -1254,9 +1256,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingLineString()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'linestring');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` linestring not null', $statements[0]);
@@ -1264,9 +1266,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingPolygon()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'polygon');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` polygon not null', $statements[0]);
@@ -1274,9 +1276,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeometryCollection()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'geometrycollection');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
@@ -1284,9 +1286,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMultiPoint()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multipoint');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
@@ -1294,9 +1296,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMultiLineString()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multilinestring');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
@@ -1304,9 +1306,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingMultiPolygon()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multipolygon');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
@@ -1314,9 +1316,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingComment()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo')->comment("Escape ' when using words like it's");
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
@@ -1354,38 +1356,38 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_column');
         $blueprint->string('my_other_column')->virtualAs('my_column');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_column` varchar(255) not null, `my_other_column` varchar(255) as (my_column)) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->virtualAsJson('my_json_column->some_attribute');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\"'))))", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->virtualAsJson('my_json_column->some_attribute->nested');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))))", $statements[0]);
@@ -1393,14 +1395,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithVirtualAsColumnWhenJsonColumnHasArrayKey()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"foo\"[0][1]'))))", $statements[0]);
@@ -1413,38 +1415,38 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_column');
         $blueprint->string('my_other_column')->storedAs('my_column');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_column` varchar(255) not null, `my_other_column` varchar(255) as (my_column) stored) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->storedAsJson('my_json_column->some_attribute');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\"'))) stored)", $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->storedAsJson('my_json_column->some_attribute->nested');
 
-        $conn = $this->getConnection();
-        $conn->shouldReceive('getConfig')->andReturn(null);
-
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))) stored)", $statements[0]);
@@ -1493,13 +1495,26 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertTrue($c);
     }
 
-    protected function getConnection()
-    {
-        return m::mock(Connection::class);
+    protected function getConnection(
+        ?MySqlGrammar $grammar = null,
+        ?MySqlBuilder $builder = null,
+    ) {
+        $grammar ??= $this->getGrammar();
+        $builder ??= $this->getBuilder();
+
+        return m::mock(Connection::class)
+            ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
+            ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->getMock();
     }
 
     public function getGrammar()
     {
         return new MySqlGrammar;
+    }
+
+    public function getBuilder()
+    {
+        return mock(MySqlBuilder::class);
     }
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -8,7 +8,10 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Database\Schema\PostgresBuilder;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
@@ -20,20 +23,20 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->string('name')->collation('nb_NO.utf8');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame([
@@ -44,12 +47,12 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->increments('id')->startingValue(1000);
         $blueprint->string('email');
         $blueprint->string('name')->collation('nb_NO.utf8');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
@@ -58,11 +61,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddColumnsWithMultipleAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id()->from(100);
         $blueprint->increments('code')->from(200);
         $blueprint->string('name')->from(300);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertEquals([
             'alter table "users" add column "id" bigserial not null primary key',
@@ -75,11 +78,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testCreateTableAndCommentColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email')->comment('my first comment');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null)', $statements[0]);
@@ -88,12 +91,12 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testCreateTemporaryTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->temporary();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table "users" ("id" serial not null primary key, "email" varchar(255) not null)', $statements[0]);
@@ -101,9 +104,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table "users"', $statements[0]);
@@ -111,9 +114,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table if exists "users"', $statements[0]);
@@ -121,23 +124,23 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop column "foo"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
@@ -145,9 +148,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop constraint "users_pkey"', $statements[0]);
@@ -155,9 +158,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
@@ -165,9 +168,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "foo"', $statements[0]);
@@ -175,9 +178,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "geo_coordinates_spatialindex"', $statements[0]);
@@ -185,9 +188,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
@@ -195,9 +198,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
@@ -205,9 +208,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
@@ -215,9 +218,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropMorphs()
     {
-        $blueprint = new Blueprint('photos');
+        $blueprint = new Blueprint($this->getConnection(), 'photos');
         $blueprint->dropMorphs('imageable');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('drop index "photos_imageable_type_imageable_id_index"', $statements[0]);
@@ -226,9 +229,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" rename to "foo"', $statements[0]);
@@ -236,9 +239,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testRenameIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->renameIndex('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter index "foo" rename to "bar"', $statements[0]);
@@ -246,9 +249,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add primary key ("foo")', $statements[0]);
@@ -256,9 +259,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
@@ -266,9 +269,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
@@ -276,9 +279,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingIndexWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
@@ -286,9 +289,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->fulltext('body');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[0]);
@@ -296,9 +299,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndexMultipleColumns()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->fulltext(['body', 'title']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_title_fulltext" on "users" using gin ((to_tsvector(\'english\', "body") || to_tsvector(\'english\', "title")))', $statements[0]);
@@ -306,9 +309,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndexWithLanguage()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->fulltext('body')->language('spanish');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'spanish\', "body")))', $statements[0]);
@@ -316,9 +319,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndexWithFluency()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('body')->fulltext();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[1]);
@@ -326,9 +329,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
@@ -336,9 +339,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFluentSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point')->spatialIndex();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[1]);
@@ -346,9 +349,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingRawIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rawIndex('(function(column))', 'raw_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
@@ -356,9 +359,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" serial not null primary key', $statements[0]);
@@ -366,9 +369,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" smallserial not null primary key', $statements[0]);
@@ -376,9 +379,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMediumIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" serial not null primary key', $statements[0]);
@@ -386,16 +389,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" bigserial not null primary key', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" bigserial not null primary key', $statements[0]);
@@ -403,14 +406,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingForeignID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignId = $blueprint->foreignId('foo');
         $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
@@ -428,9 +431,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertSame([
             'alter table "users" add column "company_id" bigint not null',
             'alter table "users" add constraint "my_index" foreign key ("company_id") references "companies" ("id")',
@@ -439,9 +442,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" bigserial not null primary key', $statements[0]);
@@ -449,23 +452,23 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar(100) null default \'bar\'', $statements[0]);
@@ -473,18 +476,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingStringWithoutLengthLimit()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar(255) not null', $statements[0]);
 
         Builder::$defaultStringLength = null;
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         try {
             $this->assertCount(1, $statements);
@@ -496,18 +499,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingCharWithoutLengthLimit()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->char('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" char(255) not null', $statements[0]);
 
         Builder::$defaultStringLength = null;
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->char('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         try {
             $this->assertCount(1, $statements);
@@ -519,9 +522,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
@@ -529,16 +532,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" bigserial not null primary key', $statements[0]);
@@ -546,16 +549,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" serial not null primary key', $statements[0]);
@@ -563,16 +566,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" serial not null primary key', $statements[0]);
@@ -580,16 +583,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" smallserial not null primary key', $statements[0]);
@@ -597,16 +600,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" smallserial not null primary key', $statements[0]);
@@ -614,9 +617,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" float(5) not null', $statements[0]);
@@ -624,9 +627,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" double precision not null', $statements[0]);
@@ -634,9 +637,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" decimal(5, 2) not null', $statements[0]);
@@ -644,9 +647,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" boolean not null', $statements[0]);
@@ -654,9 +657,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
@@ -664,9 +667,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" date not null', $statements[0]);
@@ -674,18 +677,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingYear()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->year('birth_year');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "birth_year" integer not null', $statements[0]);
     }
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" json not null', $statements[0]);
@@ -693,205 +696,48 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" jsonb not null', $statements[0]);
     }
 
-    public function testAddingDateTime()
+    #[DataProvider('datetimeAndPrecisionProvider')]
+    public function testAddingDatetimeMethods(string $method, string $type, ?int $userPrecision, false|int|null $grammarPrecision, ?int $expected)
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTime('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        PostgresBuilder::defaultTimePrecision($grammarPrecision);
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->{$method}('created_at', $userPrecision);
+        $statements = $blueprint->toSql();
+        $type = is_null($expected) ? $type : "{$type}({$expected})";
+        $with = str_contains($method, 'Tz') ? 'with' : 'without';
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertSame("alter table \"users\" add column \"created_at\" {$type} {$with} time zone not null", $statements[0]);
     }
 
-    public function testAddingDateTimeWithPrecision()
+    #[TestWith(['timestamps'])]
+    #[TestWith(['timestampsTz'])]
+    public function testAddingTimestamps(string $method)
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTime('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
-    }
-
-    public function testAddingDateTimeWithNullPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTime('created_at', null);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp without time zone not null', $statements[0]);
-    }
-
-    public function testAddingDateTimeTz()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
-    }
-
-    public function testAddingDateTimeTzWithPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
-    }
-
-    public function testAddingDateTimeTzWithNullPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('created_at', null);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTime()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->time('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimeWithPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->time('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimeWithNullPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->time('created_at', null);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time without time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimeTz()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimeTzWithPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimeTzWithNullPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timeTz('created_at', null);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" time with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestamp()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestampWithPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestampWithNullPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('created_at', null);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp without time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestampTz()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestampTzWithPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestampTzWithNullPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('created_at', null);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "created_at" timestamp with time zone not null', $statements[0]);
-    }
-
-    public function testAddingTimestamps()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        PostgresBuilder::defaultTimePrecision(0);
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->{$method}();
+        $statements = $blueprint->toSql();
+        $with = str_contains($method, 'Tz') ? 'with' : 'without';
         $this->assertCount(2, $statements);
         $this->assertSame([
-            'alter table "users" add column "created_at" timestamp(0) without time zone null',
-            'alter table "users" add column "updated_at" timestamp(0) without time zone null',
-        ], $statements);
-    }
-
-    public function testAddingTimestampsTz()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(2, $statements);
-        $this->assertSame([
-            'alter table "users" add column "created_at" timestamp(0) with time zone null',
-            'alter table "users" add column "updated_at" timestamp(0) with time zone null',
+            "alter table \"users\" add column \"created_at\" timestamp(0) {$with} time zone null",
+            "alter table \"users\" add column \"updated_at\" timestamp(0) {$with} time zone null",
         ], $statements);
     }
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" bytea not null', $statements[0]);
@@ -899,9 +745,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" uuid not null', $statements[0]);
@@ -909,9 +755,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingUuidDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "uuid" uuid not null', $statements[0]);
@@ -919,14 +765,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingForeignUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignUuid = $blueprint->foreignUuid('foo');
         $blueprint->foreignUuid('company_id')->constrained();
         $blueprint->foreignUuid('laravel_idea_id')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
         $blueprint->foreignUuid('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
@@ -944,47 +790,47 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedAs()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('foo')->generatedAs();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null generated by default as identity primary key', $statements[0]);
         // With always modifier
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('foo')->generatedAs()->always();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null generated always as identity primary key', $statements[0]);
         // With sequence options
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('foo')->generatedAs('increment by 10 start with 100');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null generated by default as identity (increment by 10 start with 100) primary key', $statements[0]);
         // Not a primary key
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo')->generatedAs();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null generated by default as identity', $statements[0]);
     }
 
     public function testAddingVirtualAs()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo')->nullable();
         $blueprint->boolean('bar')->virtualAs('foo is not null');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add column "foo" integer null',
             'alter table "users" add column "bar" boolean not null generated always as (foo is not null)',
         ], $statements);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo')->nullable();
         $blueprint->boolean('bar')->virtualAs(new Expression('foo is not null'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add column "foo" integer null',
@@ -994,20 +840,20 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingStoredAs()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo')->nullable();
         $blueprint->boolean('bar')->storedAs('foo is not null');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add column "foo" integer null',
             'alter table "users" add column "bar" boolean not null generated always as (foo is not null) stored',
         ], $statements);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo')->nullable();
         $blueprint->boolean('bar')->storedAs(new Expression('foo is not null'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add column "foo" integer null',
@@ -1017,9 +863,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" inet not null', $statements[0]);
@@ -1027,9 +873,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "ip_address" inet not null', $statements[0]);
@@ -1037,9 +883,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" macaddr not null', $statements[0]);
@@ -1047,9 +893,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "mac_address" macaddr not null', $statements[0]);
@@ -1057,30 +903,30 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testCompileForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable(false)->initiallyImmediate();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade not deferrable', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->initiallyImmediate(false);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable initially deferred', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->notValid();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
@@ -1088,9 +934,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry not null', $statements[0]);
@@ -1098,9 +944,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingGeography()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geography('coordinates', 'pointzm', 4269);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geography(pointzm,4269) not null', $statements[0]);
@@ -1108,9 +954,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingPoint()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(point) not null', $statements[0]);
@@ -1118,9 +964,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingPointWithSrid()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point', 4269);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(point,4269) not null', $statements[0]);
@@ -1128,9 +974,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingLineString()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'linestring');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(linestring) not null', $statements[0]);
@@ -1138,9 +984,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingPolygon()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'polygon');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(polygon) not null', $statements[0]);
@@ -1148,9 +994,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingGeometryCollection()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'geometrycollection');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(geometrycollection) not null', $statements[0]);
@@ -1158,9 +1004,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMultiPoint()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multipoint');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(multipoint) not null', $statements[0]);
@@ -1168,9 +1014,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMultiLineString()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multilinestring');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(multilinestring) not null', $statements[0]);
@@ -1178,9 +1024,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingMultiPolygon()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'multipolygon');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry(multipolygon) not null', $statements[0]);
@@ -1258,14 +1104,55 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertStringContainsString("where c.relname = 'table' and n.nspname = 'public'", $statement);
     }
 
-    protected function getConnection()
-    {
-        return m::mock(Connection::class);
+    protected function getConnection(
+        ?PostgresGrammar $grammar = null,
+        ?PostgresBuilder $builder = null
+    ) {
+        $grammar ??= $this->getGrammar();
+        $builder ??= $this->getBuilder();
+
+        return m::mock(Connection::class)
+            ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
+            ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->getMock();
     }
 
     public function getGrammar()
     {
         return new PostgresGrammar;
+    }
+
+    public function getBuilder()
+    {
+        return mock(PostgresBuilder::class);
+    }
+
+    /** @return list<array{method: string, type: string, user: int|null, grammar: false|int|null, expected: int|null}> */
+    public static function datetimeAndPrecisionProvider(): array
+    {
+        $methods = [
+            ['method' => 'datetime', 'type' => 'timestamp'],
+            ['method' => 'datetimeTz', 'type' => 'timestamp'],
+            ['method' => 'timestamp', 'type' => 'timestamp'],
+            ['method' => 'timestampTz', 'type' => 'timestamp'],
+            ['method' => 'time', 'type' => 'time'],
+            ['method' => 'timeTz', 'type' => 'time'],
+        ];
+        $precisions = [
+            'user can override grammar default' => ['userPrecision' => 1, 'grammarPrecision' => null, 'expected' => 1],
+            'fallback to grammar default' => ['userPrecision' => null, 'grammarPrecision' => 5, 'expected' => 5],
+            'fallback to database default' => ['userPrecision' => null, 'grammarPrecision' => null, 'expected' => null],
+        ];
+
+        $result = [];
+
+        foreach ($methods as $datetime) {
+            foreach ($precisions as $precision) {
+                $result[] = array_merge($datetime, $precision);
+            }
+        }
+
+        return $result;
     }
 
     public function testGrammarsAreMacroable()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -23,19 +23,19 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $expected = [
@@ -47,12 +47,12 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testCreateTemporaryTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->temporary();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
@@ -60,9 +60,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table "users"', $statements[0]);
@@ -70,9 +70,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table if exists "users"', $statements[0]);
@@ -80,9 +80,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "foo"', $statements[0]);
@@ -90,9 +90,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "foo"', $statements[0]);
@@ -130,16 +130,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
 
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
-        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $blueprint->toSql();
     }
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" rename to "foo"', $statements[0]);
@@ -183,10 +183,10 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('foo')->primary();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("foo" varchar not null, primary key ("foo"))', $statements[0]);
@@ -194,12 +194,12 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingForeignKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('foo')->primary();
         $blueprint->string('order_id');
         $blueprint->foreign('order_id')->references('id')->on('orders');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
@@ -207,9 +207,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
@@ -217,9 +217,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
@@ -230,9 +230,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
 
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
-        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $blueprint->toSql();
     }
 
     public function testAddingFluentSpatialIndex()
@@ -240,16 +240,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The database driver in use does not support spatial indexes.');
 
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates')->spatialIndex();
-        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $blueprint->toSql();
     }
 
     public function testAddingRawIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rawIndex('(function(column))', 'raw_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
@@ -257,9 +257,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
@@ -267,9 +267,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
@@ -277,9 +277,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingMediumIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
@@ -287,16 +287,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
@@ -304,22 +304,20 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingForeignID()
     {
-        $blueprint = new Blueprint('users');
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getPostProcessor')->andReturn(new SQliteProcessor);
+        $connection->shouldReceive('selectFromWriteConnection')->andReturn([]);
+        $connection->shouldReceive('scalar')->andReturn('');
+
+        $blueprint = new Blueprint($connection, 'users');
         $foreignId = $blueprint->foreignId('foo');
         $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
 
-        $grammar = $this->getGrammar();
-        $connection = $this->getConnection();
-        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $connection->shouldReceive('getSchemaBuilder')->andReturn(new SQLiteBuilder($connection));
-        $connection->shouldReceive('getTablePrefix')->andReturn('');
-        $connection->shouldReceive('getPostProcessor')->andReturn(new SQliteProcessor);
-        $connection->shouldReceive('selectFromWriteConnection')->andReturn([]);
-        $connection->shouldReceive('scalar')->andReturn('');
-        $statements = $blueprint->toSql($connection, $grammar);
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
@@ -349,18 +347,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
-
-        $grammar = $this->getGrammar();
         $connection = $this->getConnection();
-        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $connection->shouldReceive('getSchemaBuilder')->andReturn(new SQLiteBuilder($connection));
         $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('getPostProcessor')->andReturn(new SQliteProcessor);
         $connection->shouldReceive('selectFromWriteConnection')->andReturn([]);
         $connection->shouldReceive('scalar')->andReturn('');
-        $statements = $blueprint->toSql($connection, $grammar);
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
+
+        $statements = $blueprint->toSql();
 
         $this->assertSame([
             'alter table "users" add column "company_id" integer not null',
@@ -373,9 +369,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
@@ -383,23 +379,23 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar default \'bar\'', $statements[0]);
@@ -407,9 +403,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
@@ -417,16 +413,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
@@ -434,16 +430,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
@@ -451,16 +447,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
@@ -468,16 +464,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
@@ -485,16 +481,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
@@ -502,9 +498,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" float not null', $statements[0]);
@@ -512,9 +508,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" double not null', $statements[0]);
@@ -522,9 +518,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" numeric not null', $statements[0]);
@@ -532,9 +528,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" tinyint(1) not null', $statements[0]);
@@ -542,9 +538,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
@@ -552,9 +548,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
@@ -562,9 +558,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
@@ -572,9 +568,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" date not null', $statements[0]);
@@ -582,126 +578,126 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingYear()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->year('birth_year');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "birth_year" integer not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertEquals([
             'alter table "users" add column "created_at" datetime',
@@ -711,9 +707,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertEquals([
             'alter table "users" add column "created_at" datetime',
@@ -723,9 +719,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingRememberToken()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rememberToken();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "remember_token" varchar', $statements[0]);
@@ -733,9 +729,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" blob not null', $statements[0]);
@@ -743,9 +739,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
@@ -753,9 +749,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingUuidDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "uuid" varchar not null', $statements[0]);
@@ -763,22 +759,20 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingForeignUuid()
     {
-        $blueprint = new Blueprint('users');
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getPostProcessor')->andReturn(new SQliteProcessor);
+        $connection->shouldReceive('selectFromWriteConnection')->andReturn([]);
+        $connection->shouldReceive('scalar')->andReturn('');
+
+        $blueprint = new Blueprint($connection, 'users');
         $foreignUuid = $blueprint->foreignUuid('foo');
         $blueprint->foreignUuid('company_id')->constrained();
         $blueprint->foreignUuid('laravel_idea_id')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
         $blueprint->foreignUuid('team_column_id')->constrained('teams');
 
-        $grammar = $this->getGrammar();
-        $connection = $this->getConnection();
-        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $connection->shouldReceive('getSchemaBuilder')->andReturn(new SQLiteBuilder($connection));
-        $connection->shouldReceive('getTablePrefix')->andReturn('');
-        $connection->shouldReceive('getPostProcessor')->andReturn(new SQliteProcessor);
-        $connection->shouldReceive('selectFromWriteConnection')->andReturn([]);
-        $connection->shouldReceive('scalar')->andReturn('');
-        $statements = $blueprint->toSql($connection, $grammar);
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
@@ -808,9 +802,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
@@ -818,9 +812,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "ip_address" varchar not null', $statements[0]);
@@ -828,9 +822,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
@@ -838,9 +832,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "mac_address" varchar not null', $statements[0]);
@@ -848,9 +842,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add column "coordinates" geometry not null', $statements[0]);
@@ -858,21 +852,21 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumn()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->create();
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('"price" - 5');
         $blueprint->integer('discounted_stored')->storedAs('"price" - 5');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "products" ("price" integer not null, "discounted_virtual" integer as ("price" - 5), "discounted_stored" integer as ("price" - 5) stored)', $statements[0]);
 
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('"price" - 5')->nullable(false);
         $blueprint->integer('discounted_stored')->storedAs('"price" - 5')->nullable(false);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(3, $statements);
         $expected = [
@@ -885,12 +879,12 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumnByExpression()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->create();
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs(new Expression('"price" - 5'));
         $blueprint->integer('discounted_stored')->storedAs(new Expression('"price" - 5'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "products" ("price" integer not null, "discounted_virtual" integer as ("price" - 5), "discounted_stored" integer as ("price" - 5) stored)', $statements[0]);
@@ -910,32 +904,32 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithVirtualAsColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('my_column');
         $blueprint->string('my_other_column')->virtualAs('my_column');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("my_column" varchar not null, "my_other_column" varchar as (my_column))', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->virtualAsJson('my_json_column->some_attribute');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("my_json_column" varchar not null, "my_other_column" varchar as (json_extract("my_json_column", \'$."some_attribute"\')))', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->virtualAsJson('my_json_column->some_attribute->nested');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("my_json_column" varchar not null, "my_other_column" varchar as (json_extract("my_json_column", \'$."some_attribute"."nested"\')))', $statements[0]);
@@ -943,14 +937,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithVirtualAsColumnWhenJsonColumnHasArrayKey()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->create();
-        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
-
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->create();
+        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("create table \"users\" (\"my_json_column\" varchar as (json_extract(\"my_json_column\", '$.\"foo\"[0][1]')))", $statements[0]);
@@ -958,32 +952,32 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithStoredAsColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('my_column');
         $blueprint->string('my_other_column')->storedAs('my_column');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("my_column" varchar not null, "my_other_column" varchar as (my_column) stored)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->storedAsJson('my_json_column->some_attribute');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("my_json_column" varchar not null, "my_other_column" varchar as (json_extract("my_json_column", \'$."some_attribute"\')) stored)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->string('my_json_column');
         $blueprint->string('my_other_column')->storedAsJson('my_json_column->some_attribute->nested');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("my_json_column" varchar not null, "my_other_column" varchar as (json_extract("my_json_column", \'$."some_attribute"."nested"\')) stored)', $statements[0]);
@@ -991,23 +985,38 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDroppingColumnsWorks()
     {
-        $blueprint = new Blueprint('users', function ($table) {
+        $blueprint = new Blueprint($this->getConnection(), 'users', function ($table) {
             $table->dropColumn('name');
         });
 
-        $this->assertEquals(['alter table "users" drop column "name"'], $blueprint->toSql($this->getConnection(), $this->getGrammar()));
+        $this->assertEquals(['alter table "users" drop column "name"'], $blueprint->toSql());
     }
 
-    protected function getConnection()
-    {
-        $connection = m::mock(Connection::class);
-        $connection->shouldReceive('getServerVersion')->andReturn('3.35');
+    protected function getConnection(
+        ?SQLiteGrammar $grammar = null,
+        ?SQLiteBuilder $builder = null,
+    ) {
+        $grammar ??= $this->getGrammar();
+        $builder ??= $this->getBuilder();
 
-        return $connection;
+        return m::mock(Connection::class)
+            ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
+            ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->shouldReceive('getServerVersion')->andReturn('3.35')
+            ->getMock();
     }
 
     public function getGrammar()
     {
-        return new SQLiteGrammar;
+        return new SQLiteGrammar();
+    }
+
+    public function getBuilder()
+    {
+        return mock(SQLiteBuilder::class)
+            ->shouldReceive('getColumns')->andReturn([])
+            ->shouldReceive('getIndexes')->andReturn([])
+            ->shouldReceive('getForeignKeys')->andReturn([])
+            ->getMock();
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+use Illuminate\Database\Schema\SqlServerBuilder;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -19,19 +20,19 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("id" int not null identity primary key, "email" nvarchar(255) not null)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame([
@@ -39,11 +40,12 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
             'alter table "users" add "email" nvarchar(255) not null',
         ], $statements);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection($this->getGrammar()->setTablePrefix('prefix_'));
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "prefix_users" ("id" int not null identity primary key, "email" nvarchar(255) not null)', $statements[0]);
@@ -51,12 +53,12 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testCreateTemporaryTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->create();
         $blueprint->temporary();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "#users" ("id" int not null identity primary key, "email" nvarchar(255) not null)', $statements[0]);
@@ -64,16 +66,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table "users"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection($this->getGrammar()->setTablePrefix('prefix_'));
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop table "prefix_users"', $statements[0]);
@@ -81,16 +84,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('if object_id(N\'"users"\', \'U\') is not null drop table "users"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection($this->getGrammar()->setTablePrefix('prefix_'));
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('if object_id(N\'"prefix_users"\', \'U\') is not null drop table "prefix_users"', $statements[0]);
@@ -98,23 +102,23 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('alter table "users" drop column "foo"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('alter table "users" drop column "foo", "bar"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('alter table "users" drop column "foo", "bar"', $statements[0]);
@@ -122,9 +126,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropColumnDropsCreatesSqlToDropDefaultConstraints()
     {
-        $blueprint = new Blueprint('foo');
+        $blueprint = new Blueprint($this->getConnection(), 'foo');
         $blueprint->dropColumn('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame("DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE \"foo\" DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM sys.columns WHERE [object_id] = OBJECT_ID(N'\"foo\"') AND [name] in ('bar') AND [default_object_id] <> 0;EXEC(@sql);alter table \"foo\" drop column \"bar\"", $statements[0]);
@@ -132,9 +136,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
@@ -142,9 +146,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "foo" on "users"', $statements[0]);
@@ -152,9 +156,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "foo" on "users"', $statements[0]);
@@ -162,9 +166,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->dropSpatialIndex(['coordinates']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('drop index "geo_coordinates_spatialindex" on "geo"', $statements[0]);
@@ -172,9 +176,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
@@ -182,9 +186,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropConstrainedForeignId()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropConstrainedForeignId('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table "users" drop constraint "users_foo_foreign"', $statements[0]);
@@ -193,9 +197,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
@@ -203,9 +207,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertStringContainsString('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
@@ -213,9 +217,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testDropMorphs()
     {
-        $blueprint = new Blueprint('photos');
+        $blueprint = new Blueprint($this->getConnection(), 'photos');
         $blueprint->dropMorphs('imageable');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
@@ -224,9 +228,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('sp_rename N\'"users"\', "foo"', $statements[0]);
@@ -234,9 +238,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testRenameIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->renameIndex('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('sp_rename N\'"users"."foo"\', "bar", N\'INDEX\'', $statements[0]);
@@ -244,9 +248,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "bar" primary key ("foo")', $statements[0]);
@@ -254,9 +258,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
@@ -264,9 +268,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
@@ -274,9 +278,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->spatialIndex('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[0]);
@@ -284,9 +288,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingFluentSpatialIndex()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates', 'point')->spatialIndex();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(2, $statements);
         $this->assertSame('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[1]);
@@ -294,9 +298,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingRawIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rawIndex('(function(column))', 'raw_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
@@ -304,9 +308,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "id" int not null identity primary key', $statements[0]);
@@ -314,9 +318,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "id" smallint not null identity primary key', $statements[0]);
@@ -324,9 +328,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingMediumIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "id" int not null identity primary key', $statements[0]);
@@ -334,16 +338,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "id" bigint not null identity primary key', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" bigint not null identity primary key', $statements[0]);
@@ -351,14 +355,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingForeignID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignId = $blueprint->foreignId('foo');
         $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
@@ -376,9 +380,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertSame([
             'alter table "users" add "company_id" bigint not null',
             'alter table "users" add constraint "my_index" foreign key ("company_id") references "companies" ("id")',
@@ -387,9 +391,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "id" bigint not null identity primary key', $statements[0]);
@@ -397,23 +401,23 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(100) null default \'bar\'', $statements[0]);
@@ -421,9 +425,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
@@ -431,16 +435,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" bigint not null identity primary key', $statements[0]);
@@ -448,16 +452,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" int not null identity primary key', $statements[0]);
@@ -465,16 +469,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" int not null identity primary key', $statements[0]);
@@ -482,16 +486,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" tinyint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" tinyint not null identity primary key', $statements[0]);
@@ -499,16 +503,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" smallint not null identity primary key', $statements[0]);
@@ -516,9 +520,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" float(5) not null', $statements[0]);
@@ -526,9 +530,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" double precision not null', $statements[0]);
@@ -536,9 +540,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" decimal(5, 2) not null', $statements[0]);
@@ -546,9 +550,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" bit not null', $statements[0]);
@@ -556,9 +560,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
@@ -566,9 +570,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
@@ -576,9 +580,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
@@ -586,9 +590,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" date not null', $statements[0]);
@@ -596,126 +600,126 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingYear()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->year('birth_year');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "birth_year" int not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
     public function testAddingTimestampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('created_at', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add "created_at" datetime null',
@@ -725,9 +729,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add "created_at" datetimeoffset null',
@@ -737,9 +741,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingRememberToken()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rememberToken();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "remember_token" nvarchar(100) null', $statements[0]);
@@ -747,9 +751,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
@@ -757,9 +761,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" uniqueidentifier not null', $statements[0]);
@@ -767,9 +771,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingUuidDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "uuid" uniqueidentifier not null', $statements[0]);
@@ -777,14 +781,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingForeignUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $foreignId = $blueprint->foreignUuid('foo');
         $blueprint->foreignUuid('company_id')->constrained();
         $blueprint->foreignUuid('laravel_idea_id')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
         $blueprint->foreignUuid('team_column_id')->constrained('teams');
 
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
@@ -802,9 +806,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(45) not null', $statements[0]);
@@ -812,9 +816,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingIpAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "ip_address" nvarchar(45) not null', $statements[0]);
@@ -822,9 +826,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(17) not null', $statements[0]);
@@ -832,9 +836,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingMacAddressDefaultsColumnName()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "mac_address" nvarchar(17) not null', $statements[0]);
@@ -842,9 +846,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geometry('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add "coordinates" geometry not null', $statements[0]);
@@ -852,9 +856,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingGeography()
     {
-        $blueprint = new Blueprint('geo');
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
         $blueprint->geography('coordinates');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
@@ -862,11 +866,11 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingGeneratedColumn()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->computed('discounted_virtual', 'price - 5');
         $blueprint->computed('discounted_stored', 'price - 5')->persisted();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(3, $statements);
         $this->assertSame([
             'alter table "products" add "price" int not null',
@@ -874,11 +878,11 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
             'alter table "products" add "discounted_stored" as (price - 5) persisted',
         ], $statements);
 
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->computed('discounted_virtual', new Expression('price - 5'));
         $blueprint->computed('discounted_stored', new Expression('price - 5'))->persisted();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql();
         $this->assertCount(3, $statements);
         $this->assertSame([
             'alter table "products" add "price" int not null',
@@ -945,13 +949,26 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         );
     }
 
-    protected function getConnection()
-    {
-        return m::mock(Connection::class);
+    protected function getConnection(
+        ?SqlServerGrammar $grammar = null,
+        ?SqlServerBuilder $builder = null
+    ) {
+        $grammar ??= $this->getGrammar();
+        $builder ??= $this->getBuilder();
+
+        return m::mock(Connection::class)
+            ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
+            ->shouldReceive('getSchemaBuilder')->andReturn($builder)
+            ->getMock();
     }
 
     public function getGrammar()
     {
         return new SqlServerGrammar;
+    }
+
+    public function getBuilder()
+    {
+        return mock(SqlServerBuilder::class);
     }
 }

--- a/tests/Integration/Database/TimestampTypeTest.php
+++ b/tests/Integration/Database/TimestampTypeTest.php
@@ -59,14 +59,12 @@ class TimestampTypeTest extends DatabaseTestCase
             $table->string('string_to_timestamp');
         });
 
-        $blueprint = new Blueprint('test', function ($table) {
+        $blueprint = new Blueprint($this->getConnection(), 'test', function ($table) {
             $table->timestamp('string_to_timestamp')->nullable()->change();
         });
 
-        $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
-
         $expected = ['alter table `test` modify `string_to_timestamp` timestamp null'];
 
-        $this->assertEquals($expected, $queries);
+        $this->assertEquals($expected, $blueprint->toSql());
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

Please see my previous PR (#51793) for context. This adds the following properties:

- New `$connection` and `$grammar` properties on `Illuminate/Database/Schema/Blueprint`.
- `Illuminate/Database/Schema/Blueprint` requires `$connection` in constructor
- New static `$defaultTimePrecision` property on `Illuminate/Database/Schema/Builder`.

Thanks!