### PR TITLE
[10.x] Set application_name and character set as PostgreSQL DSN string

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -38,19 +38,12 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
         $this->configureIsolationLevel($connection, $config);
 
-        $this->configureEncoding($connection, $config);
-
         // Next, we will check to see if a timezone has been specified in this config
         // and if it has we will issue a statement to modify the timezone with the
         // database. Setting this DB timezone is an optional configuration item.
         $this->configureTimezone($connection, $config);
 
         $this->configureSearchPath($connection, $config);
-
-        // Postgres allows an application_name to be set by the user and this name is
-        // used to when monitoring the application with pg_stat_activity. So we'll
-        // determine if the option has been specified and run a statement if so.
-        $this->configureApplicationName($connection, $config);
 
         $this->configureSynchronousCommit($connection, $config);
 
@@ -69,22 +62,6 @@ class PostgresConnector extends Connector implements ConnectorInterface
         if (isset($config['isolation_level'])) {
             $connection->prepare("set session characteristics as transaction isolation level {$config['isolation_level']}")->execute();
         }
-    }
-
-    /**
-     * Set the connection character set and collation.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return void
-     */
-    protected function configureEncoding($connection, $config)
-    {
-        if (! isset($config['charset'])) {
-            return;
-        }
-
-        $connection->prepare("set names '{$config['charset']}'")->execute();
     }
 
     /**
@@ -133,22 +110,6 @@ class PostgresConnector extends Connector implements ConnectorInterface
     }
 
     /**
-     * Set the application name on the connection.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return void
-     */
-    protected function configureApplicationName($connection, $config)
-    {
-        if (isset($config['application_name'])) {
-            $applicationName = $config['application_name'];
-
-            $connection->prepare("set application_name to '$applicationName'")->execute();
-        }
-    }
-
-    /**
      * Create a DSN string from a configuration.
      *
      * @param  array  $config
@@ -176,6 +137,17 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // string back out for usage, as this has been fully constructed here.
         if (! is_null($port)) {
             $dsn .= ";port={$port}";
+        }
+
+        if (isset($charset)) {
+            $dsn .= ";client_encoding='{$charset}'";
+        }
+
+        // Postgres allows an application_name to be set by the user and this name is
+        // used to when monitoring the application with pg_stat_activity. So we'll
+        // determine if the option has been specified and run a statement if so.
+        if (isset($application_name)) {
+            $dsn .= ";application_name='".str_replace("'", "\'", $application_name)."'";
         }
 
         return $this->addSslOptions($dsn, $config);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -75,15 +75,15 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresConnectCallsCreateConnectionWithProperArguments()
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111;client_encoding=\'utf8\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($statement);
-        $statement->shouldReceive('execute')->once();
+        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -97,16 +97,15 @@ class DatabaseConnectorTest extends TestCase
      */
     public function testPostgresSearchPathIsSet($searchPath, $expectedSql)
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\'';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => $searchPath, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($statement);
         $connection->shouldReceive('prepare')->once()->with($expectedSql)->andReturn($statement);
-        $statement->shouldReceive('execute')->twice();
+        $statement->shouldReceive('execute')->once();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -184,16 +183,15 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresSearchPathFallbackToConfigKeySchema()
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\'';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', '"user"'], 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($statement);
         $connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($statement);
-        $statement->shouldReceive('execute')->twice();
+        $statement->shouldReceive('execute')->once();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -201,16 +199,15 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresApplicationNameIsSet()
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\'';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\';application_name=\'Laravel App\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Laravel App'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($statement);
-        $connection->shouldReceive('prepare')->once()->with('set application_name to \'Laravel App\'')->andReturn($statement);
-        $statement->shouldReceive('execute')->twice();
+        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);


### PR DESCRIPTION
This pull request resolves the following

The following queries are executed when you set the character set and application name in PostgreSQL, respectively.

```sql
Set name to 'charset'
```

```sql
set application name to 'Application Name'
```

However, PostgreSQL allows you to set each in a DSN string.

```
pgsql:host=foo;dbname='bar';client_encoding='utf8';application_name='Laravel App'
```

This prevents the above two queries from being executed every time another query is executed.