### PR TITLE
[11.x] Widen typehints in base service provider

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Factory as ModelFactory;
 use Illuminate\View\Compilers\BladeCompiler;
 
 /**
- * @property array<class-string, class-string> $bindings All of the container bindings that should be registered.
- * @property array<class-string, class-string> $singletons All of the singletons that should be registered.
+ * @property array<string, string> $bindings All of the container bindings that should be registered.
+ * @property array<array-key, string> $singletons All of the singletons that should be registered.
  */
 abstract class ServiceProvider
 {


### PR DESCRIPTION
This PR addresses [typehints added in this PR](https://github.com/laravel/framework/pull/52298) that are too narrow. Technically `bind()` and `singleton()` also accept `null` for `$concrete`, but I'm not sure how useful that would be to document.