### PR TITLE
[11.x] Display migrate and db commands in their namespace

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
 
-#[AsCommand(name: 'db')]
+#[AsCommand(name: 'db:connect', aliases: ['db'])]
 class DbCommand extends Command
 {
     /**
@@ -16,7 +16,7 @@ class DbCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'db {connection? : The database connection that should be used}
+    protected $signature = 'db:connect {connection? : The database connection that should be used}
                {--read : Connect to the read connection}
                {--write : Connect to the write connection}';
 
@@ -26,6 +26,13 @@ class DbCommand extends Command
      * @var string
      */
     protected $description = 'Start a new database CLI session';
+
+    /**
+     * The console command name aliases.
+     *
+     * @var array
+     */
+    protected $aliases = ['db'];
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -16,7 +16,7 @@ use Throwable;
 
 use function Laravel\Prompts\confirm;
 
-#[AsCommand(name: 'migrate')]
+#[AsCommand(name: 'migrate:run', aliases: ['migrate'])]
 class MigrateCommand extends BaseCommand implements Isolatable
 {
     use ConfirmableTrait;
@@ -26,7 +26,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
      *
      * @var string
      */
-    protected $signature = 'migrate {--database= : The database connection to use}
+    protected $signature = 'migrate:run {--database= : The database connection to use}
                 {--force : Force the operation to run when in production}
                 {--path=* : The path(s) to the migrations files to be executed}
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
@@ -43,6 +43,13 @@ class MigrateCommand extends BaseCommand implements Isolatable
      * @var string
      */
     protected $description = 'Run the database migrations';
+
+    /**
+     * The console command name aliases.
+     *
+     * @var array
+     */
+    protected $aliases = ['migrate'];
 
     /**
      * The migrator instance.


### PR DESCRIPTION
## What is the problem?
Laravel artisan is based on Symfony console component, in which commands without ":" (colons) belong to global namespace. Thus, when listing commands in console, **migrate** is displayed in global namespace and other **migrate:*** commands are displayed in **migrate** namespace. There are 2 cases:

- When running `php artisan`, we'll see **migrate** on the top of the list but must scroll down to see other **migrate:*** commands.
- When running `php artisan list migrate`, we'll see only **migrate:*** commands and can not see **migrate**.

I mean same categorized commands (interacting with same things) like migrate commands may be displayed in different namespaces. It's a bit unconvenient, isn't it?

<details>
  <summary>Click to see the current display</summary>
  
![Screenshot_11](https://github.com/laravel/framework/assets/16967350/5c430d67-b9d8-4fa3-a75f-bf6d183c221c)

</details>

## Solution
I think it's reasonable to display migrate command in "migrate" namespace. Of course, we can use use something like "grep" on Unix-like system but there are still tricks to do it natively.

In this PR, I rename **migrate** command to **migrate:run** and set an alias for it. Then, all **migrate:*** commands are now displayed together. And as you can see, **migrate:run** is still informative (Run the database migrations). Finally, it's total backward compatibility because "php artisan migrate" still works as it does. I do the exact same thing for **db** command.

## Quick overview

```bash
php artisan migrate:run
php artisan migrate

php artisan db:connect
php artisan db
```

![Screenshot_9](https://github.com/laravel/framework/assets/16967350/fed8c1ee-bd0b-4fe2-b52b-3ede296e8150)
![Screenshot_10](https://github.com/laravel/framework/assets/16967350/25857530-e520-4550-b768-a0619fcaf7a0)