### PR TITLE
fix: support colored output from queue:listen

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -111,7 +111,7 @@ class WorkCommand extends Command
         // connection being run for the queue operation currently being executed.
         $queue = $this->getQueue($connection);
 
-        if (Terminal::hasSttyAvailable() && !self::isChildProcess()) {
+        if (Terminal::hasSttyAvailable() && ! self::isChildProcess()) {
             $this->components->info(
                 sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
             );
@@ -311,7 +311,7 @@ class WorkCommand extends Command
      */
     private static function isChildProcess()
     {
-        if (PHP_OS_FAMILY === "Windows") {
+        if (PHP_OS_FAMILY === 'Windows') {
             $pid = getmypid();
             $parentPid = shell_exec("wmic process where (processid=$pid) get parentprocessid");
             $parentPid = explode("\n", $parentPid);

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -118,13 +118,22 @@ class Listener
             $command = $this->addEnvironment($command, $options);
         }
 
-        return new Process(
+        $process = new Process(
             $command,
             $this->commandPath,
             null,
             null,
             $options->timeout
         );
+
+        // Enable TTY mode to propagate colored output if supported by the terminal
+        try {
+            $process->setPty(true);
+        } catch (\Throwable $th) {
+            // TTY mode might not be supported; handle any exceptions silently
+        }
+
+        return $process;
     }
 
     /**

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -128,7 +128,7 @@ class Listener
 
         // Enable TTY mode to propagate colored output if supported by the terminal
         try {
-            $process->setPty(true);
+            $process->setTty(true);
         } catch (\Throwable $th) {
             // TTY mode might not be supported; handle any exceptions silently
         }


### PR DESCRIPTION
Currently laravel queue jobs do not have colored output when they are run by the artisan queue listener `php artisan queue:listen --tries=1 --timeout=1800`, `php artisan queue:work --once` works just fine.

This is due to a symfony change in their dedection algorithm which I think was buggy in the past and returned true incorrectly (if their algorithm is actually wrong again and this is an upstream issue then feel free to close this one). reference: https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Console/Output/StreamOutput.php

For subprocess which we are spawning I believe the correct way of handling things is by enabling the tty feature of the process via `setTty(true)` like someone else described here https://github.com/symfony/symfony/issues/23002.

Enabling this however leads to regressions, since https://github.com/laravel/framework/pull/44971 the queue listener will only print "Processing jobs from the [] queue" once, this done via `Terminal::hasSttyAvailable()`.
The change in enabling the tty again is breaking this detection and as such we need a different way to detect if we need to print the message again, this is handled by the `isChildProcess` function. If you have better ideas on how to solve this I'm happy to change this part.
