### PR TITLE
Added the ability to expand form request validation rules

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -59,7 +59,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $errorBag = 'default';
 
     /**
-     * The rules that can be added during the process
+     * The rules that can be added during the process.
      *
      * @var array
      */

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -63,7 +63,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @var array
      */
-    public static array $extraRules = [];
+    protected static array $extraRules = [];
 
     /**
      * Indicates whether validation should stop after the first rule failure.
@@ -151,6 +151,28 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Set extra rules.
+     *
+     * @param  array $newRules
+     * @param  bool $override
+     * @return void
+     */
+    public static function setExtraRules(array $newRules, bool $override = true)
+    {
+        self::$extraRules[static::class] = $override ? $newRules : array_merge(self::getExtraRules(), $newRules);
+    }
+
+    /**
+     * Get extra rules.
+     *
+     * @return array
+     */
+    public static function getExtraRules(): array
+    {
+        return self::$extraRules[static::class] ?? [];
+    }
+
+    /**
      * Get the validation rules for this form request.
      *
      * @return array
@@ -159,7 +181,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
 
-        return array_merge($rules, self::$extraRules);
+        return array_merge($rules, self::getExtraRules());
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -153,8 +153,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Set extra rules.
      *
-     * @param  array $newRules
-     * @param  bool $override
+     * @param  array  $newRules
+     * @param  bool  $override
      * @return void
      */
     public static function setExtraRules(array $newRules, bool $override = true)

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -158,6 +158,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function validationRules()
     {
         $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+
         return array_merge($rules, self::$extraRules);
     }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -59,6 +59,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $errorBag = 'default';
 
     /**
+     * The rules that can be added during the process
+     *
+     * @var array
+     */
+    public static array $extraRules = [];
+
+    /**
      * Indicates whether validation should stop after the first rule failure.
      *
      * @var bool
@@ -150,7 +157,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function validationRules()
     {
-        return method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+        $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+        return array_merge($rules, self::$extraRules);
     }
 
     /**


### PR DESCRIPTION
I think that such a feature is needed, because often there is a need to extend (or redefine) the set of rules for form requests of third-party packages. For example, for Jetstream when there is a desire to add captcha validation.

For example, imagine that we have a class TestFormRequest, with rules **['test' => 'required']**:

```php
TestFormRequest::setExtraRules(['foo' => 'required']); // final rules will ['test' => 'required', 'foo' => 'required]
TestFormRequest::setExtraRules(['bar' => 'required']); // final rules will ['test' => 'required', 'bar' => 'required]
TestFormRequest::setExtraRules(['baz' => 'required'], false); // final rules will ['test' => 'required', 'bar' => 'required, 'baz' => 'required]
```

To get a list of extra rules you just need to call the getExtraRules method.
