### PR TITLE
[11.x] Implement changeKeyCase to Arr helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -247,6 +247,30 @@ class Arr
     }
 
     /**
+     * Change array keys to provided {$case}
+     *
+     * @param array $array
+     * @param $case
+     * @param mixed ...$parameters
+     * @return array
+     */
+    public static function changeKeyCase($array, $case, ...$parameters)
+    {
+        if (in_array($case, [CASE_LOWER, CASE_UPPER], true)) {
+            return array_change_key_case($array, $case);
+        }
+
+        $case = is_callable($case)
+            ? fn ($key) => $case($key, ...$parameters)
+            : fn ($key) => Str::{$case}($key, ...$parameters);
+
+        return self::mapWithKeys(
+            $array,
+            fn ($value, $key) => [$case($key) => $value],
+        );
+    }
+
+    /**
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  iterable  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -247,11 +247,11 @@ class Arr
     }
 
     /**
-     * Change array keys to provided {$case}
+     * Change array keys to provided {$case}.
      *
-     * @param array $array
-     * @param $case
-     * @param mixed ...$parameters
+     * @param  array  $array
+     * @param  $case
+     * @param  mixed  ...$parameters
      * @return array
      */
     public static function changeKeyCase($array, $case, ...$parameters)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -250,7 +250,7 @@ class Arr
      * Change array keys to provided {$case}.
      *
      * @param  array  $array
-     * @param  $case
+     * @param  int|string|callable  $case
      * @param  mixed  ...$parameters
      * @return array
      */


### PR DESCRIPTION
### Issue
It's nice when you might just use `compact()` built-in function, but sometimes you need the same keys as var names but not in camel case. Then, you have to handle it manually especially if you work with large dataset
`[
    'my_long_var_name' => $myLongVarName,
    ...
]`
### Solution
Now we can simply use `changeKeyCase` method
```
    $array = ['MyKey' => 1];

    // Pass CASE_LOWER or CASE_UPPER to use built-in `array_change_key_case` function
    Arr::changeKeyCase($array, CASE_LOWER); // ['mykey' => 1]
    Arr::changeKeyCase($array, CASE_UPPER); // ['MYKEY' => 1]

    // Use another built-in php function if needed
    Arr::changeKeyCase($array, 'lcfirst'); // ['myKey' => 1]
    Arr::changeKeyCase($array, lcfirst(...)); // ['myKey' => 1]

    // Pass a method of Str helper
    Arr::changeKeyCase($array, 'snake'); // ['my_key' => 1]
    Arr::changeKeyCase($array, Str::snake(...)); // ['my_key' => 1]

    // You can take advantage of Str macros as well
    Str::macro('myCustomCaseMacro', fn ($value, $additionalParameter) => $value[0].'...'.$additionalParameter);
    Arr::changeKeyCase($array, 'myCustomCaseMacro', 'Addon'); // ['M...Addon' => 1]

    // It`s also possible to pass custom callback
    Arr::changeKeyCase($testArray, fn ($key) => "prefix_$key")) // ['prefix_MyKey' => 1]

    // If method for Str helper does not exist, exception is thrown
    Arr::changeKeyCase($testArray, 'NonExistedStrHelperMethod'); // BadMethodCallException is thrown
```

Particularly, this can be used in combination with built-in `compact` function

```
    $somethingHere = 1;
    $somethingElse = 1;
    $moreSomethingElse = 1;
        
    Arr::changeKeyCase(
        array: compact('somethingHere', 'somethingElse', 'moreSomethingElse'),
        case: Str::snake(...),
    );
```

### Note
Pipelines might fail. I would like to hear your opinion about it firstly, then I`ll fix issues and finish this thing if the feedback is positive