### PR TITLE
[10.x] fix handle `shift()` on an empty collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1134,8 +1134,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             throw new InvalidArgumentException('Number of shifted items may not be less than zero.');
         }
 
-        if ($count === 0 || $this->isEmpty()) {
+        if ($count === 0) {
             return new static;
+        }
+
+        if ($this->isEmpty()) {
+            return null;
         }
 
         if ($count === 1) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1134,12 +1134,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             throw new InvalidArgumentException('Number of shifted items may not be less than zero.');
         }
 
-        if ($count === 0) {
-            return new static;
-        }
-
         if ($this->isEmpty()) {
             return null;
+        }
+
+        if ($count === 0) {
+            return new static;
         }
 
         if ($count === 1) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -406,20 +406,19 @@ class SupportCollectionTest extends TestCase
 
     public function testShiftReturnsNullOnEmptyCollection()
     {
-        $english = new \stdClass();
-        $english->text = 'f';
-        $dutch = new \stdClass();
-        $dutch->text = 'x';
+        $itemFoo = new \stdClass();
+        $itemFoo->text = 'f';
+        $itemBar = new \stdClass();
+        $itemBar->text = 'x';
 
-        $translations = collect([$english, $dutch]);
+        $items = collect([$itemFoo, $itemBar]);
 
-        $englishTranslation = $translations->shift();
-        $dutchTranslation = $translations->shift();
-        $danish = $translations->shift();
+        $foo = $items->shift();
+        $bar = $items->shift();
 
-        $englishTranslation?->text;
-        $dutchTranslation?->text;
-        $this->assertNull($danish);
+        $this->assertSame('f', $foo?->text);
+        $this->assertSame('x', $bar?->text);
+        $this->assertNull($items->shift());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,6 +404,24 @@ class SupportCollectionTest extends TestCase
         (new Collection(['foo', 'bar', 'baz']))->shift(-2);
     }
 
+    public function testShiftReturnsNullOnEmptyCollection()
+    {
+        $english = new \stdClass();
+        $english->text = 'f';
+        $dutch = new \stdClass();
+        $dutch->text = 'x';
+
+        $translations = collect([$english, $dutch]);
+
+        $englishTranslation = $translations->shift();
+        $dutchTranslation = $translations->shift();
+        $danish = $translations->shift();
+
+        $englishTranslation?->text;
+        $dutchTranslation?->text;
+        $this->assertNull($danish);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
fixes #51840

This PR fixes how the `Collection::shift()` method handles an empty collection.
Currently it will return the collection when trying to call `shift()` on an empty collection. Before it would return null.

## steps to reproduce

This is also covered in the added test.

1. create a collection with two objects
2. call shift() three times on it and assign it to variables
3. dump a property of the object for every variable
4. it will throw an exception saying it can not call the property on a collection