### PR TITLE
[11.x] Add parameters to Str::password() for mixed case and case limited passwords

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -935,9 +935,11 @@ class Str
      * @param  bool  $numbers
      * @param  bool  $symbols
      * @param  bool  $spaces
+     * @param  bool  $upperLetters
+     * @param  bool  $lowerLetters
      * @return string
      */
-    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
+    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false, $upperLetters = false, $lowerLetters = false)
     {
         $password = new Collection();
 
@@ -948,6 +950,16 @@ class Str
                 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
                 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
                 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            ] : null,
+            'upperLetters' => $upperLetters === true ? [
+                'A', 'B', 'C', 'D', 'E', 'F', 'G',
+                'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+                'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            ] : null,
+            'lowerLetters' => $lowerLetters === true ? [
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+                'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                'w', 'x', 'y', 'z',
             ] : null,
             'numbers' => $numbers === true ? [
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1511,6 +1511,14 @@ class SupportStrTest extends TestCase
         $this->assertStringContainsString(' ', Str::password(spaces: true));
 
         $this->assertTrue(
+            Str::of(Str::password(letters: false, upperLetters: true))->contains(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'])
+        );
+        
+        $this->assertTrue(
+            Str::of(Str::password(letters: false, lowerLetters: true))->contains(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'])
+        );
+
+        $this->assertTrue(
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1513,7 +1513,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(
             Str::of(Str::password(letters: false, upperLetters: true))->contains(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'])
         );
-        
+
         $this->assertTrue(
             Str::of(Str::password(letters: false, lowerLetters: true))->contains(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'])
         );


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This adds two new optional parameters, `$upperLetters` and`$lowerLetters` to `Str::password()` to ensure that a generated password contains upper case characters and/or lower case characters. 

The current `$letters` parameter pulls from a pool of both upper and lower case letters and does not guarantee inclusion of either upper case or lower case letters. Adding these option as new parameters ensure that the current `$letters` behavior remains unchanged.

There are a few benefits and reasons for this change:

- Passwords can be generated by Laravel that will pass the `mixedCase()` validator. Currently if you are trying to generate temporary passwords for users but also have the mixedCase validator implemented you have to move to rolling your own password generation method. 
- Passwords can be generated for external systems that require all lower case or all upper case letters.
