### PR TITLE
[11.x] queue:listen output should be an error when stderr

### DIFF
--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Queue\Listener;
 use Illuminate\Queue\ListenerOptions;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\Process;
 
 #[AsCommand(name: 'queue:listen')]
 class ListenCommand extends Command
@@ -124,7 +125,11 @@ class ListenCommand extends Command
     protected function setOutputHandler(Listener $listener)
     {
         $listener->setOutputHandler(function ($type, $line) {
-            $this->output->write($line);
+            if ($type === Process::ERR) {
+                $this->error($line);
+            } else {
+                $this->output->write($line);
+            }
         });
     }
 }


### PR DESCRIPTION
## Problem
The output of the `queue:listen` command should depend on whether the queue job's output is `stdout` or `stderr`. If it is `stderr`, it should use `$this->error()` to print the message.

## Demo
step 1: write a TestJob
```php
    public function handle(): void
    {
        echo "[2024-07-10 14:32:57] local.INFO: This is stdout\n";
        Log::error('This is stderr'); // use stderr log channel
    }
```

step 2: run TestJob with  `queue:listen` command
<img width="565" alt="Screen Shot 2024-07-10 at 10 48 21 PM" src="https://github.com/laravel/framework/assets/98752059/b8d02e4d-6218-4910-9574-1eb120820a0c">

## Reference
- https://symfony.com/doc/current/components/process.html#getting-real-time-process-output

