### PR TITLE
[11.x] Prevent bug (🐛) emoji on `Collection`/`Dumpable` `dd` method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -229,9 +229,7 @@ trait EnumeratesValues
      */
     public function dd(...$args)
     {
-        $this->dump(...$args);
-
-        dd();
+        dd($this->all(), ...$args);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/Dumpable.php
+++ b/src/Illuminate/Support/Traits/Dumpable.php
@@ -12,9 +12,7 @@ trait Dumpable
      */
     public function dd(...$args)
     {
-        $this->dump(...$args);
-
-        dd();
+        dd($this, ...$args);
     }
 
     /**


### PR DESCRIPTION
When calling the `dd` method on a `Collection` or a class using the `Dumpable` trait, it currently outputs a second dump containing just the 🐛 emoji.

```php
collect(['test'])->dd();
```

![image](https://github.com/user-attachments/assets/74ecd075-01ff-4bb4-9886-1b3cf58d5cdf)

```php
now()->dd();
```

![image](https://github.com/user-attachments/assets/2b40f9ac-fe7c-4e88-bbe4-c58340912836)

The emoji is output by [symfony/var-dumper](https://github.com/symfony/var-dumper/blob/5857c57c6b4b86524c08cf4f4bc95327270a816d/Resources/functions/dump.php#L52-L56) when no arguments are passed to the `dd` function.

We see it with Collections and `Dumpable` classes because our `dd` methods call their own `dump` method, followed by an empty `dd` call.

A side effect is that the response will return a 200 instead of the usual 500 that the `dd` function returns when there is no previous output, because the first `dump` prevents `dd` from setting headers.

This PR addresses this by making the `dd` methods just call the `dd` function directly. The only downside I can see is if someone has customized their `dump` method, the `dd` method will no longer use it.

An alternative would be to continue calling the `dump` method, followed by an `exit` call. However, `dd` has some additional logic to set headers which we might want to reimplement.