### PR TITLE
[11.x] Fix console prompt docblock

### DIFF
--- a/src/Illuminate/Console/View/Components/Ask.php
+++ b/src/Illuminate/Console/View/Components/Ask.php
@@ -11,6 +11,7 @@ class Ask extends Component
      *
      * @param  string  $question
      * @param  string  $default
+     * @param  bool  $multiline
      * @return mixed
      */
     public function render($question, $default = null, $multiline = false)

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 
 /**
  * @method void alert(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
- * @method mixed ask(string $question, string $default = null)
+ * @method mixed ask(string $question, string $default = null, bool $multiline = false)
  * @method mixed askWithCompletion(string $question, array|callable $choices, string $default = null)
  * @method void bulletList(array $elements, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method mixed choice(string $question, array $choices, $default = null, int $attempts = null, bool $multiple = false)


### PR DESCRIPTION
Because of changes from https://github.com/laravel/framework/pull/51055, `Illuminate\Console\View\Components\Ask::render` now accepts $multiline (boolean) as the third parameter. So I add a missing `@param` block for it and also update `Illuminate\Console\View\Components\Factory` methods comments.
