### PR TITLE
[11.x] Fix using container nesting to make the same 'abstract' in different context

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -925,7 +925,12 @@ class Container implements ArrayAccess, ContainerContract
         // hand back the results of the functions, which allows functions to be
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
-            return $concrete($this, $this->getLastParameterOverride());
+            $this->buildStack[] = spl_object_hash($concrete);
+            try {
+                return $concrete($this, $this->getLastParameterOverride());
+            } finally {
+                array_pop($this->buildStack);
+            }
         }
 
         try {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -926,6 +926,7 @@ class Container implements ArrayAccess, ContainerContract
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
             $this->buildStack[] = spl_object_hash($concrete);
+
             try {
                 return $concrete($this, $this->getLastParameterOverride());
             } finally {

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -40,6 +40,21 @@ class ContextualBindingTest extends TestCase
 
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $one->impl);
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $two->impl);
+
+        /*
+         * Test nesting to make the same 'abstract' in different context
+         */
+        $container = new Container;
+
+        $container->bind(IContainerContextContractStub::class, ContainerContextImplementationStub::class);
+
+        $container->when(ContainerTestContextInjectOne::class)->needs(IContainerContextContractStub::class)->give(function ($container) {
+            return $container->make(IContainerContextContractStub::class);
+        });
+
+        $one = $container->make(ContainerTestContextInjectOne::class);
+
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $one->impl);
     }
 
     public function testContextualBindingWorksForExistingInstancedBindings()


### PR DESCRIPTION
Although this may not seem common, it is very covert for facade Log, as shown in the following code
```php

class Service extends BaseService
{
    public function __construct(
        private readonly LoggerInterface $logger,
    ) {}
}

$this->app->when(Service::class)
            ->needs(LoggerInterface::class)
            ->give(function () {
                return Log::channel('test');
            });
```

The following examples in the documentation seem to be OK, probably without nested make. [contextual-binding](https://laravel.com/docs/11.x/container#contextual-binding)