### PR TITLE
[11.x] Improvements for the ServeCommand (add more loves & elevate DX)

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
+use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -15,6 +16,8 @@ use function Termwind\terminal;
 #[AsCommand(name: 'serve')]
 class ServeCommand extends Command
 {
+    use InteractsWithTime;
+
     /**
      * The console command name.
      *
@@ -318,7 +321,10 @@ class ServeCommand extends Command
 
                     $this->output->write("  <fg=gray>$date</> $time");
 
-                    $runTime = $this->getDateFromLine($line)->diffInSeconds($startDate);
+                    $runTime = $this->runTimeForHumans(
+                        $startDate,
+                        $this->getDateFromLine($line)
+                    );
 
                     if ($file) {
                         $this->output->write($file = " $file");

--- a/src/Illuminate/Foundation/resources/server.php
+++ b/src/Illuminate/Foundation/resources/server.php
@@ -13,4 +13,11 @@ if ($uri !== '/' && file_exists($publicPath.$uri)) {
     return false;
 }
 
+$formattedDateTime = date('D M j H:i:s Y');
+
+$requestMethod = $_SERVER['REQUEST_METHOD'];
+$remoteAddress = $_SERVER['REMOTE_ADDR'] . ':' . $_SERVER['REMOTE_PORT'];
+
+file_put_contents("php://stdout", "[$formattedDateTime] $remoteAddress [$requestMethod] URI: $uri\n");
+
 require_once $publicPath.'/index.php';


### PR DESCRIPTION
Hi guys,

As a person who really loves the `php artisan serve` and jumps into the development immediately, I'd like to add some improvements and hopefully, it would help other developers too

1. Print out a better request time, for requests that take less than 1 second, `~0s` doesn't seem so helpful at all.
2. Show the request's route instead of "........." 

Thanks all.

## Before

![before](https://github.com/laravel/framework/assets/23478115/402cba2e-944d-4b5c-9841-6d29396db34b)

## After

![after](https://github.com/laravel/framework/assets/23478115/11d12b10-8f36-4c51-b30b-f464ce5359d7)


