### PR TITLE
[11.x] Add test `testMultiplyIsLazy` to ensure LazyCollection's `multiply` method's lazy behaviour

### DIFF
--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -144,7 +144,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
 
         $this->assertEnumeratesCollectionOnce(
-            $this->make([1, 2,3]),
+            $this->make([1, 2, 3]),
             function ($collection) {
                 return $collection->multiply(3)->all();
             }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -137,6 +137,20 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         $this->assertEnumerations(1, $secondEnumerations);
     }
 
+    public function testMultiplyIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->multiply(2);
+        });
+
+        $this->assertEnumeratesCollectionOnce(
+            $this->make([1, 2,3]),
+            function ($collection) {
+                return $collection->multiply(3)->all();
+            }
+        );
+    }
+
     public function testContainsIsLazy()
     {
         $this->assertEnumerates(5, function ($collection) {


### PR DESCRIPTION
The`multiply` method, introduced in PR [#51870](https://github.com/laravel/framework/pull/51870),  later on @taylorotwell 
include this on `LazyCollection` also. This pull request introduces the `testMultiplyIsLazy` method to validate the lazy evaluation behavior of the `multiply` method.