### PR TITLE
[11.x] Added @throws docblock for `block` method for `LockTimeoutException`

### DIFF
--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -18,6 +18,8 @@ interface Lock
      * @param  int  $seconds
      * @param  callable|null  $callback
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Cache\LockTimeoutException
      */
     public function block($seconds, $callback = null);
 


### PR DESCRIPTION
<img width="991" alt="image" src="https://github.com/laravel/framework/assets/7753600/11c4149e-afad-4b78-afd1-f638084a495d">
