### PR TITLE
[11.x] Update error page to show GET <path>

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -7,7 +7,6 @@ use Composer\Autoload\ClassLoader;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class Exception
@@ -162,16 +161,6 @@ class Exception
         $json = (string) json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
 
         return str_replace('\\', '', $json);
-    }
-
-    /**
-     * Get the request's path without query string.
-     *
-     * @return string
-     */
-    public function requestPath()
-    {
-        return Str::start($this->request()->path(), '/');
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -7,6 +7,7 @@ use Composer\Autoload\ClassLoader;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class Exception
@@ -161,6 +162,16 @@ class Exception
         $json = (string) json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
 
         return str_replace('\\', '', $json);
+    }
+
+    /**
+     * Get the request's path without query string.
+     *
+     * @return string
+     */
+    public function requestPath()
+    {
+        return Str::start($this->request()->path(), '/');
     }
 
     /**

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/context.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/context.blade.php
@@ -5,7 +5,7 @@
 
     <div class="mt-2">
         <span>{{ $exception->request()->method() }}</span>
-        <span class="text-gray-500">{{ $exception->request()->httpHost() }}</span>
+        <span class="text-gray-500">/{{ $exception->request()->path() }}</span>
     </div>
 
     <div class="mt-4">

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/context.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/context.blade.php
@@ -5,7 +5,7 @@
 
     <div class="mt-2">
         <span>{{ $exception->request()->method() }}</span>
-        <span class="text-gray-500">{{ $exception->requestPath() }}</span>
+        <span class="text-gray-500">{{ Illuminate\Support\Str::start($exception->request()->path(), '/') }}</span>
     </div>
 
     <div class="mt-4">

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/context.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/context.blade.php
@@ -5,7 +5,7 @@
 
     <div class="mt-2">
         <span>{{ $exception->request()->method() }}</span>
-        <span class="text-gray-500">/{{ $exception->request()->path() }}</span>
+        <span class="text-gray-500">{{ $exception->requestPath() }}</span>
     </div>
 
     <div class="mt-4">


### PR DESCRIPTION
This PR update the Request section of the new error page to show `GET <path>` (without version) as it might be shown in curl instead of currently `GET <host>`. There are still `GET <host>` above to the right that hide in small screen.

![image](https://github.com/laravel/framework/assets/379924/fd0c3335-e114-4aea-8b7c-39d6d516b329)
