### PR TITLE
[11.x] Fix SQLite schema dumps containing internal `sqlite_*` objects

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -21,9 +21,8 @@ class SqliteSchemaState extends SchemaState
             //
         ]));
 
-        $migrations = collect(preg_split("/\r\n|\n|\r/", $process->getOutput()))->filter(function ($line) {
-            return stripos($line, 'sqlite_sequence') === false &&
-                   strlen($line) > 0;
+        $migrations = collect(preg_split("/\r\n|\n|\r/", $process->getOutput()))->reject(function ($line) {
+            return str_starts_with($line, 'CREATE TABLE sqlite_');
         })->all();
 
         $this->files->put($path, implode(PHP_EOL, $migrations).PHP_EOL);

--- a/tests/Integration/Database/SchemaStateTest.php
+++ b/tests/Integration/Database/SchemaStateTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+
+class SchemaStateTest extends DatabaseTestCase
+{
+    use InteractsWithPublishedFiles;
+
+    protected $files = [
+        'database/schema',
+    ];
+
+    protected function createSqliteDatabase(): void
+    {
+        DB::connection('sqlite')->getSchemaBuilder()->createDatabase(
+            DB::connection('sqlite')->getConfig('database')
+        );
+    }
+
+    public function testSchemaDumpOnSqlite()
+    {
+        if ($this->driver !== 'sqlite') {
+            $this->markTestSkipped('Test requires a SQLite connection.');
+        }
+
+        $connection = DB::connection('sqlite');
+
+        $this->createSqliteDatabase();
+
+        $this->app['files']->ensureDirectoryExists(database_path('schema'));
+
+        $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
+        $connection->statement('CREATE UNIQUE INDEX users_email_unique on users (email);');
+        $connection->statement('INSERT INTO users (email, name) VALUES ("taylor@laravel.com", "Taylor Otwell");');
+        $connection->statement('PRAGMA optimize;');
+
+        $connection->getSchemaState()->dump($connection, database_path('schema/sqlite-schema.sql'));
+
+        $this->assertFileDoesNotContains([
+            'sqlite_sequence',
+            'sqlite_stat1',
+            'sqlite_stat4',
+        ], 'database/schema/sqlite-schema.sql');
+    }
+}

--- a/tests/Integration/Database/SchemaStateTest.php
+++ b/tests/Integration/Database/SchemaStateTest.php
@@ -13,13 +13,6 @@ class SchemaStateTest extends DatabaseTestCase
         'database/schema',
     ];
 
-    protected function createSqliteDatabase(): void
-    {
-        DB::connection('sqlite')->getSchemaBuilder()->createDatabase(
-            DB::connection('sqlite')->getConfig('database')
-        );
-    }
-
     public function testSchemaDumpOnSqlite()
     {
         if ($this->driver !== 'sqlite') {
@@ -27,15 +20,14 @@ class SchemaStateTest extends DatabaseTestCase
         }
 
         $connection = DB::connection('sqlite');
-
-        $this->createSqliteDatabase();
-
-        $this->app['files']->ensureDirectoryExists(database_path('schema'));
+        $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
 
         $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
         $connection->statement('CREATE UNIQUE INDEX users_email_unique on users (email);');
         $connection->statement('INSERT INTO users (email, name) VALUES ("taylor@laravel.com", "Taylor Otwell");');
         $connection->statement('PRAGMA optimize;');
+
+        $this->app['files']->ensureDirectoryExists(database_path('schema'));
 
         $connection->getSchemaState()->dump($connection, database_path('schema/sqlite-schema.sql'));
 


### PR DESCRIPTION
This PR updates the SQLite schema dump to remove all `CREATE TABLE sqlite_*` statements. Laravel already removes `CREATE TABLE sqlite_sequence(...);` if it exists, this PR ensures that we also remove `CREATE TABLE sqlite_stat1(...);`, `CREATE TABLE sqlite_stat4(...);`, etc.

These SQLite [internal schema object](https://www.sqlite.org/fileformat2.html#internal_schema_objects) names are reserved and cannot be created except by SQLite itself, so trying to loading dumps that contain any of these statements will fail. The `sqlite_stat1` and `sqlite_stat4` tables will exist in any SQLite database with data in it that has ever had the `PRAGMA optimize;` command run, which is likely a significant portion of them since it's [recommended](https://www.sqlite.org/pragma.html#pragma_optimize) in the SQLite docs. There may be other tables with reserved names too, like `sqlite_stat2` or `sqlite_autoindex_1`; this PR ensures they are all removed.

Fixes #52131.