### PR TITLE
[11.x] Feature - add boolean support to CacheMiddleware

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -23,7 +23,25 @@ class SetCacheHeaders
         }
 
         return collect($options)
-            ->map(fn ($value, $key) => is_int($key) ? $value : "{$key}={$value}")
+            ->map(function ($value, $key) {
+//                return match (true) {
+//                    is_int($key) => $value,
+//                    $value === false => null,
+//                    $value === true => $key,
+//                    default => "{$key}={$value}",
+//                };
+
+                if (is_int($key)) {
+                    return $value;
+                }
+
+                if (is_bool($value)) {
+                    return $value ? $key : null;
+                }
+
+                return "{$key}={$value}";
+            })
+            ->filter()
             ->map(fn ($value) => Str::finish($value, ';'))
             ->pipe(fn ($options) => rtrim(static::class.':'.$options->implode(''), ';'));
     }

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -36,6 +36,23 @@ class CacheTest extends TestCase
         $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60', $signature);
     }
 
+    public function testItCanGenerateDefinitionViaStaticMethodWithBooleans()
+    {
+        $signature = (string) Cache::using(['etag']);
+        // original behaviour
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:etag', $signature);
+
+        $signature = (string) Cache::using([
+            'etag' => true,
+        ]);
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:etag', $signature);
+
+        $signature = (string) Cache::using([
+            'etag' => false
+        ]);
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:what should happen here?', $signature);
+    }
+
     public function testDoNotSetHeaderWhenMethodNotCacheable()
     {
         $request = new Request;


### PR DESCRIPTION
Got caught out by expecting I need to set `['etag' => true]` in order for the etag to be caluclated but I ended up with `e-tag: w/1` as `true` evaluates to 1 when it comes to string interpolation

This pull request adds support for booleans:
true means apply end up with `src/Illuminate/Http/Middleware/SetCacheHeaders:etag;`
false means remove

This PR needs some feedback before I finalise it.