### PR TITLE
[11.x] Alternative for magic strings when querying relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -33,7 +33,10 @@ use ReflectionMethod;
  */
 class Builder implements BuilderContract
 {
-    /** @use \Illuminate\Database\Concerns\BuildsQueries<TModel> */
+    /**
+     * @use \Illuminate\Database\Concerns\BuildsQueries<TModel>
+     * @use \Illuminate\Database\Eloquent\Concerns\QueriesRelationships<TModel>
+     */
     use BuildsQueries, ForwardsCalls, QueriesRelationships {
         BuildsQueries::sole as baseSole;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -15,13 +15,16 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
-/** @mixin \Illuminate\Database\Eloquent\Builder */
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ * @mixin \Illuminate\Database\Eloquent\Builder<TModel>
+ */
 trait QueriesRelationships
 {
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relations|string  $relation
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
@@ -38,6 +41,10 @@ trait QueriesRelationships
             }
 
             $relation = $this->getRelationWithoutConstraints($relation);
+        } else if ($relation instanceof Closure) {
+            $relation = Relation::noConstraints(function () use ($relation) {
+                return $relation($this->getModel());
+            });
         }
 
         if ($relation instanceof MorphTo) {
@@ -105,7 +112,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -118,7 +125,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @param  string  $boolean
      * @param  \Closure|null  $callback
      * @return $this
@@ -131,7 +138,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @return $this
      */
     public function orDoesntHave($relation)
@@ -142,7 +149,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
@@ -173,7 +180,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
@@ -187,7 +194,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @param  \Closure|null  $callback
      * @return $this
      */
@@ -199,7 +206,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|\Closure(TModel): \Illuminate\Database\Eloquent\Relation|string  $relation
      * @param  \Closure|null  $callback
      * @return $this
      */


### PR DESCRIPTION
Hello, I have been finding myself in a need to build queries that include multiple relationship subqueries, mainly via `whereHas`.

Something I have discovered and which seems to me like a design issue is that it is impossible to consistently avoid using magic strings for the name of the relationship being queried. 
For `BelongsTo` there is the `getRelationName` method and if you actually have the instance of the model you can pass the relation object directly, but these do not nearly cover even a majority of use-cases.

A solution could be the moving of the `getRelationName` (and underlying `$relationName` property) to the base relation name, but this implies a considerable change in the codebase (constructors of the relationship classes would have to be changed, along with all their uses)

Another solution is something like
```php
MyModel::query()
    ->whereHas(
        (new MyModel())->related(),
    );
```
This acutally would "compile" right now, but it produces the unexpected and unwanted result of trying to add constraints from the empty instance of `MyModel`, which I cannot imagine being the intended behaviour in any case.

The best solution I can think of is accepting a `Closure`. So, using something like

```php
MyModel::query()
    ->whereHas(
        fn (MyModel $model) => $model->related()
    );
```
which can be implied to be run in a _no-constraints_ environment (i.e. `Relation::noConstraints` which is actually already used when the relationship is passed by name). This has the advantage of removing the dependency on magic strings for all relations, with the advantage of no breaking changes.