### PR TITLE
[11.x] fix: Request::json() json errors when decoding empty string

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -405,7 +405,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function json($key = null, $default = null)
     {
         if (! isset($this->json)) {
-            $this->json = new InputBag((array) json_decode($this->getContent(), true));
+            $this->json = new InputBag((array) json_decode($this->getContent() ?: '[]', true));
         }
 
         if (is_null($key)) {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1606,4 +1606,14 @@ class HttpRequestTest extends TestCase
 
         $this->assertSame(['name' => 'Laravel'], $request->get('framework'));
     }
+
+    public function testItDoesNotGenerateJsonErrorsForEmptyContent()
+    {
+        // clear any existing errors
+        json_encode(null);
+
+        Request::create('', 'GET')->json();
+
+        $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
+    }
 }


### PR DESCRIPTION

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

I finally tracked down the root cause for the existing json errors in https://github.com/laravel/framework/pull/52188. 

When a FormRequest is resolved from the container it calls the `FormRequest::createFrom()` method with the `Request` object that, among other things, sets the FormRequest json from the Request json.

In the case where the Request does not have any content the `Request::json()` method is trying to decode an empty string as an associative array which results in a json syntax error.

This PR fixes that error by converting the empty string to an empty json array before decoding.


Thanks!