### PR TITLE
[11.x] Fix prohibit docblock

### DIFF
--- a/src/Illuminate/Console/Prohibitable.php
+++ b/src/Illuminate/Console/Prohibitable.php
@@ -15,7 +15,7 @@ trait Prohibitable
      * Indicate whether the command should be prohibited from running.
      *
      * @param  bool  $prohibit
-     * @return bool
+     * @return void
      */
     public static function prohibit($prohibit = true)
     {


### PR DESCRIPTION
`prohibit` does not return anything, so it must be `@return void`.