### PR TITLE
[11.x] Add `OnQueue` attribute

### DIFF
--- a/src/Illuminate/Bus/Attributes/OnQueue.php
+++ b/src/Illuminate/Bus/Attributes/OnQueue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Bus\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class OnQueue
+{
+    public function __construct(public readonly string $queue)
+    {
+    }
+}

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Bus;
 
 use Closure;
+use Illuminate\Bus\Attributes\OnQueue;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
@@ -12,6 +13,7 @@ use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Support\Collection;
+use ReflectionClass;
 use RuntimeException;
 
 class Dispatcher implements QueueingDispatcher
@@ -239,6 +241,12 @@ class Dispatcher implements QueueingDispatcher
      */
     protected function pushCommandToQueue($queue, $command)
     {
+        $reflection = new ReflectionClass($command);
+
+        if ($attribute = $reflection->getAttributes(OnQueue::class)[0] ?? null) {
+            $command->onQueue($attribute->newInstance()->queue);
+        }
+
         if (isset($command->queue, $command->delay)) {
             return $queue->laterOn($command->queue, $command->delay, $command);
         }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -123,7 +123,6 @@ class BusDispatcherTest extends TestCase
                 ->with('foo', $job)
                 ->once();
 
-
             return $mock;
         });
 


### PR DESCRIPTION
This pull request adds a new `OnQueue` attribute that allows specifying the queue for a job.

## Before

```php
final class UpdateTracking implements ShouldQueue
{
    use InteractsWithQueue;
    use Queueable;

    public function __construct(
        public readonly int $quoteId,
    ) {
        $this->onQueue('pipedrive');
    }

    // ...
}
```

## After

```php
use Illuminate\Bus\Attributes\OnQueue;

#[OnQueue('pipedrive')]
final class UpdateTracking implements ShouldQueue
{
    use InteractsWithQueue;
    use Queueable;

    public function __construct(
        public readonly int $quoteId,
    ) {
    }

    // ...
}
```