### PR TITLE
[11.x] Fix command argument parsing in testing

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -182,6 +182,10 @@ class Application extends SymfonyApplication implements ApplicationContract
         if (! isset($callingClass) && empty($parameters)) {
             $command = $this->getCommandName($input = new StringInput($command));
         } else {
+            $parameters = array_map(static function ($parameter) {
+                return is_array($parameter) ? array_map(strval(...), $parameter) : (string) $parameter;
+            }, $parameters);
+
             array_unshift($parameters, $command);
 
             $input = new ArrayInput($parameters);

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -55,11 +55,28 @@ class ArtisanCommandTest extends TestCase
         Artisan::command('contains', function () {
             $this->line('My name is Taylor Otwell');
         });
+
+        Artisan::command('type {args*}', function () {
+            $args = (array) $this->argument('args');
+
+            foreach ($args as $arg) {
+                $this->line(gettype($arg));
+            }
+        });
     }
 
     public function test_console_command_that_passes()
     {
         $this->artisan('exit', ['code' => 0])->assertOk();
+    }
+
+    public function test_console_arguments_are_strings()
+    {
+        $this->artisan('type', ['args' => [1, 'test', false]])
+            ->expectsOutput('string')
+            ->expectsOutput('string')
+            ->expectsOutput('string')
+            ->assertOk();
     }
 
     public function test_console_command_that_fails()


### PR DESCRIPTION
When calling an artisan command from a terminal, every argument is always a string but on the testing side it behaves differently.

For example:
```php
class MyCommand extends Command
{
    protected $signature = 'test {args*}';
    
    public function handle(): int
    {
        foreach($this->argument('args') as $arg){
            $this->line(gettype($arg));
        }
    }
}  
``` 
From a terminal, if you call `artisan test 1 false ok`, it will print : 
```
string
string
string
```

but a test like that would fail : 
```php
public function test()
{
    $this->artisan('test', ['args' => [1, 'test', false]])
        ->expectsOutput('string') // it's an int
        ->expectsOutput('string')
        ->expectsOutput('string'); // it's a bool
}
```

I'm not sure about the solution though...