### PR TITLE
Add custom separator option to Arr::dot() method for flattening multi-dimensional arrays

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -102,19 +102,20 @@ class Arr
     }
 
     /**
-     * Flatten a multi-dimensional associative array with dots.
+     * Flatten a multi-dimensional associative array with separator.
      *
      * @param  iterable  $array
      * @param  string  $prepend
+     * @param  string  $separator
      * @return array
      */
-    public static function dot($array, $prepend = '')
+    public static function dot($array, $prepend = '', $separator = '.')
     {
         $results = [];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results = array_merge($results, static::dot($value, $prepend.$key.$separator, $separator));
             } else {
                 $results[$prepend.$key] = $value;
             }


### PR DESCRIPTION
**Summary**
This pull request enhances the `Arr::dot()` method by adding an optional `$separator` parameter. This allows developers to specify a custom separator when flattening multi-dimensional arrays.

**Benefits to End Users**

- Customizability: Users can now specify a custom separator, making the method more flexible for various use cases, such as database operations where a specific separator is required (e.g., `->` for JSON columns).
- Backward Compatibility: The default separator remains a dot (`.`), ensuring that existing functionality is not disrupted.
- Enhanced Readability: By allowing custom separators, the flattened array keys can be made more readable and context-specific.

**Implementation Details**

- Method Signature Change: The method signature of `Arr::dot()` now includes an additional parameter `$separator` with a default value of `.`.
- Code Adjustments: The method now uses the provided `$separator` when constructing keys for the flattened array.