### PR TITLE
[11.x] Reduce the number of queries with `Cache::many` and `Cache::putMany` methods in  the database driver

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -380,11 +380,8 @@ class DatabaseStore implements LockProvider, Store
 
     /**
      * Remove all items from the cache.
-     *
-     * @param  string  $key
-     * @return bool
      */
-    protected function forgetMany(array $keys)
+    protected function forgetMany(array $keys): bool
     {
         $this->table()->whereIn('key', array_map(function ($key) {
             return $this->prefix.$key;
@@ -395,10 +392,8 @@ class DatabaseStore implements LockProvider, Store
 
     /**
      * Remove all expired items from the given set from the cache.
-     *
-     * @return bool
      */
-    protected function forgetManyIfExpired(array $keys, bool $prefixed = false)
+    protected function forgetManyIfExpired(array $keys, bool $prefixed = false): bool
     {
         $this->table()
             ->whereIn('key', $prefixed ? $keys : array_map(function ($key) {

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -99,7 +99,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
         $table->shouldReceive('delete')->once();
 
         $store->forget('foo');

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -22,8 +22,8 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('first')->once()->andReturn(null);
+        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
+        $table->shouldReceive('get')->once()->andReturn(collect([]));
 
         $this->assertNull($store->get('foo'));
     }
@@ -31,11 +31,17 @@ class CacheDatabaseStoreTest extends TestCase
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forgetIfExpired'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock(stdClass::class);
-        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('first')->once()->andReturn((object) ['expiration' => 1]);
-        $store->expects($this->once())->method('forgetIfExpired')->with($this->equalTo('foo'))->willReturn(null);
+
+        $getQuery = m::mock(stdClass::class);
+        $getQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($getQuery);
+        $getQuery->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'expiration' => 1]]));
+
+        $deleteQuery = m::mock(stdClass::class);
+        $deleteQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($deleteQuery);
+        $deleteQuery->shouldReceive('where')->once()->with('expiration', '<=', m::any())->andReturn($deleteQuery);
+        $deleteQuery->shouldReceive('delete')->once()->andReturnNull();
+
+        $store->getConnection()->shouldReceive('table')->twice()->with('table')->andReturn($getQuery, $deleteQuery);
 
         $this->assertNull($store->get('foo'));
     }
@@ -45,8 +51,8 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('first')->once()->andReturn((object) ['value' => serialize('bar'), 'expiration' => 999999999999999]);
+        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
+        $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 999999999999999]]));
 
         $this->assertSame('bar', $store->get('foo'));
     }
@@ -56,8 +62,8 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getPostgresStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('first')->once()->andReturn((object) ['value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]);
+        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
+        $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]]));
 
         $this->assertSame('bar', $store->get('foo'));
     }
@@ -68,7 +74,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
-        $table->shouldReceive('upsert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61], 'key')->andReturnTrue();
+        $table->shouldReceive('upsert')->once()->with([['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61]], 'key')->andReturnTrue();
 
         $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
@@ -80,7 +86,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
-        $table->shouldReceive('upsert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61], 'key')->andReturn(1);
+        $table->shouldReceive('upsert')->once()->with([['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61]], 'key')->andReturn(1);
 
         $result = $store->put('foo', "\0", 60);
         $this->assertTrue($result);

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -173,13 +173,17 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $store->add('first', 'a', 60);
         $store->add('second', 'b', 60);
 
-        $cache = $store->get(['first', 'second', 'third']);
+        $this->assertEquals([
+            'first' => 'a',
+            'second' => 'b',
+            'third' => null,
+        ], $store->get(['first', 'second', 'third']));
 
         $this->assertEquals([
             'first' => 'a',
             'second' => 'b',
             'third' => null,
-        ], $cache);
+        ], $store->many(['first', 'second', 'third']));
     }
 
     public function testResolvingSQLiteConnectionDoesNotThrowExceptions()

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -166,6 +166,22 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
     }
 
+    public function testMultiGet()
+    {
+        $store = $this->getStore();
+
+        $store->add('first', 'a', 60);
+        $store->add('second', 'b', 60);
+
+        $cache = $store->get(['first', 'second', 'third']);
+
+        $this->assertEquals([
+            'first' => 'a',
+            'second' => 'b',
+            'third' => null,
+        ], $cache);
+    }
+
     public function testResolvingSQLiteConnectionDoesNotThrowExceptions()
     {
         $originalConfiguration = config('database');

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -200,6 +200,26 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('first')]);
     }
 
+    public function testPutMany()
+    {
+        $store = $this->getStore();
+
+        $store->putMany($data = [
+            'first' => 'a',
+            'second' => 'b',
+        ], 60);
+
+        $this->assertEquals($data, $store->many(['first', 'second']));
+        $this->assertDatabaseHas($this->getCacheTableName(), [
+            'key' => $this->withCachePrefix('first'),
+            'value' => serialize('a'),
+        ]);
+        $this->assertDatabaseHas($this->getCacheTableName(), [
+            'key' => $this->withCachePrefix('second'),
+            'value' => serialize('b'),
+        ]);
+    }
+
     public function testResolvingSQLiteConnectionDoesNotThrowExceptions()
     {
         $originalConfiguration = config('database');

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -188,7 +188,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
 
     public function testManyWithExpiredKeys()
     {
-        $this->insertToCacheTable('first', 'a', -10);
+        $this->insertToCacheTable('first', 'a', 0);
         $this->insertToCacheTable('second', 'b', 60);
 
         $this->assertEquals([

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -200,6 +200,23 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('first')]);
     }
 
+    public function testManyAsAssociativeArray()
+    {
+        $this->insertToCacheTable('first', 'cached', 60);
+
+        $result = $this->getStore()->many([
+            'first' => 'aa',
+            'second' => 'bb',
+            'third',
+        ]);
+
+        $this->assertEquals([
+            'first' => 'cached',
+            'second' => 'bb',
+            'third' => null,
+        ], $result);
+    }
+
     public function testPutMany()
     {
         $store = $this->getStore();


### PR DESCRIPTION
### Changelog

- Implements the `many` and `putMany` methods in the `DatabaseStore` cache driver. The previous implementation was doing a database query for each key, but now it does only 1 query for all (2 if it finds expired keys)

---

I was exploring fragment caching on my views... then found out the `many` method of the database cache driver was doing a database query for each cache key. The new implementation does only one query for all keys and then builds the results from what it finds. Additionally, it deletes the expired keys it finds in a single query as well.

The `putMany` had a similar story: it was doing a database query for each key. Now, it only does one `upsert`.

I made the `get` and `put` methods use the `many` and `put` ones behind the scenes so we can rely on the same implementation. This step is optional and we can revert the commit, if y'all don't want that.