### PR TITLE
[11.x] fix: Route parameter mismatch when passing parameters using php named paramater

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -268,6 +268,8 @@ class RouteRegistrar
      */
     public function __call($method, $parameters)
     {
+        $parameters = array_values($parameters);
+
         if (in_array($method, $this->passthru)) {
             return $this->registerRoute($method, ...$parameters);
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1487,6 +1487,8 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function __call($method, $parameters)
     {
+        $parameters = array_values($parameters);
+
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
         }


### PR DESCRIPTION
When using php 8 named parameters in our routing with Route facade the mentiond bug appears and our routing config is not working as expected...

here is a pr to address this issue for more info see (#52061)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
