### PR TITLE
[11.x] fix BigDecimal creation with blank value on HasAttributes.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1429,7 +1429,7 @@ trait HasAttributes
     protected function asDecimal($value, $decimals)
     {
         try {
-            return (string) BigDecimal::of($value)->toScale($decimals, RoundingMode::HALF_UP);
+            return (string) BigDecimal::of(blank($value) ? 0 : $value)->toScale($decimals, RoundingMode::HALF_UP);
         } catch (BrickMathException $e) {
             throw new MathException('Unable to cast value to a decimal.', previous: $e);
         }
@@ -2164,7 +2164,7 @@ trait HasAttributes
         } elseif ($this->hasCast($key, ['object', 'collection'])) {
             return $this->fromJson($attribute) ===
                 $this->fromJson($original);
-        } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
+        } elseif ($this->hasCast($key, ['real', 'float', 'double', 'decimal'])) {
             if ($original === null) {
                 return false;
             }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3041,7 +3041,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testCleanWhenDecimalUpdateAttribute()
     {
         // test is equivalent
-        $model = new EloquentModelStub(['castedDecimal' => " "]);
+        $model = new EloquentModelStub(['castedDecimal' => ' ']);
         $model->syncOriginal();
         $model->castedDecimal = 0;
         $this->assertTrue($model->originalIsEquivalent('castedDecimal'));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3037,6 +3037,26 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($user->hasAttribute('nonexistent'));
         $this->assertFalse($user->hasAttribute('belongsToStub'));
     }
+
+    public function testCleanWhenDecimalUpdateAttribute()
+    {
+        // test is equivalent
+        $model = new EloquentModelStub(['castedDecimal' => " "]);
+        $model->syncOriginal();
+        $model->castedDecimal = 0;
+        $this->assertTrue($model->originalIsEquivalent('castedDecimal'));
+
+        $model = new EloquentModelStub(['castedDecimal' => 0]);
+        $model->syncOriginal();
+        $model->castedDecimal = 0;
+        $this->assertTrue($model->originalIsEquivalent('castedDecimal'));
+
+        $model = new EloquentModelStub(['castedDecimal' => null]);
+        $model->syncOriginal();
+        $model->castedDecimal = null;
+        $this->assertTrue($model->originalIsEquivalent('castedDecimal'));
+    }
+
 }
 
 class EloquentTestObserverStub
@@ -3071,7 +3091,10 @@ class EloquentModelStub extends Model
     public $scopesCalled = [];
     protected $table = 'stub';
     protected $guarded = [];
-    protected $casts = ['castedFloat' => 'float'];
+    protected $casts = [
+        'castedFloat' => 'float',
+        'castedDecimal' => 'decimal:10',
+    ];
 
     public function getListItemsAttribute($value)
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3056,7 +3056,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model->castedDecimal = null;
         $this->assertTrue($model->originalIsEquivalent('castedDecimal'));
     }
-
 }
 
 class EloquentTestObserverStub


### PR DESCRIPTION
### Issue
Currently you can't cast attribute of decimal type with an empty string   

```php
// Return Illuminate\Support\Exceptions\MathException: Unable to cast value to a decimal.
BigDecimal::of(" ")->toScale($decimals, RoundingMode::HALF_UP);
```

### Proposal
I propose to check value passed for BigDecimal creation for prevent MathException 

```php
// Before
BigDecimal::of($value)->toScale($decimals, RoundingMode::HALF_UP);

// After
BigDecimal::of(blank($value) ? 0 : $value)->toScale($decimals, RoundingMode::HALF_UP);
```