### PR TITLE
[11.x] Fix PasswordBroker constructor docblock

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -39,7 +39,7 @@ class PasswordBroker implements PasswordBrokerContract
      *
      * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
      * @param  \Illuminate\Contracts\Auth\UserProvider  $users
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $users
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
     public function __construct(#[\SensitiveParameter] TokenRepositoryInterface $tokens, UserProvider $users, ?Dispatcher $dispatcher = null)


### PR DESCRIPTION
The third parameter of `PasswordBroker` constructor is `$dispatcher` (an instance of `\Illuminate\Contracts\Events\Dispatcher`) but it's currently documented as `$users`. It might be accidentally copied in the past.