### PR TITLE
[11.x] Add ability to configure SQLite `busy_timeout`, `journal_mode`, and `synchronous` pragmas

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ return [
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            'busy_timeout' => env('DB_BUSY_TIMEOUT'),
+            'busy_timeout' => null,
         ],
 
         'mysql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -38,6 +38,8 @@ return [
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
             'busy_timeout' => null,
+            'journal_mode' => null,
+            'synchronous' => null,
         ],
 
         'mysql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -37,6 +37,7 @@ return [
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'busy_timeout' => env('DB_BUSY_TIMEOUT'),
         ],
 
         'mysql' => [

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -26,97 +26,9 @@ class SQLiteConnection extends Connection
         parent::__construct($pdo, $database, $tablePrefix, $config);
 
         $this->configureForeignKeyConstraints();
-
         $this->configureBusyTimeout();
-
         $this->configureJournalMode();
-
         $this->configureSynchronous();
-    }
-
-    /**
-     * Escape a binary value for safe SQL embedding.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function escapeBinary($value)
-    {
-        $hex = bin2hex($value);
-
-        return "x'{$hex}'";
-    }
-
-    /**
-     * Determine if the given database exception was caused by a unique constraint violation.
-     *
-     * @param  \Exception  $exception
-     * @return bool
-     */
-    protected function isUniqueConstraintError(Exception $exception)
-    {
-        return boolval(preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage()));
-    }
-
-    /**
-     * Get the default query grammar instance.
-     *
-     * @return \Illuminate\Database\Query\Grammars\SQLiteGrammar
-     */
-    protected function getDefaultQueryGrammar()
-    {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
-    }
-
-    /**
-     * Get a schema builder instance for the connection.
-     *
-     * @return \Illuminate\Database\Schema\SQLiteBuilder
-     */
-    public function getSchemaBuilder()
-    {
-        if (is_null($this->schemaGrammar)) {
-            $this->useDefaultSchemaGrammar();
-        }
-
-        return new SQLiteBuilder($this);
-    }
-
-    /**
-     * Get the default schema grammar instance.
-     *
-     * @return \Illuminate\Database\Schema\Grammars\SQLiteGrammar
-     */
-    protected function getDefaultSchemaGrammar()
-    {
-        ($grammar = new SchemaGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
-    }
-
-    /**
-     * Get the schema state for the connection.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem|null  $files
-     * @param  callable|null  $processFactory
-     *
-     * @throws \RuntimeException
-     */
-    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
-    {
-        return new SqliteSchemaState($this, $files, $processFactory);
-    }
-
-    /**
-     * Get the default post processor instance.
-     *
-     * @return \Illuminate\Database\Query\Processors\SQLiteProcessor
-     */
-    protected function getDefaultPostProcessor()
-    {
-        return new SQLiteProcessor;
     }
 
     /**
@@ -209,5 +121,90 @@ class SQLiteConnection extends Connection
                 throw $e;
             }
         }
+    }
+
+    /**
+     * Escape a binary value for safe SQL embedding.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "x'{$hex}'";
+    }
+
+    /**
+     * Determine if the given database exception was caused by a unique constraint violation.
+     *
+     * @param  \Exception  $exception
+     * @return bool
+     */
+    protected function isUniqueConstraintError(Exception $exception)
+    {
+        return boolval(preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage()));
+    }
+
+    /**
+     * Get the default query grammar instance.
+     *
+     * @return \Illuminate\Database\Query\Grammars\SQLiteGrammar
+     */
+    protected function getDefaultQueryGrammar()
+    {
+        ($grammar = new QueryGrammar)->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
+    }
+
+    /**
+     * Get a schema builder instance for the connection.
+     *
+     * @return \Illuminate\Database\Schema\SQLiteBuilder
+     */
+    public function getSchemaBuilder()
+    {
+        if (is_null($this->schemaGrammar)) {
+            $this->useDefaultSchemaGrammar();
+        }
+
+        return new SQLiteBuilder($this);
+    }
+
+    /**
+     * Get the default schema grammar instance.
+     *
+     * @return \Illuminate\Database\Schema\Grammars\SQLiteGrammar
+     */
+    protected function getDefaultSchemaGrammar()
+    {
+        ($grammar = new SchemaGrammar)->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
+    }
+
+    /**
+     * Get the schema state for the connection.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem|null  $files
+     * @param  callable|null  $processFactory
+     *
+     * @throws \RuntimeException
+     */
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
+    {
+        return new SqliteSchemaState($this, $files, $processFactory);
+    }
+
+    /**
+     * Get the default post processor instance.
+     *
+     * @return \Illuminate\Database\Query\Processors\SQLiteProcessor
+     */
+    protected function getDefaultPostProcessor()
+    {
+        return new SQLiteProcessor;
     }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -28,6 +28,10 @@ class SQLiteConnection extends Connection
         $this->configureForeignKeyConstraints();
 
         $this->configureBusyTimeout();
+
+        $this->configureJournalMode();
+
+        $this->configureSynchronous();
     }
 
     /**
@@ -156,6 +160,50 @@ class SQLiteConnection extends Connection
 
         try {
             $this->getSchemaBuilder()->setBusyTimeout($milliseconds);
+        } catch (QueryException $e) {
+            if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Set the journal mode if configured.
+     *
+     * @return void
+     */
+    protected function configureJournalMode(): void
+    {
+        $mode = $this->getConfig('journal_mode');
+
+        if ($mode === null) {
+            return;
+        }
+
+        try {
+            $this->getSchemaBuilder()->setJournalMode($mode);
+        } catch (QueryException $e) {
+            if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Set the synchronous mode if configured.
+     *
+     * @return void
+     */
+    protected function configureSynchronous(): void
+    {
+        $mode = $this->getConfig('synchronous');
+
+        if ($mode === null) {
+            return;
+        }
+
+        try {
+            $this->getSchemaBuilder()->setSynchronous($mode);
         } catch (QueryException $e) {
             if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
                 throw $e;

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -612,7 +612,29 @@ class SQLiteGrammar extends Grammar
      */
     public function compileSetBusyTimeout($milliseconds)
     {
-        return sprintf('PRAGMA busy_timeout = %s;', $milliseconds);
+        return $this->pragma('busy_timeout', $milliseconds);
+    }
+
+    /**
+     * Compile the command to set the journal mode.
+     *
+     * @param  string  $mode
+     * @return string
+     */
+    public function compileSetJournalMode($mode)
+    {
+        return $this->pragma('journal_mode', $mode);
+    }
+
+    /**
+     * Compile the command to set the synchronous mode.
+     *
+     * @param  string  $mode
+     * @return string
+     */
+    public function compileSetSynchronous($mode)
+    {
+        return $this->pragma('synchronous', $mode);
     }
 
     /**
@@ -633,6 +655,18 @@ class SQLiteGrammar extends Grammar
     public function compileDisableWriteableSchema()
     {
         return 'PRAGMA writable_schema = 0;';
+    }
+
+    /**
+     * Get the SQL to set a PRAGMA value.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function pragma(string $name, mixed $value): string
+    {
+        return sprintf('PRAGMA %s = %s;', $name, $value);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -605,6 +605,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the command to set the busy timeout.
+     *
+     * @param  int  $milliseconds
+     * @return string
+     */
+    public function compileSetBusyTimeout($milliseconds)
+    {
+        return sprintf('PRAGMA busy_timeout = %s;', $milliseconds);
+    }
+
+    /**
      * Compile the SQL needed to enable a writable schema.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -591,7 +591,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileEnableForeignKeyConstraints()
     {
-        return 'PRAGMA foreign_keys = ON;';
+        return $this->pragma('foreign_keys', 'ON');
     }
 
     /**
@@ -601,7 +601,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDisableForeignKeyConstraints()
     {
-        return 'PRAGMA foreign_keys = OFF;';
+        return $this->pragma('foreign_keys', 'OFF');
     }
 
     /**
@@ -644,7 +644,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileEnableWriteableSchema()
     {
-        return 'PRAGMA writable_schema = 1;';
+        return $this->pragma('writable_schema', 1);
     }
 
     /**
@@ -654,7 +654,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDisableWriteableSchema()
     {
-        return 'PRAGMA writable_schema = 0;';
+        return $this->pragma('writable_schema', 0);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -118,6 +118,32 @@ class SQLiteBuilder extends Builder
     }
 
     /**
+     * Set the journal mode.
+     *
+     * @param  string  $mode
+     * @return bool
+     */
+    public function setJournalMode($mode)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileSetJournalMode($mode)
+        );
+    }
+
+    /**
+     * Set the synchronous mode.
+     *
+     * @param  int  $mode
+     * @return bool
+     */
+    public function setSynchronous($mode)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileSetSynchronous($mode)
+        );
+    }
+
+    /**
      * Empty the database file.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -105,6 +105,19 @@ class SQLiteBuilder extends Builder
     }
 
     /**
+     * Set the busy timeout.
+     *
+     * @param  int  $milliseconds
+     * @return bool
+     */
+    public function setBusyTimeout($milliseconds)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileSetBusyTimeout($milliseconds)
+        );
+    }
+
+    /**
      * Empty the database file.
      *
      * @return void

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -144,4 +144,16 @@ class DatabaseConnectionFactoryTest extends TestCase
 
         $this->assertEquals(1, $this->db->getConnection('constraints_set')->select('PRAGMA foreign_keys')[0]->foreign_keys);
     }
+
+    public function testSqliteBusyTimeout()
+    {
+        $this->db->addConnection([
+            'url' => 'sqlite:///:memory:?busy_timeout=1234',
+        ], 'busy_timeout_set');
+
+        // Can't compare to 0, default value may be something else
+        $this->assertNotSame(1234, $this->db->getConnection()->select('PRAGMA busy_timeout')[0]->timeout);
+
+        $this->assertSame(1234, $this->db->getConnection('busy_timeout_set')->select('PRAGMA busy_timeout')[0]->timeout);
+    }
 }

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -156,4 +156,15 @@ class DatabaseConnectionFactoryTest extends TestCase
 
         $this->assertSame(1234, $this->db->getConnection('busy_timeout_set')->select('PRAGMA busy_timeout')[0]->timeout);
     }
+
+    public function testSqliteSynchronous()
+    {
+        $this->db->addConnection([
+            'url' => 'sqlite:///:memory:?synchronous=NORMAL',
+        ], 'synchronous_set');
+
+        $this->assertSame(2, $this->db->getConnection()->select('PRAGMA synchronous')[0]->synchronous);
+
+        $this->assertSame(1, $this->db->getConnection('synchronous_set')->select('PRAGMA synchronous')[0]->synchronous);
+    }
 }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -831,6 +831,21 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertTrue(Schema::hasIndex('posts', ['user_name'], 'unique'));
     }
 
+    public function testSetJournalModeOnSqlite()
+    {
+        if ($this->driver !== 'sqlite') {
+            $this->markTestSkipped('Test requires a SQLite connection.');
+        }
+
+        file_put_contents(DB::connection('sqlite')->getConfig('database'), '');
+
+        $this->assertSame('delete', DB::connection('sqlite')->select('PRAGMA journal_mode')[0]->journal_mode);
+
+        Schema::connection('sqlite')->setJournalMode('WAL');
+
+        $this->assertSame('wal', DB::connection('sqlite')->select('PRAGMA journal_mode')[0]->journal_mode);
+    }
+
     public function testAddingMacros()
     {
         Schema::macro('foo', fn () => 'foo');

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -265,6 +265,22 @@ class ConfigurationUrlParserTest extends TestCase
                     'busy_timeout' => 5000,
                 ],
             ],
+            'Sqlite with journal_mode' => [
+                'sqlite:////absolute/path/to/database.sqlite?journal_mode=WAL',
+                [
+                    'driver' => 'sqlite',
+                    'database' => '/absolute/path/to/database.sqlite',
+                    'journal_mode' => 'WAL',
+                ],
+            ],
+            'Sqlite with synchronous' => [
+                'sqlite:////absolute/path/to/database.sqlite?synchronous=NORMAL',
+                [
+                    'driver' => 'sqlite',
+                    'database' => '/absolute/path/to/database.sqlite',
+                    'synchronous' => 'NORMAL',
+                ],
+            ],
 
             'Most complex example with read and write subarrays all in string' => [
                 'mysql://root:@null/database?read[host][]=192.168.1.1&write[host][]=196.168.1.2&sticky=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&prefix=',

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -257,6 +257,14 @@ class ConfigurationUrlParserTest extends TestCase
                     'foreign_key_constraints' => true,
                 ],
             ],
+            'Sqlite with busy_timeout' => [
+                'sqlite:////absolute/path/to/database.sqlite?busy_timeout=5000',
+                [
+                    'driver' => 'sqlite',
+                    'database' => '/absolute/path/to/database.sqlite',
+                    'busy_timeout' => 5000,
+                ],
+            ],
 
             'Most complex example with read and write subarrays all in string' => [
                 'mysql://root:@null/database?read[host][]=192.168.1.1&write[host][]=196.168.1.2&sticky=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&prefix=',


### PR DESCRIPTION
This PR adds optional `busy_timeout`, `journal_mode`, and `synchronous` configuration options to allow setting the corresponding pragmas on SQLite database connections. Together, these three configuration options can improve SQLite's performance enormously.

### Background

This SQLite configuration:

```sql
PRAGMA busy_timeout = 5000;
PRAGMA journal_mode = WAL;
PRAGMA synchronous = NORMAL;
```

is becoming the widely recommended default for modern apps because it is orders of magnitude faster than the default setup and far less prone to `SQLITE_BUSY` errors.

- `journal_mode` configures how transactions are implemented. The default setting, `DELETE`, uses a rollback journal. Since SQLite 3.7 a `WAL` mode is available that uses a write ahead log, which is significantly faster and allows concurrent database reads and writes in more scenarios.
- `busy_timeout` configures how long SQLite will wait when a table is locked before returning a `SQLITE_BUSY` error. The default is `0`, which means any attempted concurrent writes will fail immediately. Setting it to a positive integer will make SQLite wait that many milliseconds if the database is locked, which in most cases means that operations will complete with a negligible delay instead of erroring.
- `synchronous` configures how often SQLite flushes the contents of the database to the disk. The default, `FULL`, writes data to disk more or less immediately when it changes. The `NORMAL` mode syncs data when necessary but less often, and in combination with WAL mode is much faster, fully consistent, and highly durable. `NORMAL` is SQLite's recommended setting when used with WAL mode.

Rails and Django both currently support some or all of this functionality. They both have a `timeout` configuration option, Rails 7.1 defaults to WAL mode and NORMAL, and Django 5.1 (releasing in August) is going to add configuration fields for setting transaction modes and other custom pragmas:

- https://guides.rubyonrails.org/configuring.html#configuring-an-sqlite3-database
- https://github.com/rails/rails/blob/cacf96ecd053f0a3d64c7bf478dac63f98e6aa6d/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L81
- https://docs.djangoproject.com/en/5.0/ref/databases/#database-is-locked-errors
- https://docs.djangoproject.com/en/dev/ref/databases/#setting-pragma-options

More info:

- https://www.sqlite.org/wal.html
- https://www.sqlite.org/pragma.html#pragma_busy_timeout
- https://www.sqlite.org/pragma.html#pragma_journal_mode
- https://www.sqlite.org/pragma.html#pragma_synchronous
- https://kerkour.com/sqlite-for-servers
- https://fractaledmind.github.io/2024/04/15/sqlite-on-rails-the-how-and-why-of-optimal-performance/
- https://www.bigbinary.com/blog/rails-7-1-comes-with-an-optimized-default-sqlite3-adapter-connection-configuration
- https://gcollazo.com/optimal-sqlite-settings-for-django/

### Implementation

I based this on the existing code for setting the `foreign_keys` pragma, it works exactly the same way except that the new options accept custom values instead of just being on or off.

`busy_timeout` and `synchronous` are per-_connection_ settings and have to be set every time Laravel connects to a SQLite database (like the existing `foreign_keys` pragma), so it makes sense to store them in the config like `foreign_keys`. `journal_mode` is a persistent setting and technically only has to be set once, but the implementation is much simpler and more consistent if we just set it on every connection too.

The new configuration options all default to `null` so that existing apps will be completely unaffected by this change.

### Alternatives

How I'm currently doing this:

```php
// in AppServiceProvider.php

public function boot(): void
{
    Event::listen(function (ConnectionEstablished $event) {
        if ($event->connection instanceof SQLiteConnection) {
            $event->connection->statement(<<<SQL
                PRAGMA busy_timeout = 5000;
                PRAGMA journal_mode = WAL;
                PRAGMA synchronous = NORMAL;
                SQL);
        }
    });
}
```

### Future Scope

I'm going to work on a PR for [immediate transactions](https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions) too, which also combine really well with these settings but will have to be implemented differently.