### PR TITLE
[11.x] Improve PHPDoc for `mapSpread` Method in `Arr` Class & Remove Warning from IDE

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -643,7 +643,7 @@ class Arr
      * Run a map over each nested chunk of items.
      *
      * @template TKey
-     * @template TMapSpreadValue
+     * @template TValue
      *
      * @param  array<TKey, array>  $array
      * @param  callable(mixed...): TMapSpreadValue  $callback

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -646,8 +646,8 @@ class Arr
      * @template TValue
      *
      * @param  array<TKey, array>  $array
-     * @param  callable(mixed...): TMapSpreadValue  $callback
-     * @return array<TKey, TMapSpreadValue>
+     * @param  callable(mixed...): TValue  $callback
+     * @return array<TKey, TValue>
      */
     public static function mapSpread(array $array, callable $callback)
     {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -642,9 +642,10 @@ class Arr
     /**
      * Run a map over each nested chunk of items.
      *
+     * @template TKey
      * @template TMapSpreadValue
      *
-     * @param  array  $array
+     * @param  array<TKey, array>  $array
      * @param  callable(mixed...): TMapSpreadValue  $callback
      * @return array<TKey, TMapSpreadValue>
      */


### PR DESCRIPTION

#### Description
This pull request updates the PHPDoc block for the `mapSpread` method in the `Arr` class to improve accuracy and clarity. The updated doc block provides more specific type hints for the parameters and return type.

#### Changes
- Added `@template TKey` to indicate the keys are preserved.
- Updated the `@param` type for `$array` to `array<TKey, array>` to specify the structure of the input array.

#### Before
```php
/**
 * Run a map over each nested chunk of items.
 *
 * @template TMapSpreadValue
 *
 * @param  array  $array
 * @param  callable(mixed...): TMapSpreadValue  $callback
 * @return array<TKey, TMapSpreadValue>
 */
public static function mapSpread(array $array, callable $callback)
{
    return static::map($array, function ($chunk, $key) use ($callback) {
        $chunk[] = $key;

        return $callback(...$chunk);
    });
}
```

#### After
```php
/**
 * Run a map over each nested chunk of items.
 *
 * @template TKey
 * @template TMapSpreadValue
 *
 * @param  array<TKey, array>  $array
 * @param  callable(mixed...): TMapSpreadValue  $callback
 * @return array<TKey, TMapSpreadValue>
 */
public static function mapSpread(array $array, callable $callback)
{
    return static::map($array, function ($chunk, $key) use ($callback) {
        $chunk[] = $key;

        return $callback(...$chunk);
    });
}
```
