### PR TITLE
[11.x] Update tests to ensure mail Message implements the fluent interface pattern

### DIFF
--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -26,65 +26,65 @@ class MailMessageTest extends TestCase
 
     public function testFromMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->from('foo@bar.baz', 'Foo'));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getFrom()[0]);
+        $this->assertSame($this->message, $this->message->from('foo@bar.baz', 'Foo'));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getFrom()[0]);
     }
 
     public function testSenderMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->sender('foo@bar.baz', 'Foo'));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getSender());
+        $this->assertSame($this->message, $this->message->sender('foo@bar.baz', 'Foo'));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getSender());
     }
 
     public function testReturnPathMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->returnPath('foo@bar.baz'));
-        $this->assertEquals(new Address('foo@bar.baz'), $message->getSymfonyMessage()->getReturnPath());
+        $this->assertSame($this->message, $this->message->returnPath('foo@bar.baz'));
+        $this->assertEquals(new Address('foo@bar.baz'), $this->message->getSymfonyMessage()->getReturnPath());
     }
 
     public function testToMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->to('foo@bar.baz', 'Foo'));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getTo()[0]);
+        $this->assertSame($this->message, $this->message->to('foo@bar.baz', 'Foo'));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getTo()[0]);
 
-        $this->assertInstanceOf(Message::class, $message = $this->message->to(['bar@bar.baz' => 'Bar']));
-        $this->assertEquals(new Address('bar@bar.baz', 'Bar'), $message->getSymfonyMessage()->getTo()[0]);
+        $this->assertSame($this->message, $this->message->to(['bar@bar.baz' => 'Bar']));
+        $this->assertEquals(new Address('bar@bar.baz', 'Bar'), $this->message->getSymfonyMessage()->getTo()[0]);
     }
 
     public function testToMethodWithOverride()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->to('foo@bar.baz', 'Foo', true));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getTo()[0]);
+        $this->assertSame($this->message, $this->message->to('foo@bar.baz', 'Foo', true));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getTo()[0]);
     }
 
     public function testCcMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->cc('foo@bar.baz', 'Foo'));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getCc()[0]);
+        $this->assertSame($this->message, $this->message->cc('foo@bar.baz', 'Foo'));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getCc()[0]);
     }
 
     public function testBccMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->bcc('foo@bar.baz', 'Foo'));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getBcc()[0]);
+        $this->assertSame($this->message, $this->message->bcc('foo@bar.baz', 'Foo'));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getBcc()[0]);
     }
 
     public function testReplyToMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->replyTo('foo@bar.baz', 'Foo'));
-        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getReplyTo()[0]);
+        $this->assertSame($this->message, $this->message->replyTo('foo@bar.baz', 'Foo'));
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getReplyTo()[0]);
     }
 
     public function testSubjectMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->subject('foo'));
-        $this->assertSame('foo', $message->getSymfonyMessage()->getSubject());
+        $this->assertSame($this->message, $this->message->subject('foo'));
+        $this->assertSame('foo', $this->message->getSymfonyMessage()->getSubject());
     }
 
     public function testPriorityMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->priority(1));
-        $this->assertEquals(1, $message->getSymfonyMessage()->getPriority());
+        $this->assertSame($this->message, $this->message->priority(1));
+        $this->assertEquals(1, $this->message->getSymfonyMessage()->getPriority());
     }
 
     public function testBasicAttachment()


### PR DESCRIPTION
Because `Illuminate\Mail\Message` implements the fluent interface pattern. Each of these methods: `from`, `sender`, `returnPath`, `to`, `cc`, `bcc`, `replyTo`, `subject` and `priority` must change and return the instance itself. But current tests can be passed if a method return a clone/new static Message instance.

Let's take a look at `from` method.

```php
<?php

public function from($address, $name = null)
{
    $msg = clone $this; // Clone the called object.

    is_array($address)
        ? $msg->message->from(...$address)
        : $msg->message->from(new Address($address, (string) $name));

    return $msg; // Return the cloned one.
}

public function testFromMethod()
{
    # These assertions are still passed.
    $this->assertInstanceOf(Message::class, $message = $this->message->from('foo@bar.baz', 'Foo'));
    $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getFrom()[0]);

    # But these won't because we check the message instance itself.
    $this->assertSame($this->message, $this->message->from('foo@bar.baz', 'Foo'));
        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $this->message->getSymfonyMessage()->getFrom()[0]);
}
```

I think if a class implements the fluent interface pattern, `assertSame` is the required assertion when writing tests.
