### PR TITLE
[11.x] Fixes escaping path via Process given commands as array

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -204,7 +204,7 @@ class Composer
      */
     protected function phpBinary()
     {
-        return ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
+        return (string) (new PhpExecutableFinder)->find(false);
     }
 
     /**

--- a/tests/Support/SupportComposerTest.php
+++ b/tests/Support/SupportComposerTest.php
@@ -24,9 +24,7 @@ class SupportComposerTest extends TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommandWhenCustomComposerPharIsPresent()
     {
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
-
-        $expectedProcessArguments = [$escape.PHP_BINARY.$escape,  'composer.phar', 'dump-autoload'];
+        $expectedProcessArguments = [PHP_BINARY,  'composer.phar', 'dump-autoload'];
         $customComposerPhar = true;
 
         $composer = $this->mockComposer($expectedProcessArguments, $customComposerPhar);


### PR DESCRIPTION
Introduced in https://github.com/symfony/symfony/pull/52409 we no longer can use `Illuminate\Support\ProcessUtils::escapeArgument()` when providing the command as `array`. 

`ProcessUtils::escapeArgument()` is only required when calling `Process` via `Process::fromShellCommandline()`

fixes #51820

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
