### PR TITLE
Enhancing Laravel Schema Definitions with `timestampsWithCurrent` Method for MySQL Timestamps

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1267,6 +1267,19 @@ class Blueprint
     }
 
     /**
+     * Add timestamps with `CURRENT_TIMESTAMP` for `created_at` and updates to `updated_at` (MySQL).
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function timestampsWithCurrent($precision = 0)
+    {
+        $this->timestamp('created_at', $precision)->useCurrent();
+
+        $this->timestamp('updated_at', $precision)->useCurrent()->useCurrentOnUpdate();
+    }
+
+    /**
      * Add creation and update datetime columns to the table.
      *
      * @param  int|null  $precision

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -1097,6 +1097,18 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingTimestampsWithCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsWithCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertSame([
+            'alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP',
+            'alter table `users` add `updated_at` timestamp not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP',
+        ], $statements);
+    }
+
     public function testAddingRememberToken()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1097,6 +1097,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingTimestampsWithCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsWithCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertSame([
+            'alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP',
+            'alter table `users` add `updated_at` timestamp not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP',
+        ], $statements);
+    }
+
     public function testAddingRememberToken()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -887,6 +887,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingTimestampsWithCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsWithCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertSame([
+            'alter table "users" add column "created_at" timestamp(0) without time zone not null default CURRENT_TIMESTAMP',
+            'alter table "users" add column "updated_at" timestamp(0) without time zone not null default CURRENT_TIMESTAMP',
+        ], $statements);
+    }
+
     public function testAddingBinary()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -721,6 +721,18 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingTimestampsWithCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsWithCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertEquals([
+            'alter table "users" add column "created_at" datetime not null default CURRENT_TIMESTAMP',
+            'alter table "users" add column "updated_at" datetime not null default CURRENT_TIMESTAMP',
+        ], $statements);
+    }
+
     public function testAddingRememberToken()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -735,6 +735,18 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingTimestampsWithCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsWithCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertSame([
+            'alter table "users" add "created_at" datetime not null default CURRENT_TIMESTAMP',
+            'alter table "users" add "updated_at" datetime not null default CURRENT_TIMESTAMP',
+        ], $statements);
+    }
+
     public function testAddingRememberToken()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION

The current `timestamps` method adds nullable `created_at` and `updated_at` columns in MySQL. This works when data is saved through the application, but issues arise when adding records directly in MySQL, as `created_at` and `updated_at` values are often forgotten, affecting data order.

To address this, we should use the `useCurrent` method:
```php
$table->timestamp('created_at')->useCurrent();
$table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
```

However, it makes sense to separate this into another method (`timestampsWithCurrent`) to simplify the code. It would look like this:

```php
Schema::create('users', function (Blueprint $table) {
    $table->id();
    $table->string('name');
    $table->string('email')->unique();
    $table->timestamp('email_verified_at')->nullable();
    $table->string('password');
    $table->rememberToken();
    $table->timestampsWithCurrent();
});
```

instead of:

```php
Schema::create('users', function (Blueprint $table) {
    $table->id();
    $table->string('name');
    $table->string('email')->unique();
    $table->timestamp('email_verified_at')->nullable();
    $table->string('password');
    $table->rememberToken();
    $table->timestamp('created_at')->useCurrent();
    $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
});
```
