### PR TITLE
[11.x] Add `toggle` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1198,6 +1198,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Toggle a column's value.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  array  $extra
+     * @return bool
+     */
+    public function toggle($column, array $extra = [])
+    {
+        return $this->toBase()->toggle(
+            $column, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
      * Add the "updated at" column to an array of values.
      *
      * @param  array  $values

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -987,6 +987,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Toggle a column's value.
+     *
+     * @param  string  $column
+     * @param  array  $extra
+     * @return bool
+     */
+    public function toggle($column, array $extra = [])
+    {
+        return $this->setKeysForSaveQuery($this->newModelQuery())->toggle($column, $extra);
+    }
+
+    /**
      * Update the model in the database.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3906,6 +3906,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Toggle a column's value.
+     *
+     * @param  string  $column
+     * @param  array  $extra
+     * @return bool
+     */
+    public function toggle($column, array $extra = [])
+    {
+        $columns[$column] = $this->raw("!{$this->grammar->wrap($column)}");
+
+        return $this->update(array_merge($columns, $extra));
+    }
+
+    /**
      * Delete records from the database.
      *
      * @param  mixed  $id


### PR DESCRIPTION
This PR helps to toggle the boolean attribute value easily so, lemme demonstrate it in both the old and new version

## Old Version

```PHP
auth()->user()->update(['is_admin' => !auth()->user()->is_admin]);
```

## New Version

```PHP
auth()->user()->toggle('is_admin');
```

It's working with the collections too:

```PHP
use App\Models\User;

User::whereIn('id', [1, 2])->get()->each->toggle('is_admin');
```

Also, you can pass an array of columns to update them with the toggle operation:

```PHP
auth()->user()->toggle('is_admin', ['name' => 'Mahmoud Ramadan']);
```

**If this PR is merged, I will work on a `toggleEach` which accepts an array of columns that need to be toggled.**