### PR TITLE
[11.x] Fix SQLite schema dumps missing most tables

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -21,7 +21,7 @@ class SqliteSchemaState extends SchemaState
             //
         ]));
 
-        $migrations = preg_replace('/CREATE TABLE sqlite_.+\);[\r\n]+/is', '', $process->getOutput());
+        $migrations = preg_replace('/CREATE TABLE sqlite_.+?\);[\r\n]+/is', '', $process->getOutput());
 
         $this->files->put($path, $migrations.PHP_EOL);
 

--- a/tests/Integration/Database/Sqlite/SchemaStateTest.php
+++ b/tests/Integration/Database/Sqlite/SchemaStateTest.php
@@ -50,7 +50,8 @@ class SchemaStateTest extends TestCase
         $connection = DB::connection();
         $connection->getSchemaBuilder()->createDatabase($connection->getConfig('database'));
 
-        $connection->statement('CREATE TABLE users(id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
+        $connection->statement('CREATE TABLE IF NOT EXISTS migrations (id integer primary key autoincrement not null, migration varchar not null, batch integer not null);');
+        $connection->statement('CREATE TABLE users (id integer primary key autoincrement not null, email varchar not null, name varchar not null);');
         $connection->statement('INSERT INTO users (email, name) VALUES ("taylor@laravel.com", "Taylor Otwell");');
 
         $this->assertTrue($connection->table('sqlite_sequence')->exists());
@@ -60,6 +61,7 @@ class SchemaStateTest extends TestCase
         $connection->getSchemaState()->dump($connection, database_path('schema/sqlite-schema.sql'));
 
         $this->assertFileContains([
+            'CREATE TABLE migrations',
             'CREATE TABLE users',
         ], 'database/schema/sqlite-schema.sql');
         $this->assertFileNotContains([


### PR DESCRIPTION
Fixes a bug I introduced in #52172 that would cause SQLite schema dumps to be mostly empty. My original regular expression was too greedy and removed almost the entire file contents. This PR adds a test to cover this case and adds the `?` modifier to make the relevant part of the regex lazy, so it will consume at most one `CREATE TABLE` statement at a time as intended. See [regexr.com/83vo9](https://regexr.com/83vo9) (includes global flag but that isn't necessary for `preg_replace`).

Closes #52254.