### PR TITLE
[11.x] Add Ability To Expect Specific Validation Error Keys In Tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -234,14 +234,6 @@ trait InteractsWithExceptionHandling
                     sprintf('Failed asserting that key "%s" was invalid', $key),
                 );
             }
-        } catch (Throwable $exception) {
-            Assert::fail(
-                sprintf(
-                    'Failed asserting that exception of type "%s" is an instance of "%s".',
-                    get_class($exception),
-                    ValidationException::class,
-                ),
-            );
         }
 
         Assert::assertTrue(

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -212,8 +212,9 @@ trait InteractsWithExceptionHandling
      *
      * @param  Closure  $test
      * @param  array<string>  $keys
-     * @throws \PHPUnit\Framework\AssertionFailedError
      * @return $this
+     *
+     * @throws \PHPUnit\Framework\AssertionFailedError
      */
     protected function expectValidationErrors(Closure $test, array $keys)
     {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -206,4 +206,48 @@ trait InteractsWithExceptionHandling
 
         return $this;
     }
+
+    /**
+     * Assert that the given callback throws a ValidationException with the given error keys.
+     *
+     * @param  Closure  $test
+     * @param  array<string>  $keys
+     * @throws \PHPUnit\Framework\AssertionFailedError
+     * @return $this
+     */
+    protected function expectValidationErrors(Closure $test, array $keys)
+    {
+        $thrown = true;
+
+        try {
+            $test();
+
+            $thrown = false;
+        } catch (ValidationException $exception) {
+            $errors = $exception->errors();
+
+            foreach ($keys as $key) {
+                Assert::assertArrayHasKey(
+                    $key,
+                    $errors,
+                    sprintf('Failed asserting that key "%s" was invalid', $key),
+                );
+            }
+        } catch (Throwable $exception) {
+            Assert::fail(
+                sprintf(
+                    'Failed asserting that exception of type "%s" is an instance of "%s".',
+                    get_class($exception),
+                    ValidationException::class,
+                ),
+            );
+        }
+
+        Assert::assertTrue(
+            $thrown,
+            sprintf('Failed asserting that exception of type "%s" is thrown.', ValidationException::class),
+        );
+
+        return $this;
+    }
 }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -541,7 +541,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     public function testItAssertsValidationKeys()
     {
         $this->mockValidatorFacadeMake();
-        
+
         $this->expectValidationErrors(function () {
             throw ValidationException::withMessages([
                 'some_key' => 'Some error message',


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adds method `expectValidationErrors` to `InteractsWithExceptionHandling` trait. This allows for asserting that specific validation keys are failing, which is not possible through the more general `$this->expectException(ValidationException::class)`, where a ValidationException of any kind will suffice

For instance, you could have a test that ensures whether an invalid `some_key` field triggers a `ValidationException`. However, due to a bug in your code, `some_key` is actually valid, but `some_other_key` triggers a `ValidationException`. Since you're only expecting the exception and not the specific key, this test appears to pass (and masks a bug in your code)

Code loosely based on #42155 

A few examples
```php
// Will fail ❌ 
$this->expectValidationErrors(function () {
    // Do nothing
}, ['some_key']);

// Will fail ❌ (Exception will bubble)
$this->expectValidationErrors(function () {
    throw new Exception;
}, ['some_key']);

// Will fail ❌
$this->expectValidationErrors(function () {
    throw ValidationException::withMessages([
        'some_key' => 'Some error message',
    ]);
}, ['some_other_key']);

// Will pass ✅ 
$this->expectValidationErrors(function () {
    throw ValidationException::withMessages([
        'some_key' => 'Some error message',
    ]);
}, ['some_key']);

// Will pass ✅ 
$this->expectValidationErrors(function () {
    throw ValidationException::withMessages([
        'some_key' => 'Some error message',
        'another_key' => 'Another error message',
    ]);
}, ['some_key', 'another_key']);

// Will pass ✅ 
$this->expectValidationErrors(function () {
    throw ValidationException::withMessages([
        'some_key' => 'Some error message',
        'another_key' => 'Another error message',
    ]);
}, ['another_key']);
```