### PR TITLE
[11.x] Add `toggle` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1183,6 +1183,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Toggle a column's value.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  array  $extra
+     * @return bool
+     */
+    public function toggle($column, array $extra = [])
+    {
+        return $this->toBase()->toggle(
+            $column, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
      * Decrement a column's value by a given amount.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3839,6 +3839,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Toggle a column's value.
+     *
+     * @param  string  $column
+     * @param  array  $extra
+     * @return bool
+     */
+    public function toggle($column, array $extra = [])
+    {
+        return $this->update(array_merge([$column => !$this->value($column)], $extra));
+    }
+
+    /**
      * Increment the given column's values by the given amounts.
      *
      * @param  array<string, float|int|numeric-string>  $columns


### PR DESCRIPTION
This PR helps to toggle the boolean attribute value easily so, lemme demonstrate it in both the old and new version

## Old Version

```PHP
auth()->user()->update(['is_admin' => !auth()->user()->is_admin]);
```

## New Version

```PHP
auth()->user()->toggle('is_admin');
```

Also, you can pass an array of columns to update them with the toggle operation:

```PHP
auth()->user()->toggle('is_admin', ['name' => 'Mahmoud Ramadan']);
```

**If this PR is merged, I will work on a `toggleEach` which accepts an array of columns that need to be toggled.**