### PR TITLE
[11.x] Introduces `thresholdPerRun` parameters for `MassPrunable@pruneAll`

### DIFF
--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -11,9 +11,10 @@ trait MassPrunable
      * Prune all prunable models in the database.
      *
      * @param  int  $chunkSize
+     * @param  int|null  $thresholdPerRun
      * @return int
      */
-    public function pruneAll(int $chunkSize = 1000)
+    public function pruneAll(int $chunkSize = 1000, ?int $thresholdPerRun = null)
     {
         $query = tap($this->prunable(), function ($query) use ($chunkSize) {
             $query->when(! $query->getQuery()->limit, function ($query) use ($chunkSize) {
@@ -30,6 +31,10 @@ trait MassPrunable
 
             if ($count > 0) {
                 event(new ModelsPruned(static::class, $total));
+            }
+
+            if ($thresholdPerRun && $total >= $thresholdPerRun) {
+                break;
             }
         } while ($count > 0);
 

--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -33,7 +33,7 @@ trait MassPrunable
                 event(new ModelsPruned(static::class, $total));
             }
 
-            if ($thresholdPerRun && $total >= $thresholdPerRun) {
+            if (!is_null($thresholdPerRun) && $total >= $thresholdPerRun) {
                 break;
             }
         } while ($count > 0);


### PR DESCRIPTION
So I have a huge table with millions of expired records and want to clear them periodically. 

With the current implementation, I want to set up a cron that run hourly with a threshold, to avoid overwhelming the DB, locking, etc (first-time run)

It is not possible to define the `prunable` like the below code, `MassPrunable` would use **50k** as a limit and run until it cleared all of the records.

```php
return Table::query()->where('expired_at', '<=', now())->limit(50_000);
```

So this PR adds the `$thresholdPerRun` optional parameter to achieve that, there is no breaking change. 