### PR TITLE
[11.x] Adds support for using castAsJson with a MariaDb connection

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -32,4 +32,15 @@ class MariaDbGrammar extends MySqlGrammar
     {
         return false;
     }
+
+    /**
+     * Compile a "JSON value cast" statement into SQL.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function compileJsonValueCast($value)
+    {
+        return "json_query($value, '$')";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -23,6 +23,17 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Compile a "JSON value cast" statement into SQL.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function compileJsonValueCast($value)
+    {
+        return "json_query({$value}, '$')";
+    }
+
+    /**
      * Determine whether to use a legacy group limit clause for MySQL < 8.0.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -31,16 +42,5 @@ class MariaDbGrammar extends MySqlGrammar
     public function useLegacyGroupLimit(Builder $query)
     {
         return false;
-    }
-
-    /**
-     * Compile a "JSON value cast" statement into SQL.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public function compileJsonValueCast($value)
-    {
-        return "json_query($value, '$')";
     }
 }

--- a/tests/Testing/Concerns/InteractsWithDatabaseTest.php
+++ b/tests/Testing/Concerns/InteractsWithDatabaseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Testing\Concerns;
 
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\Grammars\MariaDbGrammar;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
@@ -114,6 +115,29 @@ class InteractsWithDatabaseTest extends TestCase
 
         $this->assertEquals(<<<'TEXT'
         cast('{"foo":"bar"}' as json)
+        TEXT,
+            $this->castAsJson((object) ['foo' => 'bar'], $grammar)
+        );
+    }
+
+    public function testCastToJsonMariaDb()
+    {
+        $grammar = new MariaDbGrammar();
+
+        $this->assertEquals(<<<'TEXT'
+        json_query('["foo","bar"]', '$')
+        TEXT,
+            $this->castAsJson(['foo', 'bar'], $grammar)
+        );
+
+        $this->assertEquals(<<<'TEXT'
+        json_query('["foo","bar"]', '$')
+        TEXT,
+            $this->castAsJson(collect(['foo', 'bar']), $grammar)
+        );
+
+        $this->assertEquals(<<<'TEXT'
+        json_query('{"foo":"bar"}', '$')
         TEXT,
             $this->castAsJson((object) ['foo' => 'bar'], $grammar)
         );


### PR DESCRIPTION
Hey Laravel team, hope you're doing well 🙂.

This PR implements `compileJsonValueCast` method for MariaDbGrammar and adds some test cases for `castAsJson` using MariaDbGrammar (related to #43863).

___
More explanation:
While running some tests on a json column using a MariaDb connection faced an issue with castAsJson method.
Currently the method tries to run `cast(? as json)` on MariaDb which at the moment doesn't support casting to json using cast function ([MariaDb cast docs](https://mariadb.com/kb/en/cast/)).

It's returning this error:
> SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax;

Instead of using cast I've added [JSON_QUERY](https://mariadb.com/kb/en/json_query/) which works as needed.
Tried to add it the same way as the [related PR](https://github.com/laravel/framework/pull/44196) did for other databases.

Tested with MariaDb 10.6, 11.3, 11.4 and it works well.