### PR TITLE
[11.x] Fix docblock for RoutingServiceProvider

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -130,8 +130,6 @@ class RoutingServiceProvider extends ServiceProvider
      * Register a binding for the PSR-7 request implementation.
      *
      * @return void
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function registerPsrRequest()
     {
@@ -159,8 +157,6 @@ class RoutingServiceProvider extends ServiceProvider
      * Register a binding for the PSR-7 response implementation.
      *
      * @return void
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function registerPsrResponse()
     {


### PR DESCRIPTION
The `registerPsrRequest` and `registerPsrResponse` methods of `RoutingServiceProvider` just register binding resolutions and don't actually throw exceptions.

In Laravel app, it only throws exceptions when someone calls `->make(Psr\Http\Message\ServerRequestInterface::class)` or `->make(Psr\Http\Message\ResponseInterface::class)` without installing the `nyholm/psr7` package,