### PR TITLE
[11.x] Describe the purpose and function of `queue:work --memory`

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -40,7 +40,7 @@ class WorkCommand extends Command
                             {--max-jobs=0 : The number of jobs to process before stopping}
                             {--max-time=0 : The maximum number of seconds the worker should run}
                             {--force : Force the worker to run even in maintenance mode}
-                            {--memory=128 : The memory limit in megabytes}
+                            {--memory=128 : The worker stops to free leaked memory if more megabytes of memory are used while idle}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -131,7 +131,7 @@ class WorkCommandTest extends QueueTestCase
             '--max-jobs' => 1,
         ]);
 
-        // Memory limit isn't checked until after the first job is attempted.
+        // Processing stops after max jobs are exceeded.
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
@@ -151,7 +151,7 @@ class WorkCommandTest extends QueueTestCase
             '--max-time' => 1,
         ]);
 
-        // Memory limit isn't checked until after the first job is attempted.
+        // ThirdJob sleeps for 1 second, thus no further jobs are processed.
         $this->assertSame(2, Queue::size());
         $this->assertTrue(ThirdJob::$ran);
         $this->assertFalse(FirstJob::$ran);


### PR DESCRIPTION
The implementation of `--memory` is actually really clever. I found it to be very useful to prevent potential memory leaks. However, its description does not fully describe what it does.

My first interpretation of its function was that it sets a limit on the amount of memory that individual jobs may use. Thus, I set it to a value that equals [the PHP INI setting `memory_limit`](https://www.php.net/manual/de/ini.core.php#ini.memory-limit). This setting essentially made the option useless, as the worker now kept running until it was right at the cusp of using up all memory. Subsequently, the next job to start processing would fail.

I found that it is probably best to just leave the default, unless your queue worker uses a lot of memory while idle. If this were the case, the queue worker would always stop after processing a single job, causing unnecessary restarts. For most applications, 128MB should be sufficient.

In conclusion, I think it is valuable to describe this option in more detail. Even though most users will not have to modify it, there is potential for misunderstanding is purpose, leading to a misconfiguration that actually makes your queue worker less reliable.

I also updated the documentation in https://github.com/laravel/docs/pull/9719.