### PR TITLE
[11.x] Ignoring column definitions when determining if a blueprint has a create command

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -327,7 +327,7 @@ class Blueprint
     public function creating()
     {
         return collect($this->commands)->contains(function ($command) {
-            return $command->name === 'create';
+            return !($command instanceof ColumnDefinition) && $command->name === 'create';
         });
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -327,7 +327,7 @@ class Blueprint
     public function creating()
     {
         return collect($this->commands)->contains(function ($command) {
-            return ! ($command instanceof ColumnDefinition) && $command->name === 'create';
+            return ! $command instanceof ColumnDefinition && $command->name === 'create';
         });
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -327,7 +327,7 @@ class Blueprint
     public function creating()
     {
         return collect($this->commands)->contains(function ($command) {
-            return !($command instanceof ColumnDefinition) && $command->name === 'create';
+            return ! ($command instanceof ColumnDefinition) && $command->name === 'create';
         });
     }
 

--- a/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
@@ -507,6 +507,61 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals($expected, $queries);
     }
 
+    public function testAddColumnNamedCreateWorks()
+    {
+        DB::connection()->getSchemaBuilder()->create('users', function ($table) {
+            $table->string('name')->nullable();
+        });
+
+        $blueprintMySql = new Blueprint('users', function ($table) {
+            $table->string('create')->nullable(false);
+        });
+
+        $queries = $blueprintMySql->toSql(DB::connection(), new MySqlGrammar);
+
+        $expected = [
+            'alter table `users` add `create` varchar(255) not null',
+        ];
+
+        $this->assertEquals($expected, $queries);
+
+        $blueprintPostgres = new Blueprint('users', function ($table) {
+            $table->string('create')->nullable(false);
+        });
+
+        $queries = $blueprintPostgres->toSql(DB::connection(), new PostgresGrammar);
+
+        $expected = [
+            'alter table "users" add column "create" varchar(255) not null',
+        ];
+
+        $this->assertEquals($expected, $queries);
+
+        $blueprintSQLite = new Blueprint('users', function ($table) {
+            $table->string('create')->nullable(false);
+        });
+
+        $queries = $blueprintSQLite->toSql(DB::connection(), new SQLiteGrammar);
+
+        $expected = [
+            'alter table "users" add column "create" varchar not null',
+        ];
+
+        $this->assertEquals($expected, $queries);
+
+        $blueprintSqlServer = new Blueprint('users', function ($table) {
+            $table->string('create')->nullable(false);
+        });
+
+        $queries = $blueprintSqlServer->toSql(DB::connection(), new SqlServerGrammar);
+
+        $expected = [
+            'alter table "users" add "create" nvarchar(255) not null',
+        ];
+
+        $this->assertEquals($expected, $queries);
+    }
+
     public function testDropIndexOnColumnChangeWorks()
     {
         $connection = DB::connection();

--- a/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
@@ -509,57 +509,15 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testAddColumnNamedCreateWorks()
     {
-        DB::connection()->getSchemaBuilder()->create('users', function ($table) {
-            $table->string('name')->nullable();
+        Schema::create('users', function (Blueprint $table) {
+            $table->string('name');
         });
 
-        $blueprintMySql = new Blueprint('users', function ($table) {
-            $table->string('create')->nullable(false);
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('create');
         });
 
-        $queries = $blueprintMySql->toSql(DB::connection(), new MySqlGrammar);
-
-        $expected = [
-            'alter table `users` add `create` varchar(255) not null',
-        ];
-
-        $this->assertEquals($expected, $queries);
-
-        $blueprintPostgres = new Blueprint('users', function ($table) {
-            $table->string('create')->nullable(false);
-        });
-
-        $queries = $blueprintPostgres->toSql(DB::connection(), new PostgresGrammar);
-
-        $expected = [
-            'alter table "users" add column "create" varchar(255) not null',
-        ];
-
-        $this->assertEquals($expected, $queries);
-
-        $blueprintSQLite = new Blueprint('users', function ($table) {
-            $table->string('create')->nullable(false);
-        });
-
-        $queries = $blueprintSQLite->toSql(DB::connection(), new SQLiteGrammar);
-
-        $expected = [
-            'alter table "users" add column "create" varchar not null',
-        ];
-
-        $this->assertEquals($expected, $queries);
-
-        $blueprintSqlServer = new Blueprint('users', function ($table) {
-            $table->string('create')->nullable(false);
-        });
-
-        $queries = $blueprintSqlServer->toSql(DB::connection(), new SqlServerGrammar);
-
-        $expected = [
-            'alter table "users" add "create" nvarchar(255) not null',
-        ];
-
-        $this->assertEquals($expected, $queries);
+        $this->assertTrue(Schema::hasColumn('users', 'create'));
     }
 
     public function testDropIndexOnColumnChangeWorks()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/52175