### PR TITLE
[11.x] fix: Model/JsonResource::toJson should not fail with prior json errors

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use JsonException;
 use JsonSerializable;
 use LogicException;
 use Stringable;
@@ -1661,10 +1662,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw JsonEncodingException::forModel($this, json_last_error_msg());
+        try {
+            $json = json_encode($this->jsonSerialize(), $options | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw JsonEncodingException::forModel($this, $e->getMessage());
         }
 
         return $json;

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\DelegatesToResource;
+use JsonException;
 use JsonSerializable;
 
 class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
@@ -144,10 +145,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw JsonEncodingException::forResource($this, json_last_error_msg());
+        try {
+            $json = json_encode($this->jsonSerialize(), $options | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw JsonEncodingException::forResource($this, $e->getMessage());
         }
 
         return $json;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3037,6 +3037,17 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($user->hasAttribute('nonexistent'));
         $this->assertFalse($user->hasAttribute('belongsToStub'));
     }
+
+    public function testModelToJsonSucceedsWithPriorErrors(): void
+    {
+        $user = new EloquentModelStub(['name' => 'Mateus']);
+
+        // Simulate a JSON error
+        json_decode('{');
+        $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
+
+        $this->assertSame('{"name":"Mateus"}', $user->toJson(JSON_THROW_ON_ERROR));
+    }
 }
 
 class EloquentTestObserverStub

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Http;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class JsonResourceTest extends TestCase
@@ -23,5 +24,21 @@ class JsonResourceTest extends TestCase
 
         $this->assertNull($resource->whenAggregated('relation', 'column', 'sum'));
         $this->assertNull($resource->whenCounted('relation'));
+    }
+
+    public function testJsonResourceToJsonSucceedsWithPriorErrors(): void
+    {
+        $model = new class extends Model {};
+
+        $resource = m::mock(JsonResource::class, ['resource' => $model])
+            ->makePartial()
+            ->shouldReceive('jsonSerialize')->once()->andReturn(['foo' => 'bar'])
+            ->getMock();
+
+        // Simulate a JSON error
+        json_decode('{');
+        $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
+
+        $this->assertSame('{"foo":"bar"}', $resource->toJson(JSON_THROW_ON_ERROR));
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR updates the Model/JsonResource::toJson methods so they succeed if there's been prior json errors. It does this by using the `JSON_THROW_ON_ERROR` flag in conjunction with a try/catch.

#### The problem
Out of the blue, a `Js::from($model)` call in a blade template started throwing `JsonEncodingException`s when the model in question hasn't been updated in two years. It turns out that `Js::from` passes the `JSON_THROW_ON_ERROR` flag to the `Model::toJson` method which was in turn just checking [`json_last_error()`](https://www.php.net/manual/en/function.json-last-error.php) after the `json_encode` call.

However, according to the PHP docs the `json_last_error` method:
> Returns the last error (if any) occurred during the last JSON encoding/decoding, which did not specify [JSON_THROW_ON_ERROR](https://www.php.net/manual/en/json.constants.php#constant.json-throw-on-error).

As the `Model::toJson` method was now being called with the `JSON_THROW_ON_ERROR` flag the call to `json_encode` did not reset the global json state and the method was failing from a json call introduced in a middleware.

Thanks!