### PR TITLE
Revert "[11.x] Allow non-`ContextualAttribute` attributes to have an `after` callback"

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1366,8 +1366,12 @@ class Container implements ArrayAccess, ContainerContract
     protected function fireAfterResolvingAttributeCallbacks(array $attributes, $object)
     {
         foreach ($attributes as $attribute) {
-            if (method_exists($instance = $attribute->newInstance(), 'after')) {
-                $instance->after($instance, $object, $this);
+            if (is_a($attribute->getName(), ContextualAttribute::class, true)) {
+                $instance = $attribute->newInstance();
+
+                if (method_exists($instance, 'after')) {
+                    $instance->after($instance, $object, $this);
+                }
             }
 
             $callbacks = $this->getCallbacksForType(

--- a/tests/Container/AfterResolvingAttributeCallbackTest.php
+++ b/tests/Container/AfterResolvingAttributeCallbackTest.php
@@ -11,22 +11,18 @@ class AfterResolvingAttributeCallbackTest extends TestCase
     public function testCallbackIsCalledAfterDependencyResolutionWithAttribute()
     {
         $container = new Container();
-        $stack = [];
 
-        $container->afterResolvingAttribute(ContainerTestOnTenant::class, function (ContainerTestOnTenant $attribute, HasTenantImpl $hasTenantImpl, Container $container) use (&$stack) {
+        $container->afterResolvingAttribute(ContainerTestOnTenant::class, function (ContainerTestOnTenant $attribute, HasTenantImpl $hasTenantImpl, Container $container) {
             $hasTenantImpl->onTenant($attribute->tenant);
-            $stack[] = $attribute->tenant;
         });
 
         $hasTenantA = $container->make(ContainerTestHasTenantImplPropertyWithTenantA::class);
         $this->assertInstanceOf(HasTenantImpl::class, $hasTenantA->property);
         $this->assertEquals(Tenant::TenantA, $hasTenantA->property->tenant);
-        $this->assertContains(Tenant::TenantA, $stack);
 
         $hasTenantB = $container->make(ContainerTestHasTenantImplPropertyWithTenantB::class);
         $this->assertInstanceOf(HasTenantImpl::class, $hasTenantB->property);
         $this->assertEquals(Tenant::TenantB, $hasTenantB->property->tenant);
-        $this->assertContains(Tenant::TenantB, $stack);
     }
 
     public function testCallbackIsCalledAfterClassWithAttributeIsResolved()
@@ -61,19 +57,6 @@ class AfterResolvingAttributeCallbackTest extends TestCase
         $this->assertInstanceOf(ContainerTestHasSelfConfiguringAttributeAndConstructor::class, $instance);
         $this->assertEquals('the-right-value', $instance->value);
     }
-
-    public function testAfterCallbackIsCalled()
-    {
-        $container = new Container();
-
-        $hasTenantA = $container->make(ContainerTestHasTenantImplPropertyWithTenantA::class);
-        $this->assertInstanceOf(HasTenantImpl::class, $hasTenantA->property);
-        $this->assertEquals(Tenant::TenantA, $hasTenantA->property->tenant);
-
-        $hasTenantB = $container->make(ContainerTestHasTenantImplPropertyWithTenantB::class);
-        $this->assertInstanceOf(HasTenantImpl::class, $hasTenantB->property);
-        $this->assertEquals(Tenant::TenantB, $hasTenantB->property->tenant);
-    }
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
@@ -82,11 +65,6 @@ final class ContainerTestOnTenant
     public function __construct(
         public readonly Tenant $tenant
     ) {
-    }
-
-    public function after(self $attribute, HasTenantImpl $class, Container $container): void
-    {
-        $class->onTenant($attribute->tenant);
     }
 }
 


### PR DESCRIPTION
Reverts laravel/framework#52167