### PR TITLE
[11.x] URL Encoding email for Password Reset link.

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -96,7 +96,7 @@ class ResetPassword extends Notification
 
         return url(route('password.reset', [
             'token' => $this->token,
-            'email' => $notifiable->getEmailForPasswordReset(),
+            'email' => urlencode($notifiable->getEmailForPasswordReset()),
         ], false));
     }
 


### PR DESCRIPTION
Currently if there is a "+" symbol in the password reset link, the functionality no longer works as the email field in the search params is invalid.

Fixed by URL encoding the link in the resetUrl() function in the ResetPassword Notification.
