### PR TITLE
[11.x] Fix Moving Files in Sorted Order in vendor:publish

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -309,7 +309,7 @@ class VendorPublishCommand extends Command
      */
     protected function moveManagedFiles($from, $manager)
     {
-        foreach ($manager->listContents('from://', true) as $file) {
+        foreach ($manager->listContents('from://', true)->sortByPath() as $file) {
             $path = Str::after($file['path'], 'from://');
 
             if (


### PR DESCRIPTION
This PR addresses an issue where files are not published in the correct order after publishing them. This issue is discussed in [issue #52074](https://github.com/laravel/framework/issues/52074).

To ensure files are published in the correct order, leveraging the `sortByPath()` method introduced in [flysystem PR #1330](https://github.com/thephpleague/flysystem/pull/1330). This method is also utilized in the `Illuminate\Filesystem` for retrieving the file list, as seen [here](https://github.com/laravel/framework/blob/68e88bbcee1e9b0b02ca267916ee25f45ab3935c/src/Illuminate/Filesystem/FilesystemAdapter.php#L814).