### PR TITLE
[11.x] Allow to set a name when registering a blade extension

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -682,7 +682,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function extend(callable $compiler, ?string $name = null): void
     {
-        if (! empty($name)) {
+        if (filled($name)) {
             $this->extensions[$name] = $compiler;
         } else {
             $this->extensions[] = $compiler;

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -679,13 +679,22 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
     /**
      * Register a custom Blade compiler.
-     *
-     * @param  callable  $compiler
-     * @return void
      */
-    public function extend(callable $compiler)
+    public function extend(callable $compiler, ?string $name = null): void
     {
-        $this->extensions[] = $compiler;
+        if (! empty($name)) {
+            $this->extensions[$name] = $compiler;
+        } else {
+            $this->extensions[] = $compiler;
+        }
+    }
+
+    /**
+     * Determine if a named extension is registered.
+     */
+    public function hasExtension(string $name): bool
+    {
+        return array_key_exists($name, $this->getExtensions());
     }
 
     /**

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -24,6 +24,27 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertSame('bar', $this->compiler->compileString('foo'));
     }
 
+    public function testCustomNamedExtensionsAreCompiled()
+    {
+        $this->compiler->extend(function ($value) {
+            return str_replace('foo', 'bar', $value);
+        }, 'replace');
+        $this->assertSame('bar', $this->compiler->compileString('foo'));
+    }
+
+    public function testHasCustomNamedExtension()
+    {
+        $this->compiler->extend(function ($value) {
+            return str_replace('foo', 'bar', $value);
+        }, 'replace');
+        $this->assertTrue($this->compiler->hasExtension('replace'));
+    }
+
+    public function testDoesNotHaveCustomNamedExtension()
+    {
+        $this->assertFalse($this->compiler->hasExtension('replace'));
+    }
+
     public function testCustomStatements()
     {
         $this->assertCount(0, $this->compiler->getCustomDirectives());


### PR DESCRIPTION
This change allows to set a name when registering a blade extension, which can be used to override or control extensions added by third party packages.
