### PR TITLE
[11.x] Refactor: Replace get_called_class() with static::class for consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -16,7 +16,7 @@ trait HasFactory
      */
     public static function factory($count = null, $state = [])
     {
-        $factory = static::newFactory() ?? Factory::factoryForModel(get_called_class());
+        $factory = static::newFactory() ?? Factory::factoryForModel(static::class);
 
         return $factory
                     ->count(is_numeric($count) ? $count : null)


### PR DESCRIPTION
This pull request refactors instances of `get_called_class()` to `static::class` across the project to maintain consistency in the codebase. The use of static::class offers a slight performance benefit as it avoids a function call.