### PR TITLE
[12.x] Fix chunked queries not honoring user-defined limits and offsets

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -45,9 +45,9 @@ trait BuildsQueries
             // and page numbers, providing precise control over the dataset.
             $offset = (($page - 1) * $count) + (is_null($skip) ? 0 : intval($skip));
 
-            // If a limit is defined, it will serve as the upper bound for chunks.
-            // We'll decrement from the remaining limit with each result chunk,
-            // until it reaches the limit. Otherwise, chunk size is the limit.
+            // If a limit was defined, we'll use that as the upper bound for chunks.
+            // We'll decrement from the remainder limit on every iteration, until
+            // the limit is reached. Otherwise, we use the chunk size as limit.
             $limit = is_null($remaining) ? $count : min($count, intval($remaining));
 
             // Saves a useless database query when the limit is already zero...

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -34,8 +34,8 @@ trait BuildsQueries
         $this->enforceOrderBy();
 
         // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
-        $skip = $this->query->unions ? $this->query->unionOffset : $this->query->offset;
-        $remaining = $this->query->unions ? $this->query->unionLimit : $this->query->limit;
+        $skip = $this->query->getOffset();
+        $remaining = $this->query->getLimit();
 
         $page = 1;
 
@@ -172,8 +172,8 @@ trait BuildsQueries
         $lastId = null;
 
         // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
-        $skip = $this->query->unions ? $this->query->unionOffset : $this->query->offset;
-        $remaining = $this->query->unions ? $this->query->unionLimit : $this->query->limit;
+        $skip = $this->query->getOffset();
+        $remaining = $this->query->getLimit();
 
         $page = 1;
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -34,8 +34,8 @@ trait BuildsQueries
         $this->enforceOrderBy();
 
         // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
-        $skip = $this->query->getOffset();
-        $remaining = $this->query->getLimit();
+        $skip = $this->getOffset();
+        $remaining = $this->getLimit();
 
         $page = 1;
 
@@ -172,8 +172,8 @@ trait BuildsQueries
         $lastId = null;
 
         // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
-        $skip = $this->query->getOffset();
-        $remaining = $this->query->getLimit();
+        $skip = $this->getOffset();
+        $remaining = $this->getLimit();
 
         $page = 1;
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -64,7 +64,7 @@ trait BuildsQueries
             }
 
             // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
-            if (!is_null($remaining)) {
+            if (! is_null($remaining)) {
                 $remaining = max($remaining - $countResults, 0);
             }
 
@@ -211,7 +211,7 @@ trait BuildsQueries
             }
 
             // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
-            if (!is_null($remaining)) {
+            if (! is_null($remaining)) {
                 $remaining = max($remaining - $countResults, 0);
             }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -43,12 +43,12 @@ trait BuildsQueries
             // Calculating the offset while considering any existing query offset
             // ensures user-defined offsets stay independent of the chunk size
             // and page numbers, providing precise control over the dataset.
-            $offset = (($page - 1) * $count) + intval($skip);
+            $offset = (($page - 1) * $count) + $skip;
 
             // If a limit was defined, we'll use that as the upper bound for chunks.
             // We'll decrement from the remainder limit on every iteration, until
             // the limit is reached. Otherwise, we use the chunk size as limit.
-            $limit = is_null($remaining) ? $count : min($count, intval($remaining));
+            $limit = is_null($remaining) ? $count : min($count, $remaining);
 
             // Saves an unnecessary database query when the limit is already zero...
             if ($limit == 0) {
@@ -65,7 +65,7 @@ trait BuildsQueries
 
             // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
             if (!is_null($remaining)) {
-                $remaining = max(intval($remaining) - $countResults, 0);
+                $remaining = max($remaining - $countResults, 0);
             }
 
             // On each chunk result set, we will pass them to the callback and then let the
@@ -188,7 +188,7 @@ trait BuildsQueries
             // If a limit was defined, we'll use that as the upper bound for chunks.
             // We'll decrement from the remainder limit on every iteration, until
             // the limit is reached. Otherwise, we use the chunk size as limit.
-            $limit = is_null($remaining) ? $count : min($count, intval($remaining));
+            $limit = is_null($remaining) ? $count : min($count, $remaining);
 
             // Saves an unnecessary database query when the limit is already zero...
             if ($limit == 0) {
@@ -212,7 +212,7 @@ trait BuildsQueries
 
             // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
             if (!is_null($remaining)) {
-                $remaining = max(intval($remaining) - $countResults, 0);
+                $remaining = max($remaining - $countResults, 0);
             }
 
             // On each chunk result set, we will pass them to the callback and then let the

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -43,7 +43,7 @@ trait BuildsQueries
             // Calculating the offset while considering any existing query offset
             // ensures user-defined offsets stay independent of the chunk size
             // and page numbers, providing precise control over the dataset.
-            $offset = (($page - 1) * $count) + (is_null($skip) ? 0 : intval($skip));
+            $offset = (($page - 1) * $count) + intval($skip);
 
             // If a limit was defined, we'll use that as the upper bound for chunks.
             // We'll decrement from the remainder limit on every iteration, until
@@ -172,6 +172,7 @@ trait BuildsQueries
         $lastId = null;
 
         // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
+        $skip = $this->query->unions ? $this->query->unionOffset : $this->query->offset;
         $remaining = $this->query->unions ? $this->query->unionLimit : $this->query->limit;
 
         $page = 1;
@@ -180,7 +181,7 @@ trait BuildsQueries
             $clone = clone $this;
 
             // Any pre-existing offset should be reset after the first page, since we'll use the $lastId from there...
-            if ($page > 1) {
+            if ($skip && $page > 1) {
                 $clone->offset(0);
             }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -171,24 +171,47 @@ trait BuildsQueries
 
         $lastId = null;
 
+        // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
+        $remaining = $this->query->unions ? $this->query->unionLimit : $this->query->limit;
+
         $page = 1;
 
         do {
             $clone = clone $this;
 
+            // Any pre-existing offset should be reset after the first page, since we'll use the $lastId from there...
+            if ($page > 1) {
+                $clone->offset(0);
+            }
+
+            // If a limit was defined, we'll use that as the upper bound for chunks.
+            // We'll decrement from the remainder limit on every iteration, until
+            // the limit is reached. Otherwise, we use the chunk size as limit.
+            $limit = is_null($remaining) ? $count : min($count, intval($remaining));
+
+            // Saves an unnecessary database query when the limit is already zero...
+            if ($limit == 0) {
+                break;
+            }
+
             // We'll execute the query for the given page and get the results. If there are
             // no results we can just break and return from here. When there are results
             // we will call the callback with the current chunk of these results here.
             if ($descending) {
-                $results = $clone->forPageBeforeId($count, $lastId, $column)->get();
+                $results = $clone->forPageBeforeId($limit, $lastId, $column)->get();
             } else {
-                $results = $clone->forPageAfterId($count, $lastId, $column)->get();
+                $results = $clone->forPageAfterId($limit, $lastId, $column)->get();
             }
 
             $countResults = $results->count();
 
             if ($countResults == 0) {
                 break;
+            }
+
+            // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
+            if (!is_null($remaining)) {
+                $remaining = max(intval($remaining) - $countResults, 0);
             }
 
             // On each chunk result set, we will pass them to the callback and then let the

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -43,7 +43,7 @@ trait BuildsQueries
             // Calculating the offset while considering any existing query offset
             // ensures user-defined offsets stay independent of the chunk size
             // and page numbers, providing precise control over the dataset.
-            $offset = (($page - 1) * $count) + $skip;
+            $offset = (($page - 1) * $count) + intval($skip);
 
             // If a limit was defined, we'll use that as the upper bound for chunks.
             // We'll decrement from the remainder limit on every iteration, until

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -33,18 +33,24 @@ trait BuildsQueries
     {
         $this->enforceOrderBy();
 
+        $remaining = $this->query->unions ? $this->query->unionLimit : $this->query->limit;
+
         $page = 1;
 
         do {
             // We'll execute the query for the given page and get the results. If there are
             // no results we can just break and return from here. When there are results
             // we will call the callback with the current chunk of these results here.
-            $results = $this->forPage($page, $count)->get();
+            $results = $this->forPage($page, is_null($remaining) ? $count : min($count, $remaining))->get();
 
             $countResults = $results->count();
 
             if ($countResults == 0) {
                 break;
+            }
+
+            if (!is_null($remaining)) {
+                $remaining = max($remaining - $countResults, 0);
             }
 
             // On each chunk result set, we will pass them to the callback and then let the

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -33,15 +33,29 @@ trait BuildsQueries
     {
         $this->enforceOrderBy();
 
+        // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
+        $skip = $this->query->unions ? $this->query->unionOffset : $this->query->offset;
         $remaining = $this->query->unions ? $this->query->unionLimit : $this->query->limit;
 
         $page = 1;
 
         do {
-            // We'll execute the query for the given page and get the results. If there are
-            // no results we can just break and return from here. When there are results
-            // we will call the callback with the current chunk of these results here.
-            $results = $this->forPage($page, is_null($remaining) ? $count : min($count, $remaining))->get();
+            // Calculating the offset while considering any existing query offset
+            // ensures user-defined offsets stay independent of the chunk size
+            // and page numbers, providing precise control over the dataset.
+            $offset = (($page - 1) * $count) + (is_null($skip) ? 0 : intval($skip));
+
+            // If a limit is defined, it will serve as the upper bound for chunks.
+            // We'll decrement from the remaining limit with each result chunk,
+            // until it reaches the limit. Otherwise, chunk size is the limit.
+            $limit = is_null($remaining) ? $count : min($count, intval($remaining));
+
+            // Saves a useless database query when the limit is already zero...
+            if ($limit == 0) {
+                break;
+            }
+
+            $results = $this->offset($offset)->limit($limit)->get();
 
             $countResults = $results->count();
 
@@ -49,8 +63,9 @@ trait BuildsQueries
                 break;
             }
 
+            // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
             if (!is_null($remaining)) {
-                $remaining = max($remaining - $countResults, 0);
+                $remaining = max(intval($remaining) - $countResults, 0);
             }
 
             // On each chunk result set, we will pass them to the callback and then let the

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -33,24 +33,16 @@ trait BuildsQueries
     {
         $this->enforceOrderBy();
 
-        // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
         $skip = $this->getOffset();
         $remaining = $this->getLimit();
 
         $page = 1;
 
         do {
-            // Calculating the offset while considering any existing query offset
-            // ensures user-defined offsets stay independent of the chunk size
-            // and page numbers, providing precise control over the dataset.
             $offset = (($page - 1) * $count) + intval($skip);
 
-            // If a limit was defined, we'll use that as the upper bound for chunks.
-            // We'll decrement from the remainder limit on every iteration, until
-            // the limit is reached. Otherwise, we use the chunk size as limit.
             $limit = is_null($remaining) ? $count : min($count, $remaining);
 
-            // Saves an unnecessary database query when the limit is already zero...
             if ($limit == 0) {
                 break;
             }
@@ -63,14 +55,10 @@ trait BuildsQueries
                 break;
             }
 
-            // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
             if (! is_null($remaining)) {
                 $remaining = max($remaining - $countResults, 0);
             }
 
-            // On each chunk result set, we will pass them to the callback and then let the
-            // developer take care of everything within the callback, which allows us to
-            // keep the memory low for spinning through large result sets for working.
             if ($callback($results, $page) === false) {
                 return false;
             }
@@ -166,12 +154,8 @@ trait BuildsQueries
     public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false)
     {
         $column ??= $this->defaultKeyName();
-
         $alias ??= $column;
-
         $lastId = null;
-
-        // Taking into account user-defined limits and offsets (if any) for more precise control over chunks...
         $skip = $this->getOffset();
         $remaining = $this->getLimit();
 
@@ -180,17 +164,12 @@ trait BuildsQueries
         do {
             $clone = clone $this;
 
-            // Any pre-existing offset should be reset after the first page, since we'll use the $lastId from there...
             if ($skip && $page > 1) {
                 $clone->offset(0);
             }
 
-            // If a limit was defined, we'll use that as the upper bound for chunks.
-            // We'll decrement from the remainder limit on every iteration, until
-            // the limit is reached. Otherwise, we use the chunk size as limit.
             $limit = is_null($remaining) ? $count : min($count, $remaining);
 
-            // Saves an unnecessary database query when the limit is already zero...
             if ($limit == 0) {
                 break;
             }
@@ -210,7 +189,6 @@ trait BuildsQueries
                 break;
             }
 
-            // Decrements from the remainder (user-defined limits, if any) on each chunked iteration...
             if (! is_null($remaining)) {
                 $remaining = max($remaining - $countResults, 0);
             }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -50,7 +50,7 @@ trait BuildsQueries
             // the limit is reached. Otherwise, we use the chunk size as limit.
             $limit = is_null($remaining) ? $count : min($count, intval($remaining));
 
-            // Saves a useless database query when the limit is already zero...
+            // Saves an unnecessary database query when the limit is already zero...
             if ($limit == 0) {
                 break;
             }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1023,6 +1023,26 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the "offset" value from the query or null if it's not set.
+     *
+     * @return mixed
+     */
+    public function getOffset()
+    {
+        return $this->query->getOffset();
+    }
+
+    /**
+     * Get the current "limit" value from the query or null if not set.
+     *
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        return $this->query->getLimit();
+    }
+
+    /**
      * Ensure the proper order by required for cursor pagination.
      *
      * @param  bool  $shouldReverse

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1023,26 +1023,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the "offset" value from the query or null if it's not set.
-     *
-     * @return mixed
-     */
-    public function getOffset()
-    {
-        return $this->query->getOffset();
-    }
-
-    /**
-     * Get the current "limit" value from the query or null if not set.
-     *
-     * @return mixed
-     */
-    public function getLimit()
-    {
-        return $this->query->getLimit();
-    }
-
-    /**
      * Ensure the proper order by required for cursor pagination.
      *
      * @param  bool  $shouldReverse
@@ -1880,6 +1860,26 @@ class Builder implements BuilderContract
     public function withoutEagerLoads()
     {
         return $this->setEagerLoads([]);
+    }
+
+    /**
+     * Get the "limit" value from the query or null if it's not set.
+     *
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        return $this->query->getLimit();
+    }
+
+    /**
+     * Get the "offset" value from the query or null if it's not set.
+     *
+     * @return mixed
+     */
+    public function getOffset()
+    {
+        return $this->query->getOffset();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2610,18 +2610,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the "offset" value from the query or null if it's not set.
-     *
-     * @return mixed
-     */
-    public function getOffset()
-    {
-        $value = $this->unions ? $this->unionOffset : $this->offset;
-
-        return ! is_null($value) ? (int) $value : null;
-    }
-
-    /**
      * Alias to set the "limit" value of the query.
      *
      * @param  int  $value
@@ -2647,18 +2635,6 @@ class Builder implements BuilderContract
         }
 
         return $this;
-    }
-
-    /**
-     * Get the current "limit" value from the query or null if not set.
-     *
-     * @return mixed
-     */
-    public function getLimit()
-    {
-        $value = $this->unions ? $this->unionLimit : $this->limit;
-
-        return ! is_null($value) ? (int) $value : null;
     }
 
     /**
@@ -4011,6 +3987,30 @@ class Builder implements BuilderContract
         return isset($this->unions)
             ? collect($this->unions)->pluck('query')
             : collect();
+    }
+
+    /**
+     * Get the "limit" value for the query or null if it's not set.
+     *
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        $value = $this->unions ? $this->unionLimit : $this->limit;
+
+        return ! is_null($value) ? (int) $value : null;
+    }
+
+    /**
+     * Get the "offset" value for the query or null if it's not set.
+     *
+     * @return mixed
+     */
+    public function getOffset()
+    {
+        $value = $this->unions ? $this->unionOffset : $this->offset;
+
+        return ! is_null($value) ? (int) $value : null;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2610,6 +2610,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the "offset" value from the query or null if it's not set.
+     *
+     * @return mixed
+     */
+    public function getOffset()
+    {
+        $value = $this->unions ? $this->unionOffset : $this->offset;
+
+        return !is_null($value) ? (int) $value : null;
+    }
+
+    /**
      * Alias to set the "limit" value of the query.
      *
      * @param  int  $value
@@ -2635,6 +2647,18 @@ class Builder implements BuilderContract
         }
 
         return $this;
+    }
+
+    /**
+     * Get the current "limit" value from the query or null if not set.
+     *
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        $value = $this->unions ? $this->unionLimit : $this->limit;
+
+        return !is_null($value) ? (int) $value : null;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2618,7 +2618,7 @@ class Builder implements BuilderContract
     {
         $value = $this->unions ? $this->unionOffset : $this->offset;
 
-        return !is_null($value) ? (int) $value : null;
+        return ! is_null($value) ? (int) $value : null;
     }
 
     /**
@@ -2658,7 +2658,7 @@ class Builder implements BuilderContract
     {
         $value = $this->unions ? $this->unionLimit : $this->limit;
 
-        return !is_null($value) ? (int) $value : null;
+        return ! is_null($value) ? (int) $value : null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -369,7 +369,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -396,7 +396,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -419,7 +419,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkCanBeStoppedByReturningFalse()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -444,7 +444,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithCountZero()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('getOffset')->once()->andReturn(null);
@@ -460,7 +460,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
@@ -485,7 +485,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
@@ -507,7 +507,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithCountZero()
     {
-        $builder = m::mock(Builder::class . '[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('getOffset')->andReturnNull();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -369,15 +369,19 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
         $chunk2 = new Collection(['foo3', 'foo4']);
         $chunk3 = new Collection([]);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->once()->with(3, 2)->andReturnSelf();
+
+        $builder->shouldReceive('getOffset')->once()->andReturn(null);
+        $builder->shouldReceive('getLimit')->once()->andReturn(null);
+        $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
+        $builder->shouldReceive('offset')->once()->with(2)->andReturnSelf();
+        $builder->shouldReceive('offset')->once()->with(4)->andReturnSelf();
+        $builder->shouldReceive('limit')->times(3)->with(2)->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
         $callbackAssertor = m::mock(stdClass::class);
@@ -392,13 +396,16 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
         $chunk2 = new Collection(['foo3']);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
+        $builder->shouldReceive('getOffset')->once()->andReturn(null);
+        $builder->shouldReceive('getLimit')->once()->andReturn(null);
+        $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
+        $builder->shouldReceive('offset')->once()->with(2)->andReturnSelf();
+        $builder->shouldReceive('limit')->twice()->with(2)->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
         $callbackAssertor = m::mock(stdClass::class);
@@ -412,13 +419,16 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkCanBeStoppedByReturningFalse()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
         $chunk2 = new Collection(['foo3']);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->never()->with(2, 2);
+
+        $builder->shouldReceive('getOffset')->once()->andReturn(null);
+        $builder->shouldReceive('getLimit')->once()->andReturn(null);
+        $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
+        $builder->shouldReceive('limit')->once()->with(2)->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk1);
 
         $callbackAssertor = m::mock(stdClass::class);
@@ -434,29 +444,30 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithCountZero()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,offset,limit,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk = new Collection([]);
-        $builder->shouldReceive('forPage')->once()->with(1, 0)->andReturnSelf();
-        $builder->shouldReceive('get')->times(1)->andReturn($chunk);
+        $builder->shouldReceive('getOffset')->once()->andReturn(null);
+        $builder->shouldReceive('getLimit')->once()->andReturn(null);
+        $builder->shouldReceive('offset')->never();
+        $builder->shouldReceive('limit')->never();
+        $builder->shouldReceive('get')->never();
 
-        $callbackAssertor = m::mock(stdClass::class);
-        $callbackAssertor->shouldReceive('doSomething')->never();
-
-        $builder->chunk(0, function ($results) use ($callbackAssertor) {
-            $callbackAssertor->doSomething($results);
+        $builder->chunk(0, function () {
+            $this->fail('Should not be called.');
         });
     }
 
     public function testChunkPaginatesUsingIdWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
         $chunk3 = new Collection([]);
+        $builder->shouldReceive('getOffset')->andReturnNull();
+        $builder->shouldReceive('getLimit')->andReturnNull();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
@@ -474,11 +485,13 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $chunk2 = new Collection([(object) ['someIdField' => 10]]);
+        $builder->shouldReceive('getOffset')->andReturnNull();
+        $builder->shouldReceive('getLimit')->andReturnNull();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -494,18 +507,19 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithCountZero()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getOffset,getLimit,forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk = new Collection([]);
-        $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
-        $builder->shouldReceive('get')->times(1)->andReturn($chunk);
+        $builder->shouldReceive('getOffset')->andReturnNull();
+        $builder->shouldReceive('getLimit')->andReturnNull();
+        $builder->shouldReceive('forPageAfterId')->never();
+        $builder->shouldReceive('get')->never();
 
         $callbackAssertor = m::mock(stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
-        $builder->chunkById(0, function ($results) use ($callbackAssertor) {
-            $callbackAssertor->doSomething($results);
+        $builder->chunkById(0, function () {
+            $this->fail('Should never be called.');
         }, 'someIdField');
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -679,9 +679,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::query()->orderBy('id', 'asc')->chunk(2, function (Collection $users, $page) use (&$chunks) {
             if ($page == 1) {
+                $this->assertCount(2, $users);
                 $this->assertSame('First', $users[0]->name);
                 $this->assertSame('Second', $users[1]->name);
             } else {
+                $this->assertCount(1, $users);
                 $this->assertSame('Third', $users[0]->name);
             }
 
@@ -701,6 +703,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::query()->orderBy('id', 'asc')->limit(2)->chunk(2, function (Collection $users, $page) use (&$chunks) {
             if ($page == 1) {
+                $this->assertCount(2, $users);
                 $this->assertSame('First', $users[0]->name);
                 $this->assertSame('Second', $users[1]->name);
             } else {
@@ -723,9 +726,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::query()->orderBy('id', 'asc')->limit(10)->chunk(2, function (Collection $users, $page) use (&$chunks) {
             if ($page == 1) {
+                $this->assertCount(2, $users);
                 $this->assertSame('First', $users[0]->name);
                 $this->assertSame('Second', $users[1]->name);
             } elseif ($page === 2) {
+                $this->assertCount(1, $users);
                 $this->assertSame('Third', $users[0]->name);
             } else {
                 $this->fail('Should have had two pages.');
@@ -747,6 +752,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::query()->orderBy('id', 'asc')->offset(1)->chunk(2, function (Collection $users, $page) use (&$chunks) {
             if ($page == 1) {
+                $this->assertCount(2, $users);
                 $this->assertSame('Second', $users[0]->name);
                 $this->assertSame('Third', $users[1]->name);
             } else {
@@ -814,6 +820,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::query()->limit(2)->chunkById(2, function (Collection $users, $page) use (&$chunks) {
             if ($page == 1) {
+                $this->assertCount(2, $users);
                 $this->assertSame('First', $users[0]->name);
                 $this->assertSame('Second', $users[1]->name);
             } else {
@@ -836,6 +843,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::query()->offset(1)->chunkById(2, function (Collection $users, $page) use (&$chunks) {
             if ($page == 1) {
+                $this->assertCount(2, $users);
                 $this->assertSame('Second', $users[0]->name);
                 $this->assertSame('Third', $users[1]->name);
             } else {
@@ -887,9 +895,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $i = 0;
         EloquentTestNonIncrementingSecond::query()->chunkById(2, function (Collection $users) use (&$i) {
             if (! $i) {
+                $this->assertCount(2, $users);
                 $this->assertSame(' First', $users[0]->name);
                 $this->assertSame(' Second', $users[1]->name);
             } else {
+                $this->assertCount(1, $users);
                 $this->assertSame(' Third', $users[0]->name);
             }
             $i++;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -895,11 +895,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $i = 0;
         EloquentTestNonIncrementingSecond::query()->chunkById(2, function (Collection $users) use (&$i) {
             if (! $i) {
-                $this->assertCount(2, $users);
                 $this->assertSame(' First', $users[0]->name);
                 $this->assertSame(' Second', $users[1]->name);
             } else {
-                $this->assertCount(1, $users);
                 $this->assertSame(' Third', $users[0]->name);
             }
             $i++;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -737,6 +737,73 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(2, $chunks);
     }
 
+    public function testChunksWithOffset()
+    {
+        EloquentTestUser::create(['name' => 'First', 'email' => 'first@example.com']);
+        EloquentTestUser::create(['name' => 'Second', 'email' => 'second@example.com']);
+        EloquentTestUser::create(['name' => 'Third', 'email' => 'third@example.com']);
+
+        $chunks = 0;
+
+        EloquentTestUser::query()->orderBy('id', 'asc')->offset(1)->chunk(2, function (Collection $users, $page) use (&$chunks) {
+            if ($page == 1) {
+                $this->assertSame('Second', $users[0]->name);
+                $this->assertSame('Third', $users[1]->name);
+            } else {
+                $this->fail('Should only have had one page.');
+            }
+
+            $chunks++;
+        });
+
+        $this->assertEquals(1, $chunks);
+    }
+
+    public function testChunksWithOffsetWhereMoreThanTotal()
+    {
+        EloquentTestUser::create(['name' => 'First', 'email' => 'first@example.com']);
+        EloquentTestUser::create(['name' => 'Second', 'email' => 'second@example.com']);
+        EloquentTestUser::create(['name' => 'Third', 'email' => 'third@example.com']);
+
+        $chunks = 0;
+
+        EloquentTestUser::query()->orderBy('id', 'asc')->offset(3)->chunk(2, function () use (&$chunks) {
+            $chunks++;
+        });
+
+        $this->assertEquals(0, $chunks);
+    }
+
+    public function testChunksWithLimitsAndOffsets()
+    {
+        EloquentTestUser::create(['name' => 'First', 'email' => 'first@example.com']);
+        EloquentTestUser::create(['name' => 'Second', 'email' => 'second@example.com']);
+        EloquentTestUser::create(['name' => 'Third', 'email' => 'third@example.com']);
+        EloquentTestUser::create(['name' => 'Fourth', 'email' => 'fourth@example.com']);
+        EloquentTestUser::create(['name' => 'Fifth', 'email' => 'fifth@example.com']);
+        EloquentTestUser::create(['name' => 'Sixth', 'email' => 'sixth@example.com']);
+        EloquentTestUser::create(['name' => 'Seventh', 'email' => 'seventh@example.com']);
+
+        $chunks = 0;
+
+        EloquentTestUser::query()->orderBy('id', 'asc')->offset(2)->limit(3)->chunk(2, function (Collection $users, $page) use (&$chunks) {
+            if ($page == 1) {
+                $this->assertCount(2, $users);
+                $this->assertSame('Third', $users[0]->name);
+                $this->assertSame('Fourth', $users[1]->name);
+            } elseif ($page == 2) {
+                $this->assertCount(1, $users);
+                $this->assertSame('Fifth', $users[0]->name);
+            } else {
+                $this->fail('Should only have had two pages.');
+            }
+
+            $chunks++;
+        });
+
+        $this->assertEquals(2, $chunks);
+    }
+
     public function testChunkByIdWithNonIncrementingKey()
     {
         EloquentTestNonIncrementingSecond::create(['name' => ' First']);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4599,9 +4599,13 @@ SQL;
         $chunk1 = collect(['foo1', 'foo2']);
         $chunk2 = collect(['foo3', 'foo4']);
         $chunk3 = collect([]);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->once()->with(3, 2)->andReturnSelf();
+
+        $builder->shouldReceive('getOffset')->once()->andReturnNull();
+        $builder->shouldReceive('getLimit')->once()->andReturnNull();
+        $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
+        $builder->shouldReceive('offset')->once()->with(2)->andReturnSelf();
+        $builder->shouldReceive('offset')->once()->with(4)->andReturnSelf();
+        $builder->shouldReceive('limit')->times(3)->with(2)->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
         $callbackAssertor = m::mock(stdClass::class);
@@ -4621,8 +4625,12 @@ SQL;
 
         $chunk1 = collect(['foo1', 'foo2']);
         $chunk2 = collect(['foo3']);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
+
+        $builder->shouldReceive('getOffset')->once()->andReturnNull();
+        $builder->shouldReceive('getLimit')->once()->andReturnNull();
+        $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
+        $builder->shouldReceive('offset')->once()->with(2)->andReturnSelf();
+        $builder->shouldReceive('limit')->twice()->with(2)->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
         $callbackAssertor = m::mock(stdClass::class);
@@ -4641,8 +4649,10 @@ SQL;
 
         $chunk1 = collect(['foo1', 'foo2']);
         $chunk2 = collect(['foo3']);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('forPage')->never()->with(2, 2);
+        $builder->shouldReceive('getOffset')->once()->andReturnNull();
+        $builder->shouldReceive('getLimit')->once()->andReturnNull();
+        $builder->shouldReceive('offset')->once()->with(0)->andReturnSelf();
+        $builder->shouldReceive('limit')->once()->with(2)->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk1);
 
         $callbackAssertor = m::mock(stdClass::class);
@@ -4661,15 +4671,14 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk = collect([]);
-        $builder->shouldReceive('forPage')->once()->with(1, 0)->andReturnSelf();
-        $builder->shouldReceive('get')->times(1)->andReturn($chunk);
+        $builder->shouldReceive('getOffset')->once()->andReturnNull();
+        $builder->shouldReceive('getLimit')->once()->andReturnNull();
+        $builder->shouldReceive('offset')->never();
+        $builder->shouldReceive('limit')->never();
+        $builder->shouldReceive('get')->never();
 
-        $callbackAssertor = m::mock(stdClass::class);
-        $callbackAssertor->shouldReceive('doSomething')->never();
-
-        $builder->chunk(0, function ($results) use ($callbackAssertor) {
-            $callbackAssertor->doSomething($results);
+        $builder->chunk(0, function () {
+            $this->fail('Should never be called.');
         });
     }
 
@@ -4744,15 +4753,11 @@ SQL;
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk = collect([]);
-        $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
-        $builder->shouldReceive('get')->times(1)->andReturn($chunk);
+        $builder->shouldReceive('forPageAfterId')->never();
+        $builder->shouldReceive('get')->never();
 
-        $callbackAssertor = m::mock(stdClass::class);
-        $callbackAssertor->shouldReceive('doSomething')->never();
-
-        $builder->chunkById(0, function ($results) use ($callbackAssertor) {
-            $callbackAssertor->doSomething($results);
+        $builder->chunkById(0, function () {
+            $this->fail('Should never be called.');
         }, 'someIdField');
     }
 


### PR DESCRIPTION
### Changelog

- **ADDED**: Adds new getter methods for offset and limit to the query builder (`getOffset()` and `getLimit()`)
- **FIXED**: Honor user-defined limits and offsets in `chunk` and `chunkById` queries instead of silently overriding it
- **FIXED**: Any user-defined offset would cause the `chunkById` to silently skip the offset on every iteration (since it doesn't override it)

---

Currently, the `chunk` method ignores any user-defined limits and offsets. The `chunkById` method ignores user-defined limits, but gets tripped up by user-defined offsets (it skips the offset amount of entries on every batch iteration).

This PR ensures that user-defined limits and offsets are honored by chunked methods. For instance:

```php
$survey->emails()
  ->orderBy('id', 'asc')
  ->offset(2)
  ->limit(3)
  ->chunk(2, function (Collection $users, $page) {
    // ...
  });
```

Given there are 7 entries in the database, this query would result in the following chunks distribution:

| Entry ID | Status     | Chunk Page |
| -------- | ---------- | ----------- |
| 1        | `skipped`  | --          |
| 2        | `skipped`  | --          |
| 3        | `included` | 1           |
| 4        | `included` | 1           |
| 5        | `included` | 2           |
| 6        | `skipped`  | --          |
| 7        | `skipped`  | --          |

>[!warning]
>Anyone currently using `chunk` or `chunkById` with limits and offsets (and not testing the behavior, I guess) could be affected by this fix.

### Context

I noticed chunked queries were ignoring user-defined limits while I was working on a legacy application that had a job doing something like this:

```php
$survey->emails()
  ->orderBy('id', 'desc')
  ->limit($plan->remainingSurveysFor($survey))
  ->each(function ($email) {
    dispatch(new SendSurvey($email));
  });
```

As I was covering this with a test like this:

```php
/** @test */
public function only_sends_plan_limit()
{
  Queue::fake();

  $survey = Survey::factory()
    ->has(Email::factory()->times(10))
    ->create();

  (new BroadcastSurveys($survey))->handle((new FakePlan)->withRemainingSurveys($limit = 5));

  Queue::assertPushed(SendSurvey::class, $limit);
}
```

I noticed the test was failing saying that 10 jobs were pushed instead of the expected 5.

I decided to dig in and found out the `each` method calls `chunk` behind the scenes ([here](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Concerns/BuildsQueries.php#L104)), which calls the `forPage()` helper, which [overrides offset and limits](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Query/Builder.php#L2666) for the query.

After some searching, it looks like this was a known issue:

- https://github.com/laravel/ideas/issues/103#issuecomment-371859440
- https://github.com/laravel/framework/pull/9681

A fix hasn't been attempted in a while, so I figured it was about time for another one.

I've tested this patch in the application where I discovered it, and it works.

As I was looking for references in other frameworks, I found out that [Rails' ActiveRecord also honors limits on their batched queries](https://api.rubyonrails.org/v7.1.3.4/classes/ActiveRecord/Batches.html#method-i-find_in_batches):

> Limits are honored, and if present there is no requirement for the batch size: it can be less than, equal to, or greater than the limit.