### PR TITLE
Add editor into config app.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -187,4 +187,21 @@ return [
         // 'Example' => App\Facades\Example::class,
     ])->toArray(),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Editor
+    |--------------------------------------------------------------------------
+    |
+    | The editor can be customized and will be used by the error page
+    | in debug mode or the dump() and dd()functions to link directly
+    | into your editor at the right file and line 
+    |
+    | Supported editors: "atom", "emacs", "idea", "macvim",
+    |                    "netbeans", "nova", "phpstorm", "sublime",
+    |                    "textmate", "vscode", "vscode-insiders",
+    |                    "vscode-insiders-remote", "vscode-remote", "vscodium", "xdebug"
+    |
+    */
+    'editor' => env('APP_EDITOR'),
+
 ];


### PR DESCRIPTION
The main goal is to let devs set their favorite editor in the .env file instead of adding this line in the app.php config file.

Since the app.php file may not be published if nothing is overrided, the editor config provides no value for the application itself.