### PR TITLE
[11.x] Accept an optional config object for LogManager

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -53,7 +53,7 @@ class LogManager implements LoggerInterface
     /**
      * The registered custom driver creators.
      *
-     * @var array
+     * @var array<string, \Closure>
      */
     protected $customCreators = [];
 
@@ -65,13 +65,22 @@ class LogManager implements LoggerInterface
     protected $dateFormat = 'Y-m-d H:i:s';
 
     /**
+     * The configuration to use for managing the logs.
+     *
+     * @var \Illuminate\Config\Repository
+     */
+    protected $config;
+
+    /**
      * Create a new Log manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Config\Repository  $config
      * @return void
      */
-    public function __construct($app)
+    public function __construct($app, $config = null)
     {
+        $this->config = ($config ?: $app['config']);
         $this->app = $app;
     }
 
@@ -360,7 +369,7 @@ class LogManager implements LoggerInterface
     {
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new SyslogHandler(
-                Str::snake($this->app['config']['app.name'], '-'),
+                Str::snake($this->config['app.name'], '-'),
                 $config['facility'] ?? LOG_USER, $this->level($config)
             ), $config),
         ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
@@ -559,7 +568,7 @@ class LogManager implements LoggerInterface
      */
     protected function configurationFor($name)
     {
-        return $this->app['config']["logging.channels.{$name}"];
+        return $this->config["logging.channels.{$name}"];
     }
 
     /**
@@ -569,7 +578,7 @@ class LogManager implements LoggerInterface
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['logging.default'];
+        return $this->config['logging.default'];
     }
 
     /**
@@ -580,7 +589,7 @@ class LogManager implements LoggerInterface
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['logging.default'] = $name;
+        $this->config['logging.default'] = $name;
     }
 
     /**


### PR DESCRIPTION
Currently, all the `LogManager` instances share the same config object. Changing configurations on one of the instances will unexpectedly affect all the others.

This allows (optional) passing a clone of config repository upon object instantiation like below:

![image](https://github.com/laravel/framework/assets/6961695/65e92226-1818-4f7e-a106-9bf7a742ea52)

Practically we wanted to have `DebugLog` facade that only logs on the local dev environment and set a separate log channel for that but changing the driver for the second LogManager was affecting the default one which is bound to the 'log' string by the Laravel core.

- This way seems to be fully backward compatible as I see, even for `LogManager` extenders.