### PR TITLE
[11.x] Improve readability of SQLite schema dumps

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -273,6 +273,6 @@ jobs:
         run: php vendor/bin/testbench package:create-sqlite-db
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database
+        run: vendor/bin/phpunit tests/Integration/Database/Sqlite
         env:
           DB_CONNECTION: sqlite

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -238,3 +238,41 @@ jobs:
           DB_DATABASE: master
           DB_USERNAME: SA
           DB_PASSWORD: Forge123
+
+  sqlite:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: true
+
+    name: SQLite
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "11.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Setup SQLite Database
+        run: php vendor/bin/testbench package:create-sqlite-db
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: sqlite

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteConnectionTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteConnectionTest.php
@@ -10,9 +10,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class DatabaseSqliteConnectionTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app)
     {
-        if (getenv('DB_CONNECTION') !== 'testing') {
+        parent::defineEnvironment($app);
+
+        if ($this->driver !== 'sqlite') {
             $this->markTestSkipped('Test requires a Sqlite connection.');
         }
 

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -9,9 +9,11 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app)
     {
-        if (getenv('DB_CONNECTION') !== 'testing') {
+        parent::defineEnvironment($app);
+
+        if ($this->driver !== 'sqlite') {
             $this->markTestSkipped('Test requires a Sqlite connection.');
         }
 

--- a/tests/Integration/Database/Sqlite/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/Sqlite/EloquentModelConnectionsTest.php
@@ -10,9 +10,11 @@ use Orchestra\Testbench\TestCase;
 
 class EloquentModelConnectionsTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app)
     {
-        if (getenv('DB_CONNECTION') !== 'testing') {
+        $connection = $app['config']->get('database.default');
+
+        if ($app['config']->get("database.connections.$connection.driver") !== 'sqlite') {
             $this->markTestSkipped('Test requires a Sqlite connection.');
         }
 

--- a/tests/Integration/Database/Sqlite/EscapeTest.php
+++ b/tests/Integration/Database/Sqlite/EscapeTest.php
@@ -7,9 +7,11 @@ use RuntimeException;
 
 class EscapeTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app)
     {
-        if (getenv('DB_CONNECTION') !== 'testing') {
+        parent::defineEnvironment($app);
+
+        if ($this->driver !== 'sqlite') {
             $this->markTestSkipped('Test requires a Sqlite connection.');
         }
 

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -21,7 +21,7 @@ class SchemaStateTest extends TestCase
     {
         parent::setUp();
 
-        $this->artisan('migrate:install')->run();
+        remote('migrate:install')->mustRun();
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -31,7 +31,7 @@ class SchemaStateTest extends DatabaseTestCase
             $this->markTestSkipped('Test cannot be run using :in-memory: database connection');
         }
 
-        $connection = DB::connection('sqlite');
+        $connection = DB::connection();
         $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
 
         $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -31,6 +31,8 @@ class SchemaStateTest extends DatabaseTestCase
 
         $connection->statement('PRAGMA optimize;');
 
+        $this->assertTrue($connection->table('sqlite_stat1')->exists());
+
         $this->app['files']->ensureDirectoryExists(database_path('schema'));
 
         $connection->getSchemaState()->dump($connection, database_path('schema/sqlite-schema.sql'));

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -26,12 +26,9 @@ class SchemaStateTest extends DatabaseTestCase
         $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
 
         $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
-        $connection->statement('CREATE UNIQUE INDEX users_email_unique on users (email);');
         $connection->statement('INSERT INTO users (email, name) VALUES ("taylor@laravel.com", "Taylor Otwell");');
 
-        $connection->statement('PRAGMA optimize;');
-
-        $this->assertTrue($connection->table('sqlite_stat1')->exists());
+        $this->assertTrue($connection->table('sqlite_sequence')->exists());
 
         $this->app['files']->ensureDirectoryExists(database_path('schema'));
 
@@ -40,10 +37,8 @@ class SchemaStateTest extends DatabaseTestCase
         $this->assertFileContains([
             'CREATE TABLE users',
         ], 'database/schema/sqlite-schema.sql');
-        $this->assertFileDoesNotContains([
+        $this->assertFileNotContains([
             'sqlite_sequence',
-            'sqlite_stat1',
-            'sqlite_stat4',
         ], 'database/schema/sqlite-schema.sql');
     }
 }

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -4,12 +4,9 @@ namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
-use Orchestra\Testbench\Factories\UserFactory;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
-#[WithMigration]
 class SchemaStateTest extends DatabaseTestCase
 {
     use InteractsWithPublishedFiles;
@@ -25,15 +22,22 @@ class SchemaStateTest extends DatabaseTestCase
             $this->markTestSkipped('Test requires a SQLite connection.');
         }
 
-        UserFactory::new()->create();
+        $connection = DB::connection('sqlite');
+        $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
 
-        $connection = DB::connection();
+        $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
+        $connection->statement('CREATE UNIQUE INDEX users_email_unique on users (email);');
+        $connection->statement('INSERT INTO users (email, name) VALUES ("taylor@laravel.com", "Taylor Otwell");');
+
         $connection->statement('PRAGMA optimize;');
 
         $this->app['files']->ensureDirectoryExists(database_path('schema'));
 
         $connection->getSchemaState()->dump($connection, database_path('schema/sqlite-schema.sql'));
 
+        $this->assertFileContains([
+            'CREATE TABLE users',
+        ], 'database/schema/sqlite-schema.sql');
         $this->assertFileDoesNotContains([
             'sqlite_sequence',
             'sqlite_stat1',

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+
 use function Orchestra\Testbench\remote;
 
 class SchemaStateTest extends TestCase

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -5,9 +5,11 @@ namespace Illuminate\Tests\Integration\Database\Sqlite;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use function Orchestra\Testbench\remote;
 
-class SchemaStateTest extends DatabaseTestCase
+class SchemaStateTest extends TestCase
 {
     use InteractsWithPublishedFiles;
 
@@ -15,11 +17,25 @@ class SchemaStateTest extends DatabaseTestCase
         'database/schema',
     ];
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate:install')->run();
+    }
+
+    protected function tearDown(): void
+    {
+        remote('db:wipe')->mustRun();
+
+        parent::tearDown();
+    }
+
     protected function defineEnvironment($app)
     {
-        parent::defineEnvironment($app);
+        $connection = $app['config']->get('database.default');
 
-        if ($this->driver !== 'sqlite') {
+        if ($app['config']->get("database.connections.$connection.driver") !== 'sqlite') {
             $this->markTestSkipped('Test requires a Sqlite connection.');
         }
     }

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -15,11 +15,20 @@ class SchemaStateTest extends DatabaseTestCase
         'database/schema',
     ];
 
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        if ($this->driver !== 'sqlite') {
+            $this->markTestSkipped('Test requires a Sqlite connection.');
+        }
+    }
+
     #[RequiresOperatingSystem('Linux|Darwin')]
     public function testSchemaDumpOnSqlite()
     {
-        if ($this->driver !== 'sqlite') {
-            $this->markTestSkipped('Test requires a SQLite connection.');
+        if ($this->usesSqliteInMemoryDatabaseConnection()) {
+            $this->markTestSkipped('Test cannot be run using :in-memory: database connection');
         }
 
         $connection = DB::connection('sqlite');


### PR DESCRIPTION
This PR adds the [`--indent` option](https://sqlite.org/cli.html#querying_the_database_schema) to the SQLite schema dump command to generate an indented dump file that is much easier to read than the default (which puts each table on a single line). This also now matches the format of dumps from other databases.

**Before**

```sql
CREATE TABLE IF NOT EXISTS "users"("id" integer primary key autoincrement not null, "current_team_id" integer, "name" varchar not null, "email" varchar not null, "email_verified_at" datetime, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime);
```

**After**

```sql
CREATE TABLE IF NOT EXISTS "users"(
  "id" integer primary key autoincrement not null,
  "current_team_id" integer,
  "name" varchar not null,
  "email" varchar not null,
  "email_verified_at" datetime,
  "password" varchar not null,
  "remember_token" varchar,
  "created_at" datetime,
  "updated_at" datetime,
);
```

<details>
<summary>MySQL for comparison</summary>

```sql
CREATE TABLE `users` (
  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `current_team_id` bigint unsigned DEFAULT NULL,
  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
  `email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
  `email_verified_at` timestamp NULL DEFAULT NULL,
  `password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `remember_token` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `created_at` timestamp NULL DEFAULT NULL,
  `updated_at` timestamp NULL DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `users_email_unique` (`email`),
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

</details>

This PR also fixes the `SqliteSchemaState` test, which was changed in #52139 and generated an empty dump file, so was no longer testing anything. It requires a real database file - @crynobone if there's a cleaner way to do this I'm happy to change anything you like, but for the test to be useful there has to be an internal `sqlite_` database table created and the generated dump file has to not include it. I added assertions to make that intent clearer.