### PR TITLE
[11.x] Add addEventDiscoveryPaths to EventServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -180,6 +180,17 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
+     * Add the given event discovery paths to the application's event discovery paths.
+     *
+     * @param  string|array  $paths
+     * @return void
+     */
+    public static function addEventDiscoveryPaths(string|array $paths)
+    {
+        static::$eventDiscoveryPaths = array_merge(static::$eventDiscoveryPaths, Arr::wrap($paths));
+    }
+
+    /**
      * Get the base path to be used during event discovery.
      *
      * @return string

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -169,6 +169,17 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
+     * Add the given event discovery paths to the application's event discovery paths.
+     *
+     * @param  string|array  $paths
+     * @return void
+     */
+    public static function addEventDiscoveryPaths(array|string $paths)
+    {
+        static::$eventDiscoveryPaths = array_merge(static::$eventDiscoveryPaths, Arr::wrap($paths));
+    }
+
+    /**
      * Set the globally configured event discovery paths.
      *
      * @param  array  $paths
@@ -177,17 +188,6 @@ class EventServiceProvider extends ServiceProvider
     public static function setEventDiscoveryPaths(array $paths)
     {
         static::$eventDiscoveryPaths = $paths;
-    }
-
-    /**
-     * Add the given event discovery paths to the application's event discovery paths.
-     *
-     * @param  string|array  $paths
-     * @return void
-     */
-    public static function addEventDiscoveryPaths(string|array $paths)
-    {
-        static::$eventDiscoveryPaths = array_merge(static::$eventDiscoveryPaths, Arr::wrap($paths));
     }
 
     /**


### PR DESCRIPTION
This pull request introduces the capability to append discovery paths to the `EventServiceProvider`, rather than overwriting the entire array.

In our application, we manage a domain structure where each domain has its own event listeners. Shared Listeners are still in the original location.

In our `DomainServiceProvider` we iterate through those domains add register views, Livewire components etc. This enhancement allows us to add discovery paths in the DomainServiceProvider without overwriting the existing paths. This way, each domain can register its listeners independently.

Since I did not find tests for the method `setEventDiscoveryPaths`, I did not add any for the new method. 