### PR TITLE
[12.x] ShouldBeUnique Does Not Universally Prevent Duplicates

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -150,21 +150,6 @@ class PendingDispatch
     }
 
     /**
-     * Determine if the job should be dispatched.
-     *
-     * @return bool
-     */
-    protected function shouldDispatch()
-    {
-        if (! $this->job instanceof ShouldBeUnique) {
-            return true;
-        }
-
-        return (new UniqueLock(Container::getInstance()->make(Cache::class)))
-                    ->acquire($this->job);
-    }
-
-    /**
      * Dynamically proxy methods to the underlying job.
      *
      * @param  string  $method
@@ -185,9 +170,7 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        if (! $this->shouldDispatch()) {
-            return;
-        } elseif ($this->afterResponse) {
+        if ($this->afterResponse) {
             app(Dispatcher::class)->dispatchAfterResponse($this->job);
         } else {
             app(Dispatcher::class)->dispatch($this->job);

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -334,7 +334,7 @@ abstract class Queue
                     if (! $this->shouldDispatch($job)) {
                         return;
                     }
-            
+
                     return $this->enqueue($job, $payload, $queue, $delay, $callback);
                 }
             );

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -331,7 +331,7 @@ abstract class Queue
             $this->container->bound('db.transactions')) {
             return $this->container->make('db.transactions')->addCallback(
                 function () use ($queue, $job, $payload, $delay, $callback) {
-                    if (!$this->shouldDispatch($job)) {
+                    if (! $this->shouldDispatch($job)) {
                         return;
                     }
             
@@ -340,7 +340,7 @@ abstract class Queue
             );
         }
 
-        if (!$this->shouldDispatch($job)) {
+        if (! $this->shouldDispatch($job)) {
             return;
         }
 
@@ -348,7 +348,7 @@ abstract class Queue
     }
 
     /**
-     * Enqueue the job and dispatch queue events
+     * Enqueue the job and dispatch queue events.
      *
      * @param  \Closure|string|object  $job
      * @param  string  $payload

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\Attributes\WithMigration;
 
 #[WithMigration]
@@ -23,28 +22,6 @@ class UniqueJobTest extends QueueTestCase
         parent::defineEnvironment($app);
 
         $app['config']->set('cache.default', 'database');
-    }
-
-    public function testUniqueJobsAreNotDispatched()
-    {
-        Bus::fake();
-
-        UniqueTestJob::dispatch();
-        $this->runQueueWorkerCommand(['--once' => true]);
-        Bus::assertDispatched(UniqueTestJob::class);
-
-        $this->assertFalse(
-            $this->app->get(Cache::class)->lock($this->getLockKey(UniqueTestJob::class), 10)->get()
-        );
-
-        Bus::assertDispatchedTimes(UniqueTestJob::class);
-        UniqueTestJob::dispatch();
-        $this->runQueueWorkerCommand(['--once' => true]);
-        Bus::assertDispatchedTimes(UniqueTestJob::class);
-
-        $this->assertFalse(
-            $this->app->get(Cache::class)->lock($this->getLockKey(UniqueTestJob::class), 10)->get()
-        );
     }
 
     public function testLockIsReleasedForSuccessfulJobs()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes #51798 

This fix was suggested in the original PR which introduced `ShouldBeUnique` [here](https://github.com/laravel/framework/pull/35042#issuecomment-811893712). Specifically pulled inspiration from the [gist](https://gist.github.com/abellion/54fa7bda01204d458439cb8a67e2b326) linked in the comments of that PR.

I pulled the logic for `shouldDispatch()` from the prexisting method in the `PendingDispatch` class. However I noticed in #39302 that an additional
```
if (! Container::getInstance()->bound(Cache::class)) {
    throw new RuntimeException('Cache driver not available. Scheduling unique jobs not supported.');
}
```
Check was added before attempting to acquire a lock. I'm not sure if checking for this should be done here?

I also wasn't quite sure the best way to write tests for this (or where best to put them), as the logic is buried pretty deep into the `Queue` class and required a lot of mocks. I wrote a couple as a proof of concept, but would improve/add more if necessary (suggestions/help welcome).

Also potentially of note is that the `shouldDispatch` check happens during the *callback* for `ShouldQueueAfterCommit` jobs. This means that the uniqueness is checked after the transaction, not immediately. I would think this behavior is desired, but I'm not quite sure

Lastly, this is a breaking change, as it prevents jobs from being queued sometimes when they previously would have been, therefore I've opened the PR to master

NOTE: Removed `testUniqueJobsAreNotDispatched` as it seems like a faulty test to me? It's essentially dispatching the job unto the `BusFake` (which never executes the job, since it's a fake), attempting to run the job with the queue worker, then asserting that the job lock still exists. But if the job has already run (or run synchronously), the lock should have already been released