### PR TITLE
[11.x] Update Command::fail() dockblock and tests

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -266,6 +266,8 @@ class Command extends SymfonyCommand
      *
      * @param  \Throwable|string|null  $exception
      * @return void
+     *
+     * @throws \Illuminate\Console\ManuallyFailedException|\Throwable
      */
     public function fail(Throwable|string|null $exception = null)
     {

--- a/tests/Integration/Console/CommandManualFailTest.php
+++ b/tests/Integration/Console/CommandManualFailTest.php
@@ -28,6 +28,7 @@ class CommandManualFailTest extends TestCase
     public function testCreatesAnExceptionFromString()
     {
         $this->expectException(ManuallyFailedException::class);
+        $this->expectExceptionMessage('Whoops!');
         $command = new Command;
         $command->fail('Whoops!');
     }
@@ -35,8 +36,21 @@ class CommandManualFailTest extends TestCase
     public function testCreatesAnExceptionFromNull()
     {
         $this->expectException(ManuallyFailedException::class);
+        $this->expectExceptionMessage('Command failed manually.');
         $command = new Command;
         $command->fail();
+    }
+
+    public function testThrowsTheOriginalThrowableInstance()
+    {
+        try {
+            $command = new Command;
+            $command->fail($original = new \RuntimeException('Something went wrong.'));
+
+            $this->fail('Command::fail() method must throw the original throwable instance.');
+        } catch (\Throwable $e) {
+            $this->assertSame($original, $e);
+        }
     }
 }
 


### PR DESCRIPTION
Command::fail() method throws ManuallyFailedException or Throwable, so I added `@throws` dockblock for it.

I also add some missing assertions/tests:
- Create exception from null: The fixed string "Command failed manually." is used as message of the thrown exception.
- Create exception from string: This given string is used as message of the thrown exception.
- If Command::fail() receives a Throwable instance, it will throw it right the way without transformation/modification.

Please see tests more more details!