### PR TITLE
[11.x] Inspect exception of assertThrows

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -172,7 +172,7 @@ trait InteractsWithExceptionHandling
      * Assert that the given callback throws an exception with the given message when invoked.
      *
      * @param  \Closure  $test
-     * @param  class-string<\Throwable>|\Closure  $expectedClass
+     * @param  \Closure|class-string<\Throwable>  $expectedClass
      * @param  string|null  $expectedMessage
      * @return $this
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Closure;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
+use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Testing\Assert;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\Console\Application as ConsoleApplication;
@@ -13,6 +14,8 @@ use Throwable;
 
 trait InteractsWithExceptionHandling
 {
+    use ReflectsClosures;
+
     /**
      * The original exception handler.
      *
@@ -169,18 +172,22 @@ trait InteractsWithExceptionHandling
      * Assert that the given callback throws an exception with the given message when invoked.
      *
      * @param  \Closure  $test
-     * @param  class-string<\Throwable>  $expectedClass
+     * @param  class-string<\Throwable>|\Closure  $expectedClass
      * @param  string|null  $expectedMessage
      * @return $this
      */
-    protected function assertThrows(Closure $test, string $expectedClass = Throwable::class, ?string $expectedMessage = null)
+    protected function assertThrows(Closure $test, string|Closure $expectedClass = Throwable::class, ?string $expectedMessage = null)
     {
+        [$expectedClass, $expectedClassCallback] = $expectedClass instanceof Closure
+            ? [$this->firstClosureParameterType($expectedClass), $expectedClass]
+            : [$expectedClass, null];
+
         try {
             $test();
 
             $thrown = false;
         } catch (Throwable $exception) {
-            $thrown = $exception instanceof $expectedClass;
+            $thrown = $exception instanceof $expectedClass && ($expectedClassCallback === null || $expectedClassCallback($exception));
 
             $actualMessage = $exception->getMessage();
         }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -533,6 +533,42 @@ class FoundationExceptionsHandlerTest extends TestCase
         if ($testFailed) {
             Assert::fail('assertThrows failed: non matching message are thrown.');
         }
+
+        $this->assertThrows(function () {
+            throw new CustomException('Some message.');
+        }, function (CustomException $exception) {
+            return $exception->getMessage() === 'Some message.';
+        });
+
+        try {
+            $this->assertThrows(function () {
+                throw new CustomException('Some message.');
+            }, function (CustomException $exception) {
+                return false;
+            });
+            $testFailed = true;
+        } catch (AssertionFailedError) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrows failed: exception callback succeeded.');
+        }
+
+        try {
+            $this->assertThrows(function () {
+                throw new Exception('Some message.');
+            }, function (CustomException $exception) {
+                return true;
+            });
+            $testFailed = true;
+        } catch (AssertionFailedError) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrows failed: non matching exceptions are thrown.');
+        }
     }
 
     public function testItReportsDuplicateExceptions()


### PR DESCRIPTION
The `assertThrows` test method makes it possible to assert if a specific exception is thrown. You can also assert the message of the exception. But what if you want to assert other data/properties of the thrown exception? That is currently not possible, but this PR fixes that.

```php
$this->assertThrows(
    fn () => throw new FooException(),
    fn (FooException $exception) => $exception->getBar() === 'baz'
);
