### PR TITLE
[11.x] Add an `Arr::unique()` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -950,4 +950,15 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+    
+    /**
+     * Get all of the unique items in the array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function unique($array)
+    {
+        return array_unique($array);
+    }
 }


### PR DESCRIPTION
Adds an `Arr::unique()` method to wrap the `array_unique` function. I have held off with adding tests until I know if this feature is desired. It surprises me that there is no such method yet, so I wondered if there is a reason for it not being present, though searching for it on Google and GitHub yields nothing. Of course more than happy to add tests if this is something that can be merged.