### PR TITLE
[11.x] Explicit `id` field when reading session from database

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -94,7 +94,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     public function read($sessionId): string|false
     {
-        $session = (object) $this->getQuery()->find($sessionId);
+        $session = (object) $this->getQuery()->where('id', '=', $sessionId)->first();
 
         if ($this->expired($session)) {
             $this->exists = true;


### PR DESCRIPTION
I would like to fix the database query used by the `DatabaseSessionHandler` in order to make it compatible with a MongoDB connection provided by the package `mongodb/laravel-mongodb`.

The ID field name is hardcoded in the class `DatabaseSessionHandler`, 
https://github.com/laravel/framework/blob/68e88bbcee1e9b0b02ca267916ee25f45ab3935c/src/Illuminate/Session/DatabaseSessionHandler.php#L158
https://github.com/laravel/framework/blob/68e88bbcee1e9b0b02ca267916ee25f45ab3935c/src/Illuminate/Session/DatabaseSessionHandler.php#L173
https://github.com/laravel/framework/blob/68e88bbcee1e9b0b02ca267916ee25f45ab3935c/src/Illuminate/Session/DatabaseSessionHandler.php#L269
But for the read method, the class relies on `Query\Builder::find` implementation:
https://github.com/laravel/framework/blob/68e88bbcee1e9b0b02ca267916ee25f45ab3935c/src/Illuminate/Database/Query/Builder.php#L2899-L2902

MongoDB's default ID field is `_id`, so we overloaded `Query\Builder::find()` in the MongoDB package. The query uses the `_id` field, this is necessary for Eloquent models with MongoDB: https://github.com/mongodb/laravel-mongodb/blob/f654b833d31ec3cac96887e6db61c5fef4f68b4a/src/Query/Builder.php#L228-L231

The issue is that documents are stored by `DatabaseSessionHandler` with the field `id`, but queried with the field `_id`.
I hope this PR can be accepted to fix https://github.com/mongodb/laravel-mongodb/issues/3022.