### PR TITLE
[11.x] Fix sync is running touch query twice

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -102,7 +102,8 @@ trait InteractsWithPivotTable
             $detach = array_diff($current, array_keys($records));
 
             if (count($detach) > 0) {
-                $this->detach($detach);
+                // Detach record without touching, as this is done a bit latter
+                $this->detach($detach, false);
 
                 $changes['detached'] = $this->castKeys($detach);
             }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -102,7 +102,6 @@ trait InteractsWithPivotTable
             $detach = array_diff($current, array_keys($records));
 
             if (count($detach) > 0) {
-                // Detach record without touching, as this is done a bit latter
                 $this->detach($detach, false);
 
                 $changes['detached'] = $this->castKeys($detach);


### PR DESCRIPTION
The sync method is running touch operations twice if there is items to detach, which duplicates update queries

As we can see a little bit further in the sync method

```php
        if (count($changes['attached']) ||
            count($changes['updated']) ||
            count($changes['detached'])) {
            $this->touchIfTouching();
        }
```

So the sync method already takes care of `touchIfTouching` so we do not need to run it in `detach`