### PR TITLE
Revert and add test

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -417,7 +417,13 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function getNameInput()
     {
-        return (string) Str::of($this->argument('name'))->trim()->beforeLast('.php');
+        $name = trim($this->argument('name'));
+
+        if (Str::endsWith($name, '.php')) {
+            return Str::substr($name, 0, -4);
+        }
+
+        return $name;
     }
 
     /**

--- a/tests/Integration/Console/GeneratorCommandTest.php
+++ b/tests/Integration/Console/GeneratorCommandTest.php
@@ -13,6 +13,7 @@ class GeneratorCommandTest extends TestCase
     protected $files = [
         'app/Console/Commands/FooCommand.php',
         'resources/views/foo/php.blade.php',
+        'tests/Feature/fixtures.php/SomeTest.php',
     ];
 
     public function testItChopsPhpExtension()
@@ -33,6 +34,18 @@ class GeneratorCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFilenameExists('resources/views/foo/php.blade.php');
+    }
+
+    public function testItOnlyChopsPhpExtensionFromFilename()
+    {
+        $this->artisan('make:test', ['name' => 'fixtures.php/SomeTest'])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('tests/Feature/fixtures.php/SomeTest.php');
+
+        $this->assertFileContains([
+            'class SomeTest extends TestCase',
+        ], 'tests/Feature/fixtures.php/SomeTest.php');
     }
 
     #[DataProvider('reservedNamesDataProvider')]


### PR DESCRIPTION
This reverts #51843 as it introduced a bug. I've also included a test to demonstrate this bug and guide any future _refactor_. For example, to the [potentially new](https://github.com/laravel/framework/pull/51910) `Str::chopEnd` method.