### PR TITLE
[11.x] Add support for mime types in Resend mail transport

### DIFF
--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -75,9 +75,9 @@ class ResendTransport extends AbstractTransport
                 $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
 
                 $item = [
+                    'content_type' => $headers->get('Content-Type')->getBody(),
                     'content' => str_replace("\r\n", '', $attachment->bodyToString()),
                     'filename' => $filename,
-                    'content_type' => $headers->get('Content-Type')->getBody(),
                 ];
 
                 $attachments[] = $item;

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -77,6 +77,7 @@ class ResendTransport extends AbstractTransport
                 $item = [
                     'content' => str_replace("\r\n", '', $attachment->bodyToString()),
                     'filename' => $filename,
+                    'content_type' => $headers->get('Content-Type')->getBody(),
                 ];
 
                 $attachments[] = $item;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds support for setting mime types on attachments inside your Resend Mailable class. With the introduction of the `content_type` parameter in the Resend email API, it is now possible to pass that information along to the Resend API.

With this addition it is now possible to use the `withMime` method to set a custom type for your attachment:

```php
public function attachments(): array
{
    return [
        Attachment::fromPath('/path/to/file')
                ->as('name.pdf')
                ->withMime('application/pdf'),
    ];
}
```
