### PR TITLE
[11.x] Add translation methods to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -994,6 +994,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Translate the value with inflection.
+     *
+     * @param  int  $number
+     * @return static
+     */
+    public function transChoice($number)
+    {
+        return new static(trans_choice($this->value, $number));
+    }
+
+    /**
      * Trim the string of the given characters.
      *
      * @param  string  $characters

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -984,6 +984,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Translate the value.
+     *
+     * @return static
+     */
+    public function trans()
+    {
+        return new static(trans($this->value));
+    }
+
+    /**
      * Trim the string of the given characters.
      *
      * @param  string  $characters


### PR DESCRIPTION
This adds `trans` and `trans_choice` methods' functionalities to `Stringable`.

So instead of
```php
__(str($model::class)->afterLast('\\'))
```
You can say
```php
str($model::class)->afterLast('\\')->trans()
```
Which is more fluent.