### PR TITLE
[11.x] Fix test failure message

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -118,7 +118,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
         }
 
         throw new ExpectationFailedException(sprintf(
-            'The expected [%s] exception was not reported.',
+            'The expected [%s] exception was reported.',
             is_string($exception) ? $exception : $this->firstClosureParameterType($exception)
         ));
     }

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -144,7 +144,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertNotReportedMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+        $this->expectExceptionMessage('The expected [RuntimeException] exception was reported.');
 
         Exceptions::fake();
 
@@ -156,7 +156,7 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertNotReportedAsClosureMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+        $this->expectExceptionMessage('The expected [RuntimeException] exception was reported.');
 
         Exceptions::fake();
 


### PR DESCRIPTION
The message of the `assertReported` method is `The expected [%s] exception was not reported.`.
Then the message of the `assertNotReported` method should be reversed.
