### PR TITLE
Fix Builder - support camelCase attributes

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -2000,7 +2001,7 @@ class Builder implements BuilderContract
         // clause on the query. Then we'll increment the parameter index values.
         $bool = strtolower($connector);
 
-        $this->where(Str::snake($segment), '=', $parameters[$index], $bool);
+        $this->where(lcfirst(Model::$snakeAttributes ? Str::snake($segment) : $segment), '=', $parameters[$index], $bool);
     }
 
     /**


### PR DESCRIPTION
Use global Model::snakeAttributes for where conditions

I'm not sure how to fix this problem properly because this fix affects all models in the project.