### PR TITLE
[11.x] Allow `MultipleInstanceManager` to have studly creators

### DIFF
--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -119,21 +119,21 @@ abstract class MultipleInstanceManager
 
         if (isset($this->customCreators[$driverName])) {
             return $this->callCustomCreator($config);
-        } else {
-            $createMethod = 'create'.ucfirst($driverName).ucfirst($this->driverKey);
-
-            if (method_exists($this, $createMethod)) {
-                return $this->{$createMethod}($config);
-            }
-
-            $createMethod = 'create'.Str::studly($driverName).ucfirst($this->driverKey);
-
-            if (method_exists($this, $createMethod)) {
-                return $this->{$createMethod}($config);
-            }
-
-            throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
         }
+
+        $createMethod = 'create'.ucfirst($driverName).ucfirst($this->driverKey);
+
+        if (method_exists($this, $createMethod)) {
+            return $this->{$createMethod}($config);
+        }
+
+        $createMethod = 'create'.Str::studly($driverName).ucfirst($this->driverKey);
+
+        if (method_exists($this, $createMethod)) {
+            return $this->{$createMethod}($config);
+        }
+
+        throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
     }
 
     /**

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -119,21 +119,21 @@ abstract class MultipleInstanceManager
 
         if (isset($this->customCreators[$driverName])) {
             return $this->callCustomCreator($config);
+        } else {
+            $createMethod = 'create'.ucfirst($driverName).ucfirst($this->driverKey);
+
+            if (method_exists($this, $createMethod)) {
+                return $this->{$createMethod}($config);
+
+            }
+
+            $createMethod = 'create'.Str::studly($driverName).ucfirst($this->driverKey);
+            if (method_exists($this, $createMethod)) {
+                return $this->{$createMethod}($config);
+            }
+
+            throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
         }
-
-        $createMethod = 'create'.ucfirst($driverName).ucfirst($this->driverKey);
-
-        if (method_exists($this, $createMethod)) {
-            return $this->{$createMethod}($config);
-        }
-
-        $createMethod = 'create'.Str::studly($driverName).ucfirst($this->driverKey);
-
-        if (method_exists($this, $createMethod)) {
-            return $this->{$createMethod}($config);
-        }
-
-        throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
     }
 
     /**

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -128,6 +128,7 @@ abstract class MultipleInstanceManager
             }
 
             $createMethod = 'create'.Str::studly($driverName).ucfirst($this->driverKey);
+
             if (method_exists($this, $createMethod)) {
                 return $this->{$createMethod}($config);
             }

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -115,16 +115,24 @@ abstract class MultipleInstanceManager
             throw new RuntimeException("Instance [{$name}] does not specify a {$this->driverKey}.");
         }
 
-        if (isset($this->customCreators[$config[$this->driverKey]])) {
+        $driverName = $config[$this->driverKey];
+
+        if (isset($this->customCreators[$driverName])) {
             return $this->callCustomCreator($config);
         } else {
-            $createMethod = 'create'.ucfirst($config[$this->driverKey]).ucfirst($this->driverKey);
+            $createMethod = 'create'.ucfirst($driverName).ucfirst($this->driverKey);
 
             if (method_exists($this, $createMethod)) {
                 return $this->{$createMethod}($config);
-            } else {
-                throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
             }
+
+            $createMethod = 'create'.Str::studly($driverName).ucfirst($this->driverKey);
+
+            if (method_exists($this, $createMethod)) {
+                return $this->{$createMethod}($config);
+            }
+
+            throw new InvalidArgumentException("Instance {$this->driverKey} [{$config[$this->driverKey]}] is not supported.");
         }
     }
 

--- a/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
+++ b/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
@@ -34,6 +34,15 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
         };
     }
 
+    protected function createMysqlDatabaseConnectionDriver(array $config) {
+        return new class($config)
+        {
+            public function __construct(public $config)
+            {
+            }
+        };
+    }
+
     /**
      * Get the default instance name.
      *
@@ -73,6 +82,11 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
                 return [
                     'driver' => 'bar',
                     'bar-option' => 'option-value',
+                ];
+            case 'mysql_database-connection':
+                return [
+                    'driver' => 'mysql_database-connection',
+                    'mysql_database-connection-option' => 'option-value'
                 ];
             default:
                 return [];

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -18,10 +18,15 @@ class MultipleInstanceManagerTest extends TestCase
         $barInstance = $manager->instance('bar');
         $this->assertSame('option-value', $barInstance->config['bar-option']);
 
+        $mysqlInstance = $manager->instance('mysql_database-connection');
+        $this->assertSame('option-value', $mysqlInstance->config['mysql_database-connection-option']);
+
         $duplicateFooInstance = $manager->instance('foo');
         $duplicateBarInstance = $manager->instance('bar');
+        $duplicateMysqlInstance = $manager->instance('mysql_database-connection');
         $this->assertEquals(spl_object_hash($fooInstance), spl_object_hash($duplicateFooInstance));
         $this->assertEquals(spl_object_hash($barInstance), spl_object_hash($duplicateBarInstance));
+        $this->assertEquals(spl_object_hash($mysqlInstance), spl_object_hash($duplicateMysqlInstance));
     }
 
     public function test_unresolvable_instances_throw_errors()


### PR DESCRIPTION
`Manager` [uses studly case](https://github.com/laravel/framework/blob/c271b40e38f36baa1bcb05804f4634a15e94b364/src/Illuminate/Support/Manager.php#L103) for driver creator names. `MultipleInstanceManager` just sets the first character of the driver as upper case.

If I have a driver called `in_memory`, then in my child MultipleInstanceManager, the creator function would look like this:

```php
// Current Implementation
protected function createIn_memoryDriver() { }

// After this PR
protected function createInMemoryDriver() { }
```

This looks better, brings parity between the two Manager classes, but is **not a breaking change** because we only check for the studly case method if the `ucfirst()` formatted method doesn't exist on the class.