### PR TITLE
[11.x] Declare bindings and singletons properties in Service Provider

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -870,18 +870,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // If there are bindings / singletons set as properties on the provider we
         // will spin through them and register them with the application, which
         // serves as a convenience layer while registering a lot of bindings.
-        if (property_exists($provider, 'bindings')) {
-            foreach ($provider->bindings as $key => $value) {
-                $this->bind($key, $value);
-            }
+        foreach ($provider->bindings as $key => $value) {
+            $this->bind($key, $value);
         }
 
-        if (property_exists($provider, 'singletons')) {
-            foreach ($provider->singletons as $key => $value) {
-                $key = is_int($key) ? $value : $key;
+        foreach ($provider->singletons as $key => $value) {
+            $key = is_int($key) ? $value : $key;
 
-                $this->singleton($key, $value);
-            }
+            $this->singleton($key, $value);
         }
 
         $this->markAsRegistered($provider);

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -55,6 +55,20 @@ abstract class ServiceProvider
     protected static $publishableMigrationPaths = [];
 
     /**
+     * All of the container bindings that should be registered.
+     *
+     * @var array
+     */
+    public $bindings = [];
+
+    /**
+     * All of the container singletons that should be registered.
+     *
+     * @var array
+     */
+    public $singletons = [];
+
+    /**
      * Create a new service provider instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -20,6 +20,20 @@ abstract class ServiceProvider
     protected $app;
 
     /**
+     * All of the container bindings that should be registered.
+     *
+     * @var array
+     */
+    public $bindings = [];
+
+    /**
+     * All of the singletons that should be registered.
+     *
+     * @var array
+     */
+    public $singletons = [];
+
+    /**
      * All of the registered booting callbacks.
      *
      * @var array
@@ -53,20 +67,6 @@ abstract class ServiceProvider
      * @var array
      */
     protected static $publishableMigrationPaths = [];
-
-    /**
-     * All of the container bindings that should be registered.
-     *
-     * @var array
-     */
-    public $bindings = [];
-
-    /**
-     * All of the container singletons that should be registered.
-     *
-     * @var array
-     */
-    public $singletons = [];
 
     /**
      * Create a new service provider instance.


### PR DESCRIPTION
This PR basically repeats this [one](https://github.com/laravel/framework/pull/27638). I want to give it a second chance, maybe finally 5 years later its time has come :)

Just from developer perspective - I'm pretty tired to go every time to the documentation and check the name for these "magick" variables as I'm not able to see them in the source code + I found not many people even knowing about this small feature.

It does not hurt a performance in any way - perhaps it might have hurt legacy php versions, but definitely not a php 8.x