### PR TITLE
[11.x] Implement condition helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -531,9 +531,3 @@ if (! function_exists('condition')) {
             : value($value ? $truthy : $falsy, $value);
     }
 }
-
-
-//return bool_to($user->isAdmin());
-//return condition_to($user->isAdmin());
-//return replace_bool($user->isAdmin());
-//return when($user->isAdmin());

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -515,9 +515,9 @@ if (! function_exists('when')) {
      * @template TTruthy of mixed
      * @template TFalsy of mixed
      *
-     * @param bool|(callable(): (bool)) $condition
-     * @param TTruthy|(callable(): (TTruthy)) $truthy
-     * @param TFalsy|(callable(): (TFalsy)) $falsy
+     * @param  bool|(callable(): (bool))  $condition
+     * @param  TTruthy|(callable(): (TTruthy))  $truthy
+     * @param  TFalsy|(callable(): (TFalsy))  $falsy
      * @return TTruthy|TFalsy
      */
     function when($condition, $truthy = null, $falsy = false)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\HigherOrderWhenProxy;
 use Illuminate\Support\Once;
 use Illuminate\Support\Onceable;
 use Illuminate\Support\Optional;
@@ -512,16 +513,27 @@ if (! function_exists('when')) {
     /**
      * Return the given either truthy or falsy value depending on condition.
      *
+     * @template TValue of mixed
      * @template TTruthy of mixed
      * @template TFalsy of mixed
      *
-     * @param  bool|(callable(): (bool))  $condition
-     * @param  TTruthy|(callable(): (TTruthy))  $truthy
-     * @param  TFalsy|(callable(): (TFalsy))  $falsy
+     * @param  TValue  $value
+     * @param  TTruthy|(callable(TValue): (TTruthy))  $truthy
+     * @param  TFalsy|(callable(TValue): (TFalsy))  $falsy
      * @return TTruthy|TFalsy
      */
-    function when($condition, $truthy = null, $falsy = null)
+    function when($value, $truthy = null, $falsy = null)
     {
-        return value(value($condition) ? $truthy : $falsy);
+        $value = value($value);
+
+        return func_num_args() === 1
+            ? (new HigherOrderWhenProxy($value))->condition($value)
+            : value($value ? $truthy : $falsy, $value);
     }
 }
+
+
+//return bool_to($user->isAdmin());
+//return condition_to($user->isAdmin());
+//return replace_bool($user->isAdmin());
+//return when($user->isAdmin());

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -510,7 +510,7 @@ if (! function_exists('with')) {
 
 if (! function_exists('when')) {
     /**
-     * Return the given either truthy or falsy value depending on condition
+     * Return the given either truthy or falsy value depending on condition.
      *
      * @template TTruthy of mixed
      * @template TFalsy of mixed

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -520,7 +520,7 @@ if (! function_exists('when')) {
      * @param  TFalsy|(callable(): (TFalsy))  $falsy
      * @return TTruthy|TFalsy
      */
-    function when($condition, $truthy = true, $falsy = null)
+    function when($condition, $truthy = null, $falsy = null)
     {
         return value(value($condition) ? $truthy : $falsy);
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -507,3 +507,21 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('when')) {
+    /**
+     * Return the given either truthy or falsy value depending on condition
+     *
+     * @template TTruthy of mixed
+     * @template TFalsy of mixed
+     *
+     * @param bool|(callable(): (bool)) $condition
+     * @param TTruthy|(callable(): (TTruthy)) $truthy
+     * @param TFalsy|(callable(): (TFalsy)) $falsy
+     * @return TTruthy|TFalsy
+     */
+    function when($condition, $truthy = null, $falsy = false)
+    {
+        return value(value($condition) ? $truthy : $falsy);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -517,10 +517,10 @@ if (! function_exists('condition')) {
      * @template TTruthy of mixed
      * @template TFalsy of mixed
      *
-     * @param  TValue  $value
+     * @param  TValue|(callable(): (TValue))  $value
      * @param  TTruthy|(callable(TValue): (TTruthy))  $truthy
      * @param  TFalsy|(callable(TValue): (TFalsy))  $falsy
-     * @return TTruthy|TFalsy
+     * @return TTruthy|TFalsy|HigherOrderWhenProxy
      */
     function condition($value, $truthy = null, $falsy = null)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -520,7 +520,7 @@ if (! function_exists('when')) {
      * @param  TFalsy|(callable(): (TFalsy))  $falsy
      * @return TTruthy|TFalsy
      */
-    function when($condition, $truthy = null, $falsy = false)
+    function when($condition, $truthy = true, $falsy = null)
     {
         return value(value($condition) ? $truthy : $falsy);
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -509,7 +509,7 @@ if (! function_exists('with')) {
     }
 }
 
-if (! function_exists('when')) {
+if (! function_exists('condition')) {
     /**
      * Return the given either truthy or falsy value depending on condition.
      *
@@ -522,7 +522,7 @@ if (! function_exists('when')) {
      * @param  TFalsy|(callable(TValue): (TFalsy))  $falsy
      * @return TTruthy|TFalsy
      */
-    function when($value, $truthy = null, $falsy = null)
+    function condition($value, $truthy = null, $falsy = null)
     {
         $value = value($value);
 

--- a/tests/Integration/Generators/JobMakeCommandTest.php
+++ b/tests/Integration/Generators/JobMakeCommandTest.php
@@ -16,9 +16,9 @@ class JobMakeCommandTest extends TestCase
 
         $this->assertFileContains([
             'namespace App\Jobs;',
-            'use Illuminate\Bus\Queueable;',
             'use Illuminate\Contracts\Queue\ShouldQueue;',
             'use Illuminate\Foundation\Bus\Dispatchable;',
+            'use Illuminate\Foundation\Queue\Queueable;',
             'use Illuminate\Queue\InteractsWithQueue;',
             'use Illuminate\Queue\SerializesModels;',
             'class FooCreated implements ShouldQueue',

--- a/tests/Integration/Generators/JobMakeCommandTest.php
+++ b/tests/Integration/Generators/JobMakeCommandTest.php
@@ -22,6 +22,7 @@ class JobMakeCommandTest extends TestCase
             'use Illuminate\Queue\InteractsWithQueue;',
             'use Illuminate\Queue\SerializesModels;',
             'class FooCreated implements ShouldQueue',
+            'use Queueable;',
         ], 'app/Jobs/FooCreated.php');
 
         $this->assertFilenameNotExists('tests/Feature/Jobs/FooCreatedTest.php');
@@ -36,10 +37,12 @@ class JobMakeCommandTest extends TestCase
             'namespace App\Jobs;',
             'use Illuminate\Foundation\Bus\Dispatchable;',
             'class FooCreated',
+            'use Dispatchable;',
         ], 'app/Jobs/FooCreated.php');
 
         $this->assertFileNotContains([
             'use Illuminate\Contracts\Queue\ShouldQueue;',
+            'use Illuminate\Foundation\Queue\Queueable;',
             'use Illuminate\Queue\InteractsWithQueue;',
             'use Illuminate\Queue\SerializesModels;',
         ], 'app/Jobs/FooCreated.php');

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -757,10 +757,12 @@ class SupportHelpersTest extends TestCase
         // Callbacks
         $this->assertSame('true', condition(fn () => $foo, truthy: function ($fooParam) use ($foo) {
             $this->assertSame($foo, $fooParam);
+
             return 'true';
         }));
         $this->assertSame('false', condition(fn () => [], falsy: function ($falsy) {
             $this->assertSame([], $falsy);
+
             return 'false';
         }));
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -731,8 +731,10 @@ class SupportHelpersTest extends TestCase
 
     public function testCondition()
     {
-        $foo = new class {
+        $foo = new class
+        {
             public string $foo = 'foo';
+
             public function bar()
             {
                 return $this->foo.'_bar';
@@ -753,11 +755,11 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('true', condition($foo, 'true', 'false'));
 
         // Callbacks
-        $this->assertSame('true', condition(fn() => $foo, truthy: function ($fooParam) use ($foo) {
+        $this->assertSame('true', condition(fn () => $foo, truthy: function ($fooParam) use ($foo) {
             $this->assertSame($foo, $fooParam);
             return 'true';
         }));
-        $this->assertSame('false', condition(fn() => [], falsy: function ($falsy) use ($foo) {
+        $this->assertSame('false', condition(fn () => [], falsy: function ($falsy) {
             $this->assertSame([], $falsy);
             return 'false';
         }));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -729,6 +729,14 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($mock, tap($mock)->foo());
     }
 
+    #[DataProvider('providesWhenData')]
+    public function testWhen($tests, $commonParameters)
+    {
+        foreach ($tests as [$condition, $expected]) {
+            $this->assertSame($expected, when($condition, ...$commonParameters));
+        }
+    }
+
     public function testThrow()
     {
         $this->expectException(LogicException::class);
@@ -1196,6 +1204,15 @@ class SupportHelpersTest extends TestCase
             ['/%s/', ['a'], '', ''],
             // The internal pointer of this array is not at the beginning
             ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'],
+        ];
+    }
+
+    public static function providesWhenData()
+    {
+        return [
+            [[[true, null], [false, false]], []], // Default truthy and falsy values
+            [[[true, 1], [false, 2]], [1, 2]],    // Custom truthy and falsy values
+            [[[fn () => true, 3], [fn () => false, 4]], [fn () => 3, fn () => 4]], // Callables as a parameters
         ];
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1210,7 +1210,7 @@ class SupportHelpersTest extends TestCase
     public static function providesWhenData()
     {
         return [
-            [[[true, null], [false, false]], []], // Default truthy and falsy values
+            [[[true, true], [false, null]], []], // Default truthy and falsy values
             [[[true, 1], [false, 2]], [1, 2]],    // Custom truthy and falsy values
             [[[fn () => true, 3], [fn () => false, 4]], [fn () => 3, fn () => 4]], // Callables as a parameters
         ];


### PR DESCRIPTION
### Description
Here is a small helper which might be handy when you need an if condition like this:
```php
    if ($user->isAdmin()) {
        return true;
    }

    return null;
```
So now you might do it in one line:
```php
    return condition($user->isAdmin());
```
### Benefits
Yes, I know about ternary operator existence :D, but:

1. IMO it just looks a bit clearer (I personally just don`t really like such ternary conditions)
```php
    return $user->isAdmin() ? null : false;
    -----
    return condition(value: $user->isAdmin(), truthy: null, falsy: false)
``` 
2. You might take advantage of passing a callable for any of parameters for additional logic:
```php
    condition(
        value: fn () => // Some difficult condition
        truthy: fn () => $this->resolveDifficultTruthyValue()
        falsy: fn () => throw new RuntimeException(),
    ) 
```
### Personal comments
This helper does not bring much functionality, it's basically the syntax sugar to improve coding experience (hopefully).
**P.S.** The most recent case when I would personally use it for my project is inside `before` method of Policy.

### Update
1. If only single argument is passed, then HigherOrderWhenProxy is returned
```php
    $test = new class {
        public function sayHi() 
        {
            return 'Hi!';
        }
    };
    
    condition($test)->sayHi();  // Hi!
    condition(fn () => $this->service->resolveTestOrNull())->sayHi();  // Returns "Hi!" if Test was resolved, null otherwise
```
2. Passes the resolved "value" parameter to both "truthy" and "falsy" (if they are callbacks)
```php
    condition(new stdClass(), truthy: fn ($stdClass) => ...);
    condition(fn () => new stdClass(), truthy: fn ($stdClass) => ...);
    condition(null, falsy: fn ($null) => ...);
```
3. Naming of the helper was changed to `condition` instead of `when`