### PR TITLE
[11.x] Recreates framework storage directory

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageRecreateCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageRecreateCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'storage:framework')]
+#[AsCommand(name: 'storage:recreate')]
 class StorageRecreateCommand extends Command
 {
     /**
@@ -13,7 +13,7 @@ class StorageRecreateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'storage:framework';
+    protected $signature = 'storage:recreate';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/StorageRecreateCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageRecreateCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'storage:framework')]
+class StorageRecreateCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'storage:framework';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Recreates storage directories configured for the application';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        foreach ($this->directories() as $directory) {
+            if (file_exists($directory)) {
+                $this->components->warn("The storage path [$directory] already exists.");
+                continue;
+            }
+
+            $this->laravel->make('files')->ensureDirectoryExists($directory);
+
+            $this->components->info("The storage path [$directory] has been created.");
+        }
+    }
+
+    /**
+     * Get the default storage directories that are configured for the application.
+     *
+     * @return array
+     */
+    protected function directories()
+    {
+        return [
+            $this->laravel->storagePath('framework/cache/data'),
+            $this->laravel->storagePath('framework/sessions'),
+            $this->laravel->storagePath('framework/testings'),
+            $this->laravel->storagePath('framework/views'),
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -76,6 +76,7 @@ use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ScopeMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
+use Illuminate\Foundation\Console\StorageRecreateCommand;
 use Illuminate\Foundation\Console\StorageUnlinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
@@ -167,6 +168,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ShowModel' => ShowModelCommand::class,
         'StorageLink' => StorageLinkCommand::class,
         'StorageUnlink' => StorageUnlinkCommand::class,
+        'StorageRecreate' => StorageRecreateCommand::class,
         'Up' => UpCommand::class,
         'ViewCache' => ViewCacheCommand::class,
         'ViewClear' => ViewClearCommand::class,


### PR DESCRIPTION
## What

This simply recreates the framework storage directories if these are not found. Mainly because when calling `view:clear`, it gives an error because the view path doesn't exist (thanks to using `realpath()` on a missing directory.

```shell
php artisan storage:framework
```

Most of these errors I got in deployment since the `storage` volume is mounted from an empty disk, and creating them is a chore for every deployment regardless of the environment.

The directories created are:

- `framework/cache/data`
- `framework/sessions`
- `framework/testings`
- `framework/views`

I believe that the `logs` directory is created automatically, and the `app/public` is created when using `storage:link`, but anyone can correct me on that (because if these aren't, they need to be added to the list).