### PR TITLE
[11.x] Added trusted proxies configuration

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Trusted Proxies
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to customize the load balancers or proxies
+    | that should be trusted by your application.
+    |
+    */
+
+    'proxies' => env('TRUSTEDPROXY_PROXIES'),
+
+];


### PR DESCRIPTION
Hi everyone, this PR exposes and lists the missing configuration value for [trusted proxies](https://laravel.com/docs/11.x/requests#configuring-trusted-proxies) (see [here](https://github.com/laravel/framework/blob/0e9053da9d709c544200260cc0be5e223ea8ff93/src/Illuminate/Http/Middleware/TrustProxies.php#L68)).
In fact, in my opinion, this value is important as it is one of the few "clean" solutions for setting these values ​​(see related issue [here](https://github.com/laravel/framework/issues/51367)).

I also came across a similar closed [PR](https://github.com/laravel/framework/pull/51893), I would like to ask you if it is possible to re-evaluate the consideration in this regard for a moment, I understand the need to keep the framework "light" but, in my opinion, not recording the configuration values ​​used by the framework marks these options logically as "internal" and in the event of changes the risk is the possible generation of breaking changes in addition to the difficulty of tracking the changes (useful in case of bumps between the various versions) and the possibility of configuring the framework itself.

For example, it took me a while to realize that there was a configuration option that could adjust this value (and even @driesvints didn't note this possibility because in my opinion by not recording these values ​​in the configuration you're going to lose a "documentary" part of configuration, unless you do a reverse).

What do you think? Thank you very much.
