### PR TITLE
[11.x] Fix docblock for \Illuminate\Validation\ClosureValidationRule::message()

### DIFF
--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -72,7 +72,7 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
     /**
      * Get the validation error messages.
      *
-     * @return string
+     * @return array
      */
     public function message()
     {


### PR DESCRIPTION
`\Illuminate\Validation\ClosureValidationRule::message()` returns an array, not a string.

```php
<?php

namespace Illuminate\Validation;

class ClosureValidationRule
{
   /**
     * The validation error messages.
     *
     * @var array
     */
    public $messages = [];

    /**
     * Get the validation error messages.
     *
     * @return array
     */
    public function message()
    {
        return $this->messages;
    }
}
```