### PR TITLE
[11.x] Change IP Address Column Definition in Database Stub

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
-            $table->string('ip_address', 45)->nullable();
+            $table->ipAddress()->nullable();
             $table->text('user_agent')->nullable();
             $table->longText('payload');
             $table->integer('last_activity')->index();


### PR DESCRIPTION
This change leverages Laravel's Fluent interface, making the database schema definitions more readable and self-explanatory. The `ipAddress` method explicitly indicates that the column is intended to store IP addresses, adhering to Laravel's convention of using dedicated methods for specific column types.

Laravel already has `\Illuminate\Database\Schema\Grammars` for this method.
