### PR TITLE
[11.x] Adds command to "touch" SQLite database file

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -194,7 +194,10 @@ class MigrateCommand extends BaseCommand implements Isolatable
     protected function createMissingSqliteDatabase($path)
     {
         if ($this->option('force')) {
-            return touch($path);
+            return (bool) $this->call('db:touch', [
+                'connection' => $this->option('database'),
+                '--force' => true
+            ]);
         }
 
         if ($this->option('no-interaction')) {

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -195,7 +195,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     {
         if ($this->option('force')) {
             return (bool) $this->call('db:touch', [
-                'connection' => $this->option('database'),
+                'database' => $this->option('database'),
                 '--force' => true
             ]);
         }

--- a/src/Illuminate/Database/Console/TouchCommand.php
+++ b/src/Illuminate/Database/Console/TouchCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Support\ConfigurationUrlParser;
 use Symfony\Component\Console\Attribute\AsCommand;
 use UnexpectedValueException;
 
-#[AsCommand(name: 'db:sqlite-touch')]
+#[AsCommand(name: 'db:touch')]
 class TouchCommand extends Command
 {
     /**
@@ -15,7 +15,7 @@ class TouchCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'db:sqlite-touch {database? : The SQLite database connection that should be used
+    protected $signature = 'db:touch {database? : The SQLite database connection that should be used
                {--force : Create the directory paths forcefully}
                {--safe : Do not fail if the connection is not SQLite}';
 

--- a/src/Illuminate/Database/Console/TouchCommand.php
+++ b/src/Illuminate/Database/Console/TouchCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\ConfigurationUrlParser;
+use Symfony\Component\Console\Attribute\AsCommand;
+use UnexpectedValueException;
+
+#[AsCommand(name: 'db:sqlite-touch')]
+class TouchCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:sqlite-touch {database? : The SQLite database connection that should be used
+               {--force : Create the directory paths forcefully}
+               {--safe : Do not fail if the connection is not SQLite}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates or touches a new SQLite database file';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $db = $this->argument('database') ?? $this->laravel['config']['database.default'];
+
+        $connection = $this->getConnection($db);
+
+        if ($connection['driver'] !== 'sqlite') {
+            $message = "Database connection [{$db}] is not [sqlite].";
+
+            if ($this->option('safe')) {
+                return $this->line($message. ' Safely exiting as expected.');
+            }
+
+            throw new UnexpectedValueException($message);
+        }
+
+        $file = $connection['database'];
+
+        $this->ensureDirectoryExists($file);
+
+        $this->touch($file);
+
+        $this->line("Database file [$file] touched.");
+    }
+
+    /**
+     * Get the database connection configuration.
+     *
+     * @param  string  $db
+     * @return array
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function getConnection($db)
+    {
+        $connection = $this->laravel['config']["database.connections.$db"];
+
+        if (empty($connection)) {
+            throw new UnexpectedValueException("Invalid database connection [{$db}].");
+        }
+
+        return (new ConfigurationUrlParser)->parseConfiguration($connection);
+    }
+
+    /**
+     * Ensure the directory, where the database file should be, exists in the filesystem.
+     *
+     * @param  string  $file
+     * @return void
+     */
+    protected function ensureDirectoryExists($file)
+    {
+        $dir = pathinfo($file, PATHINFO_DIRNAME);
+
+        if (! is_dir($dir)) {
+            $this->option('force') ? @mkdir($dir, 0755, true) : mkdir($dir, 0755, true);
+        }
+    }
+
+    /**
+     * Touch the database file.
+     *
+     * @param  string  $file
+     * @return void
+     */
+    protected function touch($file)
+    {
+        if (!touch($file)) {
+            throw new UnexpectedValueException("Database file [$file] couldn't be touched.");
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -26,6 +26,7 @@ use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\ShowCommand;
 use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
+use Illuminate\Database\Console\TouchCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
@@ -127,6 +128,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,
         'DbTable' => DatabaseTableCommand::class,
+        'DbTouch' => TouchCommand::class,
         'DbWipe' => WipeCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,


### PR DESCRIPTION
## What??

Adds a command to _touch_ a SQLite database if it doesn't exist.

```shell
php artisan db:touch
```

## Why?

Mainly because three reasons:

- On development/staging/preview, the SQLite database can be automatically created be calling the command on these environment.
- On production, the command can be safely called since it can _fail successfully_ with `--safe`.
- On deployment, the developer must spin up the app to successfully get the configuration and create it from there.

## Options

The `--safe` option doesn't make the command fail if the connection is not SQLite. This means that when deploying an app, the command can remain there since it cannot _touch_ a non-file database like PostgreSQL, MariaDB/MySQL or SQL Server.

The `--force` calls `@mkdir` for _forcefully_ create the directory if it doesn't exist.

## Addendum

The `migrate` call uses `touch($db)`, and replaced it with a call to this command with the `--force` flag just to be consistent.