### PR TITLE
[11.x] Access dispatchedBatches via BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -867,4 +867,14 @@ class BusFake implements Fake, QueueingDispatcher
 
         return $this;
     }
+
+    /**
+     * Get the batches that have been dispatched.
+     *
+     * @return array
+     */
+    public function dispatchedBatches()
+    {
+        return $this->batches;
+    }
 }


### PR DESCRIPTION

The `QueueFake` class has a `pushedJobs()` method that returns all the pushed jobs. The `NotificationFake` class has a `sentNotifications` method that returns all sent notifications. This PR adds a `dispatchedBatches()` method to the `BusFake` class which does the same for batches.

Why? In some tests in a project, I needed to inspect 'catch' and 'finally' closures of a batch and the ability to execute those closures to test their behavior. There is currently no easy way to do that because there is no easy way to access the dispatched batches. This PR fixes that.
