### PR TITLE
[11.x] use `Macroable` trait on TokenGuard

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -5,10 +5,11 @@ namespace Illuminate\Auth;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
+use Illuminate\Support\Traits\Macroable;
 
 class TokenGuard implements Guard
 {
-    use GuardHelpers;
+    use GuardHelpers, Macroable;
 
     /**
      * The request instance.


### PR DESCRIPTION
The sibling `RequestGuard` and `SessionGuard` are macroable but suddenly the token guard is not. This breaks for my package users when they switch their guard to TokenGuard.

https://github.com/imanghafoori1/laravel-MasterPass/issues/53

Honestly, I do not see any reason to avoid using macroable on this particular guard.