### PR TITLE
[11.x] Test configs when the key contains dash or underline

### DIFF
--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -43,9 +43,29 @@ class RepositoryTest extends TestCase
             'a' => [
                 'b.c' => 'd',
             ],
+            'azibom-car' => 'a',
+            'azibom_car' => 'b',
+            'azibom' => [
+                'car-a' => 'c',
+                'car_b' => 'd',
+            ],
         ]);
 
         parent::setUp();
+    }
+
+    public function testGetValueWhenKeyContainDash()
+    {
+        $this->assertSame($this->repository->get('azibom-car'), 'a');
+        $this->assertNull($this->repository->get('azibom-car-a'));
+        $this->assertNull($this->repository->get('-'));
+    }
+
+    public function testGetValueWhenKeyContainUnderline()
+    {
+        $this->assertSame($this->repository->get('azibom_car'), 'b');
+        $this->assertNull($this->repository->get('azibom_car_b'));
+        $this->assertNull($this->repository->get('_'));
     }
 
     public function testGetValueWhenKeyContainDot()


### PR DESCRIPTION
Hi
I added some tests in the `Config` for when the key contains dash or underline.