### PR TITLE
[11.x] Run MySQL 9 Database Integration Tests nightly

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -1,10 +1,56 @@
 name: databases-nightly
 
 on:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
+
+  mysql_9:
+    runs-on: ubuntu-24.04
+
+    services:
+      mysql:
+        image: mysql:9
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: laravel
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: true
+
+    name: MySQL 9.0
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "11.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: mysql
 
   mariadb:
     runs-on: ubuntu-24.04

--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: true
 
-    name: MySQL 9.0
+    name: MySQL 9
 
     steps:
       - name: Checkout code

--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -6,7 +6,6 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-
   mysql_9:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -1,7 +1,6 @@
 name: databases-nightly
 
 on:
-  pull_request:
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: true
 
-    name: MySQL 8.0
+    name: MySQL 8
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
MySQL 9 was released in July 1st.

https://dev.mysql.com/doc/relnotes/mysql/9.0/en/

This PR adds MySQL 9 to the Database nightly workflow. (I don't think this needs to be run on each PR)