### PR TITLE
[11.x] Added whereNot to Enumerates

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -618,6 +618,22 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items where key isn't the value.
+     *
+     * @param  callable|string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereNot($key, $value = null)
+    {
+        if ($value === null) {
+            return $this->whereNotNull($key);
+        }
+
+        return $this->where($key, '!=', $value);
+    }
+
+    /**
      * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key


### PR DESCRIPTION
This seems a small (missing) addition to Collections in general. I've looked over the issues / discussions in the past and couldn't find anything.

If i've missed something, just ignore this.

