### PR TITLE
add phpstan assertions to Collection isEmpty and isNotEmpty

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -663,6 +663,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if the collection is empty or not.
      *
+     * @phpstan-assert-if-true null $this->first()
+     * @phpstan-assert-if-false !null $this->first()
      * @return bool
      */
     public function isEmpty()

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -664,7 +664,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Determine if the collection is empty or not.
      *
      * @phpstan-assert-if-true null $this->first()
+     *
      * @phpstan-assert-if-false !null $this->first()
+     *
      * @return bool
      */
     public function isEmpty()

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -368,7 +368,9 @@ trait EnumeratesValues
      * Determine if the collection is not empty.
      *
      * @phpstan-assert-if-true !null $this->first()
+     *
      * @phpstan-assert-if-false null $this->first()
+     *
      * @return bool
      */
     public function isNotEmpty()

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,6 +367,8 @@ trait EnumeratesValues
     /**
      * Determine if the collection is not empty.
      *
+     * @phpstan-assert-if-true !null $this->first()
+     * @phpstan-assert-if-false null $this->first()
      * @return bool
      */
     public function isNotEmpty()


### PR DESCRIPTION
This PR will add `@phpstan-assert-if-true` / `@phpstan-assert-if-false` to the `Collection` methods `isEmpty` and `isNotEmpty`.

This will allow phpstan to know if `first()` will return null or not (when not passing any filter arguments).

**Example**

```php 
/**
 * @var Collection<int, string>
 */
$collection = new Collection(['laravel']);

if ($collection->isNotEmpty()) {
    // before this PR:
    \PHPStan\dumpType($collection->first()); // Dumped type: string|null
    
    // after this PR:
    \PHPStan\dumpType($collection->first()); // Dumped type: string
}
```