### PR TITLE
[11.x] Update composer.json files to provide PSR implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",
+        "psr/log-implementation": "1.0|2.0|3.0",
         "psr/simple-cache-implementation": "1.0|2.0|3.0"
     },
     "autoload": {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -18,7 +18,8 @@
         "illuminate/collections": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
-        "illuminate/support": "^11.0"
+        "illuminate/support": "^11.0",
+        "psr/simple-cache": "^1.0|^2.0|^3.0"
     },
     "provide": {
         "psr/simple-cache-implementation": "1.0|2.0|3.0"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -18,8 +18,7 @@
         "illuminate/collections": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
-        "illuminate/support": "^11.0",
-        "psr/simple-cache": "^1.0|^2.0|^3.0"
+        "illuminate/support": "^11.0"
     },
     "provide": {
         "psr/simple-cache-implementation": "1.0|2.0|3.0"

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -17,7 +17,11 @@
         "php": "^8.2",
         "illuminate/contracts": "^11.0",
         "illuminate/support": "^11.0",
-        "monolog/monolog": "^3.0"
+        "monolog/monolog": "^3.0",
+        "psr/log": "^1.0|^2.0|^3.0"
+    },
+    "provide": {
+        "psr/log-implementation": "1.0|2.0|3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Laravel explicitly uses `psr/container` and `psr/log`, so Illuminate `container` and `log` sub-packages must also require these packages. Therefore, I added missing `require` items in `Illuminate/Log/composer.json` file.

- I also update the `provide` section of `Illuminate/Log/composer.json` file to tell packagist that laravel framework provides `psr/log-implementation`.