### PR TITLE
[11.x] Fix flat array parameter for relation upsert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -286,6 +286,10 @@ abstract class HasOneOrMany extends Relation
      */
     public function upsert(array $values, $uniqueBy, $update = null)
     {
+        if (! empty($values) && ! is_array(reset($values))) {
+            $values = [$values];
+        }
+
         foreach ($values as $key => $value) {
             $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -106,6 +106,10 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function upsert(array $values, $uniqueBy, $update = null)
     {
+        if (! empty($values) && ! is_array(reset($values))) {
+            $values = [$values];
+        }
+
         foreach ($values as $key => $value) {
             $values[$key][$this->getMorphType()] = $this->getMorphClass();
         }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -257,7 +257,21 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
 
-        $relation->getQuery()->shouldReceive('upsert')->with(
+        $relation->getQuery()->shouldReceive('upsert')->once()->with(
+            [
+                ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey()],
+            ],
+            ['email'],
+            ['name']
+        );
+
+        $relation->upsert(
+            ['email' => 'foo3', 'name' => 'bar'],
+            ['email'],
+            ['name']
+        );
+
+        $relation->getQuery()->shouldReceive('upsert')->once()->with(
             [
                 ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey()],
                 ['name' => 'bar2', 'email' => 'foo2', $relation->getForeignKeyName() => $relation->getParentKey()],

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -71,7 +71,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getManyRelation();
 
-        $relation->getQuery()->shouldReceive('upsert')->with(
+        $relation->getQuery()->shouldReceive('upsert')->once()->with(
             [
                 ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey(), $relation->getMorphType() => $relation->getMorphClass()],
             ],

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -74,6 +74,20 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('upsert')->with(
             [
                 ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey(), $relation->getMorphType() => $relation->getMorphClass()],
+            ],
+            ['email'],
+            ['name']
+        );
+
+        $relation->upsert(
+            ['email' => 'foo3', 'name' => 'bar'],
+            ['email'],
+            ['name']
+        );
+
+        $relation->getQuery()->shouldReceive('upsert')->once()->with(
+            [
+                ['email' => 'foo3', 'name' => 'bar', $relation->getForeignKeyName() => $relation->getParentKey(), $relation->getMorphType() => $relation->getMorphClass()],
                 ['name' => 'bar2', 'email' => 'foo2', $relation->getForeignKeyName() => $relation->getParentKey(), $relation->getMorphType() => $relation->getMorphClass()],
             ],
             ['email'],


### PR DESCRIPTION
This is a followup of #52239.

As is turns it's possible to pass a flat array to the upsert method, not only nested arrays.

This PR makes sure using the `upsert` method with flat arrays on a relation, works.

I used the `! is_array(reset($values))` check for nested arrays, because the query builder's `upsert` method does the same.

Also updated the tests.