### PR TITLE
[11.x] feat: Add ability to set directory with console commands

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -266,13 +266,15 @@ class ApplicationBuilder
     /**
      * Register additional Artisan commands with the application.
      *
-     * @param  array  $commands
+     * @param  array|string  $commands
      * @return $this
      */
-    public function withCommands(array $commands = [])
+    public function withCommands(array|string $commands = [])
     {
         if (empty($commands)) {
             $commands = [$this->app->path('Console/Commands')];
+        } elseif (is_string($commands)) {
+            $commands = [$this->app->path($commands)];
         }
 
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($commands) {


### PR DESCRIPTION
Hello!

I want to add the ability to specify the path to the directory for storing console commands when configuring the application.

Now in the `withCommands()` method the path is hardcoded as `Console/Commands` and it cannot be changed, and if you store commands in another directory, they must be registered manually.

In my opinion, after removing the `\Console\Kernel`, a more suitable place is `Commands`. 

```php
Application::configure(basePath: dirname(__DIR__))
  ->withCommands([
    \Commands\SomeCommand::class,
    \Commands\AnotherDir\AnotherCommand::class,
  ])
  ->create();
```
My propporsal:
```php
Application::configure(basePath: dirname(__DIR__))
  ->withCommands('Commands')
  ->create();
```
PS: I haven't found tests for the `withCommands()` method and I'm not sure if I need to write them and if so, where to do it.