### PR TITLE
[11.x] Use nullsafe operator for event dispatcher

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -82,9 +82,7 @@ class PasswordBroker implements PasswordBrokerContract
         // the current URI having nothing set in the session to indicate errors.
         $user->sendPasswordResetNotification($token);
 
-        if ($this->events) {
-            $this->events->dispatch(new PasswordResetLinkSent($user));
-        }
+        $this->events?->dispatch(new PasswordResetLinkSent($user));
 
         return static::RESET_LINK_SENT;
     }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -609,9 +609,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we have an event dispatcher instance, we can fire off the logout event
         // so any further processing can be done. This allows the developer to be
         // listening for anytime a user signs out of this application manually.
-        if (isset($this->events)) {
-            $this->events->dispatch(new Logout($this->name, $user));
-        }
+        $this->events?->dispatch(new Logout($this->name, $user));
 
         // Once we have fired the logout event we will clear the users out of memory
         // so they are no longer available as the user is no longer considered as
@@ -637,9 +635,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we have an event dispatcher instance, we can fire off the logout event
         // so any further processing can be done. This allows the developer to be
         // listening for anytime a user signs out of this application manually.
-        if (isset($this->events)) {
-            $this->events->dispatch(new CurrentDeviceLogout($this->name, $user));
-        }
+        $this->events?->dispatch(new CurrentDeviceLogout($this->name, $user));
 
         // Once we have fired the logout event we will clear the users out of memory
         // so they are no longer available as the user is no longer considered as

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -244,9 +244,7 @@ class Logger implements LoggerInterface
         // If the event dispatcher is set, we will pass along the parameters to the
         // log listeners. These are useful for building profilers or other tools
         // that aggregate all of the log messages for a given "request" cycle.
-        if (isset($this->dispatcher)) {
-            $this->dispatcher->dispatch(new MessageLogged($level, $message, $context));
-        }
+        $this->dispatcher?->dispatch(new MessageLogged($level, $message, $context));
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -117,11 +117,9 @@ abstract class Connection
 
         $time = round((microtime(true) - $start) * 1000, 2);
 
-        if (isset($this->events)) {
-            $this->event(new CommandExecuted(
-                $method, $this->parseParametersForEvent($parameters), $time, $this
-            ));
-        }
+        $this->events?->dispatch(new CommandExecuted(
+            $method, $this->parseParametersForEvent($parameters), $time, $this
+        ));
 
         return $result;
     }
@@ -142,6 +140,8 @@ abstract class Connection
      *
      * @param  mixed  $event
      * @return void
+     *
+     * @deprecated since Laravel 11.x
      */
     protected function event($event)
     {


### PR DESCRIPTION
- Nullsafe operator for the `$events` property already used in `Illuminate\Redis` and `Illuminate\Auth`, so we can change other similar null check conditions as well.
- The `\Illuminate\Log\Logger::fireLogEvent` method can also use nullsafe operator for `$dispatcher`.