### PR TITLE
[11.x] Add multiply to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -831,6 +831,23 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Multiply the items in the collection by the multiplier.
+     *
+     * @param  $multiplier
+     * @return static
+     */
+    public function multiply($multiplier)
+    {
+        $new = new static();
+
+        for ($i = 0; $i < $multiplier; $i++) {
+            $new->push(...$this->items);
+        }
+
+        return $new;
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @template TCombineValue

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -833,12 +833,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Multiply the items in the collection by the multiplier.
      *
-     * @param  $multiplier
+     * @param  int  $multiplier
      * @return static
      */
-    public function multiply($multiplier)
+    public function multiply(int $multiplier)
     {
-        $new = new static();
+        $new = new static;
 
         for ($i = 0; $i < $multiplier; $i++) {
             $new->push(...$this->items);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -842,6 +842,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Multiply the items in the collection by the multiplier.
+     *
+     * @param  $multiplier
+     * @return static
+     */
+    public function multiply($multiplier)
+    {
+        return $this->passthru('multiply', func_get_args());
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @template TCombineValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -844,10 +844,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Multiply the items in the collection by the multiplier.
      *
-     * @param  $multiplier
+     * @param  int  $multiplier
      * @return static
      */
-    public function multiply($multiplier)
+    public function multiply(int $multiplier)
     {
         return $this->passthru('multiply', func_get_args());
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -510,6 +510,21 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['visible', 'hidden'], $c[0]->getVisible());
     }
 
+    public function testMultiply()
+    {
+        $a = new TestEloquentCollectionModel();
+        $b = new TestEloquentCollectionModel();
+
+        $c = new Collection([$a, $b]);
+
+        $this->assertEquals([], $c->multiply(-1)->all());
+        $this->assertEquals([], $c->multiply(0)->all());
+
+        $this->assertEquals([$a, $b], $c->multiply(1)->all());
+
+        $this->assertEquals([$a, $b, $a, $b, $a, $b], $c->multiply(3)->all());
+    }
+
     public function testQueueableCollectionImplementation()
     {
         $c = new Collection([new TestEloquentCollectionModel, new TestEloquentCollectionModel]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1232,6 +1232,25 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testMultiplyCollection($collection)
+    {
+        $c = new $collection(['Hello', 1, ['tags' => ['a', 'b'], 'admin']]);
+
+        $this->assertEquals([], $c->multiply(-1)->all());
+        $this->assertEquals([], $c->multiply(0)->all());
+
+        $this->assertEquals(
+            ['Hello', 1, ['tags' => ['a', 'b'], 'admin']],
+            $c->multiply(1)->all()
+        );
+
+        $this->assertEquals(
+            ['Hello', 1, ['tags' => ['a', 'b'], 'admin'], 'Hello', 1, ['tags' => ['a', 'b'], 'admin'], 'Hello', 1, ['tags' => ['a', 'b'], 'admin']],
+            $c->multiply(3)->all()
+        );
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testReplaceNull($collection)
     {
         $c = new $collection(['a', 'b', 'c']);


### PR DESCRIPTION
When I'm building UIs I usually want to know what the layout will look like if there is a lot of things. I am constantly doing something like this for strings:

```blade
<div>
  {{ $user->name }} 
  {{ $user->name }} 
  {{ $user->name }} 
  {{ $user->name }}
</div>
```

But when it comes to collections things get a little more difficult.

```blade
@foreach($class->students as $student)
   <x-student :student="$student" />
@endforeach
```

I've had this method in a macro for quite some time and thought it might be useful for others.

```blade
@foreach($class->students->multiply(4) as $student)
   <x-student :student="$student" />
@endforeach
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
