### PR TITLE
[11.x] Fix expected/actual argument order for test assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -199,8 +199,8 @@ trait InteractsWithDatabase
 
             $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connectionInstance) {
                 $this->assertSame(
-                    $actual,
                     $expected,
+                    $actual,
                     "Expected {$expected} database queries on the [{$connectionInstance->getName()}] connection. {$actual} occurred."
                 );
             });

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -419,7 +419,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             $case->tearDown();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertSame("Expected 3 database queries on the [testing] connection. 4 occurred.\nFailed asserting that 3 is identical to 4.", $e->getMessage());
+            $this->assertSame("Expected 3 database queries on the [testing] connection. 4 occurred.\nFailed asserting that 4 is identical to 3.", $e->getMessage());
         }
 
         $case = new class('foo') extends TestingTestCase

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -392,7 +392,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             $case->tearDown();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertSame("Expected 3 database queries on the [testing] connection. 0 occurred.\nFailed asserting that 3 is identical to 0.", $e->getMessage());
+            $this->assertSame("Expected 3 database queries on the [testing] connection. 0 occurred.\nFailed asserting that 0 is identical to 3.", $e->getMessage());
         }
 
         $case = new class('foo') extends TestingTestCase


### PR DESCRIPTION
Fix expected/actual argument order for test assertion. `$expected` comes before `$actual`.