### PR TITLE
[10.x] Fix runPaginationCountQuery not working properly for union queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3016,10 +3016,10 @@ class Builder implements BuilderContract
                 ->get()->all();
         }
 
-        $without = $this->unions ? ['orders', 'limit', 'offset'] : ['columns', 'orders', 'limit', 'offset'];
+        $without = $this->unions ? ['unionOrders', 'unionLimit', 'unionOffset'] : ['columns', 'orders', 'limit', 'offset'];
 
         return $this->cloneWithout($without)
-                    ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
+                    ->cloneWithoutBindings($this->unions ? ['unionOrder'] : ['select', 'order'])
                     ->setAggregate('count', $this->withoutSelectAliases($columns))
                     ->get()->all();
     }


### PR DESCRIPTION
I've recently stumbled across a bug where the total number of items displayed in Laravel Nova was incorrect after updating the index query to use unions. The total would always be equal to the page size even though there are more items in the pagination.

I started debugging the issue and found the following line `Illuminate\Database\Query\Builder::runPaginationCountQuery`:

```php
$without = $this->unions ? ['orders', 'limit', 'offset'] : ['columns', 'orders', 'limit', 'offset'];

return $this->cloneWithout($without)
    ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
    ->setAggregate('count', $this->withoutSelectAliases($columns))
    ->get()->all();
```

As we can see from the code above, it's cloning the query without `orders`, `limit` and `offset` when there are unions in the query. However, if we have a look at the `limit` function from the same class:

```php
public function limit($value)
{
    $property = $this->unions ? 'unionLimit' : 'limit';

    if ($value >= 0) {
        $this->$property = ! is_null($value) ? (int) $value : null;
    }

    return $this;
}
```

We can see that the property for unions is `unionLimit` and not `limit`.

After searching through the issues, I found something that was closed previously because they did not provide a repository to test: https://github.com/laravel/framework/issues/38639

Therefore, I made a repository to show the bug in action: https://github.com/chinleung/laravel-bug-52170
