### PR TITLE
[10.x] Fix PHP_CLI_SERVER_WORKERS warning by suppressing it

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -295,7 +295,7 @@ class ServeCommand extends Command
 
                 $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
                 $this->output->writeln(" <fg=gray>~ {$runTime}s</>");
-            } elseif (str($line)->contains(['Closed without sending a request'])) {
+            } elseif (str($line)->contains(['Closed without sending a request', 'Failed to poll event'])) {
                 // ...
             } elseif (! empty($line)) {
                 $position = strpos($line, '] ');


### PR DESCRIPTION
**Context :**

When using the PHP_CLI_SERVER_WORKERS environment variable with anything but 1, the command `php artisan serve` shows a warning with each HTTP request, sometimes multiple time depending on the value:

`[Thu Jul 11 19:22:57 2024] Failed to poll event.`

This PR remove this warning by applying the same fix as on 11.x (see #50821 )


**Steps to reproduce :**

1. composer create-project laravel/laravel=10 testproject
2. cd testproject
3. PHP_CLI_SERVER_WORKERS=8 php artisan serve
4. go to http://127.0.0.1:8000

**Additional infos :**

- Before v10.40.0, the warning exists but does not show any message, just the date:
`[Thu Jul 11 19:01:20 2024]` 

- The warning come from [PHP itself](https://github.com/php/php-src/blob/master/sapi/cli/php_cli_server.c#L2737) but i did not go as far as compiling PHP myself to investigate further. 

- I assumed if the same fix was merged in 11.x, this PR was enough

This is my first PR on this repository, if you requires anything else please let me know.
