### PR TITLE
[11.x] Fixed suggestion for success component

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -343,6 +343,18 @@ trait InteractsWithIO
     }
 
     /**
+     * Write a string as success output.
+     *
+     * @param  string  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function success($string, $verbosity = null)
+    {
+        $this->line($string, 'success', $verbosity);
+    }
+
+    /**
      * Write a string as warning output.
      *
      * @param  string  $string

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
  * @method mixed choice(string $question, array $choices, $default = null, int $attempts = null, bool $multiple = false)
  * @method bool confirm(string $question, bool $default = false)
  * @method void error(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
+ * @method void success(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void info(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void line(string $style, string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void secret(string $question, bool $fallback = true)


### PR DESCRIPTION
The success methods in two files were accidentally overlooked in #52112 and this PR adds them so it can be suggested by the IDE.

PR #52112 is functioning, it just isn't being picked up by the IDE presently as an option.

This wasn't apparent during initial testing but I wanted to address it as soon as possible.

Thank you.