### PR TITLE
Install Laravel Reverb version 1.0 instead of @beta

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -151,7 +151,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         $this->requireComposerPackages($this->option('composer'), [
-            'laravel/reverb:@beta',
+            'laravel/reverb:^1.0',
         ]);
 
         $php = (new PhpExecutableFinder())->find(false) ?: 'php';


### PR DESCRIPTION
When using php artisan install:broadcasting it currently results in composer being told to use `@beta` instead of the tagged version 1.0.0.

Since Reverb isn't considered "beta" anymore in Laravel 11, ideally stable releases should be used for the automated install.