### PR TITLE
Chop PHP extension when passed to `make` commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -417,7 +417,13 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function getNameInput()
     {
-        return trim($this->argument('name'));
+        $name = trim($this->argument('name'));
+
+        if (Str::endsWith($name, '.php')) {
+            return Str::substr($name, 0, -4);
+        }
+
+        return $name;
     }
 
     /**

--- a/tests/Integration/Console/GeneratorCommandTest.php
+++ b/tests/Integration/Console/GeneratorCommandTest.php
@@ -2,11 +2,26 @@
 
 namespace Illuminate\Tests\Integration\Console;
 
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class GeneratorCommandTest extends TestCase
 {
+    use InteractsWithPublishedFiles;
+
+    protected $files = [
+        'app/Console/Commands/FooCommand.php',
+    ];
+
+    public function testItChopsPhpExtension()
+    {
+        $this->artisan('make:command', ['name' => 'FooCommand.php'])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Console/Commands/FooCommand.php');
+    }
+
     #[DataProvider('reservedNamesDataProvider')]
     public function testItCannotGenerateClassUsingReservedName($given)
     {


### PR DESCRIPTION
I mistakenly add the `.php` extension every so often when using `make` commands and it's a tiny, tiny papercut to see the double extension created. Having Laravel just "do the right thing" can be yet another one of its wonder DX improvements.

**Before**
```sh
php artisan make:controller UserController.php
# Controller [app/Http/Controllers/UserController.php.php] created successfully.
```

**After**
```sh
php artisan make:controller UserController.php
# Controller [app/Http/Controllers/UserController.php] created successfully.
```

