### PR TITLE
[11.x] Add `AsCommand` attribute to Console commands stub by default

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -3,7 +3,12 @@
 namespace {{ namespace }};
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(
+    name: '{{ command }}',
+    description: 'Command description',
+)]
 class {{ class }} extends Command
 {
     /**


### PR DESCRIPTION
Just thinking that maybe this should be the default behavior after all the work done in #50617 so I updated the stub.