### PR TITLE
[11.x] add queued closure type for soft delete events

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -165,7 +165,7 @@ trait SoftDeletes
     /**
      * Register a "softDeleted" model event callback with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function softDeleted($callback)
@@ -176,7 +176,7 @@ trait SoftDeletes
     /**
      * Register a "restoring" model event callback with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function restoring($callback)
@@ -187,7 +187,7 @@ trait SoftDeletes
     /**
      * Register a "restored" model event callback with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function restored($callback)
@@ -198,7 +198,7 @@ trait SoftDeletes
     /**
      * Register a "forceDeleting" model event callback with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function forceDeleting($callback)
@@ -209,7 +209,7 @@ trait SoftDeletes
     /**
      * Register a "forceDeleted" model event callback with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function forceDeleted($callback)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
IDEs complain about passing a `queueable` callback to soft delete events.

This PR adds the `QueuedClosure` to their type definitions.