### PR TITLE
refactor authorizeResource to use gates

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -80,6 +80,7 @@ trait AuthorizesRequests
      * @param  \Illuminate\Http\Request|null  $request
      * @return void
      */
+
     public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
     {
         $model = is_array($model) ? implode(',', $model) : $model;
@@ -88,16 +89,29 @@ trait AuthorizesRequests
 
         $parameter = $parameter ?: Str::snake(class_basename($model));
 
-        $middleware = [];
+        $request = $request ?: request();
 
-        foreach ($this->resourceAbilityMap() as $method => $ability) {
-            $modelName = in_array($method, $this->resourceMethodsWithoutModels()) ? $model : $parameter;
+        // Getting the current action method from the request
+        $currentMethod = $request->route()->getActionMethod();
 
-            $middleware["can:{$ability},{$modelName}"][] = $method;
+        // Determine if the current method should be processed based on 'only' or 'except' options
+        if (isset($options['only']) && !in_array($currentMethod, (array) $options['only'])) {
+            return; // Skip authorization if not in 'only' list
         }
 
-        foreach ($middleware as $middlewareName => $methods) {
-            $this->middleware($middlewareName, $options)->only($methods);
+        if (isset($options['except']) && in_array($currentMethod, (array) $options['except'])) {
+            return; // Skip authorization if in 'except' list
+        }
+
+        // Get the ability corresponding to the current method
+        $ability = $this->resourceAbilityMap()[$currentMethod] ?? null;
+
+        if ($ability) {
+            // Decide the model or parameter to authorize against
+            $modelName = in_array($currentMethod, $this->resourceMethodsWithoutModels()) ? $model : app($model)->resolveRouteBinding($request->route($parameter));
+
+            // Perform the authorization check
+           app(Gate::class)->authorize($ability, $modelName);
         }
     }
 


### PR DESCRIPTION
Since Laravel 11.x, the `AuthorizesRequests` trait has been removed from the base controller class. Additionally, the base controller class no longer extends `Illuminate\Routing\Controllers\Middleware`.

These changes are crucial because they affect how the `authorizeResource` method functions in controllers. There's been a lot of confusion regarding why `authorizeResource` was removed, even from the documentation.

For reference, see the following discussions:
- [GitHub issue #50673](https://github.com/laravel/framework/issues/50673)
- [GitHub discussion #50552](https://github.com/laravel/framework/discussions/50552)
- [Laracasts discussion on `authorizeResource` alternatives in Laravel 11](https://laracasts.com/discuss/channels/laravel/help-on-authorizeresource-alternative-in-laravel-11)
- [GitHub issue #50566](https://github.com/laravel/framework/issues/50566)

The proposed solutions in the above references suggest a similar approach. However, the problem with this approach is that middleware cannot be defined in controllers as recommended in the documentation [here](https://laravel.com/docs/11.x/controllers#controller-middleware), because the middleware implementation in the controller class will clash with the one in `Illuminate\Routing\Controllers\Middleware`. I suspect this clash is why the method was removed from the documentation and why the use of gates is now promoted.

This commit also embraces the use of gates and eliminates the need to extend `Illuminate\Routing\Controllers\Middleware`.

Users only need to add the Illuminate\Foundation\Auth\Access\AuthorizesRequests trait

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
