### PR TITLE
[11.x] allow custom view path when making components

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -117,6 +117,7 @@ class ComponentMakeCommand extends GeneratorCommand
     protected function getView()
     {
         $segments = explode('/', str_replace('\\', '/', $this->argument('name')));
+
         $name = array_pop($segments);
 
         $path = is_string($this->option('path'))
@@ -129,9 +130,7 @@ class ComponentMakeCommand extends GeneratorCommand
         $path[] = $name;
 
         return collect($path)
-            ->map(function ($part) {
-                return Str::kebab($part);
-            })
+            ->map(fn ($segment) => Str::kebab($segment))
             ->implode('.');
     }
 
@@ -177,10 +176,10 @@ class ComponentMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the component already exists'],
             ['inline', null, InputOption::VALUE_NONE, 'Create a component that renders an inline view'],
             ['view', null, InputOption::VALUE_NONE, 'Create an anonymous component with only a view'],
-            ['path', null, InputOption::VALUE_REQUIRED, 'Specify the view path'],
+            ['path', null, InputOption::VALUE_REQUIRED, 'The location where the component view should be created'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the component already exists'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -63,7 +63,7 @@ class ComponentMakeCommand extends GeneratorCommand
     protected function writeView()
     {
         $path = $this->viewPath(
-            str_replace('.', '/', 'components.'.$this->getView()).'.blade.php'
+            str_replace('.', '/', $this->getView()).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {
@@ -104,21 +104,31 @@ class ComponentMakeCommand extends GeneratorCommand
 
         return str_replace(
             ['DummyView', '{{ view }}'],
-            'view(\'components.'.$this->getView().'\')',
+            'view(\''.$this->getView().'\')',
             parent::buildClass($name)
         );
     }
 
     /**
-     * Get the view name relative to the components directory.
+     * Get the view name relative to the view path.
      *
      * @return string view
      */
     protected function getView()
     {
-        $name = str_replace('\\', '/', $this->argument('name'));
+        $segments = explode('/', str_replace('\\', '/', $this->argument('name')));
+        $name = array_pop($segments);
 
-        return collect(explode('/', $name))
+        $path = is_string($this->option('path'))
+            ? explode('/', trim($this->option('path'), '/'))
+            : [
+                'components',
+                ...$segments,
+            ];
+
+        $path[] = $name;
+
+        return collect($path)
             ->map(function ($part) {
                 return Str::kebab($part);
             })
@@ -170,6 +180,7 @@ class ComponentMakeCommand extends GeneratorCommand
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the component already exists'],
             ['inline', null, InputOption::VALUE_NONE, 'Create a component that renders an inline view'],
             ['view', null, InputOption::VALUE_NONE, 'Create an anonymous component with only a view'],
+            ['path', null, InputOption::VALUE_REQUIRED, 'Specify the view path'],
         ];
     }
 }

--- a/tests/Integration/Generators/ComponentMakeCommandTest.php
+++ b/tests/Integration/Generators/ComponentMakeCommandTest.php
@@ -8,6 +8,10 @@ class ComponentMakeCommandTest extends TestCase
         'app/View/Components/Foo.php',
         'resources/views/components/foo.blade.php',
         'tests/Feature/View/Components/FooTest.php',
+        'resources/views/custom/path/foo.blade.php',
+        'app/View/Components/Nested/Foo.php',
+        'resources/views/components/nested/foo.blade.php',
+        'tests/Feature/View/Components/Nested/FooTest.php',
     ];
 
     public function testItCanGenerateComponentFile()
@@ -49,5 +53,53 @@ class ComponentMakeCommandTest extends TestCase
         $this->assertFilenameExists('app/View/Components/Foo.php');
         $this->assertFilenameExists('resources/views/components/foo.blade.php');
         $this->assertFilenameExists('tests/Feature/View/Components/FooTest.php');
+    }
+
+    public function testItCanGenerateComponentFileWithCustomPath()
+    {
+        $this->artisan('make:component', ['name' => 'Foo', '--path' => 'custom/path'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\View\Components;',
+            'use Illuminate\View\Component;',
+            'class Foo extends Component',
+            "return view('custom.path.foo');",
+        ], 'app/View/Components/Foo.php');
+
+        $this->assertFilenameExists('resources/views/custom/path/foo.blade.php');
+        $this->assertFilenameNotExists('tests/Feature/View/Components/FooTest.php');
+    }
+
+    public function testItCanGenerateNestedComponentFile()
+    {
+        $this->artisan('make:component', ['name' => 'Nested/Foo'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\View\Components\Nested;',
+            'use Illuminate\View\Component;',
+            'class Foo extends Component',
+            "return view('components.nested.foo');",
+        ], 'app/View/Components/Nested/Foo.php');
+
+        $this->assertFilenameExists('resources/views/components/nested/foo.blade.php');
+        $this->assertFilenameNotExists('tests/Feature/View/Components/Nested/FooTest.php');
+    }
+
+    public function testItCanGenerateNestedComponentFileWithCustomPath()
+    {
+        $this->artisan('make:component', ['name' => 'Nested/Foo', '--path' => 'custom/path'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\View\Components\Nested;',
+            'use Illuminate\View\Component;',
+            'class Foo extends Component',
+            "return view('custom.path.foo');",
+        ], 'app/View/Components/Nested/Foo.php');
+
+        $this->assertFilenameExists('resources/views/custom/path/foo.blade.php');
+        $this->assertFilenameNotExists('tests/Feature/View/Components/Nested/FooTest.php');
     }
 }


### PR DESCRIPTION
currently the `component/` view path is hardcoded into the generator command. while definitely a good default, there can be a need for more custom view paths, depending on each application's specific organization.

this change makes it possible to pass a `--path` option to the command, which will override the location of the view file.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
