### PR TITLE
[11.x] Fix: Ensure createUserProvider Consistently Returns Expected Types

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -24,7 +24,7 @@ trait CreatesUserProviders
     public function createUserProvider($provider = null)
     {
         if (is_null($config = $this->getProviderConfiguration($provider))) {
-            return;
+            return null;
         }
 
         if (isset($this->customProviderCreators[$driver = ($config['driver'] ?? null)])) {


### PR DESCRIPTION
The `createUserProvider` method now explicitly returns `null` when the provider configuration is null, ensuring compliance with the expected return type mentioned in the doc block.