### PR TITLE
[11.x] Ask About View Next To Name For Create Mail Command

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -7,7 +7,10 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use function Laravel\Prompts\select;
 
 #[AsCommand(name: 'make:mail')]
 class MailMakeCommand extends GeneratorCommand
@@ -192,5 +195,22 @@ class MailMakeCommand extends GeneratorCommand
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable', false],
             ['view', null, InputOption::VALUE_OPTIONAL, 'Create a new Blade template for the mailable', false],
         ];
+    }
+
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $type = select('Would you like to create a view for you mailable?', [
+            'markdown' => 'Markdown View',
+            'view' => 'Empty View',
+            'none' => 'No View',
+        ]);
+
+        if ($type !== 'none') {
+            $input->setOption($type, null);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -197,13 +197,20 @@ class MailMakeCommand extends GeneratorCommand
         ];
     }
 
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         if ($this->didReceiveOptions($input)) {
             return;
         }
 
-        $type = select('Would you like to create a view for you mailable?', [
+        $type = select('Would you like to create a view?', [
             'markdown' => 'Markdown View',
             'view' => 'Empty View',
             'none' => 'No View',

--- a/tests/Integration/Generators/ViewMakeCommandTest.php
+++ b/tests/Integration/Generators/ViewMakeCommandTest.php
@@ -31,7 +31,7 @@ class ViewMakeCommandTest extends TestCase
     {
         $this->artisan('make:mail')
             ->expectsQuestion('What should the mailable be named?','FooMail')
-            ->expectsQuestion('Would you like to create a view for you mailable?','none')
+            ->expectsQuestion('Would you like to create a view?','none')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/FooMail.php');
@@ -42,7 +42,7 @@ class ViewMakeCommandTest extends TestCase
     {
         $this->artisan('make:mail')
             ->expectsQuestion('What should the mailable be named?','MyFooMail')
-            ->expectsQuestion('Would you like to create a view for you mailable?','view')
+            ->expectsQuestion('Would you like to create a view?','view')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/MyFooMail.php');
@@ -54,7 +54,7 @@ class ViewMakeCommandTest extends TestCase
         $this->artisan('make:mail')
 
             ->expectsQuestion('What should the mailable be named?','FooMail')
-            ->expectsQuestion('Would you like to create a view for you mailable?','markdown')
+            ->expectsQuestion('Would you like to create a view?','markdown')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/MyFooMail.php');

--- a/tests/Integration/Generators/ViewMakeCommandTest.php
+++ b/tests/Integration/Generators/ViewMakeCommandTest.php
@@ -26,4 +26,38 @@ class ViewMakeCommandTest extends TestCase
         $this->assertFilenameExists('resources/views/foo.blade.php');
         $this->assertFilenameExists('tests/Feature/View/FooTest.php');
     }
+
+    public function testItCanGenerateMailWithNoInitialInput()
+    {
+        $this->artisan('make:mail')
+            ->expectsQuestion('What should the mailable be named?','FooMail')
+            ->expectsQuestion('Would you like a view for you mailable?','none')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Mail/FooMail.php');
+        $this->assertFilenameDoesNotExists('resources/views/mail/foo-mail.blade.php');
+    }
+
+    public function testItCanGenerateMailWithViewWithNoInitialInput()
+    {
+        $this->artisan('make:mail')
+            ->expectsQuestion('What should the mailable be named?','MyFooMail')
+            ->expectsQuestion('Would you like a view for you mailable?','view')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Mail/MyFooMail.php');
+        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
+    }
+
+    public function testItCanGenerateMailWithMarkdownViewWithNoInitialInput()
+    {
+        $this->artisan('make:mail')
+
+            ->expectsQuestion('What should the mailable be named?','FooMail')
+            ->expectsQuestion('Would you like a view for you mailable?','markdown')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Mail/MyFooMail.php');
+        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
+    }
 }

--- a/tests/Integration/Generators/ViewMakeCommandTest.php
+++ b/tests/Integration/Generators/ViewMakeCommandTest.php
@@ -31,7 +31,7 @@ class ViewMakeCommandTest extends TestCase
     {
         $this->artisan('make:mail')
             ->expectsQuestion('What should the mailable be named?','FooMail')
-            ->expectsQuestion('Would you like a view for you mailable?','none')
+            ->expectsQuestion('Would you like to create a view for you mailable?','none')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/FooMail.php');
@@ -42,7 +42,7 @@ class ViewMakeCommandTest extends TestCase
     {
         $this->artisan('make:mail')
             ->expectsQuestion('What should the mailable be named?','MyFooMail')
-            ->expectsQuestion('Would you like a view for you mailable?','view')
+            ->expectsQuestion('Would you like to create a view for you mailable?','view')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/MyFooMail.php');
@@ -54,7 +54,7 @@ class ViewMakeCommandTest extends TestCase
         $this->artisan('make:mail')
 
             ->expectsQuestion('What should the mailable be named?','FooMail')
-            ->expectsQuestion('Would you like a view for you mailable?','markdown')
+            ->expectsQuestion('Would you like to create a view for you mailable?','markdown')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/MyFooMail.php');


### PR DESCRIPTION
This PR will help when you create a mail without arguments like `php artisan make:mail` by asking about `views` as well.

![CleanShot 2024-07-08 at 15 28 05@2x](https://github.com/laravel/framework/assets/1394539/fa6ddab6-1f11-4a5d-af2e-0cd3a5df826d)



Before, you were only asked about the `name`, and no `view` was created. Since everyone loves to use the new prompts, this will help to create mails with views this way.
