### PR TITLE
[10.x] Include forced domain in guest redirect

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -74,8 +74,8 @@ class Redirector
         $request = $this->generator->getRequest();
 
         $intended = $request->isMethod('GET') && $request->route() && ! $request->expectsJson()
-                        ? $this->generator->full()
-                        : $this->generator->previous();
+                        ? $this->generator->current()
+                        : $this->generator->to($this->generator->previous());
 
         if ($intended) {
             $this->setIntendedUrl($intended);

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -73,7 +73,7 @@ class RoutingRedirectorTest extends TestCase
 
     public function testGuestPutCurrentUrlInSession()
     {
-        $this->url->shouldReceive('full')->andReturn('http://foo.com/bar');
+        $this->url->shouldReceive('current')->andReturn('http://foo.com/bar');
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
 
         $response = $this->redirect->guest('login');
@@ -85,6 +85,7 @@ class RoutingRedirectorTest extends TestCase
     {
         $this->request->shouldReceive('isMethod')->once()->with('GET')->andReturn(false);
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+        $this->url->shouldReceive('to')->once()->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('previous')->once()->andReturn('http://foo.com/bar');
 
         $response = $this->redirect->guest('login');


### PR DESCRIPTION
When you have configured a Forced Root URL, if you try to log in, but are redirected from guest mode, the redirect destination is derived from the requested domain, not the forced root URL.

This means that if you have a proxy system, which changes the domain, the browser is redirected to a domain which the client cannot reach.

This PR fixes that.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
