### PR TITLE
[11.x] Set previous exception on `HttpResponseException`

### DIFF
--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Exceptions;
 
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class HttpResponseException extends RuntimeException
 {
@@ -20,8 +21,10 @@ class HttpResponseException extends RuntimeException
      * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @return void
      */
-    public function __construct(Response $response)
+    public function __construct(Response $response, ?Throwable $previous = null)
     {
+        parent::__construct($previous?->getMessage() ?? '', $previous?->getCode() ?? 0, $previous);
+
         $this->response = $response;
     }
 

--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -19,6 +19,7 @@ class HttpResponseException extends RuntimeException
      * Create a new HTTP response exception instance.
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Throwable  $previous
      * @return void
      */
     public function __construct(Response $response, ?Throwable $previous = null)


### PR DESCRIPTION
We need this for laravel/passport#1763

The exception handler [supports handling http response exceptions](https://github.com/laravel/framework/blob/94df3d60c9a6c2e6fdb47202d979fc92d339a5f8/src/Illuminate/Foundation/Exceptions/Handler.php#L584) by extending `\Illuminate\Http\Exceptions\HttpResponseException` but there is no way to set the actual / previous exception when extending this class?