### PR TITLE
[11.x] Added model loaded event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -123,7 +123,7 @@ trait HasEvents
     {
         return array_merge(
             [
-                'retrieved', 'creating', 'created', 'updating', 'updated',
+                'loaded', 'retrieved', 'creating', 'created', 'updating', 'updated',
                 'saving', 'saved', 'restoring', 'restored', 'replicating',
                 'deleting', 'deleted', 'forceDeleting', 'forceDeleted',
             ],
@@ -252,6 +252,17 @@ trait HasEvents
         }
 
         return $result;
+    }
+
+    /**
+     * Register a loaded model event with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @return void
+     */
+    public static function loaded($callback)
+    {
+        static::registerModelEvent('loaded', $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -721,6 +721,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $query->eagerLoadRelations([$this]);
 
+        $this->fireModelEvent('loaded', false);
+
         return $this;
     }
 


### PR DESCRIPTION

Added model loaded event that runs after the relations gets eager loaded to avoid N + 1 query issues when using relations in retrieved event because retrieved is called before relations gets eager loaded.

Considered adding new event rather than changing the retrieved event call place to avoid breaking any existing code.

