### PR TITLE
[11.x] Add `DatabaseUnseed` trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
+use Illuminate\Foundation\Testing\DatabaseUnseed;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
@@ -203,6 +204,10 @@ trait InteractsWithTestCaseLifecycle
 
         if (isset($uses[DatabaseTruncation::class])) {
             $this->truncateDatabaseTables();
+        }
+
+        if (isset($uses[DatabaseUnseed::class])) {
+            $this->startWatchingQueries();
         }
 
         if (isset($uses[DatabaseTransactions::class])) {

--- a/src/Illuminate/Foundation/Testing/DatabaseUnseed.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseUnseed.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
+use Illuminate\Support\LazyCollection;
+
+trait DatabaseUnseed
+{
+    use CanConfigureMigrationCommands;
+
+    /**
+     * Truncate the tables that get data with insert queries.
+     *
+     * @return void
+     */
+    protected function startWatchingQueries(): void
+    {
+        $database = $this->app->make('db');
+        collect($this->connectionsToUnseed())->each(
+            fn ($name) => $database->connection($name)->enableQueryLog()
+        );
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->unseedTablesForAllConnections();
+        });
+    }
+
+    /**
+     * Truncate the tables that get data with insert queries.
+     *
+     * @return void
+     */
+    protected function unseedTablesForAllConnections(): void
+    {
+        $database = $this->app->make('db');
+
+        collect($this->connectionsToUnseed())
+            ->each(function ($name) use ($database) {
+                $connection = $database->connection($name);
+
+                $connection->getSchemaBuilder()->disableForeignKeyConstraints();
+                $this->unseedTablesForConnection($connection, $name);
+                $connection->getSchemaBuilder()->enableForeignKeyConstraints();
+            });
+    }
+
+    /**
+     * Truncate the tables that get data with insert queries.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string|null  $name
+     * @return void
+     */
+    protected function unseedTablesForConnection(ConnectionInterface $connection, ?string $name): void
+    {
+        $dispatcher = $connection->getEventDispatcher();
+
+        $connection->unsetEventDispatcher();
+
+        $this->getInsertedTables($connection)
+            ->each(fn ($table) => $connection->table($this->withoutTablePrefix($connection, $table))->truncate());
+
+        $connection->setEventDispatcher($dispatcher);
+    }
+
+    /**
+     * Get a list of table names that have been subject to insert queries.
+     *
+     * @return \Illuminate\Support\LazyCollection
+     */
+    protected function getInsertedTables($connection)
+    {
+        return LazyCollection::make($connection->getQueryLog())
+            ->map(fn ($log) => $log['query'])
+            ->filter(fn ($query) => str_starts_with(strtolower($query), 'insert'))
+            ->map(function ($query) {
+                preg_match($this->getRegex(), $query, $match);
+
+                return $match[1] ?? null; // <== table name
+            })->filter()->unique();
+    }
+
+    /**
+     * Get the regex need to derive the table name from an insert query.
+     *
+     * @return string
+     */
+    protected function getRegex(): string
+    {
+        return '/^insert(?:\s+?)(?:ignore )?into (?:\s+?)?(?:\`|\[|\"|\')?(.*?)(?:\`|\]|\"|\')? .*/i';
+    }
+
+    /**
+     * Remove the table prefix from a table name, if it exists.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return string
+     */
+    protected function withoutTablePrefix(ConnectionInterface $connection, string $table)
+    {
+        $prefix = $connection->getTablePrefix();
+
+        return str_starts_with($table, $prefix)
+            ? substr($table, strlen($prefix))
+            : $table;
+    }
+
+    /**
+     * The database connections that should have their tables truncated.
+     *
+     * @return array
+     */
+    protected function connectionsToUnseed(): array
+    {
+        return property_exists($this, 'connectionsToUnseed')
+                    ? $this->connectionsToUnseed : [null];
+    }
+}


### PR DESCRIPTION
# The Problem:
Running the `truncate` query agaist all the tables (Using the `DatabaseTruncate` trait) is a good idea to improve speed and avoid running all the migrations for each test but for us this was not enough since we have 155 tables.
Practically we were inserting into only 5 or 6 tables for each test but at the end we were truncating 155 tables, (in other words we were truncating 145 tables that were already empty! ) and running 155 truncate queries was taking 1.5 seconds on github actions and since we had 300 tests the truncate process was taking almost around ~5 minutes for the whole test suite!

# The Need:
We needed to know exatcly which tables are inserted with data during each test and truncate only those.

# The Idea:
An idea which worked really well for us was to enable the queryLog on the `setUp` and inspect the raw queries on the `tearDown` method and get a unique list of table names derived from `insert into ...` queries and truncate only those tables. This way the whole suite got at least twice faster with no change in the app code or the tests. 
I wanted to share the solution here. This trait acts as a drop-in replacement for the `DatabaseTruncate` trait. You may add back some of the features to it or change the trait name into a better one.

- It is possible to cover rare ways of data insertion like `replace into`, `merge into`, `select into` as well.
- I will add the tests if the PR survives the first Taylor-review.