### PR TITLE
[11.x] Add hasPrevious method to URL

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -198,6 +198,20 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Check if has a previous url from header or session
+     *
+     * @return bool
+     */
+    public function hasPrevious()
+    {
+        $referrer = $this->request->headers->get('referer');
+
+        $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
+
+        return !empty($url);
+    }
+
+    /**
      * Generate an absolute URL to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -208,7 +208,8 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
 
-        return !empty($url);
+        return !empty($url)
+            && $url !== $this->full();
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -198,7 +198,7 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Check if has a previous url from header or session
+     * Check if has a previous url from header or session.
      *
      * @return bool
      */
@@ -208,8 +208,8 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
 
-        return !empty($url)
-            && $url !== $this->full();
+        return ! empty($url)
+            && $this->previous() !== $this->full();
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -762,6 +762,8 @@ class RoutingUrlGeneratorTest extends TestCase
 
         // Same url will return false
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/');
+
+        dump($url->full(), $url->previous());
         $this->assertFalse($url->hasPrevious());
 
         $url->getRequest()->headers->remove('referer');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -759,6 +759,12 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $url->getRequest()->headers->remove('referer');
         $this->assertFalse($url->hasPrevious());
+
+        $url->getRequest()->session->put('_previous.url', 'http://www.bar.com/');
+        $this->assertTrue($url->hasPrevious());
+
+        $url->getRequest()->session->remove('_previous.url');
+        $this->assertFalse($url->hasPrevious());
     }
 
     public function testRouteNotDefinedException()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -760,6 +760,13 @@ class RoutingUrlGeneratorTest extends TestCase
         $url->getRequest()->headers->remove('referer');
         $this->assertFalse($url->hasPrevious());
 
+        // Same url will return false
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/');
+        $this->assertFalse($url->hasPrevious());
+
+        $url->getRequest()->headers->remove('referer');
+        $this->assertFalse($url->hasPrevious());
+
         $url->getRequest()->session->put('_previous.url', 'http://www.bar.com/');
         $this->assertTrue($url->hasPrevious());
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -747,6 +747,20 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/bar', $url->previousPath('/bar'));
     }
 
+    public function testHasPrevious()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $url->getRequest()->headers->set('referer', 'http://www.bar.com/');
+        $this->assertTrue($url->hasPrevious());
+
+        $url->getRequest()->headers->remove('referer');
+        $this->assertFalse($url->hasPrevious());
+    }
+
     public function testRouteNotDefinedException()
     {
         $this->expectException(RouteNotFoundException::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Usage

In applications, I can imagine use cases such as rendering a "Go back" link if there is a previous URL.

```blade
@if(\Illuminate\Support\Facades\URL::hasPrevious())
    <a href="{{ \Illuminate\Support\Facades\URL::previous() }}">&larr; Go Back</a>
@endif
```