### PR TITLE
[10.x] Fix Http::retry so that throw is respected for call signature Http::retry([1,2], throw: false)

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -911,13 +911,15 @@ class PendingRequest
                             $response->throw($this->throwCallback);
                         }
 
-                        $tryCount = is_array($this->tries) ? count($this->tries) + 1 : $this->tries;
+                        $potentialTries = is_array($this->tries)
+                            ? count($this->tries) + 1
+                            : $this->tries;
 
-                        if ($attempt < $tryCount && $shouldRetry) {
+                        if ($attempt < $potentialTries && $shouldRetry) {
                             $response->throw();
                         }
 
-                        if ($tryCount > 1 && $this->retryThrow) {
+                        if ($potentialTries > 1 && $this->retryThrow) {
                             $response->throw();
                         }
                     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -911,11 +911,13 @@ class PendingRequest
                             $response->throw($this->throwCallback);
                         }
 
-                        if ($attempt < $this->tries && $shouldRetry) {
+                        $tryCount = is_array($this->tries) ? count($this->tries) + 1 : $this->tries;
+
+                        if ($attempt < $tryCount && $shouldRetry) {
                             $response->throw();
                         }
 
-                        if ($this->tries > 1 && $this->retryThrow) {
+                        if ($tryCount > 1 && $this->retryThrow) {
                             $response->throw();
                         }
                     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1711,6 +1711,28 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(2);
     }
 
+    public function testRequestExceptionIsThrownWhenRetriesExhaustedWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory
+                ->retry([1], 0, null, true)
+                ->get('http://foo.com/get');
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $this->factory->assertSentCount(2);
+    }
+
     public function testRequestExceptionIsThrownWithoutRetriesIfRetryNotNecessary()
     {
         $this->factory->fake([
@@ -1723,6 +1745,35 @@ class HttpClientTest extends TestCase
         try {
             $this->factory
                 ->retry(2, 1000, function ($exception) use (&$whenAttempts) {
+                    $whenAttempts++;
+
+                    return $exception->response->status() === 403;
+                }, true)
+                ->get('http://foo.com/get');
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $this->assertSame(1, $whenAttempts);
+
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testRequestExceptionIsThrownWithoutRetriesIfRetryNotNecessaryWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        $exception = null;
+        $whenAttempts = 0;
+
+        try {
+            $this->factory
+                ->retry([1000,1000], 1000, function ($exception) use (&$whenAttempts) {
                     $whenAttempts++;
 
                     return $exception->response->status() === 403;
@@ -1755,6 +1806,21 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(2);
     }
 
+    public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhaustedWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->retry([1,2], throw: false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->failed());
+
+        $this->factory->assertSentCount(3);
+    }
+
     public function testRequestExceptionIsNotThrownWithoutRetriesIfRetryNotNecessary()
     {
         $this->factory->fake([
@@ -1765,6 +1831,29 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory
             ->retry(2, 1000, function ($exception) use (&$whenAttempts) {
+                $whenAttempts++;
+
+                return $exception->response->status() === 403;
+            }, false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->failed());
+
+        $this->assertSame(1, $whenAttempts);
+
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testRequestExceptionIsNotThrownWithoutRetriesIfRetryNotNecessaryWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        $whenAttempts = 0;
+
+        $response = $this->factory
+            ->retry([1,2], 0, function ($exception) use (&$whenAttempts) {
                 $whenAttempts++;
 
                 return $exception->response->status() === 403;
@@ -1803,6 +1892,31 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testRequestCanBeModifiedInRetryCallbackWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push(['error'], 500)
+                ->push(['ok'], 200),
+        ]);
+
+        $response = $this->factory
+            ->retry([2], when: function ($exception, $request) {
+                $this->assertInstanceOf(PendingRequest::class, $request);
+
+                $request->withHeaders(['Foo' => 'Bar']);
+
+                return true;
+            }, throw: false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->successful());
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('Foo') && $request->header('Foo') === ['Bar'];
+        });
+    }
+
     public function testExceptionThrownInRetryCallbackWithoutRetrying()
     {
         $this->factory->fake([
@@ -1816,6 +1930,31 @@ class HttpClientTest extends TestCase
                 ->retry(2, 1000, function ($exception) use (&$whenAttempts) {
                     throw new Exception('Foo bar');
                 }, false)
+                ->get('http://foo.com/get');
+        } catch (Exception $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertEquals('Foo bar', $exception->getMessage());
+
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testExceptionThrownInRetryCallbackWithoutRetryingWithBackoffArray()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory
+                ->retry([1,2,3], when: function ($exception) use (&$whenAttempts) {
+                    throw new Exception('Foo bar');
+                }, throw: false)
                 ->get('http://foo.com/get');
         } catch (Exception $e) {
             $exception = $e;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1773,7 +1773,7 @@ class HttpClientTest extends TestCase
 
         try {
             $this->factory
-                ->retry([1000,1000], 1000, function ($exception) use (&$whenAttempts) {
+                ->retry([1000, 1000], 1000, function ($exception) use (&$whenAttempts) {
                     $whenAttempts++;
 
                     return $exception->response->status() === 403;
@@ -1813,7 +1813,7 @@ class HttpClientTest extends TestCase
         ]);
 
         $response = $this->factory
-            ->retry([1,2], throw: false)
+            ->retry([1, 2], throw: false)
             ->get('http://foo.com/get');
 
         $this->assertTrue($response->failed());
@@ -1853,7 +1853,7 @@ class HttpClientTest extends TestCase
         $whenAttempts = 0;
 
         $response = $this->factory
-            ->retry([1,2], 0, function ($exception) use (&$whenAttempts) {
+            ->retry([1, 2], 0, function ($exception) use (&$whenAttempts) {
                 $whenAttempts++;
 
                 return $exception->response->status() === 403;
@@ -1952,7 +1952,7 @@ class HttpClientTest extends TestCase
 
         try {
             $this->factory
-                ->retry([1,2,3], when: function ($exception) use (&$whenAttempts) {
+                ->retry([1, 2, 3], when: function ($exception) use (&$whenAttempts) {
                     throw new Exception('Foo bar');
                 }, throw: false)
                 ->get('http://foo.com/get');


### PR DESCRIPTION
`Http::retry` accepts the first parameter for times as an `array|int`.  The documentation states that:

If all of the requests fail, an instance of `Illuminate\Http\Client\RequestException` will be thrown. If you would like to disable this behavior, you may provide a throw argument with a value of false.

However an `Illuminate\Http\Client\RequestException` is thrown as can be seen by adding a test to HttpClientTest:

```php
public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhaustedWithBackoffArray()
{
    $this->factory->fake([
        '*' => $this->factory->response(['error'], 403),
    ]);

    $response = $this->factory
        ->retry([1,2], throw: false)
        ->get('http://foo.com/get');

    $this->assertTrue($response->failed());

    $this->factory->assertSentCount(3);
}
```

Other tests have just been added to cover usage of the first parameter as an array.

This issue is due to PendingRequest.php:927 and PendingRequest.php:931 where the following comparisons are used:

```php
if ($attempt < $this->tries && $shouldRetry) {
if ($this->tries > 1 && $this->retryThrow) {

```

even though `$this->tries` is an array.  Suggested fix from this PR is to use:

```php
$tryCount = is_array($this->tries) ? count($this->tries) + 1 : $this->tries;
```

in place of `$this->tries`.  The `count($this->tries) + 1` is required as specifying the retries in an array already assumes that the first request has been made and that the backoff times specified will be used.  Whereas specifying the number of tries assumes that it includes the first request.