### PR TITLE
Add support for view folder index resolution

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -149,12 +149,10 @@ class FileViewFinder implements ViewFinderInterface
     {
         $viewPath = str_replace('.', '/', $name);
 
-        return array_merge([], ...
-            array_map(fn ($extension) => [
-                $viewPath.'.'.$extension,
-                $viewPath.'/index.'.$extension,
-            ], $this->extensions)
-        );
+        return array_merge([], ...array_map(fn ($extension) => [
+            $viewPath.'.'.$extension,
+            $viewPath.'/index.'.$extension,
+        ], $this->extensions));
     }
 
     /**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -147,7 +147,14 @@ class FileViewFinder implements ViewFinderInterface
      */
     protected function getPossibleViewFiles($name)
     {
-        return array_map(fn ($extension) => str_replace('.', '/', $name).'.'.$extension, $this->extensions);
+        $viewPath = str_replace('.', '/', $name);
+
+        return array_merge([], ...
+            array_map(fn ($extension) => [
+                $viewPath.'.'.$extension,
+                $viewPath.'/index.'.$extension,
+            ], $this->extensions)
+        );
     }
 
     /**

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -28,6 +28,7 @@ class ViewFileViewFinderTest extends TestCase
     {
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/foo.php', $finder->find('foo'));
@@ -38,12 +39,25 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addLocation(__DIR__.'/nested');
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.css')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.css')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.html')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.html')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/nested/foo.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/nested/foo.blade.php', $finder->find('foo'));
+    }
+
+    public function testIndexBladeResolutionInFolders()
+    {
+        $finder = $this->getFinder();
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.blade.php')->andReturn(true);
+
+        $this->assertEquals(__DIR__.'/foo/index.blade.php', $finder->find('foo'));
     }
 
     public function testNamespacedBasicFileLoading()
@@ -60,6 +74,7 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addNamespace('foo', __DIR__.'/foo');
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz/index.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/foo/bar/baz.php', $finder->find('foo::bar.baz'));
@@ -70,9 +85,13 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addNamespace('foo', [__DIR__.'/foo', __DIR__.'/bar']);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz/index.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz/index.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.css')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz/index.css')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.html')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz/index.html')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/bar/bar/baz.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));
@@ -84,9 +103,13 @@ class ViewFileViewFinderTest extends TestCase
 
         $finder = $this->getFinder();
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.blade.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.css')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.css')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.html')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/index.html')->andReturn(false);
 
         $finder->find('foo');
     }


### PR DESCRIPTION
Add support to resolve index.blade.php in view folders

### Description
This pull request introduces a new feature that allows Laravel to automatically resolve views where the folder name is used as the view name and resolves to index.blade.php within that folder. For example, calling view('ecommerce.search') will resolve to ecommerce/search/index.blade.php.

### Example Usage
With this change, you can organize your views into folders, and Laravel will automatically resolve the index.blade.php file within those folders. For example:

Calling view('ecommerce.search') will resolve to resources/views/ecommerce/search/index.blade.php.
Calling view('admin.contact_us') will resolve to resources/views/admin/contact_us/index.blade.php.

### Route Resolution Order
Previously, the order was as follows:

ecommerce/search.blade.php
ecommerce/search.php
ecommerce/search.css
ecommerce/search.html
With this change, for each file extension, it will attempt to resolve in the following way:

ecommerce/search.blade.php
ecommerce/search/index.blade.php
ecommerce/search.php
ecommerce/search/index.php
ecommerce/search.css
ecommerce/search/index.css
ecommerce/search.html
ecommerce/search/index.html

### Benefits
Better View Organization: Helps keep views organized by allowing the use of folder names as view names.
Reduced Redundancy: Simplifies the view resolution process by reducing the need to explicitly specify index in view routes.
Backward Compatibility: The existing view resolution behavior does not change if no corresponding folder is found.

### Tests
Unit tests have been added to cover the new functionality.