### PR TITLE
`Collection::isEmpty` and `isNotEmpty` can not prove non-nullability

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -665,8 +665,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @phpstan-assert-if-true null $this->first()
      *
-     * @phpstan-assert-if-false !null $this->first()
-     *
      * @return bool
      */
     public function isEmpty()

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,8 +367,6 @@ trait EnumeratesValues
     /**
      * Determine if the collection is not empty.
      *
-     * @phpstan-assert-if-true !null $this->first()
-     *
      * @phpstan-assert-if-false null $this->first()
      *
      * @return bool


### PR DESCRIPTION
This reverts parts of https://github.com/laravel/framework/pull/51998 that are wrong.

Those annotations are wrong if the first element of a `Collection` is `null`. The following code currently passes PHPStan analysis, but errors when run:

```php
<?php declare(strict_types=1);

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Support\Collection;

final class CollectionError extends Command
{
    protected $signature = 'collection-error';

    public function handle(): void
    {
        $collection = new Collection([null, 2]);

        try {
            $this->empty($collection);
        } catch (\Throwable $e) {
            $this->error($e->getMessage());
        }

        try {
            $this->notEmpty($collection);
        } catch (\Throwable $e) {
            $this->error($e->getMessage());
        }
    }

    /** @param Collection<array-key, int|null> $collection */
    private function empty(Collection $collection): int
    {
        if ($collection->isEmpty()) {
            return 0;
        }

        return $collection->first();
    }

    /** @param Collection<array-key, int|null> $collection */
    private function notEmpty(Collection $collection): int
    {
        if ($collection->isNotEmpty()) {
            return $collection->first();
        }

        return 0;
    }
}
```

```shell
$ php artisan collection-error
App\Console\Commands\CollectionError::empty(): Return value must be of type int, null returned
App\Console\Commands\CollectionError::notEmpty(): Return value must be of type int, null returned
```

Without the annotations, PHPStan will rightfully complain that `first()` can return `null`.