### PR TITLE
[11.x] fix: Model newCollection generics; feat: add HasCollection trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * @template TCollection of \Illuminate\Database\Eloquent\Collection
+ */
+trait HasCollection
+{
+    /**
+     * Create a new Eloquent Collection instance.
+     *
+     * @param  array<array-key, \Illuminate\Database\Eloquent\Model>  $models
+     * @return TCollection
+     */
+    public function newCollection(array $models = [])
+    {
+        return new static::$collection($models);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -35,6 +35,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
         ForwardsCalls;
+    /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static>> */
+    use HasCollection;
 
     /**
      * The connection name for the model.
@@ -217,6 +219,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @var class-string<\Illuminate\Database\Eloquent\Builder<*>>
      */
     protected static string $builder = Builder::class;
+
+    /**
+     * The Eloquent collection class to use for the model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Collection<*, *>>
+     */
+    protected static string $collection = Collection::class;
 
     /**
      * The name of the "created at" column.
@@ -1586,19 +1595,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected function newBaseQueryBuilder()
     {
         return $this->getConnection()->query();
-    }
-
-    /**
-     * Create a new Eloquent Collection instance.
-     *
-     * @template TKey of array-key
-     *
-     * @param  array<TKey, static>  $models
-     * @return \Illuminate\Database\Eloquent\Collection<TKey, static>
-     */
-    public function newCollection(array $models = [])
-    {
-        return new Collection($models);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1592,10 +1592,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Create a new Eloquent Collection instance.
      *
      * @template TKey of array-key
-     * @template TModel of \Illuminate\Database\Eloquent\Model
      *
-     * @param  array<TKey, TModel>  $models
-     * @return \Illuminate\Database\Eloquent\Collection<TKey, TModel>
+     * @param  array<TKey, static>  $models
+     * @return \Illuminate\Database\Eloquent\Collection<TKey, static>
      */
     public function newCollection(array $models = [])
     {

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -3,10 +3,14 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\HasCollection;
 use Illuminate\Database\Eloquent\Model;
 
 class DatabaseNotification extends Model
 {
+    /** @use HasCollection<DatabaseNotificationCollection> */
+    use HasCollection;
+
     /**
      * The "type" of the primary key ID.
      *
@@ -44,6 +48,8 @@ class DatabaseNotification extends Model
         'data' => 'array',
         'read_at' => 'datetime',
     ];
+
+    protected static string $collection = DatabaseNotificationCollection::class;
 
     /**
      * Get the notifiable entity that the notification belongs to.
@@ -119,16 +125,5 @@ class DatabaseNotification extends Model
     public function scopeUnread(Builder $query)
     {
         return $query->whereNull('read_at');
-    }
-
-    /**
-     * Create a new database notification collection instance.
-     *
-     * @param  array  $models
-     * @return \Illuminate\Notifications\DatabaseNotificationCollection
-     */
-    public function newCollection(array $models = [])
-    {
-        return new DatabaseNotificationCollection($models);
     }
 }

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Types\Model;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\HasCollection;
 use Illuminate\Database\Eloquent\Model;
 use User;
 
@@ -31,8 +32,8 @@ function test(User $user, Post $post, Comment $comment): void
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->prunable());
     assertType('Illuminate\Database\Eloquent\Relations\MorphMany<Illuminate\Notifications\DatabaseNotification, User>', $user->notifications());
 
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $user->newCollection([new User()]));
-    assertType('Illuminate\Database\Eloquent\Collection<string, Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
+    assertType('Illuminate\Database\Eloquent\Collection<(int|string), User>', $user->newCollection([new User()]));
+    assertType('Illuminate\Types\Model\Posts<(int|string), Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
     assertType('Illuminate\Types\Model\Comments', $comment->newCollection([new Comment()]));
 
     assertType('bool', $user->restore());
@@ -42,10 +43,27 @@ function test(User $user, Post $post, Comment $comment): void
 
 class Post extends Model
 {
+    /** @use HasCollection<Posts<array-key, static>> */
+    use HasCollection;
+
+    protected static string $collection = Posts::class;
+}
+
+/**
+ * @template TKey of array-key
+ * @template TModel of Post
+ *
+ * @extends Collection<TKey, TModel> */
+class Posts extends Collection
+{
 }
 
 final class Comment extends Model
 {
+    /** @use HasCollection<Comments> */
+    use HasCollection;
+
+    /** @param  array<array-key, Comment>  $models */
     public function newCollection(array $models = []): Comments
     {
         return new Comments($models);

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Types\Model;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use User;
 
 use function PHPStan\Testing\assertType;
 
-function test(User $user): void
+function test(User $user, Post $post, Comment $comment): void
 {
     assertType('UserFactory', User::factory(function ($attributes, $model) {
         assertType('array<string, mixed>', $attributes);
@@ -31,7 +32,8 @@ function test(User $user): void
     assertType('Illuminate\Database\Eloquent\Relations\MorphMany<Illuminate\Notifications\DatabaseNotification, User>', $user->notifications());
 
     assertType('Illuminate\Database\Eloquent\Collection<int, User>', $user->newCollection([new User()]));
-    assertType('Illuminate\Database\Eloquent\Collection<string, Illuminate\Types\Model\Post>', $user->newCollection(['foo' => new Post()]));
+    assertType('Illuminate\Database\Eloquent\Collection<string, Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
+    assertType('Illuminate\Types\Model\Comments', $comment->newCollection([new Comment()]));
 
     assertType('bool', $user->restore());
     assertType('User', $user->restoreOrCreate());
@@ -39,5 +41,18 @@ function test(User $user): void
 }
 
 class Post extends Model
+{
+}
+
+final class Comment extends Model
+{
+    public function newCollection(array $models = []): Comments
+    {
+        return new Comments($models);
+    }
+}
+
+/** @extends Collection<array-key, Comment> */
+final class Comments extends Collection
 {
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR fixes some issues with the Model's newCollection generic (https://github.com/phpstan/phpstan/issues/11354) ---it appears that due to covariant/invariant constraints the method must return only static models.

I also added a `HasCollection` trait similar to the `Has{Builder,Factory}` traits that help slim down the models:
```php
// before
class Post extends Model
{
    /** @return PostCollection<array-key, static> */
    public function newCollection(array $models = []): PostCollection
    {
        return new PostCollection($models);
    }
}

// after
class Post extends Model
{
    /** @use HasCollection<PostCollection<array-key, static>> */
    use HasCollection;

    protected static string $collection = PostCollection::class;
}
```

Thanks!
