### PR TITLE
[11.x] Prevent the max password length validator exceeding bcrypt limit

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -218,6 +218,9 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function max($size)
     {
+        if ($size > 72 && config('hashing.driver') === 'bcrypt') {
+            $size = 72;
+        }
         $this->max = $size;
 
         return $this;


### PR DESCRIPTION
The `\Illuminate\Validation\Rules\Password::max` method sets the `$max` property of the Password validator to any number. The `bcrypt` password hashing algorithm, which Laravel uses by default, cannot handle passwords longer than 72 bytes, and anything submitted beyond that will simply be silently truncated. Thus if a user sets this to a large number (I encountered it in an app which had set it to 500), it will not cause a validation error even if the password is actually unusable.

This limit does not apply to the newer `argon` and `argon2id` hashing functions.

This change sets a simple rule that if the requested size is bigger than 72, and the selected password hashing driver is `bcrypt`, it sets `max` to 72 so that even if user code sets it higher, it will still cause correct validation errors.

Given the way that the `min` value in the same class is handled, it might also be appropriate to ensure that `max` > `min`, but I wanted to limit this PR to just a single concern.