### PR TITLE
[11.x] Fix explicit route binding for broadcast routes

### DIFF
--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -58,7 +58,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value, $route) use ($container, $class, $callback) {
+        return function ($value, $route = null) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -68,7 +68,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            $routeBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
+            $routeBindingMethod = $route?->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Routing\RouteBinding;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -82,6 +83,23 @@ class BroadcasterTest extends TestCase
     {
         $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', DummyBroadcastingChannel::class);
         $this->assertEquals(['model.1.instance', 'something'], $parameters);
+    }
+
+    public function testModelRouteBinding()
+    {
+        $container = new Container;
+        Container::setInstance($container);
+        $binder = m::mock(BindingRegistrar::class);
+        $callback = RouteBinding::forModel($container, BroadcasterTestEloquentModelStub::class);
+        
+        $binder->shouldReceive('getBindingCallback')->times(2)->with('model')->andReturn($callback);
+        $container->instance(BindingRegistrar::class, $binder);
+        $callback = function ($user, $model) {
+            //
+        };
+        $parameters = $this->broadcaster->extractAuthParameters('something.{model}', 'something.1', $callback);
+        $this->assertEquals(['model.1.instance'], $parameters);
+        Container::setInstance(new Container);   
     }
 
     public function testUnknownChannelAuthHandlerTypeThrowsException()

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -91,7 +91,7 @@ class BroadcasterTest extends TestCase
         Container::setInstance($container);
         $binder = m::mock(BindingRegistrar::class);
         $callback = RouteBinding::forModel($container, BroadcasterTestEloquentModelStub::class);
-        
+
         $binder->shouldReceive('getBindingCallback')->times(2)->with('model')->andReturn($callback);
         $container->instance(BindingRegistrar::class, $binder);
         $callback = function ($user, $model) {
@@ -99,7 +99,7 @@ class BroadcasterTest extends TestCase
         };
         $parameters = $this->broadcaster->extractAuthParameters('something.{model}', 'something.1', $callback);
         $this->assertEquals(['model.1.instance'], $parameters);
-        Container::setInstance(new Container);   
+        Container::setInstance(new Container);
     }
 
     public function testUnknownChannelAuthHandlerTypeThrowsException()


### PR DESCRIPTION
Fixing explicit route binding problems in broadcasting routes as explained in https://github.com/laravel/framework/issues/51726#issuecomment-2248585033

This problems started to appear because of https://github.com/laravel/framework/pull/51651 which added the new `route` parameter to the `forModel` callback, which is not passed from broadcast routes.

With this pull request the route parameter is made optional.