### PR TITLE
[11.x] Include 'success' console component

### DIFF
--- a/src/Illuminate/Console/View/Components/Line.php
+++ b/src/Illuminate/Console/View/Components/Line.php
@@ -18,6 +18,11 @@ class Line extends Component
             'fgColor' => 'white',
             'title' => 'info',
         ],
+        'success' => [
+            'bgColor' => 'green',
+            'fgColor' => 'white',
+            'title' => 'success',
+        ],
         'warn' => [
             'bgColor' => 'yellow',
             'fgColor' => 'black',
@@ -27,11 +32,6 @@ class Line extends Component
             'bgColor' => 'red',
             'fgColor' => 'white',
             'title' => 'error',
-        ],
-        'success' => [
-            'bgColor' => 'green',
-            'fgColor' => 'white',
-            'title' => 'success',
         ],
     ];
 

--- a/src/Illuminate/Console/View/Components/Line.php
+++ b/src/Illuminate/Console/View/Components/Line.php
@@ -28,6 +28,11 @@ class Line extends Component
             'fgColor' => 'white',
             'title' => 'error',
         ],
+        'success' => [
+            'bgColor' => 'green',
+            'fgColor' => 'white',
+            'title' => 'success',
+        ],
     ];
 
     /**

--- a/src/Illuminate/Console/View/Components/Success.php
+++ b/src/Illuminate/Console/View/Components/Success.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Console\View\Components;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Success extends Component
+{
+    /**
+     * Renders the component using the given arguments.
+     *
+     * @param  string  $string
+     * @param  int  $verbosity
+     * @return void
+     */
+    public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        with(new Line($this->output))->render('success', $string, $verbosity);
+    }
+}

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -43,6 +43,15 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('⇂ php artisan inspire', $output);
     }
 
+    public function testSuccess()
+    {
+        $output = new BufferedOutput();
+
+        with(new Components\Success($output))->render('The application is in the [production] environment');
+
+        $this->assertStringContainsString('SUCCESS  The application is in the [production] environment.', $output->fetch());
+    }
+
     public function testError()
     {
         $output = new BufferedOutput();


### PR DESCRIPTION
**About**
This PR adds a new 'success' component option, adding the ability to show successful outcomes but keeping in-line with the theme of components.

Currently, the best option is the 'info' component which isn't always suitable.

![CleanShot 2024-07-13 at 19 41 42](https://github.com/user-attachments/assets/eb35555f-a208-4d43-b365-c384a17bf01c)

Thanks! 
