### PR TITLE
[11.x] Support Parent Classes for Event Listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -371,7 +371,7 @@ class Dispatcher implements DispatcherContract
         );
 
         return class_exists($eventName, false)
-                    ? $this->addInterfaceListeners($eventName, $listeners)
+                    ? $this->addInterfaceAndParentListeners($eventName, $listeners)
                     : $listeners;
     }
 
@@ -397,17 +397,19 @@ class Dispatcher implements DispatcherContract
     }
 
     /**
-     * Add the listeners for the event's interfaces to the given array.
+     * Add the listeners for the event's interfaces and parents to the given array.
      *
      * @param  string  $eventName
      * @param  array  $listeners
      * @return array
      */
-    protected function addInterfaceListeners($eventName, array $listeners = [])
+    protected function addInterfaceAndParentListeners($eventName, array $listeners = [])
     {
-        foreach (class_implements($eventName) as $interface) {
-            if (isset($this->listeners[$interface])) {
-                foreach ($this->prepareListeners($interface) as $names) {
+        $types = [...class_implements($eventName), ...class_parents($eventName)];
+
+        foreach ($types as $type) {
+            if (isset($this->listeners[$type])) {
+                foreach ($this->prepareListeners($type) as $names) {
                     $listeners = array_merge($listeners, (array) $names);
                 }
             }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -393,6 +393,18 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('bar', $_SERVER['__event.test']);
     }
 
+    public function testParentsWork()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen(ParentEvent::class, function () {
+            $_SERVER['__event.test'] = 'bar';
+        });
+        $d->dispatch(new EventWithParent);
+
+        $this->assertSame('bar', $_SERVER['__event.test']);
+    }
+
     public function testBothClassesAndInterfacesWork()
     {
         unset($_SERVER['__event.test']);
@@ -628,12 +640,22 @@ class ExampleEvent
     //
 }
 
+class ParentEvent
+{
+    //
+}
+
 interface SomeEventInterface
 {
     //
 }
 
 class AnotherEvent implements SomeEventInterface
+{
+    //
+}
+
+class EventWithParent extends ParentEvent
 {
     //
 }


### PR DESCRIPTION
Hi Taylor,

I've made a slight modification to the `addInterfaceListeners` method to also support parent classes. This enhancement is useful for listening to a group of events that extend the same parent class (e.g., `TwoFactorAuthenticationEvent` abstract class from Fortify).

This change is necessary for me to create database logs when specific events from Fortify are dispatched. While it's currently possible to listen to interfaces, Fortify events do not implement any interfaces.

Thanks!