### PR TITLE
Add `assertSentTo` shorthand

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -127,11 +127,24 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * Determine if a mailable was not sent based on a truth-test callback.
      *
      * @param  string|\Closure  $mailable
-     * @param  callable|null  $callback
+     * @param  callable|string|array|null  $callback
      * @return void
      */
     public function assertNotSent($mailable, $callback = null)
     {
+        if (is_string($callback) || is_array($callback)) {
+            foreach (Arr::wrap($callback) as $address) {
+                $callback = fn ($mail) => $mail->hasTo($address);
+
+                PHPUnit::assertCount(
+                    0, $this->sent($mailable, $callback),
+                    "The unexpected [{$mailable}] mailable was sent to address [{$address}]."
+                );
+            }
+
+            return;
+        }
+
         [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
 
         PHPUnit::assertCount(
@@ -220,11 +233,24 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * Determine if a mailable was not queued based on a truth-test callback.
      *
      * @param  string|\Closure  $mailable
-     * @param  callable|null  $callback
+     * @param  callable|string|array|null  $callback
      * @return void
      */
     public function assertNotQueued($mailable, $callback = null)
     {
+        if (is_string($callback) || is_array($callback)) {
+            foreach (Arr::wrap($callback) as $address) {
+                $callback = fn ($mail) => $mail->hasTo($address);
+
+                PHPUnit::assertCount(
+                    0, $this->queued($mailable, $callback),
+                    "The unexpected [{$mailable}] mailable was queued to address [{$address}]."
+                );
+            }
+
+            return;
+        }
+
         [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
 
         PHPUnit::assertCount(

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\MailManager;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -81,6 +82,31 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             $this->sent($mailable, $callback)->count() > 0,
             $message
         );
+    }
+
+    /**
+     * Assert if a mailable was sent to an address.
+     *
+     * @param  string  $mailable
+     * @param  string|array  $address
+     * @return void
+     */
+    public function assertSentTo($mailable, $addresses)
+    {
+        foreach (Arr::wrap($addresses) as $address) {
+            $callback = fn (Mailable $mail) => $mail->hasTo($address);
+
+            $message = "The expected [{$mailable}] mailable was not sent to address [{$address}].";
+
+            if (count($this->queuedMailables) > 0) {
+                $message .= ' Did you mean to use assertQueuedTo() instead?';
+            }
+
+            PHPUnit::assertTrue(
+                $this->sent($mailable, $callback)->count() > 0,
+                $message
+            );
+        }
     }
 
     /**
@@ -174,6 +200,25 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
             $this->queued($mailable, $callback)->count() > 0,
             "The expected [{$mailable}] mailable was not queued."
         );
+    }
+
+    /**
+     * Assert if a mailable was queued to an address.
+     *
+     * @param  string  $mailable
+     * @param  string|array  $address
+     * @return void
+     */
+    public function assertQueuedTo($mailable, $addresses)
+    {
+        foreach (Arr::wrap($addresses) as $address) {
+            $callback = fn (Mailable $mail) => $mail->hasTo($address);
+
+            PHPUnit::assertTrue(
+                $this->queued($mailable, $callback)->count() > 0,
+                "The expected [{$mailable}] mailable was not queued to address [{$address}]."
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -94,7 +94,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertSentTo($mailable, $addresses)
     {
         foreach (Arr::wrap($addresses) as $address) {
-            $callback = fn (Mailable $mail) => $mail->hasTo($address);
+            $callback = fn ($mail) => $mail->hasTo($address);
 
             $message = "The expected [{$mailable}] mailable was not sent to address [{$address}].";
 
@@ -212,7 +212,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertQueuedTo($mailable, $addresses)
     {
         foreach (Arr::wrap($addresses) as $address) {
-            $callback = fn (Mailable $mail) => $mail->hasTo($address);
+            $callback = fn ($mail) => $mail->hasTo($address);
 
             PHPUnit::assertTrue(
                 $this->queued($mailable, $callback)->count() > 0,

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -53,7 +53,7 @@ class SupportTestingMailFakeTest extends TestCase
     public function testAssertSentTo()
     {
         try {
-            $this->fake->assertSentTo(MailableStub::class, 'taylor@laravel.com');
+            $this->fake->assertSent(MailableStub::class, 'taylor@laravel.com');
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent to address [taylor@laravel.com].', $e->getMessage());
@@ -61,7 +61,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->fake->assertSentTo(MailableStub::class, 'taylor@laravel.com');
+        $this->fake->assertSent(MailableStub::class, 'taylor@laravel.com');
     }
 
     public function testAssertSentToMultiple()
@@ -72,7 +72,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to(['nuno@laravel.com', 'jess@laravel.com'])->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class, 3);
-        $this->fake->assertSentTo(
+        $this->fake->assertSent(
             MailableStub::class,
             ['taylor@laravel.com', 'dries@laravel.com', 'nuno@laravel.com', 'jess@laravel.com']
         );
@@ -193,7 +193,7 @@ class SupportTestingMailFakeTest extends TestCase
     public function testAssertQueuedTo()
     {
         try {
-            $this->fake->assertQueuedTo(MailableStub::class, 'taylor@laravel.com');
+            $this->fake->assertQueued(MailableStub::class, 'taylor@laravel.com');
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued to address [taylor@laravel.com].', $e->getMessage());
@@ -201,7 +201,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
-        $this->fake->assertQueuedTo(MailableStub::class, 'taylor@laravel.com');
+        $this->fake->assertQueued(MailableStub::class, 'taylor@laravel.com');
     }
 
     public function testAssertQueuedToMultiple()
@@ -212,7 +212,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to(['nuno@laravel.com', 'jess@laravel.com'])->queue($this->mailable);
 
         $this->fake->assertQueued(MailableStub::class, 3);
-        $this->fake->assertQueuedTo(
+        $this->fake->assertQueued(
             MailableStub::class,
             ['taylor@laravel.com', 'dries@laravel.com', 'nuno@laravel.com', 'jess@laravel.com']
         );

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -146,6 +146,30 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->assertNotSent($callback);
     }
 
+    public function testAssertNotSentWithString()
+    {
+        $this->fake->assertNotSent(MailableStub::class, 'taylor@laravel.com');
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was sent to address [taylor@laravel.com].');
+
+        $this->fake->assertNotSent(MailableStub::class, 'taylor@laravel.com');
+    }
+
+    public function testAssertNotSentWithArray()
+    {
+        $this->fake->assertNotSent(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
+
+        $this->fake->to('dries@laravel.com')->send($this->mailable);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was sent to address [dries@laravel.com].');
+
+        $this->fake->assertNotSent(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
+    }
+
     public function testAssertSentTimes()
     {
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
@@ -231,6 +255,30 @@ class SupportTestingMailFakeTest extends TestCase
         }
 
         $this->fake->assertQueued(MailableStub::class, 2);
+    }
+
+    public function testAssertNotQueuedWithString()
+    {
+        $this->fake->assertNotQueued(MailableStub::class, 'taylor@laravel.com');
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was queued to address [taylor@laravel.com].');
+
+        $this->fake->assertNotQueued(MailableStub::class, 'taylor@laravel.com');
+    }
+
+    public function testAssertNotQueuedWithArray()
+    {
+        $this->fake->assertNotQueued(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
+
+        $this->fake->to('dries@laravel.com')->queue($this->mailable);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The unexpected ['.MailableStub::class.'] mailable was queued to address [dries@laravel.com].');
+
+        $this->fake->assertNotQueued(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
     }
 
     public function testAssertQueuedCount()

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -50,6 +50,28 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->assertSent(MailableStub::class);
     }
 
+    public function testAssertSentTo()
+    {
+        try {
+            $this->fake->assertSentTo(MailableStub::class, 'taylor@laravel.com');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent to address [taylor@laravel.com].', $e->getMessage());
+        }
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSentTo(MailableStub::class, 'taylor@laravel.com');
+    }
+
+    public function testAssertSentToMultiple()
+    {
+        $this->fake->to('dries@laravel.com')->send($this->mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSentTo(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
+    }
+
     public function testAssertSentWhenRecipientHasPreferredLocale()
     {
         $user = new LocalizedRecipientStub;
@@ -160,6 +182,28 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
         $this->fake->assertQueued(MailableStub::class);
+    }
+
+    public function testAssertQueuedTo()
+    {
+        try {
+            $this->fake->assertQueuedTo(MailableStub::class, 'taylor@laravel.com');
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued to address [taylor@laravel.com].', $e->getMessage());
+        }
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueuedTo(MailableStub::class, 'taylor@laravel.com');
+    }
+
+    public function testAssertQueuedToMultiple()
+    {
+        $this->fake->to('dries@laravel.com')->queue($this->mailable);
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueuedTo(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
     }
 
     public function testAssertQueuedTimes()

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -69,7 +69,13 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('dries@laravel.com')->send($this->mailable);
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->fake->assertSentTo(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
+        $this->fake->to(['nuno@laravel.com', 'jess@laravel.com'])->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, 3);
+        $this->fake->assertSentTo(
+            MailableStub::class,
+            ['taylor@laravel.com', 'dries@laravel.com', 'nuno@laravel.com', 'jess@laravel.com']
+        );
     }
 
     public function testAssertSentWhenRecipientHasPreferredLocale()
@@ -203,7 +209,13 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('dries@laravel.com')->queue($this->mailable);
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
-        $this->fake->assertQueuedTo(MailableStub::class, ['taylor@laravel.com', 'dries@laravel.com']);
+        $this->fake->to(['nuno@laravel.com', 'jess@laravel.com'])->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, 3);
+        $this->fake->assertQueuedTo(
+            MailableStub::class,
+            ['taylor@laravel.com', 'dries@laravel.com', 'nuno@laravel.com', 'jess@laravel.com']
+        );
     }
 
     public function testAssertQueuedTimes()


### PR DESCRIPTION
An easy, but strong assertion when testing mail is to assert that a particular _mailable_ was sent to a specific email address.

Currently to do this, you need to write out this logic and wrap it in a closure. The following is as trim as you can get:

```php
Mail::assertSent(MeetingMinutes::class, fn ($mail) => $mail->hasTo($user->email));
```

With this PR, you may now simply write:

```php
Mail::assertSentTo(MeetingMinutes::class, $user->email);
```

In addition, you may also pass an array as the second argument to assert a _mailable_ was sent to multiple users. For example:

```php
Mail::assertSentTo(MeetingMinutes::class, ['taylor@...', 'dries@...', 'jess@...']);
```

An `assertQueuedTo` is included for symmetry.