### PR TITLE
Fire event before query execution

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -7,6 +7,7 @@ use Closure;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryBeforeExecution;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\StatementPrepared;
 use Illuminate\Database\Events\TransactionBeginning;
@@ -395,6 +396,8 @@ class Connection implements ConnectionInterface
      */
     public function select($query, $bindings = [], $useReadPdo = true)
     {
+      $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::SELECT, $bindings, $this));
+
         return $this->run($query, $bindings, function ($query, $bindings) use ($useReadPdo) {
             if ($this->pretending()) {
                 return [];
@@ -521,6 +524,8 @@ class Connection implements ConnectionInterface
      */
     public function insert($query, $bindings = [])
     {
+       $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::INSERT, $bindings, $this));
+
         return $this->statement($query, $bindings);
     }
 
@@ -533,6 +538,8 @@ class Connection implements ConnectionInterface
      */
     public function update($query, $bindings = [])
     {
+        $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::UPDATE, $bindings, $this));
+
         return $this->affectingStatement($query, $bindings);
     }
 
@@ -545,6 +552,8 @@ class Connection implements ConnectionInterface
      */
     public function delete($query, $bindings = [])
     {
+        $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::DELETE, $bindings, $this));
+
         return $this->affectingStatement($query, $bindings);
     }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -396,7 +396,7 @@ class Connection implements ConnectionInterface
      */
     public function select($query, $bindings = [], $useReadPdo = true)
     {
-      $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::SELECT, $bindings, $this));
+        $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::SELECT, $bindings, $this));
 
         return $this->run($query, $bindings, function ($query, $bindings) use ($useReadPdo) {
             if ($this->pretending()) {
@@ -524,7 +524,7 @@ class Connection implements ConnectionInterface
      */
     public function insert($query, $bindings = [])
     {
-       $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::INSERT, $bindings, $this));
+        $this->event(new QueryBeforeExecution($query, QueryBeforeExecution::INSERT, $bindings, $this));
 
         return $this->statement($query, $bindings);
     }

--- a/src/Illuminate/Database/Events/QueryBeforeExecution.php
+++ b/src/Illuminate/Database/Events/QueryBeforeExecution.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class QueryBeforeExecution
+{
+    /**
+     * The SQL query that was executed.
+     *
+     * @var string
+     */
+    public $sql;
+
+    /**
+     * The query verb.
+     *
+     * @var string
+     */
+    public $verb;
+
+    /**
+     * The array of query bindings.
+     *
+     * @var array
+     */
+    public $bindings;
+
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    public $connection;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    const SELECT = 'SELECT';
+    const INSERT = 'INSERT';
+    const UPDATE = 'UPDATE';
+    const DELETE = 'DELETE';
+
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $sql
+     * @param  string  $verb
+     * @param  array  $bindings
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct(&$sql, $verb, $bindings, $connection)
+    {
+        $this->sql = &$sql;
+        $this->verb = $verb;
+        $this->bindings = $bindings;
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+    }
+}

--- a/src/Illuminate/Database/Events/QueryBeforeExecution.php
+++ b/src/Illuminate/Database/Events/QueryBeforeExecution.php
@@ -44,7 +44,6 @@ class QueryBeforeExecution
     const UPDATE = 'UPDATE';
     const DELETE = 'DELETE';
 
-
     /**
      * Create a new event instance.
      *

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Events\QueryBeforeExecution;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
@@ -155,6 +156,31 @@ class DatabaseConnectionTest extends TestCase
         $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn(true);
         $results = $connection->delete('foo', ['bar']);
         $this->assertTrue($results);
+    }
+
+    public function testInsertCallFireEventQueryBeforeExecution()
+    {
+        $connection = $this->getMockConnection(['statement']);
+        $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(QueryBeforeExecution::class));
+
+        $connection->insert('foo', ['bar']);
+    }
+
+    public function testUpdateCallFireEventQueryBeforeExecution()
+    {
+        $connection = $this->getMockConnection(['affectingStatement']);
+        $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(QueryBeforeExecution::class));
+        $connection->update('foo', ['bar']);
+    }
+
+    public function testDeleteCallFireEventQueryBeforeExecution()
+    {
+        $connection = $this->getMockConnection(['affectingStatement']);
+        $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(QueryBeforeExecution::class));
+        $connection->delete('foo', ['bar']);
     }
 
     public function testStatementProperlyCallsPDO()


### PR DESCRIPTION
Ability to listen query before execution.
It's possible to modify the query before execution.


->listen(QueryBeforeExecution::class, function ($event) {
 });
