### PR TITLE
[11.x] Fix variable typo at Terminating Event test

### DIFF
--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -62,7 +62,7 @@ class KernelTest extends TestCase
 
             public function handle($request, $next)
             {
-                return $next($response);
+                return $next($request);
             }
 
             public function terminate($request, $response)


### PR DESCRIPTION
The `handle` method is not called but it is a typo anyway.