### PR TITLE
[11.x] Support for multiple `partition by` columns in `groupLimit()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3010,6 +3010,7 @@ class Builder implements BuilderContract
 
         if (isset($this->groupLimit['column'])) {
             foreach ((array) $this->groupLimit['column'] as $i => $column) {
+                $column = last(explode('.', $column));
                 $keysToRemove[] = '@laravel_group'.$i.' := '.$this->grammar->wrap($column);
                 $keysToRemove[] = '@laravel_group'.$i.' := '.$this->grammar->wrap('pivot_'.$column);
             }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2642,7 +2642,7 @@ class Builder implements BuilderContract
      * Add a "group limit" clause to the query.
      *
      * @param  int  $value
-     * @param  string  $column
+     * @param  string|array  $column
      * @return $this
      */
     public function groupLimit($value, $column)
@@ -3008,11 +3008,11 @@ class Builder implements BuilderContract
     {
         $keysToRemove = ['laravel_row'];
 
-        if (is_string($this->groupLimit['column'])) {
-            $column = last(explode('.', $this->groupLimit['column']));
-
-            $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap($column);
-            $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap('pivot_'.$column);
+        if (isset($this->groupLimit['column'])) {
+            foreach ((array) $this->groupLimit['column'] as $i => $column) {
+                $keysToRemove[] = '@laravel_group'.$i.' := '.$this->grammar->wrap($column);
+                $keysToRemove[] = '@laravel_group'.$i.' := '.$this->grammar->wrap('pivot_'.$column);
+            }
         }
 
         $items->each(function ($item) use ($keysToRemove) {

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1027,13 +1027,13 @@ class Grammar extends BaseGrammar
     /**
      * Compile a row number clause.
      *
-     * @param  string  $partition
+     * @param  string|array  $partition
      * @param  string  $orders
      * @return string
      */
     protected function compileRowNumber($partition, $orders)
     {
-        $over = trim('partition by '.$this->wrap($partition).' '.$orders);
+        $over = trim('partition by '.$this->columnize((array) $partition).' '.$orders);
 
         return ', row_number() over ('.$over.') as '.$this->wrap('laravel_row');
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -149,16 +149,18 @@ class MySqlGrammar extends Grammar
         $groupOrders = [];
 
         foreach ($groupColumns as $i => $column) {
-            $groupPartitions[] = '@laravel_group'.$i.' = '.$this->wrap($column);
-
-            $groupSelects[] = '@laravel_group'.$i.' := '.$this->wrap($column);
-
             $groupInitialValues[] = '@laravel_group'.$i.' := 0';
 
             $groupOrders[] = [
                 'column' => $column,
                 'direction' => 'asc',
             ];
+
+            $column = $this->wrap(last(explode('.', $column)));
+
+            $groupPartitions[] = '@laravel_group'.$i.' = '.$column;
+
+            $groupSelects[] = '@laravel_group'.$i.' := '.$column;
         }
 
         $partition = ', @laravel_row := if('.implode(' and ', $groupPartitions).', @laravel_row + 1, 1) as `laravel_row`';

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -316,7 +316,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Compile a row number clause.
      *
-     * @param  string  $partition
+     * @param  string|array  $partition
      * @param  string  $orders
      * @return string
      */

--- a/tests/Integration/Database/EloquentEagerLoadingLimitTest.php
+++ b/tests/Integration/Database/EloquentEagerLoadingLimitTest.php
@@ -85,7 +85,7 @@ class EloquentEagerLoadingLimitTest extends DatabaseTestCase
         $this->assertEquals([3, 2], $users[0]->roles->pluck('id')->all());
         $this->assertEquals([6, 5], $users[1]->roles->pluck('id')->all());
         $this->assertArrayNotHasKey('laravel_row', $users[0]->roles[0]);
-        $this->assertArrayNotHasKey('@laravel_group := `user_id`', $users[0]->roles[0]);
+        $this->assertArrayNotHasKey('@laravel_group0 := `user_id`', $users[0]->roles[0]);
     }
 
     public function testBelongsToManyWithOffset(): void
@@ -107,7 +107,7 @@ class EloquentEagerLoadingLimitTest extends DatabaseTestCase
         $this->assertEquals([3, 2], $users[0]->posts->pluck('id')->all());
         $this->assertEquals([6, 5], $users[1]->posts->pluck('id')->all());
         $this->assertArrayNotHasKey('laravel_row', $users[0]->posts[0]);
-        $this->assertArrayNotHasKey('@laravel_group := `user_id`', $users[0]->posts[0]);
+        $this->assertArrayNotHasKey('@laravel_group0 := `user_id`', $users[0]->posts[0]);
     }
 
     public function testHasManyWithOffset(): void
@@ -129,7 +129,7 @@ class EloquentEagerLoadingLimitTest extends DatabaseTestCase
         $this->assertEquals([3, 2], $users[0]->comments->pluck('id')->all());
         $this->assertEquals([6, 5], $users[1]->comments->pluck('id')->all());
         $this->assertArrayNotHasKey('laravel_row', $users[0]->comments[0]);
-        $this->assertArrayNotHasKey('@laravel_group := `user_id`', $users[0]->comments[0]);
+        $this->assertArrayNotHasKey('@laravel_group0 := `user_id`', $users[0]->comments[0]);
     }
 
     public function testHasManyThroughWithOffset(): void


### PR DESCRIPTION
This PR builds on the "eager loading with limit" functionality introduced in #49695.

It allows `groupLimit()` to accept an array of columns, which will add multiple columns to the `partition by` part of the query. 

This is immediately achieved just by changing from `wrap()` to `columnize()` in `Grammar::compileRowNumber()`. The rest of the changes in this PR are to support the MySQL legacy workaround and of course testing.

### Use Case

The use case for this is to be able to use `groupLimit()` on its own to get a limit of _n_ records from each group, grouped by multiple columns (not just the foreign key in a relationship).

For example, say I want to get the latest address **of each type** for each user:

```php
$addresses = Address::groupLimit(1, ['user_id', 'address_type'])
    ->latest()
    ->get();
```

This generates the following SQL:
```sql
select * from (
    select *, row_number() over (
        partition by `user_id`, `address_type`
        order by `created_at` desc
    ) as `laravel_row`
    from `addresses`
) as `laravel_table`
where `laravel_row` <= 1 order by `laravel_row`
```

### Relationships

You can also use `groupLimit()` in a relationship definition:
```php
class User extends Model
{
    public function latestAddresses(): HasMany
    {
        return $this->hasMany(Address::class)
            ->groupLimit(1, ['user_id', 'address_type'])
            ->latest();
    }
}
```
Or indeed in the original eager-loading scenario:
```php
$users = User::with([
    'addresses' => fn (Builder $query) => $query->groupLimit(1, ['user_id', 'address_type'])->latest(),
])->get();
```
Both of these are similar to `ofMany()` to convert a HasMany relationship into a HasOne. But instead, it will still return multiple records for each parent, but only one from each group (in this example, one of each address type).

### Future State

I had a bit of a think about whether, on the `*Many` relationship classes, Laravel magic could take care of the foreign key and only the additional column(s) would need to be manually specified, i.e. the way `limit()` currently sends `getExistenceCompareKey()`/`getQualifiedFirstKeyName()` to `groupLimit()`.

This could be done either by adding a new optional `$columns` parameter to `limit()` or a new method altogether, but I thought I'd start with the basic change first and work from there.

Let me know if there is any interest in this and any preferences for how best to implement it.