### PR TITLE
[11.x] feat: improve Factory generics, add generics to HasFactory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -32,7 +32,7 @@ abstract class Factory
     /**
      * The name of the factory's corresponding model.
      *
-     * @var class-string<\Illuminate\Database\Eloquent\Model|TModel>
+     * @var class-string<TModel>
      */
     protected $model;
 
@@ -109,7 +109,7 @@ abstract class Factory
     /**
      * The default model name resolver.
      *
-     * @var callable
+     * @var callable(self): class-string<TModel>
      */
     protected static $modelNameResolver;
 
@@ -214,7 +214,7 @@ abstract class Factory
      * Create a single model and persist it to the database.
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|TModel
+     * @return TModel
      */
     public function createOne($attributes = [])
     {
@@ -225,7 +225,7 @@ abstract class Factory
      * Create a single model and persist it to the database without dispatching any model events.
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|TModel
+     * @return TModel
      */
     public function createOneQuietly($attributes = [])
     {
@@ -236,7 +236,7 @@ abstract class Factory
      * Create a collection of models and persist them to the database.
      *
      * @param  int|null|iterable<int, array<string, mixed>>  $records
-     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function createMany(int|iterable|null $records = null)
     {
@@ -259,7 +259,7 @@ abstract class Factory
      * Create a collection of models and persist them to the database without dispatching any model events.
      *
      * @param  int|null|iterable<int, array<string, mixed>>  $records
-     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function createManyQuietly(int|iterable|null $records = null)
     {
@@ -273,7 +273,7 @@ abstract class Factory
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>|\Illuminate\Database\Eloquent\Model|TModel
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>|TModel
      */
     public function create($attributes = [], ?Model $parent = null)
     {
@@ -301,7 +301,7 @@ abstract class Factory
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>|\Illuminate\Database\Eloquent\Model|TModel
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>|TModel
      */
     public function createQuietly($attributes = [], ?Model $parent = null)
     {
@@ -315,7 +315,7 @@ abstract class Factory
      *
      * @param  array<string, mixed>  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Closure(): (\Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>|\Illuminate\Database\Eloquent\Model|TModel)
+     * @return \Closure(): (\Illuminate\Database\Eloquent\Collection<int, TModel>|TModel)
      */
     public function lazy(array $attributes = [], ?Model $parent = null)
     {
@@ -325,7 +325,7 @@ abstract class Factory
     /**
      * Set the connection name on the results and store them.
      *
-     * @param  \Illuminate\Support\Collection  $results
+     * @param  \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Model>  $results
      * @return void
      */
     protected function store(Collection $results)
@@ -366,7 +366,7 @@ abstract class Factory
      * Make a single instance of the model.
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|TModel
+     * @return TModel
      */
     public function makeOne($attributes = [])
     {
@@ -378,7 +378,7 @@ abstract class Factory
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>|\Illuminate\Database\Eloquent\Model|TModel
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>|TModel
      */
     public function make($attributes = [], ?Model $parent = null)
     {
@@ -504,7 +504,7 @@ abstract class Factory
     /**
      * Add a new state transformation to the model definition.
      *
-     * @param  (callable(array<string, mixed>, \Illuminate\Database\Eloquent\Model|null): array<string, mixed>)|array<string, mixed>  $state
+     * @param  (callable(array<string, mixed>, TModel|null): array<string, mixed>)|array<string, mixed>  $state
      * @return static
      */
     public function state($state)
@@ -654,8 +654,10 @@ abstract class Factory
     /**
      * Retrieve a random model of a given type from previously provided models to recycle.
      *
-     * @param  string  $modelClassName
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @template TClass of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  class-string<TClass>  $modelClassName
+     * @return TClass|null
      */
     public function getRandomRecycledModel($modelClassName)
     {
@@ -665,7 +667,7 @@ abstract class Factory
     /**
      * Add a new "after making" callback to the model definition.
      *
-     * @param  \Closure(\Illuminate\Database\Eloquent\Model|TModel): mixed  $callback
+     * @param  \Closure(TModel): mixed  $callback
      * @return static
      */
     public function afterMaking(Closure $callback)
@@ -676,7 +678,7 @@ abstract class Factory
     /**
      * Add a new "after creating" callback to the model definition.
      *
-     * @param  \Closure(\Illuminate\Database\Eloquent\Model|TModel): mixed  $callback
+     * @param  \Closure(TModel): mixed  $callback
      * @return static
      */
     public function afterCreating(Closure $callback)
@@ -761,7 +763,7 @@ abstract class Factory
      * Get a new model instance.
      *
      * @param  array<string, mixed>  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|TModel
+     * @return TModel
      */
     public function newModel(array $attributes = [])
     {
@@ -773,7 +775,7 @@ abstract class Factory
     /**
      * Get the name of the model that is generated by the factory.
      *
-     * @return class-string<\Illuminate\Database\Eloquent\Model|TModel>
+     * @return class-string<TModel>
      */
     public function modelName()
     {
@@ -797,7 +799,7 @@ abstract class Factory
     /**
      * Specify the callback that should be invoked to guess model names based on factory names.
      *
-     * @param  callable(self): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
+     * @param  callable(self): class-string<TModel>  $callback
      * @return void
      */
     public static function guessModelNamesUsing(callable $callback)
@@ -819,8 +821,10 @@ abstract class Factory
     /**
      * Get a new factory instance for the given model name.
      *
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $modelName
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @template TClass of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  class-string<TClass>  $modelName
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<TClass>
      */
     public static function factoryForModel(string $modelName)
     {
@@ -853,8 +857,10 @@ abstract class Factory
     /**
      * Get the factory name for the given model name.
      *
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $modelName
-     * @return class-string<\Illuminate\Database\Eloquent\Factories\Factory>
+     * @template TClass of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  class-string<TClass>  $modelName
+     * @return class-string<\Illuminate\Database\Eloquent\Factories\Factory<TClass>>
      */
     public static function resolveFactoryName(string $modelName)
     {
@@ -880,8 +886,8 @@ abstract class Factory
     {
         try {
             return Container::getInstance()
-                            ->make(Application::class)
-                            ->getNamespace();
+                ->make(Application::class)
+                ->getNamespace();
         } catch (Throwable) {
             return 'App\\';
         }

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -2,18 +2,21 @@
 
 namespace Illuminate\Database\Eloquent\Factories;
 
+/**
+ * @template TFactory of \Illuminate\Database\Eloquent\Factories\Factory
+ */
 trait HasFactory
 {
     /**
      * Get a new factory instance for the model.
      *
-     * @param  callable|array|int|null  $count
-     * @param  callable|array  $state
-     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     * @param  (callable(array<string, mixed>, static|null): array<string, mixed>)|array<string, mixed>|int|null  $count
+     * @param  (callable(array<string, mixed>, static|null): array<string, mixed>)|array<string, mixed>  $state
+     * @return TFactory
      */
     public static function factory($count = null, $state = [])
     {
-        $factory = static::newFactory() ?: Factory::factoryForModel(get_called_class());
+        $factory = static::newFactory() ?? Factory::factoryForModel(get_called_class());
 
         return $factory
                     ->count(is_numeric($count) ? $count : null)
@@ -23,10 +26,14 @@ trait HasFactory
     /**
      * Create a new factory instance for the model.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     * @return TFactory|null
      */
     protected static function newFactory()
     {
-        //
+        if (isset(static::$factory)) {
+            return static::$factory::new();
+        }
+
+        return null;
     }
 }

--- a/tests/Database/Fixtures/Models/Money/Price.php
+++ b/tests/Database/Fixtures/Models/Money/Price.php
@@ -8,12 +8,10 @@ use Illuminate\Tests\Database\Fixtures\Factories\Money\PriceFactory;
 
 class Price extends Model
 {
+    /** @use HasFactory<PriceFactory> */
     use HasFactory;
 
     protected $table = 'prices';
 
-    public static function factory()
-    {
-        return PriceFactory::new();
-    }
+    protected static string $factory = PriceFactory::class;
 }

--- a/types/Autoload.php
+++ b/types/Autoload.php
@@ -1,7 +1,9 @@
 <?php
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\HasDatabaseNotifications;
@@ -9,9 +11,27 @@ use Illuminate\Notifications\HasDatabaseNotifications;
 class User extends Authenticatable
 {
     use HasDatabaseNotifications;
+    /** @use HasFactory<UserFactory> */
     use HasFactory;
     use MassPrunable;
     use SoftDeletes;
+
+    protected static string $factory = UserFactory::class;
+}
+
+/** @extends Factory<User> */
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
+class Post extends Model
+{
 }
 
 enum UserType

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -4,28 +4,15 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 
 use function PHPStan\Testing\assertType;
 
-/**
- * @extends Illuminate\Database\Eloquent\Factories\Factory<User>
- */
+/** @extends Illuminate\Database\Eloquent\Factories\Factory<User> */
 class UserFactory extends Factory
 {
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var class-string<User>
-     */
     protected $model = User::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition()
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 }
 
@@ -51,100 +38,60 @@ assertType('array<int|string, mixed>', $factory->raw(function ($attributes) {
     return ['string' => 'string'];
 }));
 
-// assertType('User', $factory->createOne());
-// assertType('User', $factory->createOne(['string' => 'string']));
-assertType('Illuminate\Database\Eloquent\Model', $factory->createOne());
-assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(['string' => 'string']));
-assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(function ($attributes) {
+assertType('User', $factory->createOne());
+assertType('User', $factory->createOne(['string' => 'string']));
+assertType('User', $factory->createOne(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
 
     return ['string' => 'string'];
 }));
 
-// assertType('User', $factory->createOneQuietly());
-// assertType('User', $factory->createOneQuietly(['string' => 'string']));
-assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly());
-assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(['string' => 'string']));
-assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(function ($attributes) {
+assertType('User', $factory->createOneQuietly());
+assertType('User', $factory->createOneQuietly(['string' => 'string']));
+assertType('User', $factory->createOneQuietly(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
 
     return ['string' => 'string'];
 }));
 
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createMany([['string' => 'string']]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany(
-    [['string' => 'string']]
-));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany(3));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createMany([['string' => 'string']]));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createMany(3));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createMany());
 
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createManyQuietly([['string' => 'string']]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly(
-    [['string' => 'string']]
-));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly(3));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createManyQuietly([['string' => 'string']]));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createManyQuietly(3));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createManyQuietly());
 
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create());
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create([
-//    'string' => 'string',
-// ]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->create());
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->create([
-    'string' => 'string',
-]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->create(function ($attributes) {
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create(['string' => 'string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
 
     return ['string' => 'string'];
 }));
 
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->createQuietly());
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->createQuietly([
-//     'string' => 'string',
-// ]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->createQuietly());
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->createQuietly([
-    'string' => 'string',
-]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->createQuietly(function ($attributes) {
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->createQuietly());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->createQuietly(['string' => 'string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->createQuietly(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
 
     return ['string' => 'string'];
 }));
 
-// assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->lazy());
-// assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->lazy([
-//     'string' => 'string',
-// ]));
-assertType('Closure(): (Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model)', $factory->lazy());
-assertType('Closure(): (Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model)', $factory->lazy([
-    'string' => 'string',
-]));
+assertType('Closure(): (Illuminate\Database\Eloquent\Collection<int, User>|User)', $factory->lazy());
+assertType('Closure(): (Illuminate\Database\Eloquent\Collection<int, User>|User)', $factory->lazy(['string' => 'string']));
 
-// assertType('User', $factory->makeOne());
-// assertType('User', $factory->makeOne([
-//     'string' => 'string',
-// ]));
-assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne());
-assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne([
-    'string' => 'string',
-]));
-assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne(function ($attributes) {
+assertType('User', $factory->makeOne());
+assertType('User', $factory->makeOne(['string' => 'string']));
+assertType('User', $factory->makeOne(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
 
     return ['string' => 'string'];
 }));
 
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->make());
-// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->make([
-//    'string' => 'string',
-// ]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->make());
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->make([
-    'string' => 'string',
-]));
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->make(function ($attributes) {
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->make());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->make(['string' => 'string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->make(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
 
     return ['string' => 'string'];
@@ -158,7 +105,7 @@ assertType('UserFactory', $factory->state(function ($attributes) {
 }));
 assertType('UserFactory', $factory->state(function ($attributes, $model) {
     assertType('array<string, mixed>', $attributes);
-    assertType('Illuminate\Database\Eloquent\Model|null', $model);
+    assertType('User|null', $model);
 
     return ['string' => 'string'];
 }));
@@ -176,23 +123,15 @@ assertType('UserFactory', $factory->hasAttached($factory->createOne(), function 
 assertType('UserFactory', $factory->for($factory));
 assertType('UserFactory', $factory->for($factory->createOne()));
 
-// assertType('UserFactory', $factory->afterMaking(function ($user) {
-//     assertType('User', $user);
-// }));
 assertType('UserFactory', $factory->afterMaking(function ($user) {
-    assertType('Illuminate\Database\Eloquent\Model', $user);
-}));
-assertType('UserFactory', $factory->afterMaking(function ($user) {
+    assertType('User', $user);
+
     return 'string';
 }));
 
-// assertType('UserFactory', $factory->afterCreating(function ($user) {
-//     assertType('User', $user);
-// }));
 assertType('UserFactory', $factory->afterCreating(function ($user) {
-    assertType('Illuminate\Database\Eloquent\Model', $user);
-}));
-assertType('UserFactory', $factory->afterCreating(function ($user) {
+    assertType('User', $user);
+
     return 'string';
 }));
 
@@ -200,13 +139,12 @@ assertType('UserFactory', $factory->count(10));
 
 assertType('UserFactory', $factory->connection('string'));
 
-// assertType('User', $factory->newModel());
-// assertType('User', $factory->newModel(['string' => 'string']));
-assertType('Illuminate\Database\Eloquent\Model', $factory->newModel());
-assertType('Illuminate\Database\Eloquent\Model', $factory->newModel(['string' => 'string']));
+assertType('User', $factory->newModel());
+assertType('User', $factory->newModel(['string' => 'string']));
 
-// assertType('class-string<User>', $factory->modelName());
-assertType('class-string<Illuminate\Database\Eloquent\Model>', $factory->modelName());
+assertType('class-string<User>', $factory->modelName());
+
+assertType('Post|null', $factory->getRandomRecycledModel(Post::class));
 
 Factory::guessModelNamesUsing(function (Factory $factory) {
     return match (true) {
@@ -217,9 +155,8 @@ Factory::guessModelNamesUsing(function (Factory $factory) {
 
 $factory->useNamespace('string');
 
-assertType(Factory::class, $factory::factoryForModel(User::class));
-
-assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory>', $factory->resolveFactoryName(User::class));
+assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', $factory::factoryForModel(User::class));
+assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory<User>>', $factory->resolveFactoryName(User::class));
 
 Factory::guessFactoryNamesUsing(function (string $modelName) {
     return match ($modelName) {

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -9,7 +9,19 @@ use function PHPStan\Testing\assertType;
 
 function test(User $user): void
 {
-    assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', User::factory());
+    assertType('UserFactory', User::factory(function ($attributes, $model) {
+        assertType('array<string, mixed>', $attributes);
+        assertType('User|null', $model);
+
+        return ['string' => 'string'];
+    }));
+    assertType('UserFactory', User::factory(42, function ($attributes, $model) {
+        assertType('array<string, mixed>', $attributes);
+        assertType('User|null', $model);
+
+        return ['string' => 'string'];
+    }));
+
     assertType('Illuminate\Database\Eloquent\Builder<User>', User::query());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->newQuery());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->withTrashed());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR updates the Factory generics to make the types more accurate. I also added generics to the `HasFactory` trait, as well as allow the user to define a static `$factory` property in lieu of overriding the `newFactory` method which helps slim down models. Of course the method can still be overridden if desired.

```php
// before
class User extends Authenticatable
{
    use HasFactory;

    protected function newFactory(): UserFactory
    {
        return UserFactory::new();
    }
}

// after
class User extends Authenticatable
{
    /** @use HasFactory<UserFactory> */
    use HasFactory;

    protected static string $factory = UserFactory::class;
}
```

Thanks!