### PR TITLE
[11.x] Fix the edge case of `.php` extension chopping in make commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -417,7 +417,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function getNameInput()
     {
-        return (string) Str::of($this->argument('name'))->trim()->beforeLast('.php');
+        return (string) Str::of($this->argument('name'))->trim()->rtrim('.php');
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -417,7 +417,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function getNameInput()
     {
-        return (string) Str::of($this->argument('name'))->trim()->rtrim('.php');
+        return (string) Str::of($this->argument('name'))->trim()->chopEnd('.php');
     }
 
     /**


### PR DESCRIPTION
As pointed by @jasonmccreary in this comment: https://github.com/laravel/framework/pull/51843#issuecomment-2190232393

Update: dependent on https://github.com/laravel/framework/pull/51924