### PR TITLE
[12.x] Replace facade and global function calls with DI in middleware constructors

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -4,11 +4,48 @@ namespace Illuminate\Auth\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Support\Facades\Redirect;
-use Illuminate\Support\Facades\URL;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Contracts\Routing\UrlGenerator;
 
 class EnsureEmailIsVerified
 {
+    /**
+     * The application implementation.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The response factory instance.
+     *
+     * @var \Illuminate\Contracts\Routing\ResponseFactory
+     */
+    protected $responseFactory;
+
+    /**
+     * The URL generator instance.
+     *
+     * @var \Illuminate\Contracts\Routing\UrlGenerator
+     */
+    protected $urlGenerator;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
+     * @param  \Illuminate\Contracts\Routing\UrlGenerator  $urlGenerator
+     * @return void
+     */
+    public function __construct(Application $app, ResponseFactory $responseFactory, UrlGenerator $urlGenerator)
+    {
+        $this->app = $app;
+        $this->responseFactory = $responseFactory;
+        $this->urlGenerator = $urlGenerator;
+    }
+
     /**
      * Specify the redirect route for the middleware.
      *
@@ -34,8 +71,10 @@ class EnsureEmailIsVerified
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
-                    ? abort(403, 'Your email address is not verified.')
-                    : Redirect::guest(URL::route($redirectToRoute ?: 'verification.notice'));
+                    ? $this->app->abort(403, 'Your email address is not verified.')
+                    : $this->responseFactory->redirectGuest(
+                        $this->urlGenerator->route($redirectToRoute ?: 'verification.notice')
+                    );
         }
 
         return $next($request);

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -3,19 +3,37 @@
 namespace Illuminate\Auth\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\Response;
 
 class RedirectIfAuthenticated
 {
     /**
+     * The authentication factory instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $auth;
+
+    /**
      * The callback that should be used to generate the authentication redirect path.
      *
      * @var callable|null
      */
     protected static $redirectToCallback;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @return void
+     */
+    public function __construct(Auth $auth)
+    {
+        $this->auth = $auth;
+    }
 
     /**
      * Handle an incoming request.
@@ -27,7 +45,7 @@ class RedirectIfAuthenticated
         $guards = empty($guards) ? [null] : $guards;
 
         foreach ($guards as $guard) {
-            if (Auth::guard($guard)->check()) {
+            if ($this->auth->guard($guard)->check()) {
                 return redirect($this->redirectTo($request));
             }
         }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -121,6 +121,18 @@ interface Application extends Container
     public function isDownForMaintenance();
 
     /**
+     * Throw an HttpException with the given data.
+     *
+     * @param  int  $code
+     * @param  string  $message
+     * @param  array  $headers
+     * @return never
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function abort($code, $message = '', array $headers = []);
+
+    /**
      * Register all of the configured providers.
      *
      * @return void

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1383,7 +1383,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @return never
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function abort($code, $message = '', array $headers = [])
     {

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -181,7 +181,7 @@ class VerifyCsrfToken
      */
     protected function addCookieToResponse($request, $response)
     {
-        $config = config('session');
+        $config = $this->app['config']->get('session');
 
         if ($response instanceof Responsable) {
             $response = $response->toResponse($request);

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Foundation\MaintenanceMode;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
@@ -270,7 +271,8 @@ class MiddlewareTest extends TestCase
         $mode->shouldReceive('date')->andReturn([]);
         $app = Mockery::mock(Application::class);
         $app->shouldReceive('maintenanceMode')->andReturn($mode);
-        $middleware = new PreventRequestsDuringMaintenance($app);
+        $responseFactory = Mockery::mock(ResponseFactory::class);
+        $middleware = new PreventRequestsDuringMaintenance($app, $responseFactory);
 
         $reflection = new ReflectionClass($middleware);
         $method = $reflection->getMethod('inExceptArray');

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Foundation;
 
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Events\MaintenanceModeDisabled;
@@ -122,7 +123,7 @@ class MaintenanceModeTest extends TestCase
 
     public function testMaintenanceModeCanBeBypassedOnExcludedUrls()
     {
-        $this->app->instance(PreventRequestsDuringMaintenance::class, new class($this->app) extends PreventRequestsDuringMaintenance
+        $this->app->instance(PreventRequestsDuringMaintenance::class, new class($this->app, $this->app->make(ResponseFactory::class)) extends PreventRequestsDuringMaintenance
         {
             protected $except = ['/test'];
         });


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When I was looking into various middlewares within the codebase, I noticed some inconsistent patterns in the usage of facades, global functions and constructor-injected dependencies. Considering the latter to be the neatest and (in the long run) most flexible way of using dependencies, with the added bonus of better static/IDE help, I created this PR to make middlewares more consistently use this pattern.

Given this adds the `abort` method to the `Application` contract (as it is called by the global `abort` function and thus should be there if I'm right) and moreover add/alters various middleware class constructors, this is a technical breaking change and thus targeted at `master`.

Some parts may be considered non-breaking and could be applied to `11.x`, but given that benefits are mostly limited to readability and are not changes in behavior, I think backporting parts is probably not preferable.