### PR TITLE
[11.x] Support lower version of Carbon

### DIFF
--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\Wormhole;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use PHPUnit\Framework\TestCase;
 
@@ -49,8 +50,7 @@ class WormholeTest extends TestCase
 
     public function testItCanTravelByMicroseconds()
     {
-        Date::use(CarbonImmutable::class);
-        Date::setTestNow(Date::parse('2000-01-01 00:00:00')->startOfSecond());
+        Carbon::setTestNow(Carbon::parse('2000-01-01 00:00:00')->startOfSecond());
 
         (new Wormhole(1))->microsecond();
         $this->assertSame('2000-01-01 00:00:00.000001', Date::now()->format('Y-m-d H:i:s.u'));
@@ -58,6 +58,6 @@ class WormholeTest extends TestCase
         (new Wormhole(5))->microseconds();
         $this->assertSame('2000-01-01 00:00:00.000006', Date::now()->format('Y-m-d H:i:s.u'));
 
-        Date::useDefault();
+        Carbon::setTestnow();
     }
 }


### PR DESCRIPTION
The test I introduced for `travel()->microseconds()` has broken our testsuite with `prefer-lowest` because of something in older versions Carbon not syncing.

This fixes it.