### PR TITLE
[11.x] Fix docblock of \Illuminate\Http\Response

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -94,7 +94,7 @@ class Response extends SymfonyResponse
      * Morph the given content into JSON.
      *
      * @param  mixed  $content
-     * @return string
+     * @return string|false
      */
     protected function morphToJson($content)
     {


### PR DESCRIPTION
\Illuminate\Http\Response::morphToJson() sometimes returns json_encode() result that could be either string or false (a boolean value). So, it's return docblock must contain `string|false`.
```
    /**
     * Morph the given content into JSON.
     *
     * @param  mixed  $content
     * @return string|false
     */
    protected function morphToJson($content)
    {
        if ($content instanceof Jsonable) {
            return $content->toJson();
        } elseif ($content instanceof Arrayable) {
            return json_encode($content->toArray());
        }

        return json_encode($content);
    }
```