### PR TITLE
[11.x] Fix GeneratorCommand docblock

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -117,7 +117,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     ];
 
     /**
-     * Create a new controller creator command instance.
+     * Create a new generator command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @return void


### PR DESCRIPTION
The GeneratorCommand constructor description isn't correct now.