### PR TITLE
[11.x] Include ConnectionException in ConnectionFailed events

### DIFF
--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -17,7 +17,7 @@ class ConnectionFailed
     /**
      * The ConnectionException instance
      *
-     * @var \Illuminate\Http\Client\ConnectionException $exception
+     * @var \Illuminate\Http\Client\ConnectionException
      */
     public $exception;
 

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -18,6 +18,7 @@ class ConnectionFailed
      * The ConnectionException instance
      *
      * @var \Illuminate\Http\Client\ConnectionException $exception
+     */
     public $exception;
 
     /**

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Http\Client\Events;
 
 use Illuminate\Http\Client\Request;
-use \Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\ConnectionException;
 
 class ConnectionFailed
 {

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -15,7 +15,7 @@ class ConnectionFailed
     public $request;
 
     /**
-     * The ConnectionException instance.
+     * The exception instance.
      *
      * @var \Illuminate\Http\Client\ConnectionException
      */

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client\Events;
 
 use Illuminate\Http\Client\Request;
+use \Illuminate\Http\Client\ConnectionException;
 
 class ConnectionFailed
 {
@@ -14,13 +15,21 @@ class ConnectionFailed
     public $request;
 
     /**
+     * The ConnectionException instance
+     *
+     * @var \Illuminate\Http\Client\ConnectionException $exception
+    public $exception;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Client\Request  $request
+     * @param  \Illuminate\Http\Client\ConnectionException  $exception
      * @return void
      */
-    public function __construct(Request $request)
+    public function __construct(Request $request, ConnectionException $exception)
     {
         $this->request = $request;
+        $this->exception = $exception;
     }
 }

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -15,7 +15,7 @@ class ConnectionFailed
     public $request;
 
     /**
-     * The ConnectionException instance
+     * The ConnectionException instance.
      *
      * @var \Illuminate\Http\Client\ConnectionException
      */

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -934,9 +934,11 @@ class PendingRequest
                     }
                 });
             } catch (ConnectException $e) {
-                $this->dispatchConnectionFailedEvent(new Request($e->getRequest()));
+                $exception = new ConnectionException($e->getMessage(), 0, $e);
 
-                throw new ConnectionException($e->getMessage(), 0, $e);
+                $this->dispatchConnectionFailedEvent(new Request($e->getRequest()), $exception);
+
+                throw $exception;
             }
         }, $this->retryDelay ?? 100, function ($exception) use (&$shouldRetry) {
             $result = $shouldRetry ?? ($this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $exception, $this) : true);
@@ -1024,9 +1026,11 @@ class PendingRequest
             })
             ->otherwise(function (OutOfBoundsException|TransferException $e) {
                 if ($e instanceof ConnectException) {
-                    $this->dispatchConnectionFailedEvent(new Request($e->getRequest()));
+                    $exception = new ConnectionException($e->getMessage(), 0, $e);
 
-                    return new ConnectionException($e->getMessage(), 0, $e);
+                    $this->dispatchConnectionFailedEvent(new Request($e->getRequest()), $exception);
+
+                    return $exception;
                 }
 
                 return $e instanceof RequestException && $e->hasResponse() ? $this->populateResponse($this->newResponse($e->getResponse())) : $e;
@@ -1492,12 +1496,13 @@ class PendingRequest
      * Dispatch the ConnectionFailed event if a dispatcher is available.
      *
      * @param  \Illuminate\Http\Client\Request  $request
+     * @param  \Illuminate\Http\Client\ConnectionException $exception
      * @return void
      */
-    protected function dispatchConnectionFailedEvent(Request $request)
+    protected function dispatchConnectionFailedEvent(Request $request, ConnectionException $exception)
     {
         if ($dispatcher = $this->factory?->getDispatcher()) {
-            $dispatcher->dispatch(new ConnectionFailed($request));
+            $dispatcher->dispatch(new ConnectionFailed($request, $exception));
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, you receive an event (\Illuminate\Http\Client\Events\ConnectionFailed) if a HTTP Request has hit a timeout of some kind (or some other error), however, the event only has access to the request, which doesn't include any information about the nature of the failure. There is no response that has been received, but we do have an exception (\Illuminate\Http\Client\ConnectionException) that is now being passed.