### PR TITLE
Add method `QueryExecuted::toRawSql()`

### DIFF
--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -56,4 +56,17 @@ class QueryExecuted
         $this->connection = $connection;
         $this->connectionName = $connection->getName();
     }
+
+    /**
+     * Get the raw SQL representation of the query with embedded bindings.
+     *
+     * @return string
+     */
+    public function toRawSql(): string
+    {
+        return $this->connection
+            ->query()
+            ->getGrammar()
+            ->substituteBindingsIntoRawSql($this->sql, $this->connection->prepareBindings($this->bindings));
+    }
 }

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -62,7 +62,7 @@ class QueryExecuted
      *
      * @return string
      */
-    public function toRawSql(): string
+    public function toRawSql()
     {
         return $this->connection
             ->query()

--- a/tests/Database/DatabaseIntegrationTest.php
+++ b/tests/Database/DatabaseIntegrationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Events\Dispatcher;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->setAsGlobal();
+        $db->setEventDispatcher(new Dispatcher);
+    }
+
+    public function testQueryExecutedToRawSql(): void
+    {
+        $connection = DB::connection();
+
+        $connection->listen(function (QueryExecuted $query) use (&$queryExecuted): void {
+            $queryExecuted = $query;
+        });
+
+        $connection->select('select ?', [true]);
+
+        $this->assertInstanceOf(QueryExecuted::class, $queryExecuted);
+        $this->assertSame('select ?', $queryExecuted->sql);
+        $this->assertSame([true], $queryExecuted->bindings);
+        $this->assertSame('select 1', $queryExecuted->toRawSql());
+    }
+}


### PR DESCRIPTION
This makes it easier to debug the executed queries when using `DB::listen()`.

Before, we did something like this and got a result that was hardly readable:

```php
DB::listen(function (QueryExecuted $query): void {
    $sql = str_replace("\n", ' ', $query->sql);
    $bindings = json_encode($query->bindings);

    file_put_contents(
        filename: storage_path('logs/query.log'),
        data: "SQL: {$sql} ||| Bindings: {$bindings} ||| Time: {$query->time}ms\n",
        flags: FILE_APPEND,
    );
});

// SQL: insert into `competence_detail_criteria` (`competence_criteria_id`, `competence_detail_id`, `valid_from`, `valid_to`, `userid`, `first_id`) values (?, ?, ?, ?, ?, ?) ||| Bindings: [3,1,"2024-07-19 10:59:02","9999-12-31 23:55:55",1,0] ||| Time: 0.84ms
```

With this added method, achieving a readable result becomes much simpler:

```php
DB::listen(function (QueryExecuted $query): void {
    file_put_contents(
        filename: storage_path('logs/query.log'),
        data: "SQL: {$query->toRawSql()} ||| Time: {$query->time}ms\n",
        flags: FILE_APPEND,
    );
});

// SQL: insert into `competence_detail_criteria` (`competence_criteria_id`, `competence_detail_id`, `valid_from`, `valid_to`, `userid`, `first_id`) values (4, 1, '2024-07-19 11:10:29', '9999-12-31 23:55:55', 1, 0) ||| Time: 0.2ms
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
