### PR TITLE
Enable withPivot attribute on Pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -588,8 +588,15 @@ trait InteractsWithPivotTable
      */
     public function withPivot($columns)
     {
+        $columns = is_array($columns) ? $columns : func_get_args();
+
+        if($this->using){
+            $instance = $this->newPivot();
+            $columns = array_merge($columns, $instance->withPivot);
+        }
+
         $this->pivotColumns = array_merge(
-            $this->pivotColumns, is_array($columns) ? $columns : func_get_args()
+            $this->pivotColumns, $columns
         );
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -22,4 +22,11 @@ class Pivot extends Model
      * @var array<string>|bool
      */
     protected $guarded = [];
+
+    /**
+     * Included pivot columns
+     *
+     * @var array<string>
+     */
+    public $withPivot = [];
 }


### PR DESCRIPTION
This small PR is to enable using `$withPivot` as an attribute on a `Pivot` model. It goes hand-in-hand with separation of concerns given that you are in this case already using a pivot model via `using()` method. Use case is to enable a central place for defining `withPivot()` on `belongsToMany()` relations. 

Example. Instead of this 

```php
class Purchase extends Model
{
    public function products(): BelongsToMany
    {
        return $this->belongsToMany(Product::class)
            ->withPivot([
                'unit',
                'quantity',
                'price_no_vat',
                'vat',
                'price',
                'discount',
                'barcode',
                'stock_point_id',
                'stock_point_name',
                'destination_product_id',
                'destination_product_title',
                'destination_quantity',
                'destination_price',
            ])
            ->using(ProductPurchase::class)
            ->withTimestamps();
    }
    ...
```

You would have this:

```php
class Purchase extends Model
{
    public function products(): BelongsToMany
    {
        return $this->belongsToMany(Product::class)
            ->using(ProductPurchase::class)
            ->withTimestamps();
    }
    ...
    
class ProductPurchase extends Pivot
{
    public $withPivot = [
        'unit',
        'quantity',
        'price_no_vat',
        'vat',
        'price',
        'discount',
        'barcode',
        'stock_point_id',
        'stock_point_name',
        'destination_product_id',
        'destination_product_title',
        'destination_quantity',
        'destination_price',
    ];
    ...
```