### PR TITLE
[11.x] Make MultipleInstanceManager driver field customizable

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -30,19 +30,18 @@ abstract class MultipleInstanceManager
     protected $customCreators = [];
 
     /**
+     * The key name of the "driver" equivalent configuration option.
+     *
+     * @var string
+     */
+    protected $driverKey = 'driver';
+
+    /**
      * Create a new manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-
-    /**
-     * The field name of the driver.
-     *
-     * @var string
-     */
-    protected $driverField = 'driver';
-
     public function __construct($app)
     {
         $this->app = $app;
@@ -112,19 +111,19 @@ abstract class MultipleInstanceManager
             throw new InvalidArgumentException("Instance [{$name}] is not defined.");
         }
 
-        if (! array_key_exists($this->driverField, $config)) {
-            throw new RuntimeException("Instance [{$name}] does not specify a {$this->driverField}.");
+        if (! array_key_exists($this->driverKey, $config)) {
+            throw new RuntimeException("Instance [{$name}] does not specify a {$this->driverKey}.");
         }
 
-        if (isset($this->customCreators[$config[$this->driverField]])) {
+        if (isset($this->customCreators[$config[$this->driverKey]])) {
             return $this->callCustomCreator($config);
         } else {
-            $createMethod = 'create'.ucfirst($config[$this->driverField]).ucfirst($this->driverField);
+            $createMethod = 'create'.ucfirst($config[$this->driverKey]).ucfirst($this->driverKey);
 
             if (method_exists($this, $createMethod)) {
                 return $this->{$createMethod}($config);
             } else {
-                throw new InvalidArgumentException("Instance {$this->driverField} [{$config[$this->driverField]}] is not supported.");
+                throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
             }
         }
     }
@@ -137,7 +136,7 @@ abstract class MultipleInstanceManager
      */
     protected function callCustomCreator(array $config)
     {
-        return $this->customCreators[$config[$this->driverField]]($this->app, $config);
+        return $this->customCreators[$config[$this->driverKey]]($this->app, $config);
     }
 
     /**

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -35,6 +35,14 @@ abstract class MultipleInstanceManager
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
+
+    /**
+     * The field name of the driver.
+     *
+     * @var string
+     */
+    protected $driverField = 'driver';
+
     public function __construct($app)
     {
         $this->app = $app;
@@ -104,19 +112,19 @@ abstract class MultipleInstanceManager
             throw new InvalidArgumentException("Instance [{$name}] is not defined.");
         }
 
-        if (! array_key_exists('driver', $config)) {
-            throw new RuntimeException("Instance [{$name}] does not specify a driver.");
+        if (! array_key_exists($this->driverField, $config)) {
+            throw new RuntimeException("Instance [{$name}] does not specify a {$this->driverField}.");
         }
 
-        if (isset($this->customCreators[$config['driver']])) {
+        if (isset($this->customCreators[$config[$this->driverField]])) {
             return $this->callCustomCreator($config);
         } else {
-            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+            $createMethod = 'create'.ucfirst($config[$this->driverField]).ucfirst($this->driverField);
 
-            if (method_exists($this, $driverMethod)) {
-                return $this->{$driverMethod}($config);
+            if (method_exists($this, $createMethod)) {
+                return $this->{$createMethod}($config);
             } else {
-                throw new InvalidArgumentException("Instance driver [{$config['driver']}] is not supported.");
+                throw new InvalidArgumentException("Instance {$this->driverField} [{$config[$this->driverField]}] is not supported.");
             }
         }
     }
@@ -129,7 +137,7 @@ abstract class MultipleInstanceManager
      */
     protected function callCustomCreator(array $config)
     {
-        return $this->customCreators[$config['driver']]($this->app, $config);
+        return $this->customCreators[$config[$this->driverField]]($this->app, $config);
     }
 
     /**


### PR DESCRIPTION
It's not always the case that the field is `driver`. Mail for example uses `transport`.

I want to create my own SMS Manager and my config looks like this:

```php
return [
  'default' => env('SMS_CHANNEL', 'vonage'),
  
  'channels' => [
    
    'vonage' => [
      'provider' => 'vonage',
      'key' => env('SMS_VONAGE_KEY'),
      'secret' => env('SMS_VONAGE_SECRET'),
    ],
    
    'twilio' => [
      'provider' => 'twilio',
      'account_sid' => env('SMS_TWILIO_ACCOUNT_SID'),
      'auth_token' => env('SMS_TWILIO_AUTH_TOKEN'),
    ],
    
    'log' => [
      'provider' => 'log',
    ]
  ]
]

```

I use `provider` here but the abstract class currently forces us to use `driver` only.