### PR TITLE
[11.x] Fix return for ApplicationBuilder:: withCommandRouting method

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -300,6 +300,8 @@ class ApplicationBuilder
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
             $this->app->booted(fn () => $kernel->addCommandRoutePaths($paths));
         });
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The `ApplicationBuilder::withCommandRouting ` method is missing return statement, so I added for it.