### PR TITLE
[11.x] Adds support for Markdown extensions to the `Stringable` class.

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -454,11 +454,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Convert GitHub flavored Markdown into HTML.
      *
      * @param  array  $options
+     * @param  array  $extensions
      * @return static
      */
-    public function markdown(array $options = [])
+    public function markdown(array $options = [], array $extensions = [])
     {
-        return new static(Str::markdown($this->value, $options));
+        return new static(Str::markdown($this->value, $options, $extensions));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1133,7 +1133,8 @@ class SupportStringableTest extends TestCase
         $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
 
-        $extension = new class implements ExtensionInterface {
+        $extension = new class implements ExtensionInterface
+        {
             public bool $configured = false;
 
             public function register(EnvironmentBuilderInterface $environment): void

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
 
 class SupportStringableTest extends TestCase
@@ -1130,6 +1132,17 @@ class SupportStringableTest extends TestCase
     {
         $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
+
+        $extension = new class implements ExtensionInterface {
+            public bool $configured = false;
+
+            public function register(EnvironmentBuilderInterface $environment): void
+            {
+                $this->configured = true;
+            }
+        };
+        $this->stringable('# hello world')->markdown([], [$extension]);
+        $this->assertTrue($extension->configured);
     }
 
     public function testInlineMarkdown()


### PR DESCRIPTION
Hey all!

This little PR is an add-on to #51907 and adds support for declaring extensions when using the `Stringable::markdown()` method.

```php
$html = str('# My Heading')->markdown(extensions: [new HeadingPermalinksExtension()]);
```

Thanks for the incredible work!

Kind Regards,
Luke