### PR TITLE
Add helper function app_locale() to return current application locale…

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -12,7 +12,25 @@ use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 
-if (! function_exists('append_config')) {
+if (! function_exists('app_locale')) {
+    /**
+     * Get the current application locale with replace value.
+     *
+     * @param string $search
+     * @param string $replace
+     * @param true $isReplace
+     * @return string
+     */
+    function app_locale(string $search = '_', string $replace = '-', bool $isReplace = true): string
+    {
+        if ($isReplace){
+            return str_replace($search, $replace, app()->getLocale());
+        }
+        return app()->getLocale();
+    }
+}
+
+    if (! function_exists('append_config')) {
     /**
      * Assign high numeric IDs to a config item to force appending.
      *


### PR DESCRIPTION
Add helper function app_locale() to return current application locale with replace value.


replace :

```
<!DOCTYPE html>
<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
    <head>
        <meta charset="utf-8">
        <meta name="viewport" content="width=device-width, initial-scale=1">

```

ex:

```
<!DOCTYPE html>
<html lang="{{ app_locale() }}">
    <head>
        <meta charset="utf-8">
        <meta name="viewport" content="width=device-width, initial-scale=1">

```
