### PR TITLE
[11.x] Remove unreachable code in AssertableJsonString

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -211,8 +211,6 @@ class AssertableJsonString implements ArrayAccess, Countable
             'within'.PHP_EOL.PHP_EOL.
             "[{$actual}]."
         );
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -188,7 +188,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      * Assert that the response does not contain the exact JSON fragment.
      *
      * @param  array  $data
-     * @return $this
+     * @return void
      */
     public function assertMissingExact(array $data)
     {

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -188,7 +188,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      * Assert that the response does not contain the exact JSON fragment.
      *
      * @param  array  $data
-     * @return void
+     * @return $this
      */
     public function assertMissingExact(array $data)
     {


### PR DESCRIPTION
This `return $this` statement is never touch because `PHPUnit::fail()` stands above it always throws an Exception .