### PR TITLE
Check if the cache files are really removed

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -50,8 +50,16 @@ class ConfigClearCommand extends Command
      */
     public function handle()
     {
-        $this->files->delete($this->laravel->getCachedConfigPath());
+        $cachedConfigPath = $this->laravel->getCachedConfigPath();
 
-        $this->components->info('Configuration cache cleared successfully.');
+        if ($this->files->exists($cachedConfigPath)) {
+            if ($this->files->delete($cachedConfigPath)) {
+                $this->components->info('Configuration cache cleared successfully.');
+            } else {
+                $this->components->error('Failed to clear configuration cache.');
+            }
+        } else {
+            $this->components->info('Configuration cache is not present.');
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -52,8 +52,16 @@ class EventClearCommand extends Command
      */
     public function handle()
     {
-        $this->files->delete($this->laravel->getCachedEventsPath());
+        $cachedEventsPath = $this->laravel->getCachedEventsPath();
 
-        $this->components->info('Cached events cleared successfully.');
+        if ($this->files->exists($cachedEventsPath)) {
+            if ($this->files->delete($cachedEventsPath)) {
+                $this->components->info('Cached events cleared successfully.');
+            } else {
+                $this->components->error('Failed to clear events cache.');
+            }
+        } else {
+            $this->components->info('Events cache is not present.');
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -50,8 +50,16 @@ class RouteClearCommand extends Command
      */
     public function handle()
     {
-        $this->files->delete($this->laravel->getCachedRoutesPath());
+        $cachedRoutesPath = $this->laravel->getCachedRoutesPath();
 
-        $this->components->info('Route cache cleared successfully.');
+        if ($this->files->exists($cachedRoutesPath)) {
+            if ($this->files->delete($cachedRoutesPath)) {
+                $this->components->info('Route cache cleared successfully.');
+            } else {
+                $this->components->error('Failed to clear route cache.');
+            }
+        } else {
+            $this->components->info('Route cache is not present.');
+        }
     }
 }


### PR DESCRIPTION
Currently, config:clear, event:clear, and route:clear do not check if the cache files were actually removed.

If the user running the command has only read permissions for these files, the commands simply return a “… cache cleared successfully.” message without any indication that the files weren't removed.

This problem exists because Filesystem::delete doesn't throw an exception, just returns a boolean indicating whether unlink ran successfully on all the files provided. This return value is then ignored in the command handle.

For reference, here is the filesystem delete function which is called by the clear commands:

https://github.com/laravel/framework/blob/a2f2dc25aecb8f65ed35e76bec7fce2b074e1f23/src/Illuminate/Filesystem/Filesystem.php#L300-L319

Since this change might be considered breaking, I made the pull request to the master branch.