### PR TITLE
[11.x] Run Workflows on Windows 2022 and with bash instead of powershell

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
             !vendor/**/.gitignore
 
   windows_tests:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       fail-fast: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
-          shell: powershell
+          shell: bash
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3
@@ -149,7 +149,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require phpunit/phpunit:^${{ matrix.phpunit }} --dev --no-interaction --no-update
-          shell: powershell
+          shell: bash
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,14 +140,14 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/psr7:~2.4 --no-interaction --no-update
+          command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require phpunit/phpunit:~${{ matrix.phpunit }} --dev --no-interaction --no-update
+          command: composer require phpunit/phpunit:^${{ matrix.phpunit }} --dev --no-interaction --no-update
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,6 +141,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
+          shell: powershell
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3
@@ -148,6 +149,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require phpunit/phpunit:^${{ matrix.phpunit }} --dev --no-interaction --no-update
+          shell: powershell
 
       - name: Install dependencies
         uses: nick-fields/retry@v3


### PR DESCRIPTION
Replaces `windows-2019` with `windows-2022` next version will probably be `windows-2025`.

This also fixes a long standing issue, where the `^` symbol was being escaped in the windows command line / powershell.

Solution: explicitly use bash.