### PR TITLE
Support global custom pageName for pagination links

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -60,11 +60,11 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     protected $fragment;
 
     /**
-     * The cursor string variable used to store the page.
+     * The custom cursor string variable used to store the page.
      *
-     * @var string
+     * @var string|null
      */
-    protected $cursorName = 'cursor';
+    protected $cursorName;
 
     /**
      * The current cursor.
@@ -95,6 +95,13 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     protected static $currentCursorResolver;
 
     /**
+     * The default cursor string variable used to store the page.
+     *
+     * @var string
+     */
+    protected static $defaultCursorName = 'cursor';
+
+    /**
      * Get the URL for a given cursor.
      *
      * @param  \Illuminate\Pagination\Cursor|null  $cursor
@@ -105,7 +112,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = is_null($cursor) ? [] : [$this->cursorName => $cursor->encode()];
+        $parameters = is_null($cursor) ? [] : [$this->getCursorName() => $cursor->encode()];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
@@ -340,7 +347,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     protected function addQuery($key, $value)
     {
-        if ($key !== $this->cursorName) {
+        if ($key !== $this->getCursorName()) {
             $this->query[$key] = $value;
         }
 
@@ -435,7 +442,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function getCursorName()
     {
-        return $this->cursorName;
+        return $this->cursorName ?: static::$defaultCursorName;
     }
 
     /**
@@ -488,11 +495,13 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Resolve the current cursor or return the default value.
      *
-     * @param  string  $cursorName
+     * @param  string|null  $cursorName
      * @return \Illuminate\Pagination\Cursor|null
      */
-    public static function resolveCurrentCursor($cursorName = 'cursor', $default = null)
+    public static function resolveCurrentCursor($cursorName = null, $default = null)
     {
+        $cursorName = $cursorName ?? static::$defaultCursorName;
+
         if (isset(static::$currentCursorResolver)) {
             return call_user_func(static::$currentCursorResolver, $cursorName);
         }
@@ -519,6 +528,17 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     public static function viewFactory()
     {
         return Paginator::viewFactory();
+    }
+
+    /**
+     * Set the default query string variable used to store the cursor.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public static function setDefaultCursorName($name)
+    {
+        static::$defaultCursorName = $name;
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -61,11 +61,11 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     protected $fragment;
 
     /**
-     * The query string variable used to store the page.
+     * The custom query string variable used to store the page.
      *
-     * @var string
+     * @var string|null
      */
-    protected $pageName = 'page';
+    protected $pageName;
 
     /**
      * The number of links to display on each side of current page link.
@@ -124,6 +124,13 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     public static $defaultSimpleView = 'pagination::simple-tailwind';
 
     /**
+     * The default query string variable used to store the page.
+     *
+     * @var string
+     */
+    protected static $defaultPageName = 'page';
+
+    /**
      * Determine if the given value is a valid page number.
      *
      * @param  int  $page
@@ -175,7 +182,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = [$this->getPageName() => $page];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
@@ -262,7 +269,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     protected function addQuery($key, $value)
     {
-        if ($key !== $this->pageName) {
+        if ($key !== $this->getPageName()) {
             $this->query[$key] = $value;
         }
 
@@ -407,7 +414,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function getPageName()
     {
-        return $this->pageName;
+        return $this->pageName ?: static::$defaultPageName;
     }
 
     /**
@@ -499,12 +506,14 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * Resolve the current page or return the default value.
      *
-     * @param  string  $pageName
+     * @param  string|null  $pageName
      * @param  int  $default
      * @return int
      */
-    public static function resolveCurrentPage($pageName = 'page', $default = 1)
+    public static function resolveCurrentPage($pageName = null, $default = 1)
     {
+        $pageName = $pageName ?? static::$defaultPageName;
+
         if (isset(static::$currentPageResolver)) {
             return (int) call_user_func(static::$currentPageResolver, $pageName);
         }
@@ -644,6 +653,17 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     {
         static::defaultView('pagination::bootstrap-5');
         static::defaultSimpleView('pagination::simple-bootstrap-5');
+    }
+
+    /**
+     * Set the default query string variable used to store the page.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public static function setDefaultPageName($name)
+    {
+        static::$defaultPageName = $name;
     }
 
     /**

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pagination;
 
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
@@ -123,5 +124,49 @@ class CursorPaginatorTest extends TestCase
     protected function getCursor($params, $isNext = true)
     {
         return (new Cursor($params, $isNext))->encode();
+    }
+
+    public function testCursorPaginatorSetDefaultCursorName()
+    {
+        CursorPaginator::setDefaultCursorName('c');
+
+        $cursor = new Cursor(['id' => 3]);
+        $paginator = new CursorPaginator([['id' => 3], ['id' => 4]], 2, $cursor, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertSame('c', $paginator->getCursorName());
+
+        // Reset
+        CursorPaginator::setDefaultCursorName('cursor');
+    }
+
+    public function testCursorPaginatorGetAndSetCursorName()
+    {
+        $cursor = new Cursor(['id' => 3]);
+        $paginator = new CursorPaginator([['id' => 3], ['id' => 4]], 2, $cursor, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertSame('cursor', $paginator->getCursorName());
+
+        $paginator->setCursorName('c');
+        $this->assertSame('c', $paginator->getCursorName());
+    }
+
+    public function testCursorPaginatorOverrideDefaultCursorName()
+    {
+        CursorPaginator::setDefaultCursorName('c');
+
+        $cursor = new Cursor(['id' => 3]);
+        $paginator = new CursorPaginator([['id' => 3], ['id' => 4]], 2, $cursor, [
+            'parameters' => ['id'],
+        ]);
+
+        $paginator->setCursorName('foo');
+        $this->assertSame('foo', $paginator->getCursorName());
+
+        // Reset
+        LengthAwarePaginator::setDefaultPageName('cursor');
     }
 }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -28,12 +28,32 @@ class LengthAwarePaginatorTest extends TestCase
         unset($this->p);
     }
 
+    public function testLengthAwarePaginatorSetDefaultPageName()
+    {
+        LengthAwarePaginator::setDefaultPageName('p');
+
+        $this->assertSame('p', $this->p->getPageName());
+
+        // Reset
+        LengthAwarePaginator::setDefaultPageName('page');
+    }
+
     public function testLengthAwarePaginatorGetAndSetPageName()
     {
         $this->assertSame('page', $this->p->getPageName());
 
         $this->p->setPageName('p');
         $this->assertSame('p', $this->p->getPageName());
+    }
+
+    public function testLengthAwarePaginatorOverrideDefaultPageName()
+    {
+        LengthAwarePaginator::setDefaultPageName('p');
+        $this->p->setPageName('foo');
+        $this->assertSame('foo', $this->p->getPageName());
+
+        // Reset
+        LengthAwarePaginator::setDefaultPageName('page');
     }
 
     public function testLengthAwarePaginatorCanGiveMeRelevantPageInformation()


### PR DESCRIPTION
Currently it's possible to provide a custom page name by setting the name onto an exisiting paginator instance:

```php
$paginator->setPageName('foo');
```

If you want to customize this for all paginators, for example in case of a non-English application, there's no real possibility except for explicitly calling the setter every time (or pull out some other tricks usings traits or so).

This PR allows to define a custom default for the `?page=` and `?cursor=` query parameters.

Just set it once in a service provider. And of course you'll still be able to override it whenever needed.

```php
LengthAwarePaginator::setDefaultPageName('p');

$paginator->getPageName(); // 'p'
$paginator->setPageName('foo');
$paginator->getPageName(); // 'foo'
```

This PR also includes similar functionality for the CursorPaginator.