### PR TITLE
[11.x] Change closure to arrow function in Dispatcher

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -263,9 +263,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchAfterResponse($command, $handler = null)
     {
-        $this->container->terminating(function () use ($command, $handler) {
-            $this->dispatchSync($command, $handler);
-        });
+        $this->container->terminating(fn () => $this->dispatchSync($command, $handler));
     }
 
     /**


### PR DESCRIPTION
Hi
I changed closure to arrow function in `Dispatcher` to make the code more readable.
