### PR TITLE
[11.x] Fix 'pushProcessor method not found on LoggerInterface' error

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -136,9 +136,11 @@ class LogManager implements LoggerInterface
     {
         try {
             return $this->channels[$name] ?? with($this->resolve($name, $config), function ($logger) use ($name) {
-                return $this->channels[$name] = tap($this->tap($name, new Logger($logger, $this->app['events']))
-                    ->withContext($this->sharedContext))
-                    ->pushProcessor(function ($record) {
+                $loggerWithContext = tap($this->tap($name, new Logger($logger, $this->app['events']))
+                        ->withContext($this->sharedContext));
+
+                if (method_exists($logger->getLogger(), 'pushProcessor')) {
+                    $logger->pushProcessor(function ($record) {
                         if (! $this->app->bound(ContextRepository::class)) {
                             return $record;
                         }
@@ -148,6 +150,9 @@ class LogManager implements LoggerInterface
                             ...$this->app[ContextRepository::class]->all(),
                         ]);
                     });
+                }
+
+                return $this->channels[$name] = $loggerWithContext;
             });
         } catch (Throwable $e) {
             return tap($this->createEmergencyLogger(), function ($logger) use ($e) {

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -143,7 +143,7 @@ class LogManager implements LoggerInterface
 
                 if (method_exists($loggerWithContext->getLogger(), 'pushProcessor')) {
                     $loggerWithContext->pushProcessor(function ($record) {
-                        if (!$this->app->bound(ContextRepository::class)) {
+                        if (! $this->app->bound(ContextRepository::class)) {
                             return $record;
                         }
 

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -278,21 +278,6 @@ class Logger implements LoggerInterface
     }
 
     /**
-     * Adds a processor to the stack if the logger is a Monolog logger.
-     *
-     * @param  callable  $processor
-     * @return HandlerInterface|self
-     */
-    public function pushProcessor(callable $processor)
-    {
-        if (method_exists($this->logger, 'pushProcessor')) {
-            return $this->logger->pushProcessor($processor);
-        }
-
-        return $this;
-    }
-
-    /**
      * Get the event dispatcher instance.
      *
      * @return \Illuminate\Contracts\Events\Dispatcher

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -225,7 +225,7 @@ class Logger implements LoggerInterface
      */
     public function listen(Closure $callback)
     {
-        if (!isset($this->dispatcher)) {
+        if (! isset($this->dispatcher)) {
             throw new RuntimeException('Events dispatcher has not been set.');
         }
 

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Traits\Conditionable;
-use Monolog\Handler\HandlerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Traits\Conditionable;
+use Monolog\Handler\HandlerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -224,7 +225,7 @@ class Logger implements LoggerInterface
      */
     public function listen(Closure $callback)
     {
-        if (! isset($this->dispatcher)) {
+        if (!isset($this->dispatcher)) {
             throw new RuntimeException('Events dispatcher has not been set.');
         }
 
@@ -274,6 +275,21 @@ class Logger implements LoggerInterface
     public function getLogger()
     {
         return $this->logger;
+    }
+
+    /**
+     * Adds a processor to the stack if the logger is a Monolog logger.
+     *
+     * @param  callable  $processor
+     * @return HandlerInterface|self
+     */
+    public function pushProcessor(callable $processor)
+    {
+        if (method_exists($this->logger, 'pushProcessor')) {
+            return $this->logger->pushProcessor($processor);
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -19,6 +19,8 @@ use Monolog\Processor\MemoryUsageProcessor;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Monolog\Processor\UidProcessor;
 use Orchestra\Testbench\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
 use ReflectionProperty;
 use RuntimeException;
 
@@ -709,6 +711,28 @@ class LogManagerTest extends TestCase
             '[%datetime%] %channel%.%level_name%: %message% %context% %extra%',
             rtrim($format->getValue($formatter)));
     }
+
+    public function testDriverUsersPsrLoggerManagerReturnsLogger()
+    {
+        // Given
+        $config = $this->app['config'];
+        $config->set('logging.channels.spy', [
+            'driver' => 'spy',
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        $loggerSpy = new LoggerSpy();
+        $manager->extend('spy', fn() => $loggerSpy);
+
+        // When
+        $logger = $manager->channel('spy');
+        $logger->alert("some alert");
+
+        // Then
+        $this->assertCount(1, $loggerSpy->logs);
+        $this->assertEquals("some alert", $loggerSpy->logs[0]['message']);
+    }
 }
 
 class CustomizeFormatter
@@ -720,5 +744,20 @@ class CustomizeFormatter
                 '[%datetime%] %channel%.%level_name%: %message% %context% %extra%'
             ));
         }
+    }
+}
+
+class LoggerSpy implements LoggerInterface
+{
+    use LoggerTrait;
+
+    public array $logs = [];
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
     }
 }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -723,15 +723,15 @@ class LogManagerTest extends TestCase
         $manager = new LogManager($this->app);
 
         $loggerSpy = new LoggerSpy();
-        $manager->extend('spy', fn() => $loggerSpy);
+        $manager->extend('spy', fn () => $loggerSpy);
 
         // When
         $logger = $manager->channel('spy');
-        $logger->alert("some alert");
+        $logger->alert('some alert');
 
         // Then
         $this->assertCount(1, $loggerSpy->logs);
-        $this->assertEquals("some alert", $loggerSpy->logs[0]['message']);
+        $this->assertEquals('some alert', $loggerSpy->logs[0]['message']);
     }
 }
 
@@ -752,6 +752,7 @@ class LoggerSpy implements LoggerInterface
     use LoggerTrait;
 
     public array $logs = [];
+
     public function log($level, \Stringable|string $message, array $context = []): void
     {
         $this->logs[] = [


### PR DESCRIPTION
I came across this trying to unit test a package I'm working on where I want to use a logger spy. Though the only requirement stated is that the logger must be of Psr\Log\LoggerInterface, in practice, the log channel cannot be built.

Due to the change when adding the [Context](https://github.com/laravel/framework/pull/49730/files#diff-2cb2cd03e20cac5ce00693f8d45c99ab0665862e8b2b397943cb70a8c770ad70R141-R149) functionality, there's an implicit dependency that the LoggerInterface used by Logger must have a `pushProcessor()` method (provider by Monolog's ProcessableHandlerInterface).

The alternative approach is to add a method for `Logger@pushProcessor()`.

todo:
- [x] add unit tests