### PR TITLE
[11.x] Fix event dispatcher typing in cache repository

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -43,7 +43,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * The event dispatcher implementation.
      *
-     * @var \Illuminate\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected $events;
 
@@ -661,7 +661,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get the event dispatcher instance.
      *
-     * @return \Illuminate\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
      */
     public function getEventDispatcher()
     {


### PR DESCRIPTION
The cache repository supports not having an event dispatcher, in which case it would be set to `null`. But the typings currently don't reflect this.

Example:
https://github.com/laravel/framework/blob/ae63a5b968f764ad0c5ecd86669bcc5fb8be90f7/src/Illuminate/Cache/Repository.php#L549