### PR TITLE
[11.x] Remove redundant type casts

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -39,25 +39,25 @@ class AuthenticateMiddlewareTest extends TestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) Authenticate::using('foo');
+        $signature = Authenticate::using('foo');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo', $signature);
 
-        $signature = (string) Authenticate::using('foo', 'bar');
+        $signature = Authenticate::using('foo', 'bar');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar', $signature);
 
-        $signature = (string) Authenticate::using('foo', 'bar', 'baz');
+        $signature = Authenticate::using('foo', 'bar', 'baz');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar,baz', $signature);
     }
 
     public function testItCanGenerateDefinitionViaStaticMethodForBasic()
     {
-        $signature = (string) AuthenticateWithBasicAuth::using('guard');
+        $signature = AuthenticateWithBasicAuth::using('guard');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard', $signature);
 
-        $signature = (string) AuthenticateWithBasicAuth::using('guard', 'field');
+        $signature = AuthenticateWithBasicAuth::using('guard', 'field');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard,field', $signature);
 
-        $signature = (string) AuthenticateWithBasicAuth::using(field: 'field');
+        $signature = AuthenticateWithBasicAuth::using(field: 'field');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:,field', $signature);
     }
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -55,13 +55,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) Authorize::using('ability');
+        $signature = Authorize::using('ability');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability', $signature);
 
-        $signature = (string) Authorize::using('ability', 'model');
+        $signature = Authorize::using('ability', 'model');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model', $signature);
 
-        $signature = (string) Authorize::using('ability', 'model', \App\Models\Comment::class);
+        $signature = Authorize::using('ability', 'model', \App\Models\Comment::class);
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model,App\Models\Comment', $signature);
     }
 

--- a/tests/Auth/EnsureEmailIsVerifiedTest.php
+++ b/tests/Auth/EnsureEmailIsVerifiedTest.php
@@ -9,7 +9,7 @@ class EnsureEmailIsVerifiedTest extends TestCase
 {
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) EnsureEmailIsVerified::redirectTo('route.name');
+        $signature = EnsureEmailIsVerified::redirectTo('route.name');
         $this->assertSame('Illuminate\Auth\Middleware\EnsureEmailIsVerified:route.name', $signature);
     }
 }

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -15,20 +15,20 @@ class CacheTest extends TestCase
 {
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) Cache::using('max_age=120;no-transform;s_maxage=60;');
+        $signature = Cache::using('max_age=120;no-transform;s_maxage=60;');
         $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60;', $signature);
 
-        $signature = (string) Cache::using('max_age=120;no-transform;s_maxage=60');
+        $signature = Cache::using('max_age=120;no-transform;s_maxage=60');
         $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60', $signature);
 
-        $signature = (string) Cache::using([
+        $signature = Cache::using([
             'max_age=120',
             'no-transform',
             's_maxage=60',
         ]);
         $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60', $signature);
 
-        $signature = (string) Cache::using([
+        $signature = Cache::using([
             'max_age' => 120,
             'no-transform',
             's_maxage' => '60',

--- a/tests/Integration/Auth/Middleware/RequirePasswordTest.php
+++ b/tests/Integration/Auth/Middleware/RequirePasswordTest.php
@@ -14,13 +14,13 @@ class RequirePasswordTest extends TestCase
 {
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) RequirePassword::using('route.name');
+        $signature = RequirePassword::using('route.name');
         $this->assertSame('Illuminate\Auth\Middleware\RequirePassword:route.name', $signature);
 
-        $signature = (string) RequirePassword::using('route.name', 100);
+        $signature = RequirePassword::using('route.name', 100);
         $this->assertSame('Illuminate\Auth\Middleware\RequirePassword:route.name,100', $signature);
 
-        $signature = (string) RequirePassword::using(passwordTimeoutSeconds: 100);
+        $signature = RequirePassword::using(passwordTimeoutSeconds: 100);
         $this->assertSame('Illuminate\Auth\Middleware\RequirePassword:,100', $signature);
     }
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -98,22 +98,22 @@ class ThrottleRequestsTest extends TestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) ThrottleRequests::using('gold-tier');
+        $signature = ThrottleRequests::using('gold-tier');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:gold-tier', $signature);
 
-        $signature = (string) ThrottleRequests::with(25);
+        $signature = ThrottleRequests::with(25);
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25', $signature);
 
-        $signature = (string) ThrottleRequests::with(25, 2);
+        $signature = ThrottleRequests::with(25, 2);
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25,2', $signature);
 
-        $signature = (string) ThrottleRequests::with(25, 2, 'foo');
+        $signature = ThrottleRequests::with(25, 2, 'foo');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25,2,foo', $signature);
 
-        $signature = (string) ThrottleRequests::with(maxAttempts: 25, decayMinutes: 2, prefix: 'foo');
+        $signature = ThrottleRequests::with(maxAttempts: 25, decayMinutes: 2, prefix: 'foo');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25,2,foo', $signature);
 
-        $signature = (string) ThrottleRequests::with(prefix: 'foo');
+        $signature = ThrottleRequests::with(prefix: 'foo');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:60,1,foo', $signature);
     }
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -341,16 +341,16 @@ class UrlSigningTest extends TestCase
 
     public function testItCanGenerateMiddlewareDefinitionViaStaticMethod()
     {
-        $signature = (string) ValidateSignature::relative();
+        $signature = ValidateSignature::relative();
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:relative', $signature);
 
-        $signature = (string) ValidateSignature::absolute();
+        $signature = ValidateSignature::absolute();
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature', $signature);
 
-        $signature = (string) ValidateSignature::relative(['foo', 'bar']);
+        $signature = ValidateSignature::relative(['foo', 'bar']);
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:relative,foo,bar', $signature);
 
-        $signature = (string) ValidateSignature::absolute(['foo', 'bar']);
+        $signature = ValidateSignature::absolute(['foo', 'bar']);
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:foo,bar', $signature);
     }
 


### PR DESCRIPTION
These middleware static methods always return string, no reason to use type casts here.