### PR TITLE
[11.x] Mark `$queue` as nullable

### DIFF
--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -14,7 +14,7 @@ class JobQueued
     /**
      * The queue name.
      *
-     * @var string
+     * @var string|null
      */
     public $queue;
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -317,7 +317,7 @@ abstract class Queue
      *
      * @param  \Closure|string|object  $job
      * @param  string  $payload
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  callable  $callback
      * @return mixed
@@ -384,7 +384,7 @@ abstract class Queue
     /**
      * Raise the job queued event.
      *
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @param  string|int|null  $jobId
      * @param  \Closure|string|object  $job
      * @param  string  $payload


### PR DESCRIPTION
The `$queue` variable passed to the `enqueueUsing` method may be `null` when the calling code does not specify a queue to dispatch on, i.e., they want to use the default queue.

```php
class MyJob implements ShouldQueue
{
    use Dispatchable;
}

Event::listen(fn (JobQueued $event) => dump($event->queue));

MyJob::dispatch();

// null

dispatch(function () {
    //
});

// null

```