### PR TITLE
[11.x] Add Cast attribute for eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Cast.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Cast.php
@@ -6,6 +6,9 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Cast
 {
+    /**
+     * Create a new attribute instance.
+     */
     public function __construct(private string $property, private string|array $type)
     {
     }

--- a/src/Illuminate/Database/Eloquent/Attributes/Cast.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Cast.php
@@ -3,7 +3,7 @@ namespace Illuminate\Database\Eloquent\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS| Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Cast
 {
     public function __construct(private string $property, private string|array $type)

--- a/src/Illuminate/Database/Eloquent/Attributes/Cast.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Cast.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Illuminate\Database\Eloquent\Attributes;
 
 use Attribute;

--- a/src/Illuminate/Database/Eloquent/Attributes/Cast.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Cast.php
@@ -1,0 +1,12 @@
+<?php
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS| Attribute::IS_REPEATABLE)]
+class Cast
+{
+    public function __construct(private string $property, private string|array $type)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -13,6 +13,7 @@ use DateTimeInterface;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Attributes\Cast;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
@@ -191,7 +192,7 @@ trait HasAttributes
     protected function initializeHasAttributes()
     {
         $this->casts = $this->ensureCastsAreStringValues(
-            array_merge($this->casts, $this->casts()),
+            array_merge($this->casts, $this->casts(), $this->castsFromCastAttribute()),
         );
     }
 
@@ -1620,6 +1621,18 @@ trait HasAttributes
     protected function casts()
     {
         return [];
+    }
+
+    /**
+     * Get the attributes that should be cast defined by the Cast attribute.
+     */
+    protected function castsFromCastAttribute(): array
+    {
+        return collect((new ReflectionClass($this))->getAttributes(Cast::class))
+            ->mapWithKeys(fn ($attribute) => [
+                $attribute->getArguments()[0] => $attribute->getArguments()[1]
+            ])
+            ->toArray();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1624,14 +1624,19 @@ trait HasAttributes
     }
 
     /**
-     * Get the attributes that should be cast defined by the Cast attribute.
+     * Get the class and its traits Cast attributes.
      */
     protected function castsFromCastAttribute(): array
     {
-        return collect((new ReflectionClass($this))->getAttributes(Cast::class))
-            ->mapWithKeys(fn ($attribute) => [
-                $attribute->getArguments()[0] => $attribute->getArguments()[1]
-            ])
+        $reflected = new ReflectionClass($this);
+        
+        return collect($reflected->getAttributes(Cast::class))
+            ->merge(collect($reflected->getTraits())
+                ->map(fn ($trait) => $trait->getAttributes(Cast::class))
+                ->filter()
+                ->flatten()
+            )
+            ->mapWithKeys(fn ($attribute) => [$attribute->getArguments()[0] => $attribute->getArguments()[1]])
             ->toArray();
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1629,7 +1629,7 @@ trait HasAttributes
     protected function castsFromCastAttribute(): array
     {
         $reflected = new ReflectionClass($this);
-        
+
         return collect($reflected->getAttributes(Cast::class))
             ->merge(collect($reflected->getTraits())
                 ->map(fn ($trait) => $trait->getAttributes(Cast::class))

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3059,7 +3059,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->collectionAttribute = new BaseCollection;
         $model->asCustomCollectionAttribute = new CustomCollection;
         $model->duplicateIntAttribute = '5.0';
-        
+
         // From trait
         $model->price = new Price(100.5, 'USD');
 
@@ -3764,11 +3764,11 @@ class Address implements Castable
 class EloquentModelWithAttributeCasts extends Model
 {
     use HasPrice;
-    
+
     protected $casts = [
         'datetimeAttribute' => 'datetime',
     ];
-    
+
     protected function casts()
     {
         return [
@@ -3788,7 +3788,8 @@ class EloquentModelWithAttributeCasts extends Model
 }
 
 #[Cast('price', Price::class)]
-trait HasPrice {
+trait HasPrice
+{
     public function priceEquals(Price $other): bool
     {
         return $this->amount === $other->amount && $this->currency === $other->currency;


### PR DESCRIPTION
### Proposal: Introduce a Cast attribute  to enhance model attributes type casting

<ins>**Summary**</ins>

I propose the introduction of a new `Cast` attribute for Eloquent models. This attribute allows us to specify type casting for model properties using PHP 8 attributes. The primary benefit is the ability to define casts in traits, thus reducing redundancy and improving code maintainability.

<ins>**Motivation**</ins>

Right now, defining casts in Eloquent models can get pretty repetitive, especially when you have to apply the same casts to multiple models. Using PHP 8 attributes gives us a more modern and straightforward way to handle type casting. It’s especially helpful with traits, since you won't have to keep adding the same casts to every model.

<ins>**Example usage**</ins>
Assuming that we have a basic `Price` value object which we need to use in our models (as seen in the unit tests) :
```php
#[Cast('price', Price::class)]
trait HasPrice {
    public function priceEquals(Price $other): bool
    {
        return $this->amount === $other->amount && $this->currency === $other->currency;
    }
}

#[Cast('normalModelAttribute', 'int')]
class EloquentModelWithAttributeCasts extends Model
{
    use HasPrice;
}
````