### PR TITLE
[11.x] Remove useless variable assignment

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -105,7 +105,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function resolve($request = null)
     {
         $data = $this->toArray(
-            $request = $request ?: Container::getInstance()->make('request')
+            $request ?: Container::getInstance()->make('request')
         );
 
         if ($data instanceof Arrayable) {


### PR DESCRIPTION
The `$request` variable inside `Illuminate\Http\Resources\Json\JsonResource::resolve()` is useless, so I remove it.

```php
public function resolve($request = null)
{
    $data = $this->toArray(
        // It's unneeded to re-assign $request here.
        $request = $request ?: Container::getInstance()->make('request')
    );

    if ($data instanceof Arrayable) {
        $data = $data->toArray();
    } elseif ($data instanceof JsonSerializable) {
        $data = $data->jsonSerialize();
    }

    return $this->filter((array) $data);
}
```