### PR TITLE
[11.x] Update config:show command

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -14,14 +14,14 @@ class ConfigShowCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'config:show {config : The configuration file to show}';
+    protected $signature = 'config:show {config : The configuration file or key (using "dot" annotation) to show}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Display all of the values for a given configuration file';
+    protected $description = 'Display all of the values for a given configuration file or key (using "dot" annotation)';
 
     /**
      * Execute the console command.
@@ -33,7 +33,7 @@ class ConfigShowCommand extends Command
         $config = $this->argument('config');
 
         if (! config()->has($config)) {
-            $this->components->error("Configuration file `{$config}` does not exist.");
+            $this->components->error("Configuration file or key <comment>{$config}</comment> does not exist.");
 
             return Command::FAILURE;
         }

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -14,14 +14,14 @@ class ConfigShowCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'config:show {config : The configuration file or key (using "dot" annotation) to show}';
+    protected $signature = 'config:show {config : The configuration file or key to show}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Display all of the values for a given configuration file or key (using "dot" annotation)';
+    protected $description = 'Display all of the values for a given configuration file or key';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
The `config:show` can show either configuration file or key (using "dot" annotation). So I update it's description.
