### PR TITLE
[11.x] Add a new method "whereNullOr" to the Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2271,9 +2271,9 @@ class Builder implements BuilderContract
     /**
      * Add an "or whereNull" and "orWhere" clause to the query.
      *
-     * @param string  $column
-     * @param string  $operator
-     * @param mixed  $value
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereNullOr($column, $operator = null, $value = null)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1311,6 +1311,43 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "whereNull" and "orWhere" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNullOr($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+
+        $this->whereNested(function ($query) use ($column, $operator, $value) {
+            $query
+                ->whereNull($column)
+                ->orWhere($column, $operator, $value);
+        }, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or whereNull" and "orWhere" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereNullOr($column, $operator = null, $value = null)
+    {
+        return $this->whereNullOr($column, $operator, $value, 'or');
+    }
+
+    /**
      * Add a where between statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -2242,43 +2279,6 @@ class Builder implements BuilderContract
     public function orWhereAny($columns, $operator = null, $value = null)
     {
         return $this->whereAny($columns, $operator, $value, 'or');
-    }
-
-    /**
-     * Add a "whereNull" and "orWhere" clause to the query.
-     *
-     * @param  string  $column
-     * @param  string  $operator
-     * @param  mixed  $value
-     * @param  string  $boolean
-     * @return $this
-     */
-    public function whereNullOr($column, $operator = null, $value = null, $boolean = 'and')
-    {
-        [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
-        );
-
-        $this->whereNested(function ($query) use ($column, $operator, $value) {
-            $query
-                ->whereNull($column)
-                ->orWhere($column, $operator, $value);
-        }, $boolean);
-
-        return $this;
-    }
-
-    /**
-     * Add an "or whereNull" and "orWhere" clause to the query.
-     *
-     * @param  string  $column
-     * @param  string  $operator
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function orWhereNullOr($column, $operator = null, $value = null)
-    {
-        return $this->whereNullOr($column, $operator, $value, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2245,6 +2245,43 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "whereNull" and "orWhere" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNullOr($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+
+        $this->whereNested(function ($query) use ($column, $operator, $value) {
+            $query
+                ->whereNull($column)
+                ->orWhere($column, $operator, $value);
+        }, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or whereNull" and "orWhere" clause to the query.
+     *
+     * @param string  $column
+     * @param string  $operator
+     * @param mixed  $value
+     * @return $this
+     */
+    public function orWhereNullOr($column, $operator = null, $value = null)
+    {
+        return $this->whereNullOr($column, $operator, $value, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|\Illuminate\Contracts\Database\Query\Expression|string  ...$groups

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1254,6 +1254,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
+    public function testWhereNullOr()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereNullOr('category_id', '=', 1);
+        $this->assertSame('select * from "posts" where ("category_id" is null or "category_id" = ?)', $builder->toSql());
+        $this->assertEquals([1], $builder->getBindings());
+    }
+
+    public function testOrWhereNullOr()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('title', 'like', '%Laravel%')->whereNullOr('category_id', '=', 1);
+        $this->assertSame('select * from "posts" where "title" like ? and ("category_id" is null or "category_id" = ?)', $builder->toSql());
+        $this->assertEquals(['%Laravel%', 1], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Hello guys 👋

### Introduction
The method simplifies `whereNullOr` (and `orWhereNullOr`) the process of adding a "where" clause that checks if a column is null or satisfies a given condition. This enhancement aims to improve code readability and maintainability when dealing with such common query patterns

### Motivation
I often write queries to check if a column is either null or meets a certain condition. Currently, this requires a nested closure with a where clause and sometimes using "use", which can be verbose and repetitive:
```
->where(function ($query) use ($id) {
    $query
        ->whereNull('category_id')
        ->orWhere('category_id', '=', $id);
})
```

With the introduction of the whereOrIsNull method, this can be simplified to:
```
->whereNullOr('column_name', '=', $id)
```

I think there should be another name for it, maybe `whereOrNull` or something else 🤔. So if you have a better one, it'll be great

And also, if you see it useful, I can add similar methods to others like `whereIn`, `whereDate`, etc. 

Thanks,
Alex 🐾