### PR TITLE
Fix Blade Loop Variable for Object-Casted Model Properties

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -17,14 +17,12 @@ trait ManagesLoops
     /**
      * Add new loop to the stack.
      *
-     * @param  \Countable|array  $data
+     * @param  \Countable|array|object  $data
      * @return void
      */
     public function addLoop($data)
     {
-        $length = is_countable($data) && ! $data instanceof LazyCollection
-                            ? count($data)
-                            : null;
+        $length = $this->countProperties($data);
 
         $parent = Arr::last($this->loopsStack);
 
@@ -40,6 +38,25 @@ trait ManagesLoops
             'depth' => count($this->loopsStack) + 1,
             'parent' => $parent ? (object) $parent : null,
         ];
+    }
+
+    /**
+     * Count properties of the data.
+     *
+     * @param  \Countable|array|object  $data
+     * @return int|null
+     */
+    private function countProperties($data)
+    {
+        if (is_countable($data) && !$data instanceof LazyCollection) {
+            return count($data);
+        }
+
+        if (is_object($data) && !$data instanceof LazyCollection) {
+            return count(get_object_vars($data));
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
#### Purpose
This pull request enhances the `ManagesLoops` trait in Laravel to support both array and object data structures when iterating in Blade templates using `$loop`.

#### Changes Made
- Added `countProperties` method to accurately count elements for both arrays and objects.
- Updated `addLoop` method to accept `\Countable`, `array`, or `object` for `$data` parameter.
- Ensured compatibility with existing functionality by maintaining support for arrays and extending to objects.

#### Reason for Changes
Previously, the `ManagesLoops` trait exhibited inconsistencies when using Blade directives like `$loop->last` with object-casted model properties. This update resolves these discrepancies, ensuring Laravel applications can utilize Blade's full functionality seamlessly with both array and object data types.