### PR TITLE
[11.x] Improve Bus::assertNothingDispatched(), Event::assertNothingDispatched(), Mail::assertNothingSent(), Notification::assertNothingSent() error messages

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -496,7 +496,12 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function assertNothingBatched()
     {
-        PHPUnit::assertEmpty($this->batches, 'Batched jobs were dispatched unexpectedly.');
+        $jobNames = collect($this->batches)
+            ->map(fn ($batch) => $batch->jobs->map(fn ($job) => get_class($job)))
+            ->flatten()
+            ->join("\n- ");
+
+        PHPUnit::assertEmpty($this->batches, "The following batched jobs were dispatched unexpectedly:\n\n- $jobNames\n");
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -186,7 +186,9 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function assertNothingDispatched()
     {
-        PHPUnit::assertEmpty($this->commands, 'Jobs were dispatched unexpectedly.');
+        $commandNames = implode("\n- ", array_keys($this->commands));
+
+        PHPUnit::assertEmpty($this->commands, "The following jobs were dispatched unexpectedly:\n\n- $commandNames\n");
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -192,9 +192,18 @@ class EventFake implements Dispatcher, Fake
     {
         $count = count(Arr::flatten($this->events));
 
+        $eventNames = collect($this->events)
+            ->map(fn ($events, $eventName) => sprintf(
+                '%s dispatched %s %s',
+                $eventName,
+                count($events),
+                Str::plural('time', count($events)),
+            ))
+            ->join("\n- ");
+
         PHPUnit::assertSame(
             0, $count,
-            "{$count} unexpected events were dispatched."
+            "{$count} unexpected events were dispatched:\n\n- $eventNames\n"
         );
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -152,7 +152,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             fn ($mailable) => get_class($mailable)
         )->join("\n- ");
 
-        PHPUnit::assertEmpty($this->mailables, "The following mailables were sent unexpectedly:\n\n- $mailableNames");
+        PHPUnit::assertEmpty($this->mailables, "The following mailables were sent unexpectedly:\n\n- $mailableNames\n");
     }
 
     /**
@@ -221,7 +221,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             fn ($mailable) => get_class($mailable)
         )->join("\n- ");
 
-        PHPUnit::assertEmpty($this->queuedMailables, "The following mailables were queued unexpectedly:\n\n- $mailableNames");
+        PHPUnit::assertEmpty($this->queuedMailables, "The following mailables were queued unexpectedly:\n\n- $mailableNames\n");
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -150,9 +150,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     {
         $mailableNames = collect($this->mailables)->map(
             fn ($mailable) => get_class($mailable)
-        )->join(PHP_EOL.'- ');
+        )->join("\n- ");
 
-        PHPUnit::assertEmpty($this->mailables, 'The following mailables were sent unexpectedly:'.PHP_EOL.PHP_EOL.'- '.$mailableNames.PHP_EOL);
+        PHPUnit::assertEmpty($this->mailables, "The following mailables were sent unexpectedly:\n\n- $mailableNames");
     }
 
     /**
@@ -219,9 +219,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     {
         $mailableNames = collect($this->queuedMailables)->map(
             fn ($mailable) => get_class($mailable)
-        )->join(', ');
+        )->join("\n- ");
 
-        PHPUnit::assertEmpty($this->queuedMailables, 'The following mailables were queued unexpectedly: '.$mailableNames);
+        PHPUnit::assertEmpty($this->queuedMailables, "The following mailables were queued unexpectedly:\n\n- $mailableNames");
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -150,9 +150,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     {
         $mailableNames = collect($this->mailables)->map(
             fn ($mailable) => get_class($mailable)
-        )->join(', ');
+        )->join(PHP_EOL.'- ');
 
-        PHPUnit::assertEmpty($this->mailables, 'The following mailables were sent unexpectedly: '.$mailableNames);
+        PHPUnit::assertEmpty($this->mailables, 'The following mailables were sent unexpectedly:'.PHP_EOL.PHP_EOL.'- '.$mailableNames.PHP_EOL);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -163,7 +163,13 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     public function assertNothingSent()
     {
-        PHPUnit::assertEmpty($this->notifications, 'Notifications were sent unexpectedly.');
+        $notificationNames = collect($this->notifications)
+            ->map(fn ($notifiableModels) => collect($notifiableModels)
+                ->map(fn ($notifiables) => collect($notifiables)->keys())
+            )
+            ->flatten()->join(PHP_EOL.'- ');
+
+        PHPUnit::assertEmpty($this->notifications, "The following notifications were sent unexpectedly:\n\n- $notificationNames\n");
     }
 
     /**
@@ -293,7 +299,6 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification
-     * @param  array|null  $channels
      * @return void
      */
     public function sendNow($notifiables, $notification, ?array $channels = null)
@@ -362,7 +367,6 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     /**
      * Specify if notification should be serialized and restored when being "pushed" to the queue.
      *
-     * @param  bool  $serializeAndRestore
      * @return $this
      */
     public function serializeAndRestore(bool $serializeAndRestore = true)

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -299,6 +299,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification
+     * @param  array|null  $channels
      * @return void
      */
     public function sendNow($notifiables, $notification, ?array $channels = null)
@@ -367,6 +368,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     /**
      * Specify if notification should be serialized and restored when being "pushed" to the queue.
      *
+     * @param  bool  $serializeAndRestore
      * @return $this
      */
     public function serializeAndRestore(bool $serializeAndRestore = true)

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -167,7 +167,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
             ->map(fn ($notifiableModels) => collect($notifiableModels)
                 ->map(fn ($notifiables) => collect($notifiables)->keys())
             )
-            ->flatten()->join(PHP_EOL.'- ');
+            ->flatten()->join("\n- ");
 
         PHPUnit::assertEmpty($this->notifications, "The following notifications were sent unexpectedly:\n\n- $notificationNames\n");
     }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -233,7 +233,7 @@ class EventFakeTest extends TestCase
             Event::assertNothingDispatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('2 unexpected events were dispatched.', $e->getMessage());
+            $this->assertStringContainsString("2 unexpected events were dispatched:\n\n- Illuminate\Tests\Integration\Events\ShouldDispatchAfterCommitEvent dispatched 2 times", $e->getMessage());
         }
     }
 }

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -464,7 +464,8 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fake->assertNothingDispatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('Jobs were dispatched unexpectedly.', $e->getMessage());
+            $this->assertStringContainsString('The following jobs were dispatched unexpectedly:', $e->getMessage());
+            $this->assertStringContainsString(get_class(new BusJobStub), $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -649,13 +649,15 @@ class SupportTestingBusFakeTest extends TestCase
     {
         $this->fake->assertNothingBatched();
 
-        $this->fake->batch([])->dispatch();
+        $job = new BusJobStub;
+
+        $this->fake->batch([$job])->dispatch();
 
         try {
             $this->fake->assertNothingBatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('Batched jobs were dispatched unexpectedly.', $e->getMessage());
+            $this->assertStringContainsString("The following batched jobs were dispatched unexpectedly:\n\n- ".get_class($job), $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -151,7 +151,7 @@ class SupportTestingEventFakeTest extends TestCase
             $this->fake->assertNothingDispatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('2 unexpected events were dispatched.', $e->getMessage());
+            $this->assertStringContainsString("2 unexpected events were dispatched:\n\n- Illuminate\Tests\Support\EventStub dispatched 2 times", $e->getMessage());
         }
     }
 }

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -216,7 +216,7 @@ class SupportTestingMailFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('The following mailables were sent unexpectedly: Illuminate\Tests\Support\MailableStub', $e->getMessage());
+            $this->assertStringContainsString('The following mailables were sent unexpectedly:'.PHP_EOL.PHP_EOL.'- Illuminate\Tests\Support\MailableStub', $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -216,7 +216,7 @@ class SupportTestingMailFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('The following mailables were sent unexpectedly:'.PHP_EOL.PHP_EOL.'- Illuminate\Tests\Support\MailableStub', $e->getMessage());
+            $this->assertStringContainsString("The following mailables were sent unexpectedly:\n\n- Illuminate\Tests\Support\MailableStub", $e->getMessage());
         }
     }
 
@@ -230,7 +230,7 @@ class SupportTestingMailFakeTest extends TestCase
             $this->fake->assertNothingQueued();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('The following mailables were queued unexpectedly: Illuminate\Tests\Support\MailableStub', $e->getMessage());
+            $this->assertStringContainsString("The following mailables were queued unexpectedly:\n\n- Illuminate\Tests\Support\MailableStub", $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -116,7 +116,7 @@ class SupportTestingNotificationFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('The following notifications were sent unexpectedly:'.PHP_EOL.PHP_EOL.'- '.get_class(new NotificationStub), $e->getMessage());
+            $this->assertStringContainsString("The following notifications were sent unexpectedly:\n\n- ".get_class(new NotificationStub), $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -116,7 +116,7 @@ class SupportTestingNotificationFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('Notifications were sent unexpectedly.', $e->getMessage());
+            $this->assertStringContainsString('The following notifications were sent unexpectedly:'.PHP_EOL.PHP_EOL.'- '.get_class(new NotificationStub), $e->getMessage());
         }
     }
 


### PR DESCRIPTION
Similar to #51814 for jobs, the `Bus::assertNothingDispatched()`, `Event::assertNothingDispatched()` `Mail::assertNothingSent()`, and `Notification::assertNothingSent()` methods don’t return much useful on failures:

![SCR-20240619-omhj](https://github.com/laravel/framework/assets/784333/88fca7c5-a056-4c33-abbb-663a0f1b3666)

This PR adds the names of the command(s)/mailable(s)/notification(s) that actually were pushed:

![SCR-20240619-omos](https://github.com/laravel/framework/assets/784333/28bac511-8cd8-456e-a122-e9bb2e79fc0e)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
