### PR TITLE
Add whereLike clause to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1122,6 +1122,71 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        $type = 'Like';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');
+
+        if (method_exists($this->grammar, 'prepareWhereLikeBinding')) {
+            $value = $this->grammar->prepareWhereLikeBinding($value, $caseSensitive);
+        }
+
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereLike($column, $value, $caseSensitive = false)
+    {
+        return $this->whereLike($column, $value, $caseSensitive, 'or', false);
+    }
+
+    /**
+     * Add a "where not like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLike($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereLike($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not like" clause to the query.
+     *
+     * @param  string  $columns
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWhereNotLike($column, $value, $caseSensitive = false)
+    {
+        return $this->whereNotLike($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
      * Add a "where in" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -2168,71 +2233,6 @@ class Builder implements BuilderContract
     public function orWhereFullText($columns, $value, array $options = [])
     {
         return $this->whereFulltext($columns, $value, $options, 'or');
-    }
-
-    /**
-     * Add a "where like" clause to the query.
-     *
-     * @param  string  $column
-     * @param  string  $value
-     * @param  bool  $caseSensitive
-     * @param  string  $boolean
-     * @param  bool  $not
-     * @return $this
-     */
-    public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
-    {
-        $type = 'Like';
-
-        $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');
-
-        if (method_exists($this->grammar, 'prepareWhereLikeBinding')) {
-            $value = $this->grammar->prepareWhereLikeBinding($value, $caseSensitive);
-        }
-
-        $this->addBinding($value);
-
-        return $this;
-    }
-
-    /**
-     * Add an "or where like" clause to the query.
-     *
-     * @param  string  $column
-     * @param  string  $value
-     * @param  bool  $caseSensitive
-     * @return $this
-     */
-    public function orWhereLike($column, $value, $caseSensitive = false)
-    {
-        return $this->whereLike($column, $value, $caseSensitive, 'or', false);
-    }
-
-    /**
-     * Add a "where not like" clause to the query.
-     *
-     * @param  string  $column
-     * @param  string  $value
-     * @param  bool  $caseSensitive
-     * @param  string  $boolean
-     * @return $this
-     */
-    public function whereNotLike($column, $value, $caseSensitive = false, $boolean = 'and')
-    {
-        return $this->whereLike($column, $value, $caseSensitive, $boolean, true);
-    }
-
-    /**
-     * Add an "or where not like" clause to the query.
-     *
-     * @param  string  $columns
-     * @param  string  $value
-     * @param  bool  $caseSensitive
-     * @return $this
-     */
-    public function orWhereNotLike($column, $value, $caseSensitive = false)
-    {
-        return $this->whereNotLike($column, $value, $caseSensitive, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2170,6 +2170,69 @@ class Builder implements BuilderContract
         return $this->whereFulltext($columns, $value, $options, 'or');
     }
 
+     /**
+     * Add a "where like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        $type = 'Like';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');
+
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     *
+     * @return $this
+     */
+    public function orWhereLike($column, $value, $caseSensitive = false)
+    {
+        return $this->whereLike($column, $value, $caseSensitive, 'or', false);
+    }
+
+    /**
+     * Add a "where not like" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLike($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->whereLike($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not like" clause to the query.
+     *
+     * @param  string  $columns
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     *
+     * @return $this
+     */
+    public function orWhereNotLike($column, $value, $caseSensitive = false)
+    {
+        return $this->whereNotLike($column, $value, $caseSensitive, 'or');
+    }
+
     /**
      * Add a "where" clause to the query for multiple columns with "and" conditions between them.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2186,6 +2186,10 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'value', 'caseSensitive', 'boolean', 'not');
 
+        if (method_exists($this->grammar, 'prepareWhereLikeBinding')) {
+            $value = $this->grammar->prepareWhereLikeBinding($value, $caseSensitive);
+        }
+
         $this->addBinding($value);
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2170,7 +2170,7 @@ class Builder implements BuilderContract
         return $this->whereFulltext($columns, $value, $options, 'or');
     }
 
-     /**
+    /**
      * Add a "where like" clause to the query.
      *
      * @param  string  $column
@@ -2201,7 +2201,6 @@ class Builder implements BuilderContract
      * @param  string  $column
      * @param  string  $value
      * @param  bool  $caseSensitive
-     *
      * @return $this
      */
     public function orWhereLike($column, $value, $caseSensitive = false)
@@ -2229,7 +2228,6 @@ class Builder implements BuilderContract
      * @param  string  $columns
      * @param  string  $value
      * @param  bool  $caseSensitive
-     *
      * @return $this
      */
     public function orWhereNotLike($column, $value, $caseSensitive = false)

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -769,6 +769,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        if($where['caseSensitive']){
+            throw new RuntimeException('This database engine does not support case sensitive like operations.');
+        }
+
+        $where['operator'] = $where['not'] ? 'not like' : 'like';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
      * Compile a clause based on an expression.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -309,6 +309,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        if ($where['caseSensitive']) {
+            throw new RuntimeException('This database engine does not support case sensitive like operations.');
+        }
+
+        $where['operator'] = $where['not'] ? 'not like' : 'like';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
      * Compile a "where in" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -766,24 +784,6 @@ class Grammar extends BaseGrammar
     public function whereFullText(Builder $query, $where)
     {
         throw new RuntimeException('This database engine does not support fulltext search operations.');
-    }
-
-    /**
-     * Compile a "where like" clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereLike(Builder $query, $where)
-    {
-        if ($where['caseSensitive']) {
-            throw new RuntimeException('This database engine does not support case sensitive like operations.');
-        }
-
-        $where['operator'] = $where['not'] ? 'not like' : 'like';
-
-        return $this->whereBasic($query, $where);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -777,7 +777,7 @@ class Grammar extends BaseGrammar
      */
     protected function whereLike(Builder $query, $where)
     {
-        if($where['caseSensitive']){
+        if ($where['caseSensitive']) {
             throw new RuntimeException('This database engine does not support case sensitive like operations.');
         }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -16,6 +16,22 @@ class MySqlGrammar extends Grammar
     protected $operators = ['sounds like'];
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        $where['operator'] = $where['not'] ? 'not ' : '';
+
+        $where['operator'] .= $where['caseSensitive'] ? 'like binary' : 'like';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
      * Add a "where null" clause to the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -77,21 +93,6 @@ class MySqlGrammar extends Grammar
             : '';
 
         return "match ({$columns}) against (".$value."{$mode}{$expanded})";
-    }
-
-    /**
-     * Compile a "where like" clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereLike(Builder $query, $where)
-    {
-        $where['operator'] = $where['not'] ? 'not ' : '';
-        $where['operator'] .= $where['caseSensitive'] ? 'like binary' : 'like';
-
-        return $this->whereBasic($query, $where);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -80,6 +80,21 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        $where['operator'] = $where['not'] ? 'not ' : '';
+        $where['operator'] .= $where['caseSensitive'] ? 'like binary' : 'like';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
      * Compile the index hints for the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -177,6 +177,21 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        $where['operator'] = $where['not'] ? 'not ' : '';
+        $where['operator'] .= $where['caseSensitive'] ? 'like' : 'ilike';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
      * Compile the "select *" portion of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -69,6 +69,22 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        $where['operator'] = $where['not'] ? 'not ' : '';
+
+        $where['operator'] .= $where['caseSensitive'] ? 'like' : 'ilike';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -174,21 +190,6 @@ class PostgresGrammar extends Grammar
             'tamil',
             'turkish',
         ];
-    }
-
-    /**
-     * Compile a "where like" clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereLike(Builder $query, $where)
-    {
-        $where['operator'] = $where['not'] ? 'not ' : '';
-        $where['operator'] .= $where['caseSensitive'] ? 'like' : 'ilike';
-
-        return $this->whereBasic($query, $where);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -126,7 +126,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function whereLike(Builder $query, $where)
     {
-        if($where['caseSensitive'] == false){
+        if ($where['caseSensitive'] == false) {
             return parent::whereLike($query, $where);
         }
         $where['operator'] = $where['not'] ? 'not glob' : 'glob';
@@ -137,13 +137,13 @@ class SQLiteGrammar extends Grammar
     /**
      * Convert LIKE pattern to GLOB pattern using simple string replacement.
      *
-     * @param string $value The LIKE pattern
-     * @param bool $caseSensitive Whether the pattern should be case-sensitive
+     * @param  string  $value  The LIKE pattern
+     * @param  bool  $caseSensitive  Whether the pattern should be case-sensitive
      * @return string The equivalent GLOB pattern
      */
     public function prepareWhereLikeBinding($value, $caseSensitive)
     {
-        if($caseSensitive == false){
+        if ($caseSensitive == false) {
             return $value;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -43,6 +43,39 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        if ($where['caseSensitive'] == false) {
+            return parent::whereLike($query, $where);
+        }
+        $where['operator'] = $where['not'] ? 'not glob' : 'glob';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
+     * Convert a LIKE pattern to a GLOB pattern using simple string replacement.
+     *
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return string
+     */
+    public function prepareWhereLikeBinding($value, $caseSensitive)
+    {
+        return $caseSensitive === false ? $value : str_replace(
+            ['*', '?', '%', '_'],
+            ['[*]', '[?]', '*', '?'],
+            $value
+        );
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -115,43 +148,6 @@ class SQLiteGrammar extends Grammar
         $value = $this->parameter($where['value']);
 
         return "strftime('{$type}', {$this->wrap($where['column'])}) {$where['operator']} cast({$value} as text)";
-    }
-
-    /**
-     * Compile a "where like" clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereLike(Builder $query, $where)
-    {
-        if ($where['caseSensitive'] == false) {
-            return parent::whereLike($query, $where);
-        }
-        $where['operator'] = $where['not'] ? 'not glob' : 'glob';
-
-        return $this->whereBasic($query, $where);
-    }
-
-    /**
-     * Convert LIKE pattern to GLOB pattern using simple string replacement.
-     *
-     * @param  string  $value  The LIKE pattern
-     * @param  bool  $caseSensitive  Whether the pattern should be case-sensitive
-     * @return string The equivalent GLOB pattern
-     */
-    public function prepareWhereLikeBinding($value, $caseSensitive)
-    {
-        if ($caseSensitive == false) {
-            return $value;
-        }
-
-        return str_replace(
-            ['*', '?', '%', '_'],
-            ['[*]', '[?]', '*', '?'],
-            $value
-        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -118,6 +118,43 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        if($where['caseSensitive'] == false){
+            return parent::whereLike($query, $where);
+        }
+        $where['operator'] = $where['not'] ? 'not glob' : 'glob';
+
+        return $this->whereBasic($query, $where);
+    }
+
+    /**
+     * Convert LIKE pattern to GLOB pattern using simple string replacement.
+     *
+     * @param string $value The LIKE pattern
+     * @param bool $caseSensitive Whether the pattern should be case-sensitive
+     * @return string The equivalent GLOB pattern
+     */
+    public function prepareWhereLikeBinding($value, $caseSensitive)
+    {
+        if($caseSensitive == false){
+            return $value;
+        }
+
+        return str_replace(
+            ['*', '?', '%', '_'],
+            ['[*]', '[?]', '*', '?'],
+            $value
+        );
+    }
+
+    /**
      * Compile the index hints for the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -656,6 +656,39 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1'], $builder->getBindings());
     }
 
+    public function testWhereLikeClausePostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from "users" where "id"::text ilike ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1', false);
+        $this->assertSame('select * from "users" where "id"::text ilike ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1', true);
+        $this->assertSame('select * from "users" where "id"::text like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from "users" where "id"::text not ilike ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1', false);
+        $this->assertSame('select * from "users" where "id"::text not ilike ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1', true);
+        $this->assertSame('select * from "users" where "id"::text not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+    }
+
     public function testWhereLikeClauseMysql()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -722,6 +722,44 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1'], $builder->getBindings());
     }
 
+    public function testWhereLikeClauseSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from "users" where "id" like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1', true);
+        $this->assertSame('select * from "users" where "id" glob ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereLike('description', 'Hell* _orld?%', true);
+        $this->assertSame('select * from "users" where "description" glob ?', $builder->toSql());
+        $this->assertEquals([0 => 'Hell[*] ?orld[?]*'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from "users" where "id" not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereNotLike('description', 'Hell* _orld?%', true);
+        $this->assertSame('select * from "users" where "description" not glob ?', $builder->toSql());
+        $this->assertEquals([0 => 'Hell[*] ?orld[?]*'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereLike('name', 'John%', true)->whereNotLike('name', '%Doe%', true);
+        $this->assertSame('select * from "users" where "name" glob ? and "name" not glob ?', $builder->toSql());
+        $this->assertEquals([0 => 'John*', 1 => '*Doe*'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereLike('name', 'John%')->orWhereLike('name', 'Jane%', true);
+        $this->assertSame('select * from "users" where "name" like ? or "name" glob ?', $builder->toSql());
+        $this->assertEquals([0 => 'John%', 1 => 'Jane*'], $builder->getBindings());
+    }
+
     public function testWhereDateSqlite()
     {
         $builder = $this->getSQLiteBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -656,6 +656,39 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1'], $builder->getBindings());
     }
 
+    public function testWhereLikeClauseMysql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from `users` where `id` like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1', false);
+        $this->assertSame('select * from `users` where `id` like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1', true);
+        $this->assertSame('select * from `users` where `id` like binary ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from `users` where `id` not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1', false);
+        $this->assertSame('select * from `users` where `id` not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1', true);
+        $this->assertSame('select * from `users` where `id` not like binary ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+    }
+
     public function testWhereDateSqlite()
     {
         $builder = $this->getSQLiteBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -760,6 +760,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'John%', 1 => 'Jane*'], $builder->getBindings());
     }
 
+    public function testWhereLikeClauseSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from [users] where [id] like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLike('id', '2');
+        $this->assertSame('select * from [users] where [id] like ? or [id] like ?', $builder->toSql());
+        $this->assertEquals([0 => '1', 1 => '2'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from [users] where [id] not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+    }
+
     public function testWhereDateSqlite()
     {
         $builder = $this->getSQLiteBuilder();

--- a/tests/Integration/Database/QueryBuilderWhereLikeTest.php
+++ b/tests/Integration/Database/QueryBuilderWhereLikeTest.php
@@ -1,15 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\Sqlite;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
-use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
-class WhereLikeTest extends DatabaseTestCase
+class QueryBuilderWhereLikeTest extends DatabaseTestCase
 {
     protected function afterRefreshingDatabase()
     {
@@ -38,43 +35,23 @@ class WhereLikeTest extends DatabaseTestCase
         ]);
     }
 
-
     public function testWhereLike()
     {
         $users = DB::table('users')->whereLike('email', 'john.doe@example.com')->get();
         $this->assertCount(1, $users);
         $this->assertSame('John.Doe@example.com', $users[0]->email);
 
-        $users = DB::table('users')->whereLike('email', 'john.doe@example.com', true)->get();
-        $this->assertCount(0, $users);
-
-        $users = DB::table('users')->whereLike('email', 'tim.smith@example.com', true)->get();
-        $this->assertCount(1, $users);
-        $this->assertSame('tim.smith@example.com', $users[0]->email);
-    }
-
-    public function testWhereNotLike()
-    {
         $this->assertSame(4, DB::table('users')->whereNotLike('email', 'john.doe@example.com')->count());
-        $this->assertSame(5, DB::table('users')->whereNotLike('email', 'john.doe@example.com', true)->count());
     }
 
     public function testWhereLikeWithPercentWildcard()
     {
         $this->assertSame(5, DB::table('users')->whereLike('email', '%@example.com')->count());
-        $this->assertSame(2, DB::table('users')->whereLike('email', '%Doe@example.com', true)->count());
         $this->assertSame(2, DB::table('users')->whereNotLike('email', '%Doe%')->count());
-        $this->assertSame(4, DB::table('users')->whereNotLike('email', '%smith%', true)->count());
 
         $users = DB::table('users')->whereLike('email', 'john%')->get();
         $this->assertCount(1, $users);
         $this->assertSame('John.Doe@example.com', $users[0]->email);
-
-        $users = DB::table('users')->whereLike('email', '%Doe@example.com', true)->get();
-        $this->assertCount(2, $users);
-        $this->assertSame('John.Doe@example.com', $users[0]->email);
-        $this->assertSame('Dale.Doe@example.com', $users[1]->email);
-
     }
 
     public function testWhereLikeWithUnderscoreWildcard()
@@ -83,7 +60,35 @@ class WhereLikeTest extends DatabaseTestCase
         $this->assertCount(2, $users);
         $this->assertSame('janedoe@example.com', $users[0]->email);
         $this->assertSame('Dale.Doe@example.com', $users[1]->email);
+    }
 
+    public function testWhereLikeCaseSensitive()
+    {
+        if ($this->driver === 'sqlsrv') {
+            $this->markTestSkipped('The case-sensitive whereLike clause is not supported on MSSQL.');
+        }
+
+        $users = DB::table('users')->whereLike('email', 'john.doe@example.com', true)->get();
+        $this->assertCount(0, $users);
+
+        $users = DB::table('users')->whereLike('email', 'tim.smith@example.com', true)->get();
+        $this->assertCount(1, $users);
+        $this->assertSame('tim.smith@example.com', $users[0]->email);
+        $this->assertSame(5, DB::table('users')->whereNotLike('email', 'john.doe@example.com', true)->count());
+    }
+    public function testWhereLikeWithPercentWildcardCaseSensitive()
+    {
+        $this->assertSame(2, DB::table('users')->whereLike('email', '%Doe@example.com', true)->count());
+        $this->assertSame(4, DB::table('users')->whereNotLike('email', '%smith%', true)->count());
+
+        $users = DB::table('users')->whereLike('email', '%Doe@example.com', true)->get();
+        $this->assertCount(2, $users);
+        $this->assertSame('John.Doe@example.com', $users[0]->email);
+        $this->assertSame('Dale.Doe@example.com', $users[1]->email);
+    }
+
+    public function testWhereLikeWithUnderscoreWildcardCaseSensitive()
+    {
         $users = DB::table('users')->whereLike('email', 'j__edoe@example.com', true)->get();
         $this->assertCount(1, $users);
         $this->assertSame('janedoe@example.com', $users[0]->email);

--- a/tests/Integration/Database/QueryBuilderWhereLikeTest.php
+++ b/tests/Integration/Database/QueryBuilderWhereLikeTest.php
@@ -76,8 +76,13 @@ class QueryBuilderWhereLikeTest extends DatabaseTestCase
         $this->assertSame('tim.smith@example.com', $users[0]->email);
         $this->assertSame(5, DB::table('users')->whereNotLike('email', 'john.doe@example.com', true)->count());
     }
+
     public function testWhereLikeWithPercentWildcardCaseSensitive()
     {
+        if ($this->driver === 'sqlsrv') {
+            $this->markTestSkipped('The case-sensitive whereLike clause is not supported on MSSQL.');
+        }
+
         $this->assertSame(2, DB::table('users')->whereLike('email', '%Doe@example.com', true)->count());
         $this->assertSame(4, DB::table('users')->whereNotLike('email', '%smith%', true)->count());
 
@@ -89,6 +94,10 @@ class QueryBuilderWhereLikeTest extends DatabaseTestCase
 
     public function testWhereLikeWithUnderscoreWildcardCaseSensitive()
     {
+        if ($this->driver === 'sqlsrv') {
+            $this->markTestSkipped('The case-sensitive whereLike clause is not supported on MSSQL.');
+        }
+
         $users = DB::table('users')->whereLike('email', 'j__edoe@example.com', true)->get();
         $this->assertCount(1, $users);
         $this->assertSame('janedoe@example.com', $users[0]->email);

--- a/tests/Integration/Database/Sqlite/WhereLikeTest.php
+++ b/tests/Integration/Database/Sqlite/WhereLikeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Sqlite;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+class WhereLikeTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('name', 200);
+            $table->text('email');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('users');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('users')->insert([
+            ['name' => 'John Doe', 'email' => 'John.Doe@example.com'],
+            ['name' => 'Jane Doe', 'email' => 'janedoe@example.com'],
+            ['name' => 'Dale doe', 'email' => 'Dale.Doe@example.com'],
+            ['name' => 'Earl Smith', 'email' => 'Earl.Smith@example.com'],
+            ['name' => 'tim smith', 'email' => 'tim.smith@example.com'],
+        ]);
+    }
+
+
+    public function testWhereLike()
+    {
+        $users = DB::table('users')->whereLike('email', 'john.doe@example.com')->get();
+        $this->assertCount(1, $users);
+        $this->assertSame('John.Doe@example.com', $users[0]->email);
+
+        $users = DB::table('users')->whereLike('email', 'john.doe@example.com', true)->get();
+        $this->assertCount(0, $users);
+
+        $users = DB::table('users')->whereLike('email', 'tim.smith@example.com', true)->get();
+        $this->assertCount(1, $users);
+        $this->assertSame('tim.smith@example.com', $users[0]->email);
+    }
+
+    public function testWhereNotLike()
+    {
+        $this->assertSame(4, DB::table('users')->whereNotLike('email', 'john.doe@example.com')->count());
+        $this->assertSame(5, DB::table('users')->whereNotLike('email', 'john.doe@example.com', true)->count());
+    }
+
+    public function testWhereLikeWithPercentWildcard()
+    {
+        $this->assertSame(5, DB::table('users')->whereLike('email', '%@example.com')->count());
+        $this->assertSame(2, DB::table('users')->whereLike('email', '%Doe@example.com', true)->count());
+        $this->assertSame(2, DB::table('users')->whereNotLike('email', '%Doe%')->count());
+        $this->assertSame(4, DB::table('users')->whereNotLike('email', '%smith%', true)->count());
+
+        $users = DB::table('users')->whereLike('email', 'john%')->get();
+        $this->assertCount(1, $users);
+        $this->assertSame('John.Doe@example.com', $users[0]->email);
+
+        $users = DB::table('users')->whereLike('email', '%Doe@example.com', true)->get();
+        $this->assertCount(2, $users);
+        $this->assertSame('John.Doe@example.com', $users[0]->email);
+        $this->assertSame('Dale.Doe@example.com', $users[1]->email);
+
+    }
+
+    public function testWhereLikeWithUnderscoreWildcard()
+    {
+        $users = DB::table('users')->whereLike('email', '_a_e_%@example.com')->get();
+        $this->assertCount(2, $users);
+        $this->assertSame('janedoe@example.com', $users[0]->email);
+        $this->assertSame('Dale.Doe@example.com', $users[1]->email);
+
+        $users = DB::table('users')->whereLike('email', 'j__edoe@example.com', true)->get();
+        $this->assertCount(1, $users);
+        $this->assertSame('janedoe@example.com', $users[0]->email);
+
+        $users = DB::table('users')->whereNotLike('email', '%_oe@example.com', true)->get();
+        $this->assertCount(2, $users);
+        $this->assertSame('Earl.Smith@example.com', $users[0]->email);
+        $this->assertSame('tim.smith@example.com', $users[1]->email);
+    }
+}


### PR DESCRIPTION
Add whereLike and orWhereLike methods to Query Builder

This PR introduces new methods to the Query Builder for performing LIKE queries with better control over case sensitivity:

- `whereLike($column, $value, $caseSensitive = false)`: Performs a LIKE query with optional case sensitivity
- `whereNotLike($column, $value, $caseSensitive = false)`: Performs a NOT LIKE query with optional case sensitivity
- `orWhereLike($column, $value, $caseSensitive = false)`: Adds an OR LIKE clause with optional case sensitivity
- `orWhereNotLike($column, $value, $caseSensitive = false)`: Adds an OR NOT LIKE clause with optional case sensitivity

These methods provide a more intuitive and database-agnostic way to perform string matching queries. They work across all supported databases (MySQL, PostgreSQL, SQLite, and SQL Server) while handling the differences in case-sensitivity behavior. It is by default with case-sensitivity to false, as is the default behavior in MySQL and SQLite.

Benefits:
1. Simplified API for common LIKE queries
2. Consistent behavior across different database systems
3. Explicit control over case sensitivity
4. Improved readability and maintainability of query code

Example usage:
You want to find a user in the database by looking up its email address, and the user has registered its email address using capital letters in its names `John.Doe@example.com`.

If you are using Postgres in production, and SQLite for local development (like me), then you would need to use 'ilike' in Postgres, and 'like' in SQLite, forcing you to write something like this for searching case-insensitive.

```php
$users = DB::table('users')
    ->when(DB::getDriverName() === 'pgsql',
        function (Builder $query): void {
            $query->where('email', 'ilike', 'john.doe@example.com');
        },
        function (Builder $query): void {
            $query->where('email', 'like', 'john.doe@example.com');
        },
    )->get()
```

After this PR you'll be able to achieve the same by the same query.

```php
$users = DB::table('users')
    ->whereLike('email', 'john.doe@example.com')
    ->get();
```

or for case-sensitive search 

```php
$users = DB::table('users')
    ->whereLike('email', 'John.Doe@example.com', true)
    ->get();
```

* Postgres uses `ilike` for case insensitive operations, and `like` for case sensitive.
* MySQL uses `like` for case insensitive operations, and `like binary` for case sensitive.
* SQLite uses `like` for case insensitive operations, and uses glob for case sensitive (converts the binding to use glob, replacing _ and %).
* SqlServer uses the `like` operation by default. In SQL Server, case sensitivity is determined by the collation of the database or column, therefore this implementation is configured to throw an exception if you set the case-sensitivity flag to true.