### PR TITLE
Add enum support for enum column schema

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -1108,7 +1109,12 @@ class Blueprint
     public function enum($column, string|array $allowed)
     {
         if (is_string($allowed) && enum_exists($allowed)) {
-            $allowed = array_column($allowed::cases(), 'value');
+            $allowed = array_column(
+                $allowed::cases(),
+                is_subclass_of($allowed, BackedEnum::class)
+                    ? 'value'
+                    : 'name'
+            );
         }
 
         return $this->addColumn('enum', $column, compact('allowed'));

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1102,11 +1102,15 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  string|array  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, string|array $allowed)
     {
+        if (is_string($allowed) && enum_exists($allowed)) {
+            $allowed = array_column($allowed::cases(), 'value');
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 


### PR DESCRIPTION
### Proposal: Introduce a Enum instance shorthand for `enum` columns in migrations

### Problem

Currently, defining an `enum` column in a Laravel migration requires using the `array_column` helper function to extract the enum values from the enum class. This can be verbose and repetitive, especially when working with large enums.

### Proposed Solution

Introduce a shorthand syntax that allows specifying the enum class directly, instead of using the array_column helper. This would make the migration code more concise and easier to read.

### Example

```PHP
// Existing syntax
$table->enum('type', array_column(Type::cases(), 'value'));

// Proposed shorthand syntax
$table->enum('type', Type::class);
```

### Benefits
- Improved code readability: The shorthand syntax is more concise and easier to understand, especially for developers unfamiliar with the `array_column` helper.
- Reduced code duplication: The shorthand syntax eliminates the need to repeat the `array_column` helper call, making the code more maintainable and less error-prone.
- Consistency with other Laravel conventions: Laravel already provides shorthand syntax for defining other column types, such as `timestamps` and `softDeletes`. Introducing a shorthand syntax for enums would maintain consistency with these conventions.

