### PR TITLE
[11.x] Added attempts() method to FakeJob

### DIFF
--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -14,18 +14,18 @@ class FakeJob extends Job
     public $releaseDelay;
 
     /**
-     * The exception the job failed with.
-     *
-     * @var \Throwable
-     */
-    public $failedWith;
-
-    /**
      * The number of attempts made to process the job.
      *
      * @var int
      */
     public $attempts = 1;
+
+    /**
+     * The exception the job failed with.
+     *
+     * @var \Throwable
+     */
+    public $failedWith;
 
     /**
      * Get the job identifier.

--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -21,6 +21,13 @@ class FakeJob extends Job
     public $failedWith;
 
     /**
+     * The number of attempts made to process the job.
+     *
+     * @var int
+     */
+    public $attempts = 1;
+
+    /**
      * Get the job identifier.
      *
      * @return string
@@ -50,6 +57,16 @@ class FakeJob extends Job
     {
         $this->released = true;
         $this->releaseDelay = $delay;
+    }
+
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return $this->attempts;
     }
 
     /**


### PR DESCRIPTION
I'm currently getting this error when my job is trying to get the attempts method with the new `withFakeQueueInteractions` helper: 

Error:
```bash
Error: Call to undefined method Illuminate\Queue\Jobs\FakeJob::attempts()
/Users/xxx/Sites/xxx/vendor/laravel/framework/src/Illuminate/Queue/InteractsWithQueue.php:32
```

See #51929 for further details