### PR TITLE
[11.x] Display view creation messages

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -43,9 +43,7 @@ class ComponentMakeCommand extends GeneratorCommand
     public function handle()
     {
         if ($this->option('view')) {
-            $this->writeView();
-
-            return;
+            return $this->writeView();
         }
 
         if (parent::handle() === false && ! $this->option('force')) {

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -43,9 +43,7 @@ class ComponentMakeCommand extends GeneratorCommand
     public function handle()
     {
         if ($this->option('view')) {
-            $this->writeView(function () {
-                $this->components->info($this->type.' created successfully.');
-            });
+            $this->writeView();
 
             return;
         }
@@ -62,10 +60,9 @@ class ComponentMakeCommand extends GeneratorCommand
     /**
      * Write the view for the component.
      *
-     * @param  callable|null  $onSuccess
      * @return void
      */
-    protected function writeView($onSuccess = null)
+    protected function writeView()
     {
         $path = $this->viewPath(
             str_replace('.', '/', 'components.'.$this->getView()).'.blade.php'
@@ -88,9 +85,7 @@ class ComponentMakeCommand extends GeneratorCommand
 </div>'
         );
 
-        if ($onSuccess) {
-            $onSuccess();
-        }
+        $this->components->info(sprintf('%s [%s] created successfully.', 'View', $path));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -69,6 +69,8 @@ class MailMakeCommand extends GeneratorCommand
         $this->files->ensureDirectoryExists(dirname($path));
 
         $this->files->put($path, file_get_contents(__DIR__.'/stubs/markdown.stub'));
+
+        $this->components->info(sprintf('%s [%s] created successfully.', 'Markdown', $path));
     }
 
     /**
@@ -91,6 +93,8 @@ class MailMakeCommand extends GeneratorCommand
         );
 
         $this->files->put($path, $stub);
+
+        $this->components->info(sprintf('%s [%s] created successfully.', 'View', $path));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -70,7 +70,7 @@ class MailMakeCommand extends GeneratorCommand
 
         $this->files->put($path, file_get_contents(__DIR__.'/stubs/markdown.stub'));
 
-        $this->components->info(sprintf('%s [%s] created successfully.', 'Markdown', $path));
+        $this->components->info(sprintf('%s [%s] created successfully.', 'Markdown view', $path));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -65,6 +65,8 @@ class NotificationMakeCommand extends GeneratorCommand
         }
 
         $this->files->put($path, file_get_contents(__DIR__.'/stubs/markdown.stub'));
+
+        $this->components->info(sprintf('%s [%s] created successfully.', 'Markdown', $path));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -142,7 +142,11 @@ class ViewMakeCommand extends GeneratorCommand
 
         File::ensureDirectoryExists(dirname($this->getTestPath()), 0755, true);
 
-        return File::put($this->getTestPath(), $contents);
+        $result = File::put($path = $this->getTestPath(), $contents);
+
+        $this->components->info(sprintf('%s [%s] created successfully.', 'Test', $path));
+
+        return $result !== false;
     }
 
     /**


### PR DESCRIPTION
This PR adds the messages when you create view files, etc.
This is my follow up PR to #51546.

# Example
The green line indicates messages that have been added or changed.

![2024-06-27_09h53_12](https://github.com/laravel/framework/assets/14008307/4b46ab08-fb76-4a48-b689-e3921b71d6ea)

![2024-06-27_10h00_31](https://github.com/laravel/framework/assets/14008307/2f444add-ad2f-4204-9a4e-b940d0da16e1)

![2024-06-27_10h04_43](https://github.com/laravel/framework/assets/14008307/1fa8eda1-048b-45bc-b391-f76cd4d4f404)

![2024-06-27_10h09_36](https://github.com/laravel/framework/assets/14008307/438a0e07-f9cc-4ba2-ac5e-64b940d8bdec)

# In Vscode
As I wrote in my last PR, if you use vscode's terminal, you can Ctrl/Cmd + click and open files in the editor.
![2024-06-27_10h18_43](https://github.com/laravel/framework/assets/14008307/c49d21e7-bcdc-44ab-ab23-9695dc8daa20)


By the way, `File::put` returns the number of bytes that were written to the file, or false on failure.