### PR TITLE
[11.x] Improve upsert performance by looping only once through the values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1281,6 +1281,10 @@ class Builder implements BuilderContract
             $this->model->getUpdatedAtColumn(),
         ]);
 
+        if (empty($columns)) {
+            return $values;
+        }
+
         $timestamps = [];
         foreach ($columns as $column) {
             $timestamps += [$column => $timestamp];

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1281,10 +1281,13 @@ class Builder implements BuilderContract
             $this->model->getUpdatedAtColumn(),
         ]);
 
+        $timestamps = [];
         foreach ($columns as $column) {
-            foreach ($values as &$row) {
-                $row = array_merge([$column => $timestamp], $row);
-            }
+            $timestamps += [$column => $timestamp];
+        }
+
+        foreach ($values as &$row) {
+            $row = array_merge($timestamps, $row);
         }
 
         return $values;


### PR DESCRIPTION
The upsert tries to add updated at and created at columns to the list of rows to upsert

This list can be quite large and looping only once instead of twice through it will result in a performance improvement