### PR TITLE
[11.x] Revert change to parsing migrations from sqlite dump command

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -21,9 +21,11 @@ class SqliteSchemaState extends SchemaState
             //
         ]));
 
-        $migrations = preg_replace('/CREATE TABLE sqlite_.+\);[\r\n]+/is', '', $process->getOutput());
+        $migrations = collect(preg_split("/\r\n|\n|\r/", $process->getOutput()))->reject(function ($line) {
+            return str_starts_with($line, 'CREATE TABLE sqlite_');
+        })->all();
 
-        $this->files->put($path, $migrations.PHP_EOL);
+        $this->files->put($path, implode(PHP_EOL, $migrations).PHP_EOL);
 
         if ($this->hasMigrationTable()) {
             $this->appendMigrationData($path);


### PR DESCRIPTION
I updated an app to the latest framework today and noticed that https://github.com/laravel/framework/pull/52172 had changed how it parsed out the new indented output for sqlite schema dumps.

The change seems to have affected how it would get the list of migrations somehow causing it to not always get the list when using a sqlite database file. I reverted this section locally and tested and it worked as it did before for me, but now with the new indented format.

Here is how I've been generating these dump files which worked prior to that merge:

#### Create a new sqlite database
`rm database/database.sqlite && touch database/database.sqlite`

#### Run migrations
`php artisan migrate:fresh --database=sqlite`

#### Dump the schema file
`php artisan schema:dump --database=sqlite`

Previously after the 3rd step, the schema dump had all of my tables (`CREATE xyz`), but now is just one single `CREATE migrations` entry in the file and this PR fixes that while still retaining the indention improvement from the other PR.