### PR TITLE
[10.x] fix: update doc blocks in database rule to accept query builder type

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -154,7 +154,7 @@ trait DatabaseRule
      * Set a "where in" constraint on the query.
      *
      * @param  string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\Illuminate\Contracts\Database\Query\Builder|\BackedEnum|array  $values
      * @return $this
      */
     public function whereIn($column, $values)
@@ -168,7 +168,7 @@ trait DatabaseRule
      * Set a "where not in" constraint on the query.
      *
      * @param  string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\Illuminate\Contracts\Database\Query\Builder|\BackedEnum|array  $values
      * @return $this
      */
     public function whereNotIn($column, $values)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The `whereIn` and `whereNotIn` methods on the database query builder can accept a query builder as the second argument. However in the database validation rules, the types that are passed to the `whereIn` and `whereNotIn` methods on the query builder are expected to be `Illuminate\Contracts\Support\Arrayable`, `BackedEnum` or `array`.

This PR adds `Illuminate\Contracts\Database\Query\Builder` to the expected types for the `$values` parameter on the phpdoc `@param` tag.