### PR TITLE
[11.x] Rename `Model::$collection` to `$collectionClass`

### DIFF
--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -15,6 +15,6 @@ trait HasCollection
      */
     public function newCollection(array $models = [])
     {
-        return new static::$collection($models);
+        return new static::$collectionClass($models);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -225,7 +225,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @var class-string<\Illuminate\Database\Eloquent\Collection<*, *>>
      */
-    protected static string $collection = Collection::class;
+    protected static string $collectionClass = Collection::class;
 
     /**
      * The name of the "created at" column.

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -52,7 +52,7 @@ class DatabaseNotification extends Model
     /**
      * The type of collection that should be used for the model.
      */
-    protected static string $collection = DatabaseNotificationCollection::class;
+    protected static string $collectionClass = DatabaseNotificationCollection::class;
 
     /**
      * Get the notifiable entity that the notification belongs to.

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -46,7 +46,7 @@ class Post extends Model
     /** @use HasCollection<Posts<array-key, static>> */
     use HasCollection;
 
-    protected static string $collection = Posts::class;
+    protected static string $collectionClass = Posts::class;
 }
 
 /**


### PR DESCRIPTION
After https://github.com/laravel/framework/pull/52171, all projects using the package `mongodb/laravel-mongodb` will be broken. The property `$collection` is used for years as an alias for `$table`, as documented in [Laravel MongoDB / Eloquent Models](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/eloquent-models/model-class/#change-the-model-collection-name).

Would it be possible to choose a different name for the new static property in order to prevent update issues for hundreds of projects.