### PR TITLE
[11.x] fix: dont use web middleware on health endpoint

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -203,7 +203,7 @@ class ApplicationBuilder
             }
 
             if (is_string($health)) {
-                Route::middleware('web')->get($health, function () {
+                Route::get($health, function () {
                     Event::dispatch(new DiagnosingHealth);
 
                     return View::file(__DIR__.'/../resources/health-up.blade.php');


### PR DESCRIPTION
I noticed while doing some kubernetes liveliness and readiness probe stuff that my sessions table was being flilled with `kube-probe` useragents due to hitting the health endpoint every 5 seconds.

After some initial investigations I came to the conclusion that this endpoint doesn't need to be wrapped in the `web` middleware.

This PR removes the middleware. Now my sessions table has about ~17k less new entries every day.