### PR TITLE
Fix issue with $loop object-casted data

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -17,14 +17,12 @@ trait ManagesLoops
     /**
      * Add new loop to the stack.
      *
-     * @param  \Countable|array  $data
+     * @param  \Countable|array|object  $data
      * @return void
      */
     public function addLoop($data)
     {
-        $length = is_countable($data) && ! $data instanceof LazyCollection
-                            ? count($data)
-                            : null;
+        $length = $this->countProperties($data);
 
         $parent = Arr::last($this->loopsStack);
 
@@ -40,6 +38,25 @@ trait ManagesLoops
             'depth' => count($this->loopsStack) + 1,
             'parent' => $parent ? (object) $parent : null,
         ];
+    }
+
+    /**
+     * Count properties of the data.
+     *
+     * @param  \Countable|array|object  $data
+     * @return int|null
+     */
+    private function countProperties($data)
+    {
+        if (is_countable($data) && ! $data instanceof LazyCollection) {
+            return count($data);
+        }
+
+        if (is_object($data) && ! $data instanceof LazyCollection) {
+            return count(get_object_vars($data));
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Purpose
Enhance the `ManagesLoops` trait in Laravel to fully support object-type data structures for the `$loop` variable in Blade templates. This update addresses issues where directives like `$loop->last` did not function correctly with object-casted model properties, compared to their functionality with array-casted data.

### Changes Made
- Added comprehensive support for object-type data structures in the `ManagesLoops` trait.
- Updated `$loop` variable handling to correctly interpret and iterate over both arrays and objects.
- Ensured `$loop->last` and related directives work consistently across different data types (arrays and objects).

### Reason for Changes
Previously, the `ManagesLoops` trait exhibited inconsistencies when using Blade directives like `$loop->last` with object-casted model properties. The `remaining`, `count`, and `last` properties were not correctly set and resulted in null values. This update resolves these discrepancies, ensuring Laravel applications can utilize Blade's full functionality seamlessly with both array and object data types.

### Examples

### Before:

**Using `$loop` with Object-Casted Data**
```php
$gateway = (object) [
    'bank_name' => (object) ['name' => 'Bank Name', 'value' => 'ABC Bank'],
    'account_number' => (object) ['name' => 'Account Number', 'value' => '123456789'],
    'routing_number' => (object) ['name' => 'Routing Number', 'value' => '12345678'],
];
```

**Blade Template:**
```blade
@foreach ($gateway as $key => $value)
    @dump($loop)
@endforeach
```

**Output Before Fix:**
```text
{#2434 ▼ // resources/views/gateway.blade.php
  +"iteration": 3
  +"index": 2
  +"remaining": null
  +"count": null
  +"first": true
  +"last": null
  +"odd": true
  +"even": false
  +"depth": 1
  +"parent": null
}
```

**Issue:**
`$loop->last`, `remaining`, and `count` do not work correctly with object-casted data.

**Screenshot (Before Fix):**
![Before Fix](https://github.com/user-attachments/assets/fc2cb73d-1741-4623-bba7-94037fc3a099)


### After:

**Using `$loop` with Enhanced Support for Objects**
```php
$gateway = (object) [
    'bank_name' => (object) ['name' => 'Bank Name', 'value' => 'ABC Bank'],
    'account_number' => (object) ['name' => 'Account Number', 'value' => '123456789'],
    'routing_number' => (object) ['name' => 'Routing Number', 'value' => '12345678'],
];
```

**Blade Template:**
```blade
@foreach ($gateway as $key => $value)
    @dump($loop)
@endforeach
```

**Output After Fix:**
```text
{#2434 ▼ // resources/views/gateway.blade.php
  +"iteration": 3
  +"index": 2
  +"remaining": 0
  +"count": 3
  +"first": false
  +"last": true
  +"odd": true
  +"even": false
  +"depth": 1
  +"parent": null
}
```

**Result:**
`$loop->last`, `remaining`, and `count` now work correctly with object-casted data.

**Screenshot (After Fix):**
![After Fix](https://github.com/user-attachments/assets/7b284601-290c-42e1-949e-a76e14ae0b83)