### PR TITLE
[11.x] Fix typo in SupportCollectionTest

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1379,7 +1379,7 @@ class SupportCollectionTest extends TestCase
     public function testDiffUsingWithCollection($collection)
     {
         $c = new $collection(['en_GB', 'fr', 'HR']);
-        // demonstrate that diffKeys won't support case insensitivity
+        // demonstrate that diff won't support case insensitivity
         $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diff(new $collection(['en_gb', 'hr']))->values()->toArray());
         // allow for case insensitive difference
         $this->assertEquals(['fr'], $c->diffUsing(new $collection(['en_gb', 'hr']), 'strcasecmp')->values()->toArray());


### PR DESCRIPTION
Corrects the comment in `testDiffUsingWithCollection` to refer to the appropriate method.

It was likely inadvertently copied from [line 1415](https://github.com/laravel/framework/blob/94df3d60c9a6c2e6fdb47202d979fc92d339a5f8/tests/Support/SupportCollectionTest.php#L1415).