### PR TITLE
Improve accuracy of `Collection::isEmpty` and `isNotEmpty` assertions

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -665,7 +665,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @phpstan-assert-if-true null $this->first()
      *
-     * @phpstan-assert-if-false !null $this->first()
+     * @phpstan-assert-if-false TValue $this->first()
      *
      * @return bool
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,7 +367,7 @@ trait EnumeratesValues
     /**
      * Determine if the collection is not empty.
      *
-     * @phpstan-assert-if-true !null $this->first()
+     * @phpstan-assert-if-true TValue $this->first()
      *
      * @phpstan-assert-if-false null $this->first()
      *

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -489,13 +489,17 @@ assertType('string|User', $collection->first(null, function () {
 }));
 if ($collection->isNotEmpty()) {
     assertType('User', $collection->first());
+    assertType('string|User', $collection->first(null, 'foo'));
 } else {
     assertType('null', $collection->first());
+    assertType('string|User', $collection->first(null, 'foo'));
 }
 if ($collection->isEmpty()) {
     assertType('null', $collection->first());
+    assertType('string|User', $collection->first(null, 'foo'));
 } else {
     assertType('User', $collection->first());
+    assertType('string|User', $collection->first(null, 'foo'));
 }
 
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -487,6 +487,16 @@ assertType('string|User', $collection->first(function ($user) {
 assertType('string|User', $collection->first(null, function () {
     return 'string';
 }));
+if ($collection->isNotEmpty()) {
+    assertType('User', $collection->first());
+} else {
+    assertType('null', $collection->first());
+}
+if ($collection->isEmpty()) {
+    assertType('null', $collection->first());
+} else {
+    assertType('User', $collection->first());
+}
 
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\Collection<int, mixed>', $collection::make(['string' => 'string'])->flatten(4));


### PR DESCRIPTION
Those methods do not necessarily prove that the result of `first()` is not null. However, they can prove that the result of `first()` is of the type contained within the `Collection`.