### PR TITLE
[10.x] Fixes unable to call another command as a initialized instance of `Command` class

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -236,11 +236,13 @@ class Command extends SymfonyCommand
      */
     protected function resolveCommand($command)
     {
-        if (! class_exists($command)) {
-            return $this->getApplication()->find($command);
-        }
+        if (is_string($command)) {
+            if (! class_exists($command)) {
+                return $this->getApplication()->find($command);
+            }
 
-        $command = $this->laravel->make($command);
+            $command = $this->laravel->make($command);
+        }
 
         if ($command instanceof SymfonyCommand) {
             $command->setApplication($this->getApplication());

--- a/tests/Integration/Console/CallCommandsTest.php
+++ b/tests/Integration/Console/CallCommandsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Foundation\Console\ViewClearCommand;
+use Illuminate\Support\Facades\Artisan;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
+
+class CallCommandsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->afterApplicationCreated(function () {
+            Artisan::command('test:a', function () {
+                $this->call('view:clear');
+            });
+
+            Artisan::command('test:b', function () {
+                $this->call(ViewClearCommand::class);
+            });
+
+            Artisan::command('test:c', function () {
+                $this->call($this->laravel->make(ViewClearCommand::class));
+            });
+        });
+
+        parent::setUp();
+    }
+
+    #[TestWith(['test:a'])]
+    #[TestWith(['test:b'])]
+    #[TestWith(['test:c'])]
+    public function testItCanCallCommands(string $command)
+    {
+        $this->artisan($command)->assertSuccessful();
+    }
+}


### PR DESCRIPTION
fixes #51822

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
