### PR TITLE
[11.x] Test application storage path

### DIFF
--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -75,13 +75,12 @@ class FoundationApplicationBuilderTest extends TestCase
     public function testStoragePathBasedOnBasePath()
     {
         $app = Application::configure()->create();
-        $this->assertSame($app->basePath() . DIRECTORY_SEPARATOR . 'storage', $app->storagePath());
+        $this->assertSame($app->basePath().DIRECTORY_SEPARATOR.'storage', $app->storagePath());
     }
 
     public function testStoragePathCanBeCustomized()
     {
         $_ENV['LARAVEL_STORAGE_PATH'] = __DIR__.'/env-storage';
-        $_SERVER['LARAVEL_STORAGE_PATH'] = __DIR__.'/server-storage';
 
         $app = Application::configure()->create();
         $app->useStoragePath(__DIR__.'/custom-storage');

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -14,6 +14,8 @@ class FoundationApplicationBuilderTest extends TestCase
 
         unset($_ENV['APP_BASE_PATH']);
 
+        unset($_ENV['LARAVEL_STORAGE_PATH'], $_SERVER['LARAVEL_STORAGE_PATH']);
+
         parent::tearDown();
     }
 
@@ -40,5 +42,50 @@ class FoundationApplicationBuilderTest extends TestCase
         $app = Application::configure()->create();
 
         $this->assertSame(dirname(__DIR__, 2), $app->basePath());
+    }
+
+    public function testStoragePathWithGlobalEnvVariable()
+    {
+        $_ENV['LARAVEL_STORAGE_PATH'] = __DIR__.'/env-storage';
+
+        $app = Application::configure()->create();
+
+        $this->assertSame(__DIR__.'/env-storage', $app->storagePath());
+    }
+
+    public function testStoragePathWithGlobalServerVariable()
+    {
+        $_SERVER['LARAVEL_STORAGE_PATH'] = __DIR__.'/server-storage';
+
+        $app = Application::configure()->create();
+
+        $this->assertSame(__DIR__.'/server-storage', $app->storagePath());
+    }
+
+    public function testStoragePathPrefersEnvVariable()
+    {
+        $_ENV['LARAVEL_STORAGE_PATH'] = __DIR__.'/env-storage';
+        $_SERVER['LARAVEL_STORAGE_PATH'] = __DIR__.'/server-storage';
+
+        $app = Application::configure()->create();
+
+        $this->assertSame(__DIR__.'/env-storage', $app->storagePath());
+    }
+
+    public function testStoragePathBasedOnBasePath()
+    {
+        $app = Application::configure()->create();
+        $this->assertSame($app->basePath() . DIRECTORY_SEPARATOR . 'storage', $app->storagePath());
+    }
+
+    public function testStoragePathCanBeCustomized()
+    {
+        $_ENV['LARAVEL_STORAGE_PATH'] = __DIR__.'/env-storage';
+        $_SERVER['LARAVEL_STORAGE_PATH'] = __DIR__.'/server-storage';
+
+        $app = Application::configure()->create();
+        $app->useStoragePath(__DIR__.'/custom-storage');
+
+        $this->assertSame(__DIR__.'/custom-storage', $app->storagePath());
     }
 }


### PR DESCRIPTION
The usage of application storage path is a bit complex, so I add some tests based on current behavior.

- If `$_ENV['LARAVEL_STORAGE_PATH']` is set, it will be used.
- If `$_SERVER['LARAVEL_STORAGE_PATH']` is set, it will be used.
- If both `$_ENV['LARAVEL_STORAGE_PATH']` and `$_SERVER['LARAVEL_STORAGE_PATH']` are set, the `$_ENV` global variable is preferred.
- If both `$_ENV['LARAVEL_STORAGE_PATH']` and `$_SERVER['LARAVEL_STORAGE_PATH']` are **NOT** set, it will be based on the base path.
- `useStoragePath` will override the storage path and ignore earlier setup.