### PR TITLE
[11.x] chore: update to PHPStan Level 1

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -1,9 +1,10 @@
 parameters:
-    level: 0
+    level: 1
     paths:
         - src
     excludePaths:
         - src/Illuminate/Testing/ParallelRunner.php
+        - src/*/views/*
     ignoreErrors:
         - "#\\(void\\) is used#"
         - "#Access to an undefined property#"

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -575,7 +575,7 @@ class Gate implements GateContract
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string  $ability
      * @param  array  $arguments
-     * @param  bool  $result
+     * @param  bool|null  $result
      * @return bool|null
      */
     protected function callAfterCallbacks($user, $ability, array $arguments, $result)

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -358,9 +358,7 @@ class PendingBatch
         try {
             $batch = $batch->add($this->jobs);
         } catch (Throwable $e) {
-            if (isset($batch)) {
-                $batch->delete();
-            }
+            $batch->delete();
 
             throw $e;
         }

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -21,6 +21,7 @@ trait RetrievesMultipleKeys
         })->all();
 
         foreach ($keys as $key => $default) {
+            /** @phpstan-ignore arguments.count (some clients don't accept a default) */
             $return[$key] = $this->get($key, $default);
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -582,7 +582,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  callable|string  $value
+     * @param  callable|string|null  $value
      * @param  string|null  $glue
      * @return string
      */

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -188,7 +188,9 @@ class ConnectionFactory
                 }
             }
 
-            throw $e;
+            if (isset($e)) {
+                throw $e;
+            }
         };
     }
 

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -77,11 +77,9 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getHostDsn(array $config)
     {
-        extract($config, EXTR_SKIP);
-
-        return isset($port)
-                    ? "mysql:host={$host};port={$port};dbname={$database}"
-                    : "mysql:host={$host};dbname={$database}";
+        return isset($config['port'])
+                    ? "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']}"
+                    : "mysql:host={$config['host']};dbname={$config['database']}";
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -127,7 +127,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // Sometimes - users may need to connect to a database that has a different
         // name than the database used for "information_schema" queries. This is
         // typically the case if using "pgbouncer" type software when pooling.
-        $database = $connect_via_database ?? $database;
+        $database = $connect_via_database ?? $database ?? null;
         $port = $connect_via_port ?? $port ?? null;
 
         $dsn = "pgsql:{$host}dbname='{$database}'";

--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -58,7 +58,7 @@ abstract class DatabaseInspectionCommand extends Command
     /**
      * Get the connection configuration details for the given connection.
      *
-     * @param  string  $database
+     * @param  string|null  $database
      * @return array
      */
     protected function getConfigFromDatabase($database)

--- a/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
@@ -13,7 +13,7 @@ class ObservedBy
      * @param  array|string  $classes
      * @return void
      */
-    public function __construct(array|string $classes)
+    public function __construct(public array|string $classes)
     {
     }
 }

--- a/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
@@ -13,7 +13,7 @@ class ScopedBy
      * @param  array|string  $classes
      * @return void
      */
-    public function __construct(array|string $classes)
+    public function __construct(public array|string $classes)
     {
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -394,8 +394,8 @@ trait HasAttributes
             // If the relation value has been set, we will set it on this attributes
             // list for returning. If it was not arrayable or null, we'll not set
             // the value on the array because it is some type of invalid value.
-            if (isset($relation)) {
-                $attributes[$key] = $relation;
+            if (array_key_exists('relation', get_defined_vars())) { // check if $relation is in scope (could be null)
+                $attributes[$key] = $relation ?? null;
             }
 
             unset($relation);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -394,7 +394,7 @@ trait HasAttributes
             // If the relation value has been set, we will set it on this attributes
             // list for returning. If it was not arrayable or null, we'll not set
             // the value on the array because it is some type of invalid value.
-            if (isset($relation) || is_null($value)) {
+            if (isset($relation)) {
                 $attributes[$key] = $relation;
             }
 
@@ -1208,7 +1208,7 @@ trait HasAttributes
      * Set the value of an enum castable attribute.
      *
      * @param  string  $key
-     * @param  \UnitEnum|string|int  $value
+     * @param  \UnitEnum|string|int|null  $value
      * @return void
      */
     protected function setEnumCastableAttribute($key, $value)
@@ -1326,7 +1326,7 @@ trait HasAttributes
     /**
      * Decode the given JSON back into an array or object.
      *
-     * @param  string  $value
+     * @param  string|null  $value
      * @param  bool  $asObject
      * @return mixed
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -329,7 +329,7 @@ trait HasRelationships
      * @param  string  $name
      * @param  string  $type
      * @param  string  $id
-     * @param  string  $ownerKey
+     * @param  string|null  $ownerKey
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo<\Illuminate\Database\Eloquent\Model, $this>
      */
     protected function morphInstanceTo($target, $name, $type, $id, $ownerKey)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -214,7 +214,7 @@ trait CanBeOneOfMany
             }
         }
 
-        $this->addOneOfManySubQueryConstraints($subQuery, $groupBy, $columns, $aggregate);
+        $this->addOneOfManySubQueryConstraints($subQuery, column: null, aggregate: $aggregate);
 
         return $subQuery;
     }
@@ -237,7 +237,7 @@ trait CanBeOneOfMany
                     $join->on($this->qualifySubSelectColumn($onColumn.'_aggregate'), '=', $this->qualifyRelatedColumn($onColumn));
                 }
 
-                $this->addOneOfManyJoinSubQueryConstraints($join, $on);
+                $this->addOneOfManyJoinSubQueryConstraints($join);
             });
         });
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -163,7 +163,7 @@ class Builder implements BuilderContract
     /**
      * The number of records to skip.
      *
-     * @var int
+     * @var int|null
      */
     public $offset;
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -144,6 +144,7 @@ class Builder
     {
         $table = $this->connection->getTablePrefix().$table;
 
+        /** @phpstan-ignore arguments.count (SQLite accepts a withSize argument) */
         foreach ($this->getTables(false) as $value) {
             if (strtolower($table) === strtolower($value['name'])) {
                 return true;

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -332,13 +332,12 @@ abstract class Grammar extends BaseGrammar
      * Wrap a value in keyword identifiers.
      *
      * @param  \Illuminate\Support\Fluent|\Illuminate\Contracts\Database\Query\Expression|string  $value
-     * @param  bool  $prefixAlias
      * @return string
      */
-    public function wrap($value, $prefixAlias = false)
+    public function wrap($value)
     {
         return parent::wrap(
-            $value instanceof Fluent ? $value->name : $value, $prefixAlias
+            $value instanceof Fluent ? $value->name : $value,
         );
     }
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -87,7 +87,7 @@ class DownCommand extends Command
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
             'secret' => $this->getSecret(),
-            'status' => (int) $this->option('status', 503),
+            'status' => (int) ($this->option('status') ?? 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];
     }

--- a/src/Illuminate/Foundation/stubs/facade.stub
+++ b/src/Illuminate/Foundation/stubs/facade.stub
@@ -5,7 +5,7 @@ namespace DummyNamespace;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DummyTarget
+ * @mixin \DummyTarget
  */
 class DummyClass extends Facade
 {

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -108,4 +108,14 @@ class HashManager extends Manager implements Hasher
     {
         return $this->config->get('hashing.driver', 'bcrypt');
     }
+
+    /**
+     * Verifies that the configuration is less than or equal to what is configured.
+     *
+     * @internal
+     */
+    public function verifyConfiguration($value)
+    {
+        return $this->driver()->verifyConfiguration($value);
+    }
 }

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -56,7 +56,7 @@ class UploadedFile extends SymfonyUploadedFile
      * Store the uploaded file on a filesystem disk with public visibility.
      *
      * @param  string  $path
-     * @param  string  $name
+     * @param  array|string|null  $name
      * @param  array|string  $options
      * @return string|false
      */

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -408,9 +408,9 @@ class Mailer implements MailerContract, MailQueueContract
      * Add the content to a given message.
      *
      * @param  \Illuminate\Mail\Message  $message
-     * @param  string  $view
-     * @param  string  $plain
-     * @param  string  $raw
+     * @param  string|null  $view
+     * @param  string|null  $plain
+     * @param  string|null  $raw
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -226,7 +226,7 @@ class SimpleMessage
     /**
      * Format the given line of text.
      *
-     * @param  \Illuminate\Contracts\Support\Htmlable|string|array  $line
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|array|null  $line
      * @return \Illuminate\Contracts\Support\Htmlable|string
      */
     protected function formatLine($line)

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -35,9 +35,10 @@ class SubstituteBindings
      */
     public function handle($request, Closure $next)
     {
-        try {
-            $this->router->substituteBindings($route = $request->route());
+        $route = $request->route();
 
+        try {
+            $this->router->substituteBindings($route);
             $this->router->substituteImplicitBindings($route);
         } catch (ModelNotFoundException $exception) {
             if ($route->getMissing()) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -796,7 +796,7 @@ class Route
     /**
      * Add a prefix to the route URI.
      *
-     * @param  string  $prefix
+     * @param  string|null  $prefix
      * @return $this
      */
     public function prefix($prefix)

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -59,13 +59,14 @@ class RouteCollection extends AbstractRouteCollection
      */
     protected function addToCollections($route)
     {
+        $methods = $route->methods();
         $domainAndUri = $route->getDomain().$route->uri();
 
-        foreach ($route->methods() as $method) {
+        foreach ($methods as $method) {
             $this->routes[$method][$domainAndUri] = $route;
         }
 
-        $this->allRoutes[$method.$domainAndUri] = $route;
+        $this->allRoutes[implode('|', $methods).$domainAndUri] = $route;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -140,7 +140,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Foundation\Application
+ * @mixin \Illuminate\Foundation\Application
  */
 class App extends Facade
 {

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -23,7 +23,7 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
  * @method static \Illuminate\Foundation\Console\Kernel addCommandPaths(array $paths)
  * @method static \Illuminate\Foundation\Console\Kernel addCommandRoutePaths(array $paths)
  *
- * @see \Illuminate\Foundation\Console\Kernel
+ * @mixin \Illuminate\Foundation\Console\Kernel
  */
 class Artisan extends Facade
 {

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -64,8 +64,8 @@ use RuntimeException;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Auth\AuthManager
- * @see \Illuminate\Auth\SessionGuard
+ * @mixin \Illuminate\Auth\AuthManager
+ * @mixin \Illuminate\Auth\SessionGuard
  */
 class Auth extends Facade
 {

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -45,7 +45,7 @@ namespace Illuminate\Support\Facades;
  * @method static string compileEchos(string $value)
  * @method static string applyEchoHandler(string $value)
  *
- * @see \Illuminate\View\Compilers\BladeCompiler
+ * @mixin \Illuminate\View\Compilers\BladeCompiler
  */
 class Blade extends Facade
 {

--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -33,8 +33,8 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
  * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string $channel, callable|string $callback, array $options = [])
  * @method static \Illuminate\Support\Collection getChannels()
  *
- * @see \Illuminate\Broadcasting\BroadcastManager
- * @see \Illuminate\Broadcasting\Broadcasters\Broadcaster
+ * @mixin \Illuminate\Broadcasting\BroadcastManager
+ * @mixin \Illuminate\Broadcasting\Broadcasters\Broadcaster
  */
 class Broadcast extends Facade
 {

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -49,8 +49,8 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static \Illuminate\Support\Testing\Fakes\BusFake serializeAndRestore(bool $serializeAndRestore = true)
  * @method static array dispatchedBatches()
  *
- * @see \Illuminate\Bus\Dispatcher
- * @see \Illuminate\Support\Testing\Fakes\BusFake
+ * @mixin \Illuminate\Bus\Dispatcher
+ * @mixin \Illuminate\Support\Testing\Fakes\BusFake
  */
 class Bus extends Facade
 {

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -53,8 +53,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Cache\Lock lock(string $name, int $seconds = 0, string|null $owner = null)
  * @method static \Illuminate\Contracts\Cache\Lock restoreLock(string $name, string $owner)
  *
- * @see \Illuminate\Cache\CacheManager
- *
+ * @mixin \Illuminate\Cache\CacheManager
  * @mixin \Illuminate\Cache\Repository
  */
 class Cache extends Facade

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -20,7 +20,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Config\Repository
+ * @mixin \Illuminate\Config\Repository
  */
 class Config extends Facade
 {

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -34,7 +34,7 @@ namespace Illuminate\Support\Facades;
  * @method static void flushMacros()
  * @method static \Illuminate\Database\Eloquent\Model restoreModel(\Illuminate\Contracts\Database\ModelIdentifier $value)
  *
- * @see \Illuminate\Log\Context\Repository
+ * @mixin \Illuminate\Log\Context\Repository
  */
 class Context extends Facade
 {

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -19,7 +19,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Cookie\CookieJar
+ * @mixin \Illuminate\Cookie\CookieJar
  */
 class Cookie extends Facade
 {

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -14,7 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static array getPreviousKeys()
  * @method static \Illuminate\Encryption\Encrypter previousKeys(array $keys)
  *
- * @see \Illuminate\Encryption\Encrypter
+ * @mixin \Illuminate\Encryption\Encrypter
  */
 class Crypt extends Facade
 {

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -110,7 +110,7 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static int transactionLevel()
  * @method static void afterCommit(callable $callback)
  *
- * @see \Illuminate\Database\DatabaseManager
+ * @mixin \Illuminate\Database\DatabaseManager
  */
 class DB extends Facade
 {

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -85,7 +85,7 @@ use Illuminate\Support\DateFactory;
  * @method static void useYearsOverflow($yearsOverflow = true)
  * @method static \Illuminate\Support\Carbon yesterday($tz = null)
  *
- * @see \Illuminate\Support\DateFactory
+ * @mixin \Illuminate\Support\DateFactory
  */
 class Date extends Facade
 {

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -36,8 +36,8 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static bool hasDispatched(string $event)
  * @method static array dispatchedEvents()
  *
- * @see \Illuminate\Events\Dispatcher
- * @see \Illuminate\Support\Testing\Fakes\EventFake
+ * @mixin \Illuminate\Events\Dispatcher
+ * @mixin \Illuminate\Support\Testing\Fakes\EventFake
  */
 class Event extends Facade
 {

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -33,9 +33,9 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwFirstReported()
  * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake setHandler(\Illuminate\Contracts\Debug\ExceptionHandler $handler)
  *
- * @see \Illuminate\Foundation\Exceptions\Handler
- * @see \Illuminate\Contracts\Debug\ExceptionHandler
- * @see \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
+ * @mixin \Illuminate\Foundation\Exceptions\Handler
+ * @mixin \Illuminate\Contracts\Debug\ExceptionHandler
+ * @mixin \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
  */
 class Exceptions extends Facade
 {

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -56,7 +56,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Filesystem\Filesystem
+ * @mixin \Illuminate\Filesystem\Filesystem
  */
 class File extends Facade
 {

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -32,7 +32,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static \Illuminate\Auth\Access\Response denyWithStatus(int $status, string|null $message = null, int|null $code = null)
  * @method static \Illuminate\Auth\Access\Response denyAsNotFound(string|null $message = null, int|null $code = null)
  *
- * @see \Illuminate\Auth\Access\Gate
+ * @mixin \Illuminate\Auth\Access\Gate
  */
 class Gate extends Facade
 {

--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -19,8 +19,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Hashing\HashManager setContainer(\Illuminate\Contracts\Container\Container $container)
  * @method static \Illuminate\Hashing\HashManager forgetDrivers()
  *
- * @see \Illuminate\Hashing\HashManager
- * @see \Illuminate\Hashing\AbstractHasher
+ * @mixin \Illuminate\Hashing\HashManager
+ * @mixin \Illuminate\Hashing\AbstractHasher
  */
 class Hash extends Facade
 {

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -91,7 +91,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Http\Client\PendingRequest|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  *
- * @see \Illuminate\Http\Client\Factory
+ * @mixin \Illuminate\Http\Client\Factory
  */
 class Http extends Facade
 {

--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -31,7 +31,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Translation\Translator
+ * @mixin \Illuminate\Translation\Translator
  */
 class Lang extends Facade
 {

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -35,7 +35,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Log\Logger|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Log\Logger|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  *
- * @see \Illuminate\Log\LogManager
+ * @mixin \Illuminate\Log\LogManager
  */
 class Log extends Facade
 {

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -57,8 +57,8 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static \Illuminate\Support\Collection queued(string|\Closure $mailable, callable|null $callback = null)
  * @method static bool hasQueued(string $mailable)
  *
- * @see \Illuminate\Mail\MailManager
- * @see \Illuminate\Support\Testing\Fakes\MailFake
+ * @mixin \Illuminate\Mail\MailManager
+ * @mixin \Illuminate\Support\Testing\Fakes\MailFake
  */
 class Mail extends Facade
 {

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -38,8 +38,8 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Notifications\ChannelManager
- * @see \Illuminate\Support\Testing\Fakes\NotificationFake
+ * @mixin \Illuminate\Notifications\ChannelManager
+ * @mixin \Illuminate\Support\Testing\Fakes\NotificationFake
  */
 class Notification extends Facade
 {

--- a/src/Illuminate/Support/Facades/ParallelTesting.php
+++ b/src/Illuminate/Support/Facades/ParallelTesting.php
@@ -18,7 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static mixed option(string $option)
  * @method static string|false token()
  *
- * @see \Illuminate\Testing\ParallelTesting
+ * @mixin \Illuminate\Testing\ParallelTesting
  */
 class ParallelTesting extends Facade
 {

--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -16,8 +16,8 @@ use Illuminate\Contracts\Auth\PasswordBroker;
  * @method static bool tokenExists(\Illuminate\Contracts\Auth\CanResetPassword $user, string $token)
  * @method static \Illuminate\Auth\Passwords\TokenRepositoryInterface getRepository()
  *
- * @see \Illuminate\Auth\Passwords\PasswordBrokerManager
- * @see \Illuminate\Auth\Passwords\PasswordBroker
+ * @mixin \Illuminate\Auth\Passwords\PasswordBrokerManager
+ * @mixin \Illuminate\Auth\Passwords\PasswordBroker
  */
 class Password extends Facade
 {

--- a/src/Illuminate/Support/Facades/Pipeline.php
+++ b/src/Illuminate/Support/Facades/Pipeline.php
@@ -13,7 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Pipeline\Pipeline|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Pipeline\Pipeline|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  *
- * @see \Illuminate\Pipeline\Pipeline
+ * @mixin \Illuminate\Pipeline\Pipeline
  */
 class Pipeline extends Facade
 {

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -44,8 +44,8 @@ use Illuminate\Process\Factory;
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
  *
- * @see \Illuminate\Process\PendingProcess
- * @see \Illuminate\Process\Factory
+ * @mixin \Illuminate\Process\PendingProcess
+ * @mixin \Illuminate\Process\Factory
  */
 class Process extends Facade
 {

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -53,9 +53,9 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static array pushedJobs()
  * @method static \Illuminate\Support\Testing\Fakes\QueueFake serializeAndRestore(bool $serializeAndRestore = true)
  *
- * @see \Illuminate\Queue\QueueManager
- * @see \Illuminate\Queue\Queue
- * @see \Illuminate\Support\Testing\Fakes\QueueFake
+ * @mixin \Illuminate\Queue\QueueManager
+ * @mixin \Illuminate\Queue\Queue
+ * @mixin \Illuminate\Support\Testing\Fakes\QueueFake
  */
 class Queue extends Facade
 {

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -18,7 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static int availableIn(string $key)
  * @method static string cleanRateLimiterKey(string $key)
  *
- * @see \Illuminate\Cache\RateLimiter
+ * @mixin \Illuminate\Cache\RateLimiter
  */
 class RateLimiter extends Facade
 {

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -23,7 +23,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Routing\Redirector
+ * @mixin \Illuminate\Routing\Redirector
  */
 class Redirect extends Facade
 {

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -30,7 +30,7 @@ namespace Illuminate\Support\Facades;
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
  *
- * @see \Illuminate\Redis\RedisManager
+ * @mixin \Illuminate\Redis\RedisManager
  */
 class Redis extends Facade
 {

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -180,7 +180,7 @@ namespace Illuminate\Support\Facades;
  * @method static array validateWithBag(string $errorBag, array $rules, ...$params)
  * @method static bool hasValidSignature(bool $absolute = true)
  *
- * @see \Illuminate\Http\Request
+ * @mixin \Illuminate\Http\Request
  */
 class Request extends Facade
 {

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -25,7 +25,7 @@ use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Routing\ResponseFactory
+ * @mixin \Illuminate\Routing\ResponseFactory
  */
 class Response extends Facade
 {

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -101,7 +101,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
  * @method static \Illuminate\Routing\RouteRegistrar withoutScopedBindings()
  *
- * @see \Illuminate\Routing\Router
+ * @mixin \Illuminate\Routing\Router
  */
 class Route extends Facade
 {

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -19,7 +19,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Console\Scheduling\Schedule
+ * @mixin \Illuminate\Console\Scheduling\Schedule
  */
 class Schedule extends Facade
 {

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -46,7 +46,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Database\Schema\Builder
+ * @mixin \Illuminate\Database\Schema\Builder
  */
 class Schema extends Facade
 {

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -69,7 +69,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Session\SessionManager
+ * @mixin \Illuminate\Session\SessionManager
  */
 class Session extends Facade
 {

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -80,7 +80,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static void write(string $location, string $contents, array $config = [])
  * @method static void createDirectory(string $location, array $config = [])
  *
- * @see \Illuminate\Filesystem\FilesystemManager
+ * @mixin \Illuminate\Filesystem\FilesystemManager
  */
 class Storage extends Facade
 {

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -48,7 +48,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Routing\UrlGenerator
+ * @mixin \Illuminate\Routing\UrlGenerator
  */
 class URL extends Facade
 {

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -18,7 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Container\Container|null getContainer()
  * @method static \Illuminate\Validation\Factory setContainer(\Illuminate\Contracts\Container\Container $container)
  *
- * @see \Illuminate\Validation\Factory
+ * @mixin \Illuminate\Validation\Factory
  */
 class Validator extends Facade
 {

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -81,7 +81,7 @@ namespace Illuminate\Support\Facades;
  * @method static void startTranslation(array $replacements = [])
  * @method static string renderTranslation()
  *
- * @see \Illuminate\View\Factory
+ * @mixin \Illuminate\View\Factory
  */
 class View extends Facade
 {

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -27,7 +27,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Foundation\Vite
+ * @mixin \Illuminate\Foundation\Vite
  */
 class Vite extends Facade
 {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -867,12 +867,12 @@ class TestResponse implements ArrayAccess
                         break;
                     }
                 }
-            }
 
-            if ($errorMissing) {
-                PHPUnit::withResponse($this)->fail(
-                    "Failed to find a validation error in the response for key and message: '$key' => '$expectedMessage'".PHP_EOL.PHP_EOL.$errorMessage
-                );
+                if ($errorMissing) {
+                    PHPUnit::withResponse($this)->fail(
+                        "Failed to find a validation error in the response for key and message: '$key' => '$expectedMessage'".PHP_EOL.PHP_EOL.$errorMessage
+                    );
+                }
             }
         }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -276,8 +276,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
             }
 
-            $shouldReplace[':'.Str::ucfirst($key ?? '')] = Str::ucfirst($value ?? '');
-            $shouldReplace[':'.Str::upper($key ?? '')] = Str::upper($value ?? '');
+            $shouldReplace[':'.Str::ucfirst($key)] = Str::ucfirst($value ?? '');
+            $shouldReplace[':'.Str::upper($key)] = Str::upper($value ?? '');
             $shouldReplace[':'.$key] = $value;
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -16,7 +16,7 @@ trait CompilesLoops
     /**
      * Compile the for-else statements into valid PHP.
      *
-     * @param  string  $expression
+     * @param  string|null  $expression
      * @return string
      *
      * @throws \Illuminate\Contracts\View\ViewCompilationException
@@ -93,7 +93,7 @@ trait CompilesLoops
     /**
      * Compile the for-each statements into valid PHP.
      *
-     * @param  string  $expression
+     * @param  string|null  $expression
      * @return string
      *
      * @throws \Illuminate\Contracts\View\ViewCompilationException

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
+use Illuminate\Support\Collection;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseConcernsHasAttributesTest extends TestCase
@@ -20,6 +22,24 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $instance = new HasAttributesWithConstructorArguments(null);
         $attributes = $instance->getMutatedAttributes();
         $this->assertEquals(['some_attribute'], $attributes);
+    }
+
+    public function testRelationsToArray()
+    {
+        $mock = m::mock(HasAttributesWithoutConstructor::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('getArrayableRelations')->andReturn([
+                'arrayable_relation' => Collection::make(['foo' => 'bar']),
+                'invalid_relation' => 'invalid',
+                'null_relation' => null,
+            ])
+            ->getMock();
+
+        $this->assertEquals([
+            'arrayable_relation' => ['foo' => 'bar'],
+            'null_relation' => null,
+        ], $mock->relationsToArray());
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR cleans up some bugs and brings the framework to PHPStan Level 1.

For reference, here is all of the errors on 11.x:

<details>

```
 ------ ------------------------------------------------------------------------- 
  Line   Illuminate/Auth/Access/Gate.php                                          
 ------ ------------------------------------------------------------------------- 
  590    Variable $result on left side of ??= always exists and is not nullable.  
         🪪  nullCoalesce.variable                                                
 ------ ------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   Illuminate/Bus/PendingBatch.php                                
 ------ --------------------------------------------------------------- 
  361    Variable $batch in isset() always exists and is not nullable.  
         🪪  isset.variable                                             
 ------ --------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------- 
  Line   Illuminate/Cache/RetrievesMultipleKeys.php (in context of class Illuminate\Cache\ApcStore)  
 ------ -------------------------------------------------------------------------------------------- 
  24     Method Illuminate\Cache\ApcStore::get() invoked with 2 parameters, 1 required.              
         🪪  arguments.count                                                                         
 ------ -------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   Illuminate/Cache/RetrievesMultipleKeys.php (in context of class Illuminate\Cache\ArrayStore)  
 ------ ---------------------------------------------------------------------------------------------- 
  24     Method Illuminate\Cache\ArrayStore::get() invoked with 2 parameters, 1 required.              
         🪪  arguments.count                                                                           
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------- 
  Line   Illuminate/Cache/RetrievesMultipleKeys.php (in context of class Illuminate\Cache\DatabaseStore)  
 ------ ------------------------------------------------------------------------------------------------- 
  24     Method Illuminate\Cache\DatabaseStore::get() invoked with 2 parameters, 1 required.              
         🪪  arguments.count                                                                              
 ------ ------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------- 
  Line   Illuminate/Cache/RetrievesMultipleKeys.php (in context of class Illuminate\Cache\FileStore)  
 ------ --------------------------------------------------------------------------------------------- 
  24     Method Illuminate\Cache\FileStore::get() invoked with 2 parameters, 1 required.              
         🪪  arguments.count                                                                          
 ------ --------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------- 
  Line   Illuminate/Cache/RetrievesMultipleKeys.php (in context of class Illuminate\Cache\NullStore)  
 ------ --------------------------------------------------------------------------------------------- 
  24     Method Illuminate\Cache\NullStore::get() invoked with 2 parameters, 1 required.              
         🪪  arguments.count                                                                          
 ------ --------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   Illuminate/Collections/Collection.php                                  
 ------ ----------------------------------------------------------------------- 
  601    Variable $value on left side of ?? always exists and is not nullable.  
         🪪  nullCoalesce.variable                                              
 ------ ----------------------------------------------------------------------- 

 ------ --------------------------------------------------------- 
  Line   Illuminate/Console/resources/views/components/alert.php  
 ------ --------------------------------------------------------- 
  2      Variable $content might not be defined.                  
         🪪  variable.undefined                                   
 ------ --------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   Illuminate/Console/resources/views/components/bullet-list.php  
 ------ --------------------------------------------------------------- 
  2      Variable $elements might not be defined.                       
         🪪  variable.undefined                                         
 ------ --------------------------------------------------------------- 

 ------ -------------------------------------------------------- 
  Line   Illuminate/Console/resources/views/components/line.php  
 ------ -------------------------------------------------------- 
  1      Variable $marginTop might not be defined.               
         🪪  variable.undefined                                  
  2      Variable $bgColor might not be defined.                 
         🪪  variable.undefined                                  
  2      Variable $fgColor might not be defined.                 
         🪪  variable.undefined                                  
  2      Variable $title might not be defined.                   
         🪪  variable.undefined                                  
  3      Variable $title might not be defined.                   
         🪪  variable.undefined                                  
  6      Variable $content might not be defined.                 
         🪪  variable.undefined                                  
 ------ -------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   Illuminate/Console/resources/views/components/two-column-detail.php  
 ------ --------------------------------------------------------------------- 
  3      Variable $first might not be defined.                                
         🪪  variable.undefined                                               
  6      Variable $second might not be defined.                               
         🪪  variable.undefined                                               
 ------ --------------------------------------------------------------------- 

 ------ ------------------------------------------------------ 
  Line   Illuminate/Database/Connectors/ConnectionFactory.php  
 ------ ------------------------------------------------------ 
  191    Variable $e might not be defined.                     
         🪪  variable.undefined                                
 ------ ------------------------------------------------------ 

 ------ --------------------------------------------------- 
  Line   Illuminate/Database/Connectors/MySqlConnector.php  
 ------ --------------------------------------------------- 
  83     Variable $database might not be defined.           
         🪪  variable.undefined                             
  83     Variable $host might not be defined.               
         🪪  variable.undefined                             
  84     Variable $database might not be defined.           
         🪪  variable.undefined                             
  84     Variable $host might not be defined.               
         🪪  variable.undefined                             
 ------ --------------------------------------------------- 

 ------ ------------------------------------------------------ 
  Line   Illuminate/Database/Connectors/PostgresConnector.php  
 ------ ------------------------------------------------------ 
  169    Variable $database might not be defined.              
         🪪  variable.undefined                                
 ------ ------------------------------------------------------ 

 ------ --------------------------------------------------------------------------- 
  Line   Illuminate/Database/Console/DatabaseInspectionCommand.php                  
 ------ --------------------------------------------------------------------------- 
  66     Variable $database on left side of ??= always exists and is not nullable.  
         🪪  nullCoalesce.variable                                                  
 ------ --------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------- 
  Line   Illuminate/Database/Eloquent/Attributes/ObservedBy.php                                                     
 ------ ----------------------------------------------------------------------------------------------------------- 
  16     Constructor of class Illuminate\Database\Eloquent\Attributes\ObservedBy has an unused parameter $classes.  
         🪪  constructor.unusedParameter                                                                            
 ------ ----------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------- 
  Line   Illuminate/Database/Eloquent/Attributes/ScopedBy.php                                                     
 ------ --------------------------------------------------------------------------------------------------------- 
  16     Constructor of class Illuminate\Database\Eloquent\Attributes\ScopedBy has an unused parameter $classes.  
         🪪  constructor.unusedParameter                                                                          
 ------ --------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   Illuminate/Database/Eloquent/Concerns/HasAttributes.php (in context of class Illuminate\Database\Eloquent\Model)  
 ------ ------------------------------------------------------------------------------------------------------------------ 
  398    Variable $relation might not be defined.                                                                          
         🪪  variable.undefined                                                                                            
  1218   Variable $value in isset() always exists and is not nullable.                                                     
         🪪  isset.variable                                                                                                
  1335   Variable $value on left side of ?? always exists and is not nullable.                                             
         🪪  nullCoalesce.variable                                                                                         
  1399   Call to an undefined static method Illuminate\Support\Facades\Hash::verifyConfiguration().                        
         🪪  staticMethod.notFound                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   Illuminate/Database/Eloquent/Concerns/HasRelationships.php (in context of class Illuminate\Database\Eloquent\Model)  
 ------ --------------------------------------------------------------------------------------------------------------------- 
  320    Variable $ownerKey on left side of ?? always exists and is not nullable.                                             
         🪪  nullCoalesce.variable                                                                                            
 ------ --------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php (in context of class Illuminate\Database\Eloquent\Relations\HasOne)  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------- 
  217    Method Illuminate\Database\Eloquent\Relations\HasOne::addOneOfManySubQueryConstraints() invoked with 4 parameters, 1-3 required.        
         🪪  arguments.count                                                                                                                     
  240    Method Illuminate\Database\Eloquent\Relations\HasOne::addOneOfManyJoinSubQueryConstraints() invoked with 2 parameters, 1 required.      
         🪪  arguments.count                                                                                                                     
 ------ ---------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php (in context of class Illuminate\Database\Eloquent\Relations\MorphOne)  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  217    Method Illuminate\Database\Eloquent\Relations\MorphOne::addOneOfManySubQueryConstraints() invoked with 4 parameters, 1-3 required.        
         🪪  arguments.count                                                                                                                       
  240    Method Illuminate\Database\Eloquent\Relations\MorphOne::addOneOfManyJoinSubQueryConstraints() invoked with 2 parameters, 1 required.      
         🪪  arguments.count                                                                                                                       
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------- 
  Line   Illuminate/Database/Query/Grammars/Grammar.php                  
 ------ ---------------------------------------------------------------- 
  997    Variable $offset in isset() always exists and is not nullable.  
         🪪  isset.variable                                              
  1020   Variable $offset in isset() always exists and is not nullable.  
         🪪  isset.variable                                              
 ------ ---------------------------------------------------------------- 

 ------ ---------------------------------------------------------------- 
  Line   Illuminate/Database/Query/Grammars/MySqlGrammar.php             
 ------ ---------------------------------------------------------------- 
  137    Variable $offset in isset() always exists and is not nullable.  
         🪪  isset.variable                                              
  167    Variable $offset in isset() always exists and is not nullable.  
         🪪  isset.variable                                              
 ------ ---------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   Illuminate/Database/Schema/Builder.php                                                        
 ------ ---------------------------------------------------------------------------------------------- 
  147    Method Illuminate\Database\Schema\Builder::getTables() invoked with 1 parameter, 0 required.  
         🪪  arguments.count                                                                           
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   Illuminate/Database/Schema/Grammars/Grammar.php                                    
 ------ ----------------------------------------------------------------------------------- 
  328    Method Illuminate\Database\Grammar::wrap() invoked with 2 parameters, 1 required.  
         🪪  arguments.count                                                                
 ------ ----------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------- 
  Line   Illuminate/Foundation/Console/DownCommand.php                                         
 ------ -------------------------------------------------------------------------------------- 
  90     Method Illuminate\Console\Command::option() invoked with 2 parameters, 0-1 required.  
         🪪  arguments.count                                                                   
 ------ -------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   Illuminate/Http/UploadedFile.php                                     
 ------ --------------------------------------------------------------------- 
  66     Variable $name on left side of ?? always exists and is always null.  
         🪪  nullCoalesce.variable                                            
 ------ --------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------- 
  Line   Illuminate/Log/Context/ContextServiceProvider.php                                    
 ------ ------------------------------------------------------------------------------------- 
  30     Call to an undefined static method Illuminate\Support\Facades\Context::dehydrate().  
         🪪  staticMethod.notFound                                                            
  39     Call to an undefined static method Illuminate\Support\Facades\Context::hydrate().    
         🪪  staticMethod.notFound                                                            
 ------ ------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   Illuminate/Mail/Mailer.php                                     
 ------ --------------------------------------------------------------- 
  422    Variable $view in isset() always exists and is not nullable.   
         🪪  isset.variable                                             
  426    Variable $plain in isset() always exists and is not nullable.  
         🪪  isset.variable                                             
  430    Variable $raw in isset() always exists and is not nullable.    
         🪪  isset.variable                                             
 ------ --------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Illuminate/Notifications/Messages/SimpleMessage.php                   
 ------ ---------------------------------------------------------------------- 
  242    Variable $line on left side of ?? always exists and is not nullable.  
         🪪  nullCoalesce.variable                                             
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------- 
  Line   Illuminate/Notifications/resources/views/email.blade.php  
 ------ ---------------------------------------------------------- 
  22     Variable $level might not be defined.                     
         🪪  variable.undefined                                    
 ------ ---------------------------------------------------------- 

 ------ ------------------------------------------------------ 
  Line   Illuminate/Routing/Middleware/SubstituteBindings.php  
 ------ ------------------------------------------------------ 
  43     Variable $route might not be defined.                 
         🪪  variable.undefined                                
  44     Variable $route might not be defined.                 
         🪪  variable.undefined                                
 ------ ------------------------------------------------------ 

 ------ ------------------------------------------------------------------------- 
  Line   Illuminate/Routing/Route.php                                             
 ------ ------------------------------------------------------------------------- 
  804    Variable $prefix on left side of ??= always exists and is not nullable.  
         🪪  nullCoalesce.variable                                                
 ------ ------------------------------------------------------------------------- 

 ------ ---------------------------------------- 
  Line   Illuminate/Routing/RouteCollection.php  
 ------ ---------------------------------------- 
  68     Variable $method might not be defined.  
         🪪  variable.undefined                  
 ------ ---------------------------------------- 

 ------ ------------------------------------------------- 
  Line   Illuminate/Testing/TestResponse.php              
 ------ ------------------------------------------------- 
  872    Variable $errorMissing might not be defined.     
         🪪  variable.undefined                           
  874    Variable $expectedMessage might not be defined.  
         🪪  variable.undefined                           
 ------ ------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   Illuminate/Translation/Translator.php                                
 ------ --------------------------------------------------------------------- 
  279    Variable $key on left side of ?? always exists and is not nullable.  
         🪪  nullCoalesce.variable                                            
  280    Variable $key on left side of ?? always exists and is not nullable.  
         🪪  nullCoalesce.variable                                            
 ------ --------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------- 
  Line   Illuminate/View/Compilers/Concerns/CompilesLoops.php (in context of class Illuminate\View\Compilers\BladeCompiler)  
 ------ -------------------------------------------------------------------------------------------------------------------- 
  28     Variable $expression on left side of ?? always exists and is not nullable.                                          
         🪪  nullCoalesce.variable                                                                                           
  103    Variable $expression on left side of ?? always exists and is not nullable.                                          
         🪪  nullCoalesce.variable                                                                                           
 ------ -------------------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 61 errors                                                                                                
```
</details>


Thanks!