### PR TITLE
[11.x] Fix dumping migrations table with schema or prefixed name

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -74,7 +74,7 @@ class DumpCommand extends Command
         $migrationTable = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;
 
         return $connection->getSchemaState()
-                ->withMigrationTable($connection->getTablePrefix().$migrationTable)
+                ->withMigrationTable($migrationTable)
                 ->handleOutputUsing(function ($type, $buffer) {
                     $this->output->write($buffer);
                 });

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -55,7 +55,7 @@ class MySqlSchemaState extends SchemaState
     protected function appendMigrationData(string $path)
     {
         $process = $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand().' '.$this->migrationTable.' --no-create-info --skip-extended-insert --skip-routines --compact --complete-insert'
+            $this->baseDumpCommand().' '.$this->getMigrationTable().' --no-create-info --skip-extended-insert --skip-routines --compact --complete-insert'
         ), null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -254,7 +254,7 @@ class PostgresBuilder extends Builder
      * @param  string  $reference
      * @return array
      */
-    protected function parseSchemaAndTable($reference)
+    public function parseSchemaAndTable($reference)
     {
         $parts = explode('.', $reference);
 

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -20,7 +20,7 @@ class PostgresSchemaState extends SchemaState
         ]);
 
         if ($this->hasMigrationTable()) {
-            $commands->push($this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path);
+            $commands->push($this->baseDumpCommand().' -t '.$this->getMigrationTable().' --data-only >> '.$path);
         }
 
         $commands->map(function ($command, $path) {
@@ -78,5 +78,17 @@ class PostgresSchemaState extends SchemaState
             'PGPASSWORD' => $config['password'],
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
+    }
+
+    /**
+     * Get the name of the application's migration table.
+     *
+     * @return string
+     */
+    protected function getMigrationTable(): string
+    {
+        [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($this->migrationTable);
+
+        return $schema.'.'.$this->connection->getTablePrefix().$table;
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -52,6 +52,18 @@ class PostgresSchemaState extends SchemaState
     }
 
     /**
+     * Get the name of the application's migration table.
+     *
+     * @return string
+     */
+    protected function getMigrationTable(): string
+    {
+        [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($this->migrationTable);
+
+        return $schema.'.'.$this->connection->getTablePrefix().$table;
+    }
+
+    /**
      * Get the base dump command arguments for PostgreSQL as a string.
      *
      * @return string
@@ -78,17 +90,5 @@ class PostgresSchemaState extends SchemaState
             'PGPASSWORD' => $config['password'],
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
-    }
-
-    /**
-     * Get the name of the application's migration table.
-     *
-     * @return string
-     */
-    protected function getMigrationTable(): string
-    {
-        [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($this->migrationTable);
-
-        return $schema.'.'.$this->connection->getTablePrefix().$table;
     }
 }

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -105,6 +105,16 @@ abstract class SchemaState
     }
 
     /**
+     * Get the name of the application's migration table.
+     *
+     * @return string
+     */
+    protected function getMigrationTable(): string
+    {
+        return $this->connection->getTablePrefix().$this->migrationTable;
+    }
+
+    /**
      * Specify the name of the application's migration table.
      *
      * @param  string  $table
@@ -115,16 +125,6 @@ abstract class SchemaState
         $this->migrationTable = $table;
 
         return $this;
-    }
-
-    /**
-     * Get the name of the application's migration table.
-     *
-     * @return string
-     */
-    protected function getMigrationTable(): string
-    {
-        return $this->connection->getTablePrefix().$this->migrationTable;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -118,6 +118,16 @@ abstract class SchemaState
     }
 
     /**
+     * Get the name of the application's migration table.
+     *
+     * @return string
+     */
+    protected function getMigrationTable(): string
+    {
+        return $this->connection->getTablePrefix().$this->migrationTable;
+    }
+
+    /**
      * Specify the callback that should be used to handle process output.
      *
      * @param  callable  $output

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -42,7 +42,7 @@ class SqliteSchemaState extends SchemaState
     protected function appendMigrationData(string $path)
     {
         with($process = $this->makeProcess(
-            $this->baseCommand().' ".dump \''.$this->migrationTable.'\'"'
+            $this->baseCommand().' ".dump \''.$this->getMigrationTable().'\'"'
         ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));


### PR DESCRIPTION
Alternative to #52076

Dump command uses `hasMigrationTable()` method to determine if the `migrations` table exists before dumping its data, this methods call `Schema::hasTable()` under the hood which handles the table's prefix and schema name on PostgreSQL.

This PR fixes 2 related problems:
1. Makes sure the [migrations table name used on `hasMigrationTable()` is without prefix](https://github.com/laravel/framework/pull/52098/files#diff-370ef1cdb9c1416f8dab85a229fdc513bb05f3f9a673a739f49386be77eda346R104), otherwise the table name will get prefixed twice and not be found.
2. On PostgreSQL, it makes sure that the dump command respects the schema name the same way that `Schema::hasTable()` does; Otherwise we are checking if migrations table exists within the `search_path` and dump it from default schema instead!