### PR TITLE
Fix typo in `<!DOCTYPE>` declaration

### DIFF
--- a/tests/Foundation/fixtures/fake-compiled-view-without-source-map.php
+++ b/tests/Foundation/fixtures/fake-compiled-view-without-source-map.php
@@ -1,4 +1,4 @@
-<<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">

--- a/tests/Foundation/fixtures/fake-compiled-view.php
+++ b/tests/Foundation/fixtures/fake-compiled-view.php
@@ -1,4 +1,4 @@
-<<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
I hope it's really a typo and it wasn't intended that way.