### PR TITLE
[11.x] Dump Postgres migration table from all schemas

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -20,7 +20,14 @@ class PostgresSchemaState extends SchemaState
         ]);
 
         if ($this->hasMigrationTable()) {
-            $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path);
+            $table = $this->migrationTable;
+
+            if (!str_contains($table, '.')) {
+                $searchPath = $connection->getConfig('search_path');
+                $table = (str_contains($searchPath, ',') ? '*' : $searchPath).'.'.$table;
+            }
+
+            $commands->push($this->baseDumpCommand().' -t "'.$table.'" --data-only >> '.$path);
         }
 
         $commands->map(function ($command, $path) {


### PR DESCRIPTION
If a pgsql connection is using a `search_path` other than `public`, the current `schema:dump` command fails because `public.migrations` doesn't exist. `pg_dump` doesn't provide a way to set `search_path`, so just dump the `migrations` table from all schemas instead.