### PR TITLE
feat: Add Number::pairs

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -235,20 +235,20 @@ class Number
     /**
      * Split the given number into pairs of min/max values.
      *
-     * @param int|float $number
-     * @param int|float $split
+     * @param int|float $to
+     * @param int|float $by
      * @param int|float $offset
      * @return array
      */
-    public static function pairs(int|float $number, int|float $split, int|float $offset = 1)
+    public static function pairs(int|float $to, int|float $by, int|float $offset = 1)
     {
         $output = [];
 
-        for ($lower = 0; $lower < $number; $lower += $split) {
-            $upper = $lower + $split;
+        for ($lower = 0; $lower < $to; $lower += $by) {
+            $upper = $lower + $by;
 
-            if ($upper > $number) {
-                $upper = $number;
+            if ($upper > $to) {
+                $upper = $to;
             }
 
             $output[] = [$lower + $offset, $upper];

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -233,6 +233,31 @@ class Number
     }
 
     /**
+     * Split the given number into pairs of min/max values.
+     *
+     * @param int|float $number
+     * @param int|float $split
+     * @param int|float $offset
+     * @return array
+     */
+    public static function pairs(int|float $number, int|float $split, int|float $offset = 1)
+    {
+        $output = [];
+
+        for ($lower = 0; $lower < $number; $lower += $split) {
+            $upper = $lower + $split;
+
+            if ($upper > $number) {
+                $upper = $number;
+            }
+
+            $output[] = [$lower + $offset, $upper];
+        }
+
+        return $output;
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -286,4 +286,11 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
     }
+
+    public function testPairs()
+    {
+        $this->assertSame([[1,10],[11,20],[21,25]], Number::pairs(25, 10));
+        $this->assertSame([[0,10],[10,20],[20,25]], Number::pairs(25, 10, 0));
+        $this->assertSame([[0,2.5],[2.5,5.0],[5.0,7.5],[7.5,10.0]], Number::pairs(10, 2.5, 0));
+    }
 }


### PR DESCRIPTION
The `Number::pairs()` method provides the ability to "split" a number into pairs of min/max values. It's sort of like `sliding`, except the method will determine the values for you.

The method can create pairs of integers or floats.

Examples:

```php
$output = Number::pairs(25, 10);

// [[1, 10], [11, 20], [21, 25]]

$output = Number::pairs(25, 10, 0);

// [[0, 10], [10, 20], [20, 25]]

$output = Number::pairs(10, 2.5, 0)

// [[0, 2.5], [2.5, 5.0], [5.0, 7.5], [7.5, 10.0]]
```

Thanks!