### PR TITLE
[11.x] feat: add generics to tap() helper

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -540,7 +540,7 @@ trait BuildsQueries
     /**
      * Pass the query to a given callback.
      *
-     * @param  callable  $callback
+     * @param  callable($this): mixed  $callback
      * @return $this
      */
     public function tap($callback)

--- a/src/Illuminate/Support/Traits/Tappable.php
+++ b/src/Illuminate/Support/Traits/Tappable.php
@@ -7,8 +7,8 @@ trait Tappable
     /**
      * Call the given Closure with this instance then return the instance.
      *
-     * @param  callable|null  $callback
-     * @return $this|\Illuminate\Support\HigherOrderTapProxy
+     * @param  (callable($this): mixed)|null  $callback
+     * @return ($callback is null ? \Illuminate\Support\HigherOrderTapProxy : $this)
      */
     public function tap($callback = null)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -350,9 +350,11 @@ if (! function_exists('tap')) {
     /**
      * Call the given Closure with the given value then return the value.
      *
-     * @param  mixed  $value
-     * @param  callable|null  $callback
-     * @return mixed
+     * @template TValue
+     *
+     * @param  TValue  $value
+     * @param  (callable(TValue): mixed)|null  $callback
+     * @return ($callback is null ? \Illuminate\Support\HigherOrderTapProxy : TValue)
      */
     function tap($value, $callback = null)
     {

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -67,3 +67,8 @@ assertType('null', transform([], fn () => 1));
 assertType('int|null', rescue(fn () => 123));
 assertType('int', rescue(fn () => 123, 345));
 assertType('int', rescue(fn () => 123, fn () => 345));
+
+assertType('User', tap(new User(), function ($user) {
+    assertType('User', $user);
+}));
+assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello! 

This PR adds generics to the `tap()` helper so it properly knows the correct return type:

```php
        // returned mixed, now returns RepositoryFake
        return tap(new RepositoryFake($feed), function ($fake) {
            static::swap($fake);
        });
```

I also went ahead and made some of the other `tap` methods more specific.

Thanks!