### PR TITLE
[10.x] Ensure`schema:dump` will dump the migrations table only if it exists

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Schema;
 
 use Exception;
 use Illuminate\Database\Connection;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -27,7 +26,7 @@ class MySqlSchemaState extends SchemaState
 
         $this->removeAutoIncrementingState($path);
 
-        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+        if ($this->hasMigrationTable()) {
             $this->appendMigrationData($path);
         }
     }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Schema;
 
 use Exception;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -26,7 +27,9 @@ class MySqlSchemaState extends SchemaState
 
         $this->removeAutoIncrementingState($path);
 
-        $this->appendMigrationData($path);
+        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+            $this->appendMigrationData($path);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Config;
 
 class PostgresSchemaState extends SchemaState
 {
@@ -17,8 +18,11 @@ class PostgresSchemaState extends SchemaState
     {
         $commands = collect([
             $this->baseDumpCommand().' --schema-only > '.$path,
-            $this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path,
         ]);
+
+        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+            $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path);
+        }
 
         $commands->map(function ($command, $path) {
             $this->makeProcess($command)->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Config;
 
 class PostgresSchemaState extends SchemaState
 {
@@ -17,8 +18,11 @@ class PostgresSchemaState extends SchemaState
     {
         $commands = collect([
             $this->baseDumpCommand().' --schema-only > '.$path,
-            $this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path,
         ]);
+
+        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+            $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path,);
+        }
 
         $commands->map(function ($command, $path) {
             $this->makeProcess($command)->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
-use Illuminate\Support\Facades\Config;
 
 class PostgresSchemaState extends SchemaState
 {
@@ -20,7 +19,7 @@ class PostgresSchemaState extends SchemaState
             $this->baseDumpCommand().' --schema-only > '.$path,
         ]);
 
-        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+        if ($this->hasMigrationTable()) {
             $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path);
         }
 

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -21,7 +21,7 @@ class PostgresSchemaState extends SchemaState
         ]);
 
         if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
-            $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path,);
+            $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path);
         }
 
         $commands->map(function ($command, $path) {

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -95,6 +95,16 @@ abstract class SchemaState
     }
 
     /**
+     * Determine if the current connection has a migration table.
+     *
+     * @return bool
+     */
+    public function hasMigrationTable(): bool
+    {
+        return $this->connection->getSchemaBuilder()->hasTable($this->migrationTable);
+    }
+
+    /**
      * Specify the name of the application's migration table.
      *
      * @param  string  $table
@@ -118,15 +128,5 @@ abstract class SchemaState
         $this->output = $output;
 
         return $this;
-    }
-
-    /**
-     * Check if the current connection has a migration table.
-     *
-     * @return bool
-     */
-    public function hasMigrationTable(): bool
-    {
-        return $this->connection->getSchemaBuilder()->hasTable($this->migrationTable);
     }
 }

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -119,4 +119,14 @@ abstract class SchemaState
 
         return $this;
     }
+
+    /**
+     * Check if the current connection has a migration table.
+     *
+     * @return bool
+     */
+    public function hasMigrationTable(): bool
+    {
+        return $this->connection->getSchemaBuilder()->hasTable($this->migrationTable);
+    }
 }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
-use Illuminate\Support\Facades\Config;
 
 class SqliteSchemaState extends SchemaState
 {
@@ -29,7 +28,7 @@ class SqliteSchemaState extends SchemaState
 
         $this->files->put($path, implode(PHP_EOL, $migrations).PHP_EOL);
 
-        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+        if ($this->hasMigrationTable()) {
             $this->appendMigrationData($path);
         }
     }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Config;
 
 class SqliteSchemaState extends SchemaState
 {
@@ -28,7 +29,9 @@ class SqliteSchemaState extends SchemaState
 
         $this->files->put($path, implode(PHP_EOL, $migrations).PHP_EOL);
 
-        $this->appendMigrationData($path);
+        if ($this->connection->getConfig()['name'] === Config::get('database.default')) {
+            $this->appendMigrationData($path);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes [#51813](https://github.com/laravel/framework/issues/51813)

The `migrations` table is only available in then default connection.
When running `schema:dump --database=Something` the command attempts to dump the migration table, too.

This results in:
```
Symfony\Component\Process\Exception\ProcessFailedException 

The command "mysqldump  --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc "${:LARAVEL_LOAD_DATABASE}" migrations --no-create-info --skip-extended-insert --skip-routines --compact --complete-insert" failed.

Exit Code: 6(Unknown error)

Working directory: /Users/Nick/Projects/blub

Output:
================


Error Output:
================
mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysqldump: Couldn't find table: "migrations"

  at /Users/Nick/.composer/vendor/symfony/process/Process.php:267
    263▕      */
    264▕     public function mustRun(?callable $callback = null, array $env = []): static
    265▕     {
    266▕         if (0 !== $this->run($callback, $env)) {
  ➜ 267▕             throw new ProcessFailedException($this);
    268▕         }
    269▕ 
    270▕         return $this;
    271▕     }

      +18 vendor frames 

  19  artisan:46
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

This PR checks if we are on the default connection and skips dumping migrations if not.

The command has not had any tests.
I don't think the scope of this PR requires to change this?