### PR TITLE
[12.x] Enhancing redirect logic in `RedirectIfAuthenticated` middleware by passing the `$guard`

### DIFF
--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -28,7 +28,7 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
-                return redirect($this->redirectTo($request));
+                return redirect($this->redirectTo($request, $guard));
             }
         }
 
@@ -38,10 +38,10 @@ class RedirectIfAuthenticated
     /**
      * Get the path the user should be redirected to when they are authenticated.
      */
-    protected function redirectTo(Request $request): ?string
+    protected function redirectTo(Request $request, ?string $guard): ?string
     {
         return static::$redirectToCallback
-            ? call_user_func(static::$redirectToCallback, $request)
+            ? call_user_func(static::$redirectToCallback, $request, $guard)
             : $this->defaultRedirectUri();
     }
 

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -73,7 +73,7 @@ class RedirectIfAuthenticated
      * @param  callable  $redirectToCallback
      * @return void
      */
-    public static function redirectUsing(callable $redirectToCallback)
+    public static function redirectUsing(callable $redirectToCallback): void
     {
         static::$redirectToCallback = $redirectToCallback;
     }

--- a/tests/Integration/Auth/Middleware/RedirectIfAuthenticatedTest.php
+++ b/tests/Integration/Auth/Middleware/RedirectIfAuthenticatedTest.php
@@ -26,13 +26,6 @@ class RedirectIfAuthenticatedTest extends TestCase
 
         UserFactory::new()->create();
 
-        $user = AuthenticationTestUser::first();
-        $this->router->get('/login', function () {
-            return response('Login Form');
-        })->middleware(RedirectIfAuthenticated::class);
-
-        UserFactory::new()->create();
-
         $this->user = AuthenticationTestUser::first();
     }
 


### PR DESCRIPTION
## Overview

This pull request introduces a significant enhancement to the `RedirectIfAuthenticated` middleware in Laravel, offering more flexibility and customization in redirecting logged-in users based on their authentication guard. The current implementation limits redirection based on the `Request $request`, but with this enhancement, developers can tailor redirection based on specific guards, empowering them to create more dynamic and context-aware applications.

## Reason for Resubmission

I previously targeted these changes to version 11 in the following pull request: #50837 (https://github.com/laravel/framework/pull/50837). It was closed due to the potential for breaking changes, which I completely understand. However, over the last few months, I have received several comments on the closed PR from developers expressing that this feature would be highly beneficial and requesting its inclusion in the framework.

This feedback has prompted me to reopen the pull request, this time targeting the `master` branch, with the hope that it can be considered for the next major release.

## Breaking Change Justification

The breaking change is minimal and justified, as developers seeking custom redirect logic should ideally use the `redirectUsing` method instead of overwriting the `redirectTo` method. With the `$guard` parameter added, this enhancement allows developers to avoid extending the `RedirectIfAuthenticated` class, thereby keeping the middleware namespace cleaner.

## Implementation Details

With this pull request, the `RedirectIfAuthenticated` middleware will now accept a callback function with `?string $guard` as the second parameter, allowing developers to define custom redirection logic based on the authenticated guard. Here's how it works:

```php
$middleware->redirectUsersTo(static function (Request $request, ?string $guard): string {
    return match ($guard) {
        'admins' => Dashboard::getUrl(panel: 'administrator'),
        'market_vendors' => Dashboard::getUrl(panel: 'market-vendor'),
        default => '/dashboard',
    };
});
```

In this example, the callback receives the current request and the guard name. Developers can then use a match expression to determine the appropriate redirect URL based on the guard. This enhancement enables more granular control over user redirection, facilitating better user experiences and application flows.