### PR TITLE
[11.x] Fix validation attributes when translations are empty or missing

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -305,8 +305,12 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
+        if (($attributes = $this->translator->get('validation.attributes')) === 'validation.attributes') {
+            return null;
+        }
+        
         return $this->getAttributeFromLocalArray(
-            $name, Arr::dot((array) $this->translator->get('validation.attributes'))
+            $name, Arr::dot((array) $attributes)
         );
     }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -305,7 +305,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        if (!is_array($attributes = $this->translator->get('validation.attributes'))) {
+        if (! is_array($attributes = $this->translator->get('validation.attributes'))) {
             return null;
         }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -305,13 +305,11 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        if (($attributes = $this->translator->get('validation.attributes')) === 'validation.attributes') {
+        if (!is_array($attributes = $this->translator->get('validation.attributes'))) {
             return null;
         }
-        
-        return $this->getAttributeFromLocalArray(
-            $name, Arr::dot((array) $attributes)
-        );
+
+        return $this->getAttributeFromLocalArray($name, Arr::dot($attributes));
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -592,6 +592,20 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('User ID is required!', $v->messages()->first('users.0.id'));
     }
 
+    public function testTranslatedAttributesCanBeMissing()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.gt.numeric' => ':attribute must be greater than :value.'], 'en');
+        $trans->addLines(['validation.attributes' => []], 'en');
+        $v = new Validator($trans, ['total' => 0], ['total' => 'gt:0']);
+        $this->assertSame("total must be greater than 0.", $v->messages()->first('total'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.gt.numeric' => ':attribute must be greater than :value.'], 'en');
+        $v = new Validator($trans, ['total' => 0], ['total' => 'gt:0']);
+        $this->assertSame("total must be greater than 0.", $v->messages()->first('total'));
+    }
+
     public function testInputIsReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -598,12 +598,12 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.gt.numeric' => ':attribute must be greater than :value.'], 'en');
         $trans->addLines(['validation.attributes' => []], 'en');
         $v = new Validator($trans, ['total' => 0], ['total' => 'gt:0']);
-        $this->assertSame("total must be greater than 0.", $v->messages()->first('total'));
+        $this->assertSame('total must be greater than 0.', $v->messages()->first('total'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.gt.numeric' => ':attribute must be greater than :value.'], 'en');
         $v = new Validator($trans, ['total' => 0], ['total' => 'gt:0']);
-        $this->assertSame("total must be greater than 0.", $v->messages()->first('total'));
+        $this->assertSame('total must be greater than 0.', $v->messages()->first('total'));
     }
 
     public function testInputIsReplaced()


### PR DESCRIPTION
Resolves issue #51849 that was introduced with #51805 (released in 11.11.0) where validation attributes would be replaced with the string `validation.attributes` if no inline attribute name was provided and the custom attribute translations were either empty or not set.

Includes a test to catch this in the future.