### PR TITLE
[11.X] "Model::preventAccessingMissingAttributes()" Causes Exception During Pagination with ResourceCollection

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -28,7 +28,7 @@ class PaginatedResourceResponse extends ResourceResponse
             $this->resource->jsonOptions()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource->map(function ($item) {
-                return is_array($item) ? Arr::get($item, 'resource') : $item->resource;
+                return is_array($item) ? Arr::get($item, 'resource') : optional($item)->resource;
             });
 
             $this->resource->withResponse($request, $response);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1723,6 +1723,30 @@ class ResourceTest extends TestCase
         ], ['data' => [0 => 10, 1 => 20, 'total' => 30]]);
     }
 
+    public function testItThrowsNoErrorInStrictModeWhenResourceIsPaginated()
+    {
+        $originalMode = Model::preventsAccessingMissingAttributes();
+        Model::preventAccessingMissingAttributes();
+        try {
+            Route::get('/', function () {
+                $paginator = new LengthAwarePaginator(
+                    collect([new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0])]),
+                    10, 15, 1
+                );
+
+                return PostResourceWithJsonOptions::collection($paginator);
+            });
+
+            $response = $this->withoutExceptionHandling()->get(
+                '/', ['Accept' => 'application/json']
+            );
+
+            $response->assertStatus(200);
+        } finally {
+            Model::preventAccessingMissingAttributes($originalMode);
+        }
+    }
+
     private function assertJsonResourceResponse($data, $expectedJson)
     {
         Route::get('/', function () use ($data) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Will close #52214

Hopefully the test will pass, I had some problems with it while running it locally.

The problem is that we expect a null value here, but at the same time we prevent a non present access of properties