### PR TITLE
[11.x] Add Support for Extensions in Str::markdown Method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -641,11 +641,11 @@ class Str
     {
         $converter = new GithubFlavoredMarkdownConverter($options);
 
-		$environment = $converter->getEnvironment();
+        $environment = $converter->getEnvironment();
 
-		foreach ($extensions as $extension) {
-			$environment->addExtension($extension);
-		}
+        foreach ($extensions as $extension) {
+            $environment->addExtension($extension);
+        }
 
         return (string) $converter->convert($string);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -637,9 +637,15 @@ class Str
      * @param  array  $options
      * @return string
      */
-    public static function markdown($string, array $options = [])
+    public static function markdown($string, array $options = [], array $extensions = [])
     {
         $converter = new GithubFlavoredMarkdownConverter($options);
+
+		$environment = $converter->getEnvironment();
+
+		foreach ($extensions as $extension) {
+			$environment->addExtension($extension);
+		}
 
         return (string) $converter->convert($string);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -635,6 +635,7 @@ class Str
      *
      * @param  string  $string
      * @param  array  $options
+     * @param  array  $extensions
      * @return string
      */
     public static function markdown($string, array $options = [], array $extensions = [])


### PR DESCRIPTION
Hey Taylor and team 👋 Hope you guys are doing well!

I wanted to submit a simple PR that allows anyone using the `Str::markdown(...)` method to add some [CommonMark Extensions](https://commonmark.thephpleague.com/extensions/overview/) as a third parameter. Here is a quick example of how you could use this in a controller:

```php

public function parseMarkdownFromFile($file_location){

    $markdown_contents = File::get($file_location);
    
    $html = Str::markdown($markdown_contents, [], [
        new AttributesExtension(),
        new TaskListExtension(),
    ]);

    return $html;

}
```

Here's a quick 60 second video of this in action 👍 Sound on 🔉

https://github.com/laravel/framework/assets/601261/5a5cb36a-e3e3-4f37-b813-16afe6d37e76

I didn't see any tests associated with the `Str::markdown()` method, but if there are some you would like me to update, let me know 😉 I'm open to making any changes if there's another way you want to see this implemented. 

Really appreciate it. Talk to you soon!