### PR TITLE
[11.x] Support LazyCollection / generators to add jobs to an active Batch

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -179,7 +179,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add jobs to a batch using a lazy collection or generator.
      *
-     * @param LazyCollection|(Closure(): \Generator) $jobs
+     * @param  LazyCollection|(Closure(): \Generator)  $jobs
      * @return self
      */
     public function addLazy($jobs, $chunkSize = 1000)
@@ -196,7 +196,7 @@ class Batch implements Arrayable, JsonSerializable
         [$prepared] = $this->prepareJobs($jobs);
 
         $this->repository->transaction(function () use ($chunkSize, $prepared) {
-            $prepared->chunk($chunkSize)->each(function($chunk) {
+            $prepared->chunk($chunkSize)->each(function ($chunk) {
                 $jobsForChunk = $chunk->all();
 
                 // Calculate the total number of jobs in the chunk, counting chains correctly
@@ -225,13 +225,14 @@ class Batch implements Arrayable, JsonSerializable
      * until the jobs are added to the batch.
      *
      * @template TCollectionType of LazyCollection|Collection
-     * @param TCollectionType $jobs
+     *
+     * @param  TCollectionType  $jobs
      * @return array{0: TCollectionType, 1: int}
      */
     protected function prepareJobs($jobs)
     {
         $count = 0;
-        $prepared = $jobs->map(function($job) use (&$count){
+        $prepared = $jobs->map(function ($job) use (&$count){
             $job = $job instanceof Closure ? CallQueuedClosure::create($job) : $job;
             if (is_array($job)) {
                 $count += count($job);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -201,7 +201,7 @@ class Batch implements Arrayable, JsonSerializable
 
                 // Calculate the total number of jobs in the chunk, counting chains correctly
                 // which have been converted into a collection at this point.
-                $count = array_reduce($jobsForChunk, function($carry, $item) {
+                $count = array_reduce($jobsForChunk, function ($carry, $item) {
                     return $carry + ($item instanceof Collection ? $item->count() : 1);
                 }, 0);
 
@@ -232,7 +232,7 @@ class Batch implements Arrayable, JsonSerializable
     protected function prepareJobs($jobs)
     {
         $count = 0;
-        $prepared = $jobs->map(function ($job) use (&$count){
+        $prepared = $jobs->map(function ($job) use (&$count) {
             $job = $job instanceof Closure ? CallQueuedClosure::create($job) : $job;
             if (is_array($job)) {
                 $count += count($job);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -156,11 +156,15 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add additional jobs to the batch.
      *
-     * @param  \Illuminate\Support\Enumerable|object|array  $jobs
+     * @param  \Illuminate\Support\Enumerable|(Closure(): \Generator)|object|array  $jobs
      * @return self
      */
     public function add($jobs)
     {
+        if ($jobs instanceof LazyCollection || $jobs instanceof \Closure) {
+            return $this->addLazy($jobs);
+        }
+
         [$jobs, $count] = $this->prepareJobs(Collection::wrap($jobs));
 
         $this->repository->transaction(function () use ($jobs, $count) {

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -152,7 +152,7 @@ class BusBatchTest extends TestCase
                 && is_string($args[2]->batchId);
         }), '', 'test-queue');
 
-        $batch = $batch->addLazy(LazyCollection::make(function () use ($job, $secondJob, $thirdJob) {
+        $batch = $batch->add(LazyCollection::make(function () use ($job, $secondJob, $thirdJob) {
             yield $job;
             yield $secondJob;
             yield $thirdJob;

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -121,7 +121,8 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
-    public function test_jobs_can_be_added_lazily_to_the_batch(){
+    public function test_jobs_can_be_added_lazily_to_the_batch()
+    {
         $queue = m::mock(Factory::class);
 
         $batch = $this->createTestBatch($queue);
@@ -151,7 +152,7 @@ class BusBatchTest extends TestCase
                 && is_string($args[2]->batchId);
         }), '', 'test-queue');
 
-        $batch = $batch->addLazy(LazyCollection::make(function() use ($job, $secondJob, $thirdJob) {
+        $batch = $batch->addLazy(LazyCollection::make(function () use ($job, $secondJob, $thirdJob) {
             yield $job;
             yield $secondJob;
             yield $thirdJob;
@@ -163,7 +164,8 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
-    public function test_jobs_can_be_added_lazily_to_the_batch_using_custom_chunk_size(){
+    public function test_jobs_can_be_added_lazily_to_the_batch_using_custom_chunk_size()
+    {
         $queue = m::mock(Factory::class);
 
         $batch = $this->createTestBatch($queue);
@@ -199,7 +201,7 @@ class BusBatchTest extends TestCase
                     && is_string($args[2]->batchId);
             }), '', 'test-queue');
 
-        $batch = $batch->addLazy(LazyCollection::make(function() use ($job, $secondJob, $thirdJob) {
+        $batch = $batch->addLazy(LazyCollection::make(function () use ($job, $secondJob, $thirdJob) {
             yield $job;
             yield $secondJob;
             yield $thirdJob;


### PR DESCRIPTION
This PR implements a new `addLazy` method to add jobs from a LazyCollection or generator to an active, stored `Batch`.

The current implementation of `add` on the `Batch` class converts any `LazyCollection` to a base `Collection` object, which loses the benefit of the generators when adding many jobs to an existing batch.
This bit me in a project where I'm iterating over models on the scale of hundreds of thousands, where it would OOM on me and not throw an exception because of it, leading me on a wild-goose-chase to figure out why that was happening, which led me to this implementation.

The need for a separate method was apparent when doing the counting of jobs that were being added; since the generators are not executed until the actual chunking, references to `$count` are only updated after we've already returned the prepared jobs. Therefore, the count has to be done on each chunk, and then that is used to update the total count.

I tried to split out the common functionality to the `prepareJobs` method, which _could_ handle both types of collections as it stood; the `$count` would just be unused in the lazy version.

The one thing I wasn't entirely sure about was the chunking strategy and transactions; I think it probably makes sense to keep all of the operations inside a single transaction, so that any failure along the way can be rolled back, but I could be convinced that it makes more sense to handle each chunk inside of a transaction.

I looked to see what it would take to be able to just have a generator as part of a pending batch too, but that proved to be a little outside of the range of what I wanted to work on this particular improvement. It would be a welcome addition in the future though if we could provide a lazy collection or generator to `Bus::batch()` or a separate `Bus::batchLazy()` to handle that specific use case.