### PR TITLE
[10.x] Fix `compileHaving` in `Grammar` to support Bitwise operations

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -779,7 +779,7 @@ class Grammar extends BaseGrammar
             'between' => $this->compileHavingBetween($having),
             'Null' => $this->compileHavingNull($having),
             'NotNull' => $this->compileHavingNotNull($having),
-            'bit' => $this->compileHavingBit($having),
+            'Bitwise' => $this->compileHavingBitwise($having),
             'Expression' => $this->compileHavingExpression($having),
             'Nested' => $this->compileNestedHavings($having),
             default => $this->compileBasicHaving($having),
@@ -852,7 +852,7 @@ class Grammar extends BaseGrammar
      * @param  array  $having
      * @return string
      */
-    protected function compileHavingBit($having)
+    protected function compileHavingBitwise($having)
     {
         $column = $this->wrap($having['column']);
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -238,36 +238,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile a single having clause.
-     *
-     * @param  array  $having
-     * @return string
-     */
-    protected function compileHaving(array $having)
-    {
-        if ($having['type'] === 'Bitwise') {
-            return $this->compileHavingBitwise($having);
-        }
-
-        return parent::compileHaving($having);
-    }
-
-    /**
-     * Compile a having clause involving a bitwise operator.
-     *
-     * @param  array  $having
-     * @return string
-     */
-    protected function compileHavingBitwise($having)
-    {
-        $column = $this->wrap($having['column']);
-
-        $parameter = $this->parameter($having['value']);
-
-        return '('.$column.' '.$having['operator'].' '.$parameter.') != 0';
-    }
-
-    /**
      * Compile a delete statement without joins into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
There was a typo in the `compileHaving` method where the type was incorrectly specified as `bit` instead of `Bitwise`. This caused the Bitwise operations not to work properly. This has now been corrected. Additionally, the child method in `SqlServerGrammar` has been removed since it is now identical to the parent class method.