### PR TITLE
[11.x] Ensure existence of Enums or Enumerations directory when not exist

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -69,6 +69,16 @@ class EnumMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
+        $path = app_path('Enums');
+
+        if (!is_dir($path)) {
+            $path = app_path('Enumerations');
+        }
+
+        if (! $this->files->isDirectory(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0755, true);
+        }
+
         return match (true) {
             is_dir(app_path('Enums')) => $rootNamespace.'\\Enums',
             is_dir(app_path('Enumerations')) => $rootNamespace.'\\Enumerations',


### PR DESCRIPTION
This PR is provided to add a change to the `make:enum` command. Currently, if the '`Enums`' or `'Enumerations`' folders do not exist in the project, this PR ensures that they are created. This allows users to easily generate different enums using this without worrying about the required folders.

Why is this change important?
This change ensures that the enum creation process in Laravel is easier and faster for developers. By creating the required folders automatically, users can easily create the enums they want and use them in their projects, without having to create these folders manually. create it and then the problem will be solved, but it is better to create it automatically at the very beginning.

Of course, the Enums folder is created by default, and the majority use this name.
