### PR TITLE
feat: mergeIfMissing allows merging with nested arrays

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -983,6 +983,16 @@ class HttpRequestTest extends TestCase
         $request->mergeIfMissing($merge);
         $this->assertSame('Taylor', $request->input('name'));
         $this->assertSame(1, $request->input('boolean_setting'));
+
+        $request = Request::create('/', 'GET', ['user' => [ 'first_name' => 'Taylor', 'email' => 'taylor@laravel.com' ]]);
+        $merge = ['user.last_name' => 'Otwell'];
+        $request->mergeIfMissing($merge);
+        $this->assertSame('Otwell', $request->input('user.last_name'));
+
+        $request = Request::create('/', 'GET', ['user' => [ 'first_name' => 'Taylor', 'email' => 'taylor@laravel.com' ]]);
+        $merge = ['user.first_name' => 'John'];
+        $request->mergeIfMissing($merge);
+        $this->assertSame('Taylor', $request->input('user.first_name'));
     }
 
     public function testReplaceMethod()


### PR DESCRIPTION
Hello,

This PR updates the `mergeIfMissing` method from the Http/Request class to allow merging with nested arrays using the "." (dot) notation.

The section named "Actual Behaviour" marks Laravel's current implementation output for described scenario, while the "Expected Behaviour" shows the output if using my changes to the Http/Request class.

I've added 2 assertions to the `testMergeIfMissingMethod` test.

## Problem / Setting up the scenario:
- I've been sending POST requests to my endpoint with the following payload: 
```
{
    "user": {
        "first_name: "Taylor"
    }
}
``` 
and tried merging the input in my controller with:
```
$request->mergeIfMissing([
    'user.last_name' => 'Otwell'
]);
```
## Expected Behaviour
expecting to set the current request input to:
```
[
    'user' => [
        'first_name' => 'Taylor',
        'last_name' => 'Otwell
    ]
]
```
## Actual Behaviour
but instead I was getting:
```
{
    "user": {
        "first_name": "Taylor"
    },
    "user.last_name": "Otwell"
}
```