### PR TITLE
[11.x] Adds terminating event

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Events\Terminating;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
@@ -212,6 +213,8 @@ class Kernel implements KernelContract
      */
     public function terminate($input, $status)
     {
+        $this->events->dispatch(new Terminating);
+
         $this->app->terminate();
 
         if ($this->commandStartedAt === null) {

--- a/src/Illuminate/Foundation/Events/Terminating.php
+++ b/src/Illuminate/Foundation/Events/Terminating.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+class Terminating
+{
+    //
+}

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
+use Illuminate\Foundation\Events\Terminating;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
@@ -210,6 +211,8 @@ class Kernel implements KernelContract
      */
     public function terminate($request, $response)
     {
+        $this->app['events']->dispatch(new Terminating);
+
         $this->terminateMiddleware($request, $response);
 
         $this->app->terminate();

--- a/tests/Foundation/Console/KernelTest.php
+++ b/tests/Foundation/Console/KernelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Console\Kernel;
+use Illuminate\Foundation\Events\Terminating;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+
+class KernelTest extends TestCase
+{
+    public function testItDispatchesTerminatingEvent()
+    {
+        $called = [];
+        $app = new Application;
+        $events = new Dispatcher($app);
+        $app->instance('events', $events);
+        $kernel = new Kernel($app, $events);
+        $events->listen(function (Terminating $terminating) use (&$called) {
+            $called[] = 'terminating event';
+        });
+        $app->terminating(function () use (&$called) {
+            $called[] = 'terminating callback';
+        });
+
+        $kernel->terminate(new StringInput('tinker'), 0);
+
+        $this->assertSame([
+            'terminating event',
+            'terminating callback',
+        ], $called);
+    }
+}

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Foundation\Http;
 
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Events\Terminating;
 use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
 
@@ -41,6 +44,49 @@ class KernelTest extends TestCase
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Illuminate\Auth\Middleware\Authorize::class,
         ], $kernel->getMiddlewarePriority());
+    }
+
+    public function testItTriggersTerminatingEvent()
+    {
+        $called = [];
+        $app = $this->getApplication();
+        $events = new Dispatcher($app);
+        $app->instance('events', $events);
+        $kernel = new Kernel($app, $this->getRouter());
+        $app->instance('terminating-middleware', new class($called)
+        {
+            public function __construct(private &$called)
+            {
+                //
+            }
+
+            public function handle($request, $next)
+            {
+                return $next($response);
+            }
+
+            public function terminate($request, $response)
+            {
+                $this->called[] = 'terminating middleware';
+            }
+        });
+        $kernel->setGlobalMiddleware([
+            'terminating-middleware',
+        ]);
+        $events->listen(function (Terminating $terminating) use (&$called) {
+            $called[] = 'terminating event';
+        });
+        $app->terminating(function () use (&$called) {
+            $called[] = 'terminating callback';
+        });
+
+        $kernel->terminate(new Request(), new Response());
+
+        $this->assertSame([
+            'terminating event',
+            'terminating middleware',
+            'terminating callback',
+        ], $called);
     }
 
     /**


### PR DESCRIPTION
This PR adds a dedicated terminating event. It does not receive any arguments intentionally as it is a "flag" event to indicate that terminating has begun.

The terminating middleware and `App::terminating` hooks are still how applications should hook into the terminating process within their applications.