### PR TITLE
[11.x] Add `withoutHeader()` test method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -91,6 +91,19 @@ trait MakesHttpRequests
     }
 
     /**
+     * Remove a header from being sent with the request.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function withoutHeader(string $name)
+    {
+        unset($this->defaultHeaders[$name]);
+
+        return $this;
+    }
+
+    /**
      * Add an authorization token for the request.
      *
      * @param  string  $token
@@ -121,9 +134,7 @@ trait MakesHttpRequests
      */
     public function withoutToken()
     {
-        unset($this->defaultHeaders['Authorization']);
-
-        return $this;
+        return $this->withoutHeader('Authorization');
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -91,7 +91,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Remove a header from being sent with the request.
+     * Remove a header from the request.
      *
      * @param  string  $name
      * @return $this


### PR DESCRIPTION
You can add a header using the `withHeader()` method in a test.
```php
$this->withHeader('Foo', 'bar')->get(...);
```
There is currently no method to remove a header. This PR fixes that:
```php
$this->withoutHeader('Foo')->get(...);
```
This can be useful if you set a header in the `setUp()` method of the base `TestCase` class so the header is present on all requests in the test suite, but you want to remove that header in one or more specific tests in that entire test suite.

I also updated the existing `withoutToken()` method to use the `withoutHeader()` method in the background.