### PR TITLE
[11.x] Make:model --all flag would auto-fire make:test

### DIFF
--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -32,7 +32,7 @@ trait CreatesMatchingTest
      */
     protected function handleTestCreation($path)
     {
-        if (! $this->option('test') && ! $this->option('pest') && ! $this->option('phpunit')) {
+        if (! $this->option('test') && ! $this->option('pest') && ! $this->option('phpunit') && ! ($this->type === 'Model' && $this->option('all'))) {
             return false;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -56,6 +56,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('controller', true);
             $this->input->setOption('policy', true);
             $this->input->setOption('resource', true);
+            $this->input->setOption('test', true);
         }
 
         if ($this->option('factory')) {
@@ -143,7 +144,7 @@ class ModelMakeCommand extends GeneratorCommand
             '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
             '--requests' => $this->option('requests') || $this->option('all'),
-            '--test' => $this->option('test'),
+            '--test' => $this->option('test') || $this->option('all'),
             '--pest' => $this->option('pest'),
         ]));
     }


### PR DESCRIPTION
Given that we choose the test engine at the beginning of each project and the make:test command can identify the chosen type, it would be wonderful if the `--all` flag of the `make:model` command also triggers the `--test` flag. 

This would reinforce the good practice of using tests to reduce problems in the code.