### PR TITLE
[11.x] Allow passing Enum casts to `Rule::enum()->only()` and `->except()`

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
@@ -80,12 +81,12 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Specify the cases that should be considered valid.
      *
-     * @param  \UnitEnum[]|\UnitEnum  $values
+     * @param  \UnitEnum[]|\UnitEnum|\Illuminate\Contracts\Support\Arrayable<array-key, \UnitEnum>  $values
      * @return $this
      */
     public function only($values)
     {
-        $this->only = Arr::wrap($values);
+        $this->only = $values instanceof Arrayable ? $values->toArray() : Arr::wrap($values);
 
         return $this;
     }
@@ -93,12 +94,12 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Specify the cases that should be considered invalid.
      *
-     * @param  \UnitEnum[]|\UnitEnum  $values
+     * @param  \UnitEnum[]|\UnitEnum|\Illuminate\Contracts\Support\Arrayable<array-key, \UnitEnum>  $values
      * @return $this
      */
     public function except($values)
     {
-        $this->except = Arr::wrap($values);
+        $this->except = $values instanceof Arrayable ? $values->toArray() : Arr::wrap($values);
 
         return $this;
     }

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -256,7 +256,6 @@ class ValidationEnumRuleTest extends TestCase
             [IntegerStatus::done, [IntegerStatus::done, IntegerStatus::pending], true],
             [IntegerStatus::done, new ArrayObject([IntegerStatus::done, IntegerStatus::pending]), true],
             [IntegerStatus::done, new Collection([IntegerStatus::done, IntegerStatus::pending]), true],
-            [IntegerStatus::done, [IntegerStatus::done, IntegerStatus::pending], true],
             [IntegerStatus::pending->value, [IntegerStatus::done, IntegerStatus::pending], true],
             [IntegerStatus::done->value, IntegerStatus::pending, false],
         ];

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -3,6 +3,9 @@
 namespace Illuminate\Tests\Validation;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Casts\ArrayObject;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
@@ -101,7 +104,7 @@ class ValidationEnumRuleTest extends TestCase
     #[DataProvider('conditionalCasesDataProvider')]
     public function testValidationPassesWhenOnlyCasesProvided(
         IntegerStatus|int $enum,
-        array|IntegerStatus $only,
+        array|Arrayable|IntegerStatus $only,
         bool $expected
     ) {
         $v = new Validator(
@@ -120,7 +123,7 @@ class ValidationEnumRuleTest extends TestCase
     #[DataProvider('conditionalCasesDataProvider')]
     public function testValidationPassesWhenExceptCasesProvided(
         int|IntegerStatus $enum,
-        array|IntegerStatus $except,
+        array|Arrayable|IntegerStatus $except,
         bool $expected
     ) {
         $v = new Validator(
@@ -250,6 +253,9 @@ class ValidationEnumRuleTest extends TestCase
     {
         return [
             [IntegerStatus::done, IntegerStatus::done, true],
+            [IntegerStatus::done, [IntegerStatus::done, IntegerStatus::pending], true],
+            [IntegerStatus::done, new ArrayObject([IntegerStatus::done, IntegerStatus::pending]), true],
+            [IntegerStatus::done, new Collection([IntegerStatus::done, IntegerStatus::pending]), true],
             [IntegerStatus::done, [IntegerStatus::done, IntegerStatus::pending], true],
             [IntegerStatus::pending->value, [IntegerStatus::done, IntegerStatus::pending], true],
             [IntegerStatus::done->value, IntegerStatus::pending, false],


### PR DESCRIPTION
This PR adds support for passing model properties that use Laravel's built-in `AsEnumArrayObject` and `AsEnumCollection` casts directly into `Rule::enum()->only()` and `Rule::enum()->except()`:

```php
validator([
    'user_type' => $request->input('user_type')
], [
    Rule::enum(UserType::class)->only(
        Tenant::first()->supported_user_types // <-- new in this PR, no need to call ->toArray() here
    ),
]);
```

In that example `UserType` is an enum and the `Tenant` model has this cast:

```php
protected $casts = [
    'supported_user_types' => AsEnumArrayObject::class.':'.UserType::class,
];
```

Right now you can only pass enums or plain arrays to `->only()` and `->except()`, which means if you have a cast model property you have to always call `->toArray()` on it, which is tedious.

The `AsEnumArrayObject` and `AsEnumCollection` casts and `Rule::enum()->only()` feel like they were made to be used together, so this PR makes that experience a bit smoother.