### PR TITLE
[11.x] feat: add virtual methods to SoftDeletes trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -6,6 +6,8 @@ namespace Illuminate\Database\Eloquent;
  * @method static \Illuminate\Database\Eloquent\Builder<static> withTrashed(bool $withTrashed = true)
  * @method static \Illuminate\Database\Eloquent\Builder<static> onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static> withoutTrashed()
+ * @method static static restoreOrCreate(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
+ * @method static static createOrRestore(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
  *
  * @mixin \Illuminate\Database\Eloquent\Model
  */

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -20,6 +20,10 @@ function test(User $user): void
 
     assertType('Illuminate\Database\Eloquent\Collection<int, User>', $user->newCollection([new User()]));
     assertType('Illuminate\Database\Eloquent\Collection<string, Illuminate\Types\Model\Post>', $user->newCollection(['foo' => new Post()]));
+
+    assertType('bool', $user->restore());
+    assertType('User', $user->restoreOrCreate());
+    assertType('User', $user->createOrRestore());
 }
 
 class Post extends Model


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR adds the other SoftDelete macros to the trait as virtual methods.


Thanks!