### PR TITLE
[11.x] Test Improvements

### DIFF
--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -1,10 +1,14 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+use Orchestra\Testbench\Factories\UserFactory;
 
+#[WithMigration]
 class SchemaStateTest extends DatabaseTestCase
 {
     use InteractsWithPublishedFiles;
@@ -19,12 +23,9 @@ class SchemaStateTest extends DatabaseTestCase
             $this->markTestSkipped('Test requires a SQLite connection.');
         }
 
-        $connection = DB::connection('sqlite');
-        $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
+        UserFactory::new()->create();
 
-        $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
-        $connection->statement('CREATE UNIQUE INDEX users_email_unique on users (email);');
-        $connection->statement('INSERT INTO users (email, name) VALUES ("taylor@laravel.com", "Taylor Otwell");');
+        $connection = DB::connection();
         $connection->statement('PRAGMA optimize;');
 
         $this->app['files']->ensureDirectoryExists(database_path('schema'));

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -17,6 +17,7 @@ class SchemaStateTest extends DatabaseTestCase
         'database/schema',
     ];
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function testSchemaDumpOnSqlite()
     {
         if ($this->driver !== 'sqlite') {

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -7,6 +7,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\Factories\UserFactory;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[WithMigration]
 class SchemaStateTest extends DatabaseTestCase


### PR DESCRIPTION
While GitHub Actions can install `sqlite3` it still need to be added to Window `PATH` before we can run `schema:dump` on Windows environment:

```
 1) Illuminate\Tests\Integration\Database\Sqlite\SchemaStateTest::testSchemaDumpOnSqlite
Symfony\Component\Process\Exception\ProcessFailedException: The command "sqlite3 "${:LARAVEL_LOAD_DATABASE}" .schema" failed.

Exit Code: 1(General error)

Working directory: D:\a\framework\framework

Output:
================


Error Output:
================
'sqlite3' is not recognized as an internal or external command,
operable program or batch file.
```