### PR TITLE
[11.x] Add secret method declaration to Components\Factory class

### DIFF
--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
  * @method void error(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void info(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void line(string $style, string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
+ * @method void secret(string $question, bool $fallback = true)
  * @method void task(string $description, ?callable $task = null, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void twoColumnDetail(string $first, ?string $second = null, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void warn(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)


### PR DESCRIPTION
Because of Components\Secret, I added `secret` method declaration to Components\Factory class like other components.

```php
<?php
/**
 * @method void secret(string $question, bool $fallback = true)
 */
class Factory {}
```

```php
<?php

namespace Illuminate\Console\View\Components;

use Symfony\Component\Console\Question\Question;

class Secret extends Component
{
    public function render($question, $fallback = true)
    {
        // 
    }
}

```