### PR TITLE
[11.x] Implement HasV7Uuids to use with MariaDB native uuid data type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasV7Uuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasV7Uuids.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Support\Str;
+
+trait HasV7Uuids
+{
+    use HasUuids;
+
+    /**
+     * Generate a new UUID (version 7) for the model.
+     *
+     * @return string
+     */
+    public function newUniqueId()
+    {
+        return (string) Str::uuid7();
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasVersion7Uuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasVersion7Uuids.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Support\Str;
 
-trait HasV7Uuids
+trait HasVersion7Uuids
 {
     use HasUuids;
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -52,13 +52,6 @@ class Str
     protected static $uuidFactory;
 
     /**
-     * The callback that should be used to generate UUID7s.
-     *
-     * @var callable|null
-     */
-    protected static $uuid7Factory;
-
-    /**
      * The callback that should be used to generate ULIDs.
      *
      * @var callable|null

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1737,6 +1737,18 @@ class Str
     }
 
     /**
+     * Generate a UUID (version 7).
+     *
+     * @return \Ramsey\Uuid\UuidInterface
+     */
+    public static function uuid7()
+    {
+        return static::$uuidFactory
+                    ? call_user_func(static::$uuidFactory)
+                    : Uuid::uuid7();
+    }
+
+    /**
      * Generate a time-ordered UUID.
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1744,6 +1744,19 @@ class Str
     }
 
     /**
+     * Generate a UUID (version 7).
+     *
+     * @param  \DateTimeInterface|null  $time
+     * @return \Ramsey\Uuid\UuidInterface
+     */
+    public static function uuid7($time = null)
+    {
+        return static::$uuidFactory
+                    ? call_user_func(static::$uuidFactory)
+                    : Uuid::uuid7($time);
+    }
+
+    /**
      * Generate a time-ordered UUID.
      *
      * @return \Ramsey\Uuid\UuidInterface
@@ -1844,97 +1857,6 @@ class Str
     public static function createUuidsNormally()
     {
         static::$uuidFactory = null;
-    }
-
-    /**
-     * Generate a UUID (version 7).
-     *
-     * @param  \DateTimeInterface|null  $time
-     * @return \Ramsey\Uuid\UuidInterface
-     */
-    public static function uuid7($time = null)
-    {
-        return static::$uuid7Factory
-                    ? call_user_func(static::$uuid7Factory)
-                    : Uuid::uuid7($time);
-    }
-
-    /**
-     * Set the callable that will be used to generate UUID7s.
-     *
-     * @param  callable|null  $factory
-     * @return void
-     */
-    public static function createUuid7sUsing(?callable $factory = null)
-    {
-        static::$uuid7Factory = $factory;
-    }
-
-    /**
-     * Set the sequence that will be used to generate UUID7s.
-     *
-     * @param  array  $sequence
-     * @param  callable|null  $whenMissing
-     * @return void
-     */
-    public static function createUuid7sUsingSequence(array $sequence, $whenMissing = null)
-    {
-        $next = 0;
-
-        $whenMissing ??= function () use (&$next) {
-            $factoryCache = static::$uuid7Factory;
-
-            static::$uuid7Factory = null;
-
-            $uuid7 = static::uuid7();
-
-            static::$uuid7Factory = $factoryCache;
-
-            $next++;
-
-            return $uuid7;
-        };
-
-        static::createUuid7sUsing(function () use (&$next, $sequence, $whenMissing) {
-            if (array_key_exists($next, $sequence)) {
-                return $sequence[$next++];
-            }
-
-            return $whenMissing();
-        });
-    }
-
-    /**
-     * Always return the same UUID7 when generating new UUID7s.
-     *
-     * @param  \Closure|null  $callback
-     * @return \Ramsey\Uuid\UuidInterface
-     */
-    public static function freezeUuid7s(?Closure $callback = null)
-    {
-        $uuid7 = Str::uuid7();
-
-        Str::createUuid7sUsing(fn () => $uuid7);
-
-        if ($callback !== null) {
-            try {
-                $callback($uuid7);
-            } finally {
-                Str::createUuid7sNormally();
-            }
-        }
-
-        return $uuid7;
-    }
-
-    /**
-     * Indicate that UUID7s should be created normally and not using a custom factory.
-     *
-     * @return void
-     */
-    public static function createUuid7sNormally()
-    {
-        static::$uuid7Factory = null;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1101,6 +1101,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
+        $this->assertInstanceOf(UuidInterface::class, Str::uuid7());
     }
 
     public function testAsciiNull()
@@ -1354,7 +1355,7 @@ class SupportStrTest extends TestCase
     {
         Str::createUuidsUsingSequence([
             0 => ($zeroth = Str::uuid()),
-            1 => ($first = Str::uuid()),
+            1 => ($first = Str::uuid7()),
             // just generate a random one here...
             3 => ($third = Str::uuid()),
             // continue to generate random uuids...


### PR DESCRIPTION
This PR addresses issue #51883. The referenced issue points out that the `uuid` data type in MariaDB has problems with `orderedUuid`, which is used by the `HasUuid` trait. 

MariaDB's documentation suggests using `uuid1` or UUID versions >= 6 as a better option.

With this PR, Laravel developers can better utilize their MariaDB UUID columns in terms of performance, indexing, ordering, and storage. Using UUID v7 instead of the ordered UUID v4 currently used by Laravel will:

- Fix the incorrect order bug in MariaDB.
- Improve performance during insertion.
- Align with the standard method of ordering UUIDs by using a truly ordered UUID version instead of simulating one.

Additionally, this PR introduces a new `uuid7` helper method in `Str`.

If this PR is merged, necessary edits to the documentation will be required to guide users on using this trait with MariaDB instead of HasUuid.