### PR TITLE
[11.x] Allow view content dependent mail callbacks

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -303,21 +303,15 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['mailer'] = $this->name;
 
-        // First we need to parse the view, which could either be a string or an array
-        // containing both an HTML and plain text versions of the view which should
-        // be used when sending an e-mail. We will extract both of them out here.
+        // Once we have retrieved the view content for the e-mail we will set the body
+        // of this message using the HTML type, which will provide a simple wrapper
+        // to creating view based emails that are able to receive arrays of data.
         [$view, $plain, $raw] = $this->parseView($view);
 
         $data['message'] = $message = $this->createMessage();
 
-        // Next we need to generate the view content, allowing pass-through callbacks
-        // following content generation to utilise said content in header generation.
-        // For example Symfony's DKIM signing which requires html and plain content.
         $this->addContent($message, $view, $plain, $raw, $data);
 
-        // Once we have retrieved the view content for the e-mail we will set the body
-        // of this message using the HTML type, which will provide a simple wrapper
-        // to creating view based emails that are able to receive arrays of data.
         if (! is_null($callback)) {
             $callback($message);
         }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -310,14 +310,17 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $message = $this->createMessage();
 
+        // Next we need to generate the view content, allowing pass-through callbacks
+        // following content generation to utilise said content in header generation.
+        // For example Symfony's DKIM signing which requires html and plain content.
+        $this->addContent($message, $view, $plain, $raw, $data);
+
         // Once we have retrieved the view content for the e-mail we will set the body
         // of this message using the HTML type, which will provide a simple wrapper
         // to creating view based emails that are able to receive arrays of data.
         if (! is_null($callback)) {
             $callback($message);
         }
-
-        $this->addContent($message, $view, $plain, $raw, $data);
 
         // If a global "to" address has been set, we will set that address on the mail
         // message. This is primarily useful during local development in which each


### PR DESCRIPTION
Since the swap from SwiftMailer to Symfony Mailer DKIM has been difficult to work with as per [this discussion](https://github.com/laravel/framework/discussions/38523).

Symfony's signing has only been able to execute after Message generation, but requires content for its signature generation which is only set after its execution, throwing `A message must have a text or an HTML part or attachments.` when it's missing.

By executing the callback after content generation we allow DKIM signing to use it and succeed, for example:
```
$mailable->withSymfonyMessage(function (Email $message): void {
    $dkimSigner = new DkimSigner('private', 'domain', 'selector');
    $dkimSigner->sign($message);
});
```