### PR TITLE
[11.x] Allow microsecond travel

### DIFF
--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -25,6 +25,30 @@ class Wormhole
     }
 
     /**
+     * Travel forward the given number of microseconds.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function microsecond($callback = null)
+    {
+        return $this->microseconds($callback);
+    }
+
+    /**
+     * Travel forward the given number of microseconds.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function microseconds($callback = null)
+    {
+        Carbon::setTestNow(Carbon::now()->addMicroseconds($this->value));
+
+        return $this->handleCallback($callback);
+    }
+
+    /**
      * Travel forward the given number of milliseconds.
      *
      * @param  callable|null  $callback

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -46,4 +46,18 @@ class WormholeTest extends TestCase
         // Restore the default Date Factory...
         Date::useDefault();
     }
+
+    public function testItCanTravelByMicroseconds()
+    {
+        Date::use(CarbonImmutable::class);
+        Date::setTestNow(Date::parse('2000-01-01 00:00:00')->startOfSecond());
+
+        (new Wormhole(1))->microsecond();
+        $this->assertSame('2000-01-01 00:00:00.000001', Date::now()->format('Y-m-d H:i:s.u'));
+
+        (new Wormhole(5))->microseconds();
+        $this->assertSame('2000-01-01 00:00:00.000006', Date::now()->format('Y-m-d H:i:s.u'));
+
+        Date::useDefault();
+    }
 }


### PR DESCRIPTION
Adds support to `travel(5)->microseconds()`.

Currently, millisecond is the highest precision.