### PR TITLE
[11.x] Apply relation constraints on upsert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -290,7 +290,7 @@ abstract class HasOneOrMany extends Relation
             $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
         }
 
-        return $this->related->upsert($values, $uniqueBy, $update);
+        return $this->getQuery()->upsert($values, $uniqueBy, $update);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -277,6 +277,23 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @param  array|null  $update
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy, $update = null)
+    {
+        foreach ($values as $key => $value) {
+            $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
+        }
+
+        return $this->related->upsert($values, $uniqueBy, $update);
+    }
+
+    /**
      * Attach a model instance to the parent model.
      *
      * @param  TRelatedModel  $model

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -96,6 +96,23 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getMorphType()} = $this->morphClass;
     }
 
+    /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @param  array|null  $update
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy, $update = null)
+    {
+        foreach ($values as $key => $value) {
+            $values[$key][$this->getMorphType()] = $this->getMorphClass();
+        }
+
+        return parent::upsert($values, $uniqueBy, $update);
+    }
+
     /** @inheritDoc */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
@@ -132,22 +149,5 @@ abstract class MorphOneOrMany extends HasOneOrMany
     public function getMorphClass()
     {
         return $this->morphClass;
-    }
-
-    /**
-     * Insert new records or update the existing ones.
-     *
-     * @param  array  $values
-     * @param  array|string  $uniqueBy
-     * @param  array|null  $update
-     * @return int
-     */
-    public function upsert(array $values, $uniqueBy, $update = null)
-    {
-        foreach ($values as $key => $value) {
-            $values[$key][$this->getMorphType()] = $this->getMorphClass();
-        }
-
-        return parent::upsert($values, $uniqueBy, $update);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -133,4 +133,21 @@ abstract class MorphOneOrMany extends HasOneOrMany
     {
         return $this->morphClass;
     }
+
+    /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @param  array|null  $update
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy, $update = null)
+    {
+        foreach ($values as $key => $value) {
+            $values[$key][$this->getMorphType()] = $this->getMorphClass();
+        }
+
+        return parent::upsert($values, $uniqueBy, $update);
+    }
 }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -253,6 +253,29 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
+    public function testRelationUpsertFillsForeignKey()
+    {
+        $relation = $this->getRelation();
+
+        $relation->getQuery()->shouldReceive('upsert')->with(
+            [
+                ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey()],
+                ['name' => 'bar2', 'email' => 'foo2', $relation->getForeignKeyName() => $relation->getParentKey()],
+            ],
+            ['email'],
+            ['name']
+        );
+
+        $relation->upsert(
+            [
+                ['email' => 'foo3', 'name' => 'bar'],
+                ['name' => 'bar2', 'email' => 'foo2'],
+            ],
+            ['email'],
+            ['name']
+        );
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -67,6 +67,29 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
+    public function testMorphRelationUpsertFillsForeignKey()
+    {
+        $relation = $this->getManyRelation();
+
+        $relation->getQuery()->shouldReceive('upsert')->with(
+            [
+                ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey(), $relation->getMorphType() => $relation->getMorphClass()],
+                ['name' => 'bar2', 'email' => 'foo2', $relation->getForeignKeyName() => $relation->getParentKey(), $relation->getMorphType() => $relation->getMorphClass()],
+            ],
+            ['email'],
+            ['name']
+        );
+
+        $relation->upsert(
+            [
+                ['email' => 'foo3', 'name' => 'bar'],
+                ['name' => 'bar2', 'email' => 'foo2'],
+            ],
+            ['email'],
+            ['name']
+        );
+    }
+
     public function testMakeFunctionOnMorph()
     {
         $_SERVER['__eloquent.saved'] = false;


### PR DESCRIPTION
Currently when using `upsert` via a relationship (`HasOne`, `HasMany`, `MorphOne`, `MorhpMany`) we need to pass the foreign key (and morph type) explicitly.

For example I have a `User` model with a has many relation called `consents`. Before this PR we have to pass the `user_id => 4` explicitly for the records (for polymorphic relation the morph type as well). 

After the PR these values are filled automatically:

```php
User::find(4)->consents()->upsert(
    [
        ['type' => 'foo', 'value' => 'disabled'],
        ['type' => 'bar', 'value' => 'enabled'],
    ],
    ['user_id', 'type'], 
    ['value']
);
```

In other relationship methods like `create`, `updateOrCreate` or `save` Eloquent already does the job for us.