### PR TITLE
Added the ability to expand form request validation rules

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -59,7 +59,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $errorBag = 'default';
 
     /**
-     * The rules that can be added during the process
+     * The rules that can be added during the process.
      *
      * @var array
      */

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -63,7 +63,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @var array
      */
-    public static array $extraRules = [];
+    protected static array $extraRules = [];
 
     /**
      * Indicates whether validation should stop after the first rule failure.
@@ -151,6 +151,28 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Set extra rules.
+     *
+     * @param  array $newRules
+     * @param  bool $override
+     * @return void
+     */
+    public static function setExtraRules(array $newRules, bool $override = true)
+    {
+        self::$extraRules[static::class] = $override ? $newRules : array_merge(self::getExtraRules(), $newRules);
+    }
+
+    /**
+     * Get extra rules.
+     *
+     * @return array
+     */
+    public static function getExtraRules(): array
+    {
+        return self::$extraRules[static::class] ?? [];
+    }
+
+    /**
      * Get the validation rules for this form request.
      *
      * @return array
@@ -159,7 +181,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
 
-        return array_merge($rules, self::$extraRules);
+        return array_merge($rules, self::getExtraRules());
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -153,8 +153,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Set extra rules.
      *
-     * @param  array $newRules
-     * @param  bool $override
+     * @param  array  $newRules
+     * @param  bool  $override
      * @return void
      */
     public static function setExtraRules(array $newRules, bool $override = true)

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -158,6 +158,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function validationRules()
     {
         $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+
         return array_merge($rules, self::$extraRules);
     }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -59,6 +59,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $errorBag = 'default';
 
     /**
+     * The rules that can be added during the process
+     *
+     * @var array
+     */
+    public static array $extraRules = [];
+
+    /**
      * Indicates whether validation should stop after the first rule failure.
      *
      * @var bool
@@ -150,7 +157,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function validationRules()
     {
-        return method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+        $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+        return array_merge($rules, self::$extraRules);
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -541,7 +541,7 @@ class FoundationTestFormRequestExtraRules extends FormRequest
     public function rules()
     {
         return [
-            'foo' => 'required'
+            'foo' => 'required',
         ];
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -229,6 +229,25 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
     }
 
+    public function testExtraRules()
+    {
+        $request = $this->createRequest([], FoundationTestFormRequestExtraRules::class);
+
+        $this->assertEquals($request->validationRules(), ['foo' => 'required']);
+
+        FoundationTestFormRequestExtraRules::setExtraRules(['bar' => 'required']);
+
+        $this->assertEquals($request->validationRules(), ['foo' => 'required', 'bar' => 'required']);
+
+        $this->assertEquals(['bar' => 'required'], FoundationTestFormRequestExtraRules::getExtraRules());
+
+        FoundationTestFormRequestExtraRules::setExtraRules(['baz' => 'required']);
+        $this->assertEquals(['baz' => 'required'], FoundationTestFormRequestExtraRules::getExtraRules());
+
+        FoundationTestFormRequestExtraRules::setExtraRules(['qux' => 'required'], override: false);
+        $this->assertEquals(['baz' => 'required', 'qux' => 'required'], FoundationTestFormRequestExtraRules::getExtraRules());
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -514,5 +533,20 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
                 'a' => ['required', 'int', 'min:2'],
             ];
         }
+    }
+}
+
+class FoundationTestFormRequestExtraRules extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'foo' => 'required'
+        ];
+    }
+
+    public function validationRules(): array
+    {
+        return parent::validationRules();
     }
 }


### PR DESCRIPTION
I consider the ability to expand FormRequest rules necessary. Example - I recently worked on a project where I needed to add a captcha validation rule to the Laravel\Fortify\Http\Requests\LoginRequest class. To do this, I need to create my own FormRequest inherited from the Fortify package LoginRequest, redefine the route and controller. This is much more difficult than simply adding the necessary rules to a specific FormRequest in the Provider, as I propose in this PR.

I added static methods **setExtraRules** and **getExtraRules**.
The **getExtraRules** returns the current array of added rules of a specific FormRequest class. The **setExtraRules** method allows you to set additional rules for a specific FormRequest class, and takes the arguments **$newRules** (an array of rules to add) and **$override** (a boolean flag, _true_ by default). If **$override** == _true_ then all additional rules for a specific FormRequest class will be overwritten. If _false_, then the new rules passed to **$newRules** will be added to the previously added additional rules (based on the _array_merge_ principle. Rules added via **setExtraRules** have priority over those specified in the **rules** method of a specific FromRequest class, which allows them to be conveniently overridden. Here are examples of using this functionality:

```php
class ExtraRulesFormRequest extends FormRequest
{
    public function rules()
    {
        return [
            'foo' => 'required'
        ];
    }
}

// The code is expected to be called in the service provider:

/* Adding rules
*  getExtraRules: ['bar' => 'required']
*  validationRules: ['foo' => 'required', 'bar' => 'required']
*/
ExtraRulesFormRequest::setExtraRules(['bar' => 'required']);

/* Overwriting added rules
*  getExtraRules: ['baz' => 'required']
*  validationRules: ['foo' => 'required', 'baz' => 'required']
*/
ExtraRulesFormRequest::setExtraRules(['baz' => 'required']);

/* Adding rules to already added rules
*  getExtraRules: ['baz' => 'required', 'qux' => 'required']
*  validationRules: ['foo' => 'required', 'baz' => 'required', 'qux' => 'required']
*/
ExtraRulesFormRequest::setExtraRules(['qux' => 'required'], override: false); 
```

Thanks.