### PR TITLE
[11.x] Fix schedule:list to handle fluent-style scheduling constraints

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -75,6 +75,33 @@ class ScheduleListCommand extends Command
         $this->line(
             $events->flatten()->filter()->prepend('')->push('')->toArray()
         );
+
+        $this->table(
+            ['Expression', 'Command', 'Next Due'],
+            $this->getScheduleList()
+        );
+    }
+
+    protected function getScheduleList()
+    {
+        $events = $this->laravel->make(Schedule::class)->events();
+        $list = [];
+
+        foreach ($events as $event) {
+            $expression = $event->expression;
+            $command = $event->command ?? $event->description;
+            $nextDue = $event->nextRunDate()->diffForHumans();
+
+            // Handle the 'between' constraint manually
+            if ($event->filters && isset($event->filters['between'])) {
+                $between = $event->filters['between'];
+                $expression .= " between " . implode(' and ', $between);
+            }
+
+            $list[] = [$expression, $command, $nextDue];
+        }
+
+        return $list;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -95,7 +95,7 @@ class ScheduleListCommand extends Command
             // Handle the 'between' constraint manually
             if ($event->filters && isset($event->filters['between'])) {
                 $between = $event->filters['between'];
-                $expression .= " between " . implode(' and ', $between);
+                $expression .= ' between '.implode(' and ', $between);
             }
 
             $list[] = [$expression, $command, $nextDue];
@@ -103,7 +103,6 @@ class ScheduleListCommand extends Command
 
         return $list;
     }
-
     /**
      * Get the spacing to be used on each event row.
      *


### PR DESCRIPTION
### Fix schedule:list to handle fluent-style scheduling constraints

**Issue:** `php artisan schedule:list` does not correctly display tasks that use fluent-style scheduling methods such as `between()`. 

**Example:**
```php
$schedule->command('emails:send')
         ->hourly()
         ->between('7:00', '22:00');
