### PR TITLE
[11.x] Add DeploymentFinish command

### DIFF
--- a/src/Illuminate/Foundation/Console/DeploymentFinishCommand.php
+++ b/src/Illuminate/Foundation/Console/DeploymentFinishCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Events\DeploymentFinished;
+use Illuminate\Support\Facades\Event;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'deploy:finish')]
+class DeploymentFinishCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'deploy:finish';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Finish a deployment and restart long-running processes';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        Event::dispatch(new DeploymentFinished);
+
+        $this->components->info('DeploymentFinished event has been broadcast.');
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Foundation/Events/DeploymentFinished.php
+++ b/src/Illuminate/Foundation/Events/DeploymentFinished.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+class DeploymentFinished
+{
+    //
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -41,6 +41,7 @@ use Illuminate\Foundation\Console\ConfigClearCommand;
 use Illuminate\Foundation\Console\ConfigPublishCommand;
 use Illuminate\Foundation\Console\ConfigShowCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
+use Illuminate\Foundation\Console\DeploymentFinishCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnumMakeCommand;
@@ -128,6 +129,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'DbShow' => ShowCommand::class,
         'DbTable' => DatabaseTableCommand::class,
         'DbWipe' => WipeCommand::class,
+        'DeploymentFinish' => DeploymentFinishCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
         'EnvironmentDecrypt' => EnvironmentDecryptCommand::class,

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Aws\DynamoDb\DynamoDbClient;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Foundation\Events\DeploymentFinished;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
 use Illuminate\Queue\Connectors\DatabaseConnector;
 use Illuminate\Queue\Connectors\NullConnector;
@@ -17,6 +18,7 @@ use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -38,6 +40,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->registerConnection();
         $this->registerWorker();
         $this->registerListener();
+        $this->registerDeploymentListener();
         $this->registerFailedJobServices();
     }
 
@@ -235,6 +238,18 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         $this->app->singleton('queue.listener', function ($app) {
             return new Listener($app->basePath());
+        });
+    }
+
+    /**
+     * Register the deployment listener.
+     *
+     * @return void
+     */
+    protected function registerDeploymentListener()
+    {
+        $this->app['events']->listen(function (DeploymentFinished $event) {
+            $this->app['cache']->forever('illuminate:queue:restart', Carbon::now()->getTimestamp());
         });
     }
 


### PR DESCRIPTION
## Issue
Currently, each 'service' has its own restart command:

php artisan reverb:restart
php artisan octane:reload
php artisan queue:restart
php artisan horizon:terminate
php artisan pulse:restart

Deploy scrips (either with Laravel Forge, something like Capistrano/Deployer) can be somewhat easily updated, but easy to forget. Manual deployments (eg. git pull) make it even more easy to forget one of those, leading to weird behavior.

## Proposal
I propose a php artisan deploy:finish (or deploy / restart) command to reload all those services at once. Each service should be responsible for registering itself to this reload command. This can be either:

Something similar is done with php artisan optimize although this one is not configurable. This makes it easy for deploy scripts to just add php artisan reload and not worry about specific services.

I currently named it `deploy:finish` just in case we would perhaps want to add a `deploy:start` command also.
Only queue is covered in this PR. Rest would go to their own repo.

(as discussed in https://github.com/laravel/framework/discussions/50900)