### PR TITLE
[11.x] Fix Table's alias and SoftDelete are incompatible

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -183,10 +183,10 @@ class SoftDeletingScope implements Scope
         $fromPart = $builder->getQuery()->from;
 
         if (is_string($fromPart)) {
-            $fromParts = array_filter(explode(' ', Str::trim($fromPart)), fn(string $part) => $part !== '');
+            $fromParts = array_filter(explode(' ', Str::trim($fromPart)), fn (string $part) => $part !== '');
 
             return count($fromParts) === 3
-                ? end($fromParts) . '.' . $model->getDeletedAtColumn()
+                ? end($fromParts).'.'.$model->getDeletedAtColumn()
                 : $model->getQualifiedDeletedAtColumn();
         }
 
@@ -195,7 +195,7 @@ class SoftDeletingScope implements Scope
             $aliasSubquery = explode(' ', Str::trim(Str::afterLast($subQueryFrom, ') ')));
             $aliasSubquery = Str::trim(end($aliasSubquery), '"');
 
-            return $aliasSubquery . '.' . $model->getDeletedAtColumn();
+            return $aliasSubquery.'.'.$model->getDeletedAtColumn();
         }
 
         return $model->getQualifiedDeletedAtColumn();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2427,7 +2427,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from (select * from table) As my_sub_query_raw_alias where "my_sub_query_raw_alias"."deleted_at" is null', $query->toSql());
     }
 
-
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2522,7 +2522,7 @@ class EloquentBuilderTestNestedStub extends Model
 
 class EloquentBuilderTestSoftDeleteStub extends Model
 {
-    protected  $table = 'table';
+    protected $table = 'table';
     use SoftDeletes;
 }
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -23,7 +23,11 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testApplyingScopeToABuilder()
     {
         $scope = m::mock(SoftDeletingScope::class.'[extend]');
-        $builder = m::mock(EloquentBuilder::class);
+        $builder = m::mock(new EloquentBuilder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            m::mock(Grammar::class),
+            m::mock(Processor::class)
+        )));
         $model = m::mock(Model::class);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->once()->andReturn('table.deleted_at');
         $builder->shouldReceive('whereNull')->once()->with('table.deleted_at');


### PR DESCRIPTION
When working with Eloquent `Models` and the `SoftDeletes` trait, it is not possible to assign an alias to the table using the query builder.

# Example

```php

use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\SoftDeletes;

class Person extends Model
{
    use SoftDeletes;
}
```

## Actual behaviour
```
Person::from('persons', 'my_custom_alias')
                ->toSql()
```

#### Output

```
select * from "persons" as "my_custom_alias" where "persons"."deleted_at" is null
```

## Expected behaviour
```
Person::from('persons', 'my_custom_alias')
                ->toSql()
```

#### Output

```
select * from "persons" as "my_custom_alias" where "my_custom_alias"."deleted_at" is null
```