### PR TITLE
Handle nested valid data in the Validator::valid() method

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -965,9 +965,19 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        return array_diff_key(
-            $this->data, $this->attributesThatHaveMessages()
+        $valid = array_diff_key(
+            Arr::dot($this->data), $this->attributesThatHaveMessages()
         );
+
+        $result = [];
+
+        $succeeded = Arr::except(Arr::dot($valid), array_keys($this->failed()));
+
+        foreach ($succeeded as $key => $success) {
+            Arr::set($result, $key, $success);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7800,6 +7800,37 @@ class ValidationValidatorTest extends TestCase
         );
     }
 
+    public function testNestedValidMethod()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'testvalid' => 'filled',
+            'testinvalid' => '',
+            'records' => [
+                'ABCE13',
+                'ABCF12',
+                'ABBD13',
+                'ADC123',
+            ],
+        ], [
+            'testvalid' => 'filled',
+            'testinvalid' => 'filled',
+            'records.*' => [
+                'required',
+                'regex:/[A-F]{3}[0-9]{3}/',
+            ],
+        ]);
+        $this->assertEquals(
+            [
+                'testvalid' => 'filled',
+                'records' => [
+                    3 => 'ADC123',
+                ],
+            ],
+            $v->valid()
+        );
+    }
+
     public function testMultipleFileUploads()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
## Description
I'm unsure if it's a bug, but the `valid()` method of `\Illuminate\Validation\Validator` class doesn't handle nested array fields, so I made an implementation based on the `invalid()` method, which does handle nested data.

## Environment
PHP: 8.2/8.3
Laravel: 11.x (discovered on 10.43, can be reproduced on 11.x)

## Steps to reproduce
In a Tinker session:
```php
\Validator::make(['foo' => ['invalid', '123']], ['foo.*' => 'required|numeric'])->valid()
// Returns []
// Should(?) be ['foo' => [1 => '123']]
```
Conversely, `Validator::invalid()`:
```php
\Validator::make(['foo' => ['invalid', '123']], ['foo.*' => 'required|numeric'])->invalid()
// Returns ['foo' => [0 => 'invalid']]
```

## Why the change?
This behaviour seems inconsistent with `invalid()` as the `valid()` method omits the `'foo.1'` field which is clearly valid.
My personal use case for this, is a form-based configurator, that must autosave every valid field, while omitting the invalid ones, without throwing exceptions.

This is my first time contributing, so I hope this is in the correct branch. I've made the assumption that some people may be depending on the existing behaviour of `Validator::valid()`, and that this would be a breaking change. (maybe for 12.x?)