### PR TITLE
FIX - Correction of total list count with pagination.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -920,7 +920,7 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = func_num_args() === 5 ? value(func_get_arg(4)) : $this->toBase()->getCountForPagination();
+        $total = func_num_args() === 5 ? value(func_get_arg(4)) : $this->toBase()->getCountForPagination($columns);
 
         $perPage = ($perPage instanceof Closure
             ? $perPage($total)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2887,7 +2887,7 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = func_num_args() === 5 ? value(func_get_arg(4)) : $this->getCountForPagination();
+        $total = func_num_args() === 5 ? value(func_get_arg(4)) : $this->getCountForPagination($columns);
 
         $perPage = $perPage instanceof Closure ? $perPage($total) : $perPage;
 


### PR DESCRIPTION
The situation in which the paginated list was not counted correctly has been corrected, because when there was a distinct() in the query, it did not use this parameter for the total count of items.

The option to enter the column for the correct count in paginate() has now been added.
