### PR TITLE
[11.x] Allow non-`ContextualAttribute` attributes to have an `after` callback

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1366,12 +1366,8 @@ class Container implements ArrayAccess, ContainerContract
     protected function fireAfterResolvingAttributeCallbacks(array $attributes, $object)
     {
         foreach ($attributes as $attribute) {
-            if (is_a($attribute->getName(), ContextualAttribute::class, true)) {
-                $instance = $attribute->newInstance();
-
-                if (method_exists($instance, 'after')) {
-                    $instance->after($instance, $object, $this);
-                }
+            if (method_exists($instance = $attribute->newInstance(), 'after')) {
+                $instance->after($instance, $object, $this);
             }
 
             $callbacks = $this->getCallbacksForType(


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/laravel/framework/pull/51934.

It allows all attributes to have an `after` callback, not just `ContextualAttribute` ones. As a reminder, this callback is the equivalent of `$this->app->afterResolvingAttribute`, but directly on the attribute.

The restriction to have it only on `ContextualAttribute` was accidental due to it being implemented late in the previous pull request.

**EDIT**: PR reverted because of:
- Poorly configured attributes (wrong target)
- Dev-only attributes