### PR TITLE
Support Mixin's with constructor arguments

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -47,7 +47,8 @@ trait Macroable
         );
 
         foreach ($methods as $method) {
-            if ($replace || ! static::hasMacro($method->name)) {
+            if (!$method->isConstructor() &&
+                ($replace || ! static::hasMacro($method->name))) {
                 static::macro($method->name, $method->invoke($mixin));
             }
         }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -85,6 +85,31 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('foo', $instance->methodThree());
     }
 
+    public function testMixinWithConstructorParameters()
+    {
+        $foo = 'foo';
+        $mixin = new class ($foo) {
+            public function __construct(
+                private $foo
+            ) {
+            }
+
+            public function getFoo()
+            {
+                $foo = $this->foo;
+
+                return function () use ($foo) {
+                    return $foo;
+                };
+            }
+        };
+
+        TestMacroable::mixin($mixin);
+        $instance = new TestMacroable();
+
+        $this->assertSame('foo', $instance->getFoo());
+    }
+
     public function testFlushMacros()
     {
         TestMacroable::macro('flushMethod', function () {


### PR DESCRIPTION


When defining a macro we can make use of dependencies by passing them to the closure's context via the `use` keyword. For example, we could define the following macro in a Service Provider and it would work with no issues: 

When creating a macro, we can pass any dependencies that may be needed by using the `use` keyword when defining the closure. For example, we could define the following macro in a Service Provider and it would work:

```php
$apiVersionResolver = $this->app->get(ApiVersionResolver::class);

Request::macro('apiVersion', function () use ($apiVersionResolver): string {
    return $apiVersionResolver->resolve($this);
});
```

However, there was no way to achieve the same result using a mixin, as trying to do so resulted in an exception:
```
ArgumentCountError: Too few arguments to function App\Http\RequestMixin::__construct(), 0 passed and exactly 1 expected
```

This PR excludes the constructor method from mixin objects, allowing us to specify constructor arguments, which can be used within the macro methods.

Once merged, the following will work as expected:

```php
class RequestMixin
{
    public function __construct(
        private readonly ApiVersionResolver $apiVersionResolver
    ) {
    }

    public function apiVersion(): \Closure
    {
        $apiVersionResolver = $this->apiVersionResolver;

        return function () use ($apiVersionResolver): string {
            return $apiVersionResolver->resolve($this);
        };
    }
}

// In a Service Provider:
$apiVersionResolver = $this->app->get(ApiVersionResolver::class);
Request::mixin(new RequestMixin($apiVersionResolver));
```
