### PR TITLE
[10.x] Set previous exception on `HttpResponseException`

### DIFF
--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Exceptions;
 
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class HttpResponseException extends RuntimeException
 {
@@ -20,8 +21,10 @@ class HttpResponseException extends RuntimeException
      * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @return void
      */
-    public function __construct(Response $response)
+    public function __construct(Response $response, ?Throwable $previous = null)
     {
+        parent::__construct($previous?->getMessage() ?? '', $previous?->getCode() ?? 0, $previous);
+
         $this->response = $response;
     }
 

--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -19,6 +19,7 @@ class HttpResponseException extends RuntimeException
      * Create a new HTTP response exception instance.
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  \Throwable  $previous
      * @return void
      */
     public function __construct(Response $response, ?Throwable $previous = null)


### PR DESCRIPTION
It's the same PR #51968 for 10.x branch. I chose 11.x instead of 10.x as the base ref on that PR by mistake, my bad.