### PR TITLE
[12.x] Remove deprecation since version 9.x

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -25,15 +25,6 @@ class Message
     protected $message;
 
     /**
-     * CIDs of files embedded in the message.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @var array
-     */
-    protected $embeddedFiles = [];
-
-    /**
      * Create a new message instance.
      *
      * @param  \Symfony\Component\Mime\Email  $message

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -131,29 +131,6 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     }
 
     /**
-     * Throw a method not allowed HTTP exception.
-     *
-     * @param  array  $others
-     * @param  string  $method
-     * @return void
-     *
-     * @deprecated use requestMethodNotAllowed
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
-     */
-    protected function methodNotAllowed(array $others, $method)
-    {
-        throw new MethodNotAllowedHttpException(
-            $others,
-            sprintf(
-                'The %s method is not supported for this route. Supported methods: %s.',
-                $method,
-                implode(', ', $others)
-            )
-        );
-    }
-
-    /**
      * Compile the routes for caching.
      *
      * @return array


### PR DESCRIPTION
These things are deprecated since 9.x and not used anywhere anymore.
- Illuminate\Routing\AbstractRouteCollection `methodNotAllowed` method - https://github.com/laravel/framework/pull/45206

- Illuminate\Mail\Message `$embeddedFiles` property - https://github.com/laravel/framework/pull/42563

