### PR TITLE
Feature: add environment variable to env encrypt command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -60,7 +61,7 @@ class EnvironmentEncryptCommand extends Command
     {
         $cipher = $this->option('cipher') ?: 'AES-256-CBC';
 
-        $key = $this->option('key');
+        $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
 
         $keyPassed = $key !== null;
 

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -138,6 +138,27 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
+    public function testItEncryptsWithGivenFromEnvironmentAndDisplaysIt()
+    {
+        $key = 'ponmlkjihgfedcbaponmlkjihgfedcba';
+        $_SERVER['LARAVEL_ENV_ENCRYPTION_KEY'] = 'base64:'.base64_encode($key);
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt')
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->expectsOutputToContain('base64:'.base64_encode($key))
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        unset($_SERVER['LARAVEL_ENV_ENCRYPTION_KEY']);
+    }
+
     public function testItEncryptsWithGivenGeneratedBase64KeyAndDisplaysIt()
     {
         $this->filesystem->shouldReceive('exists')


### PR DESCRIPTION
The current command `env:decrypt` supports `LARAVEL_ENV_ENCRYPTION_KEY`  environment variable.

This pull request allows `env:encrypt` command to support the same environment `LARAVEL_ENV_ENCRYPTION_KEY` without the need to specify the `--key`.

This is useful in a case where `.env` changes frequently, commonly during development phase within the same team. This allows developers the same key to encrypt and decrypt.