### PR TITLE
[11.x] Fix PHP_MAXPATHLEN check for strings slightly smaller then PHP_MAXPATHLEN

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -130,7 +130,7 @@ class FileViewFinder implements ViewFinderInterface
             foreach ($this->getPossibleViewFiles($name) as $file) {
                 $viewPath = $path.'/'.$file;
 
-                if (strlen($viewPath) <= PHP_MAXPATHLEN && $this->files->exists($viewPath)) {
+                if (strlen($viewPath) < (PHP_MAXPATHLEN - 1) && $this->files->exists($viewPath)) {
                     return $viewPath;
                 }
             }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -43,11 +43,13 @@ class BladeTest extends TestCase
             $this->assertNotFalse($iniSet, 'Could not set config for open_basedir.');
         }
 
-        $longString = str_repeat('x', PHP_MAXPATHLEN);
+        for ($i = PHP_MAXPATHLEN - 200; $i <= PHP_MAXPATHLEN + 1; $i++) {
+            $longString = str_repeat('x', $i);
 
-        $result = Blade::render($longString);
+            $result = Blade::render($longString);
 
-        $this->assertSame($longString, $result);
+            $this->assertSame($longString, $result);
+        }
     }
 
     public function test_rendering_blade_component_instance()


### PR DESCRIPTION
In #50962 we fixed a bug that was supposed to fix the `PHP_MAXLENGHT` problem with the OpenBasedir configuration. This fix was wrong, because the PHP variable `PHP_MAXLENGHT` behaves differently than the name suggests. In fact, files can have a maximum length of `PHP_MAXLENGHT - 1` character [1].

Because the test was also faulty and did not take the path into account internally, the test was unable to detect the error. 

This pull request fixes both the test (see the first commit), which shows that the problem still exists (see the tests from the first commit) and the actual problem in the second commit.  

[1] https://github.com/php/php-src/blob/7c860628cd2bf11ee867bfb41b3fd0314c5177c5/main/fopen_wrappers.c#L301