### PR TITLE
[11.x] Method to trim '0' digits after decimal point of a given number

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -258,6 +258,17 @@ class Number
     }
 
     /**
+     * Convert the number to how it will be represented in JSON.
+     *
+     * @param  int|float  $number
+     * @return int|float
+     */
+    public static function json(int|float $number)
+    {
+        return json_decode(json_encode($number));
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -258,12 +258,12 @@ class Number
     }
 
     /**
-     * Convert the number to how it will be represented in JSON.
+     * Remove zero digits after decimal point of the given number.
      *
      * @param  int|float  $number
      * @return int|float
      */
-    public static function json(int|float $number)
+    public static function trim(int|float $number)
     {
         return json_decode(json_encode($number));
     }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -258,7 +258,7 @@ class Number
     }
 
     /**
-     * Remove zero digits after decimal point of the given number.
+     * Remove any trailing zero digits after the decimal point of the given number.
      *
      * @param  int|float  $number
      * @return int|float

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -294,11 +294,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0, 2.5], [2.5, 5.0], [5.0, 7.5], [7.5, 10.0]], Number::pairs(10, 2.5, 0));
     }
 
-    public function testJson()
+    public function testTrim()
     {
-        $this->assertSame(12, Number::json(12));
-        $this->assertSame(12, Number::json(12.0));
-        $this->assertSame(12.3, Number::json(12.3));
-        $this->assertSame(12.3456789, Number::json(12.3456789));
+        $this->assertSame(12, Number::trim(12));
+        $this->assertSame(120, Number::trim(120));
+        $this->assertSame(12, Number::trim(12.0));
+        $this->assertSame(12.3, Number::trim(12.3));
+        $this->assertSame(12.3, Number::trim(12.30));
+        $this->assertSame(12.3456789, Number::trim(12.3456789));
+        $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -293,4 +293,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0, 10], [10, 20], [20, 25]], Number::pairs(25, 10, 0));
         $this->assertSame([[0, 2.5], [2.5, 5.0], [5.0, 7.5], [7.5, 10.0]], Number::pairs(10, 2.5, 0));
     }
+
+    public function testJson()
+    {
+        $this->assertSame(12, Number::json(12));
+        $this->assertSame(12, Number::json(12.0));
+        $this->assertSame(12.3, Number::json(12.3));
+        $this->assertSame(12.3456789, Number::json(12.3456789));
+    }
 }


### PR DESCRIPTION
## What

A method on the `Number` class that trims zero digits after decimal point of a given number
```php
Number::trim(12.0); // => 12
```

## Use case

When a calculated number is returned in a JSON response and the number does not have any digits after the decimal point, then the JSON response will contain an integer instead of a decimal number.
<br/>

```php
response()->json(['average_rating' => (float) Review::query()->average('rating')]); // = 4.0
```
_Results in_
```json
{"average_rating": 4}
```
<br/>

When trying to assert that using `assertJsonPath`, this causes issues because the expected value is still a float while the JSON response contains an integer
```php
// This fails because "4 !== 4.0"
$response->assertJsonPath('average_rating', $relevantReviews->average('rating'));
```
You can not just convert the expected number to an integer, because the expected number might have digits after the decimal points in other cases. The only way to fix this is JSON-encoding the expected number and then decoding it again.
```php
// This does not fail anymore
$response->assertJsonPath('average_rating', json_decode(json_encode($relevantReviews->average('rating'))));
```
But this does not look very nice. That is where this new `Number::trim($number)` method comes into play:
```php
// This does not fail
$response->assertJsonPath('average_rating', Number::trim($relevantReviews->average('rating')));
```