### PR TITLE
fix(Validator): Handle deeply messages array for custom messages

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -341,7 +341,7 @@ class Validator implements ValidatorContract
 
         $this->initialRules = $rules;
         $this->translator = $translator;
-        $this->customMessages = $messages;
+        $this->customMessages = Arr::dot($messages);
         $this->data = $this->parseData($data);
         $this->customAttributes = $attributes;
 
@@ -1397,7 +1397,7 @@ class Validator implements ValidatorContract
      */
     public function setCustomMessages(array $messages)
     {
-        $this->customMessages = array_merge($this->customMessages, $messages);
+        $this->customMessages = array_merge($this->customMessages, Arr::dot($messages));
 
         return $this;
     }


### PR DESCRIPTION
I've encountered a problem using the `Validation` process (Through `FormRequest`). When dealing with custom messages : 

```php
public function rules(): array
        {
            return [
                'custom' => [
                    'integer',
                    'boolean',
                    new CustomRule(),
                ],
            ];
        }

public function messages()
        {
            return [
                'custom.integer' => 'xxx.',
            ];
        }
```

Here, it will works as expected, the error shown for integer will be xxx. and other defaults will be used for the custom rule + boolean.

A problem come when we do something like that : 

```php
public function rules(): array
        {
            return [
                'custom' => [
                    'integer',
                    'boolean',
                    new CustomRuleTwo(),
                ],
            ];
        }

        public function messages()
        {
            return [
                'custom' => [
                    'integer' => 'xxx.',
                ],
            ];
        }
```

Here it will only show the validation messages for the integer and not for the others.

Here is a test suite I've made on my Laravel application : 

```php
<?php

use Illuminate\Contracts\Validation\ValidationRule;
use Illuminate\Foundation\Http\FormRequest;
use Illuminate\Support\Facades\Route;

test('custom rule messages with dot notation', function () {
    class CustomRule implements ValidationRule
    {
        public $implicit = true;

        public function validate(string $attribute, mixed $value, Closure $fail): void
        {
            $fail('The custom rule failed.');
        }
    }

    class FormRequestTest extends FormRequest
    {

        public function rules(): array
        {
            return [
                'custom' => [
                    'integer',
                    'boolean',
                    new CustomRule(),
                ],
            ];
        }

        public function messages()
        {
            return [
                'custom.integer' => 'xxx.',
            ];
        }

    }

    class Controller extends \App\Http\Controllers\Controller
    {
        public function __invoke(FormRequestTest $request)
        {
            return 'OK';
        }
    }

    Route::post('/form-request', Controller::class);

    $this
        ->postJson('/form-request', [
            'custom' => 'string',
        ])
        ->assertUnprocessable()
        ->assertJsonValidationErrors([
            'custom' => [
                'xxx.',
                'The custom must be true or false.',
                'The custom rule failed.',
            ],
        ]);
});

test('custom rule with messages with array notation', function () {
    class CustomRuleTwo implements ValidationRule
    {
        public $implicit = true;

        public function validate(string $attribute, mixed $value, Closure $fail): void
        {
            $fail('The custom rule failed.');
        }
    }

    class FormRequestTestTwo extends FormRequest
    {

        public function rules(): array
        {
            return [
                'custom' => [
                    'integer',
                    'boolean',
                    new CustomRuleTwo(),
                ],
            ];
        }

        public function messages()
        {
            return [
                'custom' => [
                    'integer' => 'xxx.',
                ],
            ];
        }

    }

    class ControllerTwo extends \App\Http\Controllers\Controller
    {
        public function __invoke(FormRequestTestTwo $request)
        {
            return 'OK';
        }
    }

    Route::post('/form-request-two', ControllerTwo::class);

    $this
        ->postJson('/form-request-two', [
            'custom' => 'string',
        ])
        ->assertUnprocessable()
        ->assertJsonValidationErrors([
            'custom' => [
                'xxx.',
                'The custom must be true or false.',
                'The custom rule failed.',
            ],
        ]);
});
````

And the result is : 

<img width="1064" alt="Screenshot 2024-07-03 at 00 55 22" src="https://github.com/laravel/framework/assets/39646949/e57fa98e-b30e-4bc0-8619-f746b7b6c4d0">

With the change I propose, it's working all fine : 

<img width="1123" alt="Screenshot 2024-07-03 at 00 56 04" src="https://github.com/laravel/framework/assets/39646949/881430d3-5d13-40bc-8b71-4ddc6efefe75">

I assume it's a bug as it's working with dot notation but not with deep nested array in messages (I may be wrong).

I had this issue several time while dealing with `FormRequest` and wanted to only custom translate one rule but not all the others. I had to implement things like that to get it work with the default behavior of getting the translation from the validatin file : 

```php
"{$attribute}.distinct" => trans()->has('validation.custom.secondary_beverage_types.distinct')
                ? __('validation.custom.secondary_beverage_types.distinct')
                : __('validation.distinct', ['attribute' => __('validation.attributes.secondary_beverage_types')]),
```

As I prefer to work with arrays instead of dot notation.

If this is indeed a bug, I'd like to add tests for that. I searched a bit through the repo and I'm quite not sure where would it be the best place to test that, If you could give me some insights on that it'd be highly appreciated.

Thank you: