### PR TITLE
[11.x] Adds `$config` property to `MultipleInstanceManager`

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -16,6 +16,13 @@ abstract class MultipleInstanceManager
     protected $app;
 
     /**
+     * The configuration repository instance.
+     *
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    protected $config;
+
+    /**
      * The array of resolved instances.
      *
      * @var array
@@ -45,6 +52,7 @@ abstract class MultipleInstanceManager
     public function __construct($app)
     {
         $this->app = $app;
+        $this->config = $app->make('config');
     }
 
     /**


### PR DESCRIPTION
I noticed that `Manager` has a docblock type-hinted `$config` property, but `MultipleInstanceManager` does not.

This is a nice quality of life improvement as it's no longer necessary to write `$this->app["config"]->get()` and I have the benefit of my IDE being able to tell me the methods available.