### PR TITLE
[11.x] Test Improvements

### DIFF
--- a/tests/Integration/Console/GeneratorCommandTest.php
+++ b/tests/Integration/Console/GeneratorCommandTest.php
@@ -12,6 +12,7 @@ class GeneratorCommandTest extends TestCase
 
     protected $files = [
         'app/Console/Commands/FooCommand.php',
+        'resources/views/foo/php.blade.php',
     ];
 
     public function testItChopsPhpExtension()
@@ -24,6 +25,14 @@ class GeneratorCommandTest extends TestCase
         $this->assertFileContains([
             'class FooCommand extends Command',
         ], 'app/Console/Commands/FooCommand.php');
+    }
+
+    public function testItChopsPhpExtensionFromMakeViewCommands()
+    {
+        $this->artisan('make:view', ['name' => 'foo.php'])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('resources/views/foo/php.blade.php');
     }
 
     #[DataProvider('reservedNamesDataProvider')]

--- a/tests/Integration/Console/GeneratorCommandTest.php
+++ b/tests/Integration/Console/GeneratorCommandTest.php
@@ -20,6 +20,10 @@ class GeneratorCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Console/Commands/FooCommand.php');
+
+        $this->assertFileContains([
+            'class FooCommand extends Command',
+        ], 'app/Console/Commands/FooCommand.php');
     }
 
     #[DataProvider('reservedNamesDataProvider')]


### PR DESCRIPTION
Verify generated class doesn't contain `.php` file extension. Improvements to #51842

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
