### PR TITLE
[11.x] Fix missing * in phpdoc

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1807,7 +1807,7 @@ class Blueprint
         return $this->commands;
     }
 
-    /*
+    /**
      * Determine if the blueprint has state.
      *
      * @param  mixed  $name


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`hasState` is missing a `*` on phpdoc. Happened to cause issues with some reflection I was doing.
