### PR TITLE
[11.x] Add `assertExactJsonStructure` method

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -263,16 +263,27 @@ class AssertableJsonString implements ArrayAccess, Countable
      *
      * @param  array|null  $structure
      * @param  array|null  $responseData
+     * @param  bool  $exact
      * @return $this
      */
-    public function assertStructure(?array $structure = null, $responseData = null)
+    public function assertStructure(?array $structure = null, $responseData = null, bool $exact = false)
     {
         if (is_null($structure)) {
             return $this->assertSimilar($this->decoded);
         }
 
         if (! is_null($responseData)) {
-            return (new static($responseData))->assertStructure($structure);
+            return (new static($responseData))->assertStructure($structure, null, $exact);
+        }
+
+        if ($exact) {
+            PHPUnit::assertIsArray($this->decoded);
+
+            $keys = collect($structure)->map(fn ($value, $key) => is_array($value) ? $key : $value)->values();
+
+            if ($keys->all() !== ['*']) {
+                PHPUnit::assertEquals($keys->sort()->values()->all(), collect($this->decoded)->keys()->sort()->values()->all());
+            }
         }
 
         foreach ($structure as $key => $value) {
@@ -280,12 +291,12 @@ class AssertableJsonString implements ArrayAccess, Countable
                 PHPUnit::assertIsArray($this->decoded);
 
                 foreach ($this->decoded as $responseDataItem) {
-                    $this->assertStructure($structure['*'], $responseDataItem);
+                    $this->assertStructure($structure['*'], $responseDataItem, $exact);
                 }
             } elseif (is_array($value)) {
                 PHPUnit::assertArrayHasKey($key, $this->decoded);
 
-                $this->assertStructure($structure[$key], $this->decoded[$key]);
+                $this->assertStructure($structure[$key], $this->decoded[$key], $exact);
             } else {
                 PHPUnit::assertArrayHasKey($value, $this->decoded);
             }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -848,6 +848,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has the exact JSON structure.
+     *
+     * @param  array|null  $structure
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function assertExactJsonStructure(?array $structure = null, $responseData = null)
+    {
+        $this->decodeResponseJson()->assertStructure($structure, $responseData, true);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response JSON has the expected count of items at the given key.
      *
      * @param  int  $count

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1462,6 +1462,88 @@ class TestResponseTest extends TestCase
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
+    public function testAssertExactJsonStructure()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        // Without structure
+        $response->assertExactJsonStructure();
+
+        // At root
+        try {
+            $response->assertExactJsonStructure(['foo']);
+            $failed = false;
+        } catch (AssertionFailedError $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+
+        $response->assertExactJsonStructure(['foo', 'foobar', 0, 'bars', 'baz', 'barfoo', 'numeric_keys']);
+
+        // Nested
+        try {
+            $response->assertExactJsonStructure(['foobar' => ['foobar_foo'], 'foo', 0, 'bars', 'baz', 'barfoo', 'numeric_keys']);
+            $failed = false;
+        } catch (AssertionFailedError $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+
+        $response->assertExactJsonStructure(['foobar' => ['foobar_foo', 'foobar_bar'], 'foo', 0, 'bars', 'baz', 'barfoo', 'numeric_keys']);
+
+        // Wildcard (repeating structure)
+        try {
+            $response->assertExactJsonStructure(['bars' => ['*' => ['bar']], 'foo', 'foobar', 0, 'baz', 'barfoo', 'numeric_keys']);
+            $failed = false;
+        } catch (AssertionFailedError $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+
+        $response->assertExactJsonStructure(['bars' => ['*' => ['bar', 'foo']], 'foo', 'foobar', 0, 'baz', 'barfoo', 'numeric_keys']);
+
+        // Wildcard (numeric keys)
+        try {
+            $response->assertExactJsonStructure(['numeric_keys' => ['*' => ['bar']], 'foo', 'foobar', 0, 'bars', 'baz', 'barfoo']);
+            $failed = false;
+        } catch (AssertionFailedError $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+
+        $response->assertExactJsonStructure(['numeric_keys' => ['*' => ['bar', 'foo']], 'foo', 'foobar', 0, 'bars', 'baz', 'barfoo']);
+
+        // Nested after wildcard
+        try {
+            $response->assertExactJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo']]], 'foo', 'foobar', 0, 'bars', 'barfoo', 'numeric_keys']);
+            $failed = false;
+        } catch (AssertionFailedError $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+
+        $response->assertExactJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo', 'bar']]], 'foo', 'foobar', 0, 'bars', 'barfoo', 'numeric_keys']);
+
+        // Wildcard (repeating structure) at root
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        try {
+            $response->assertExactJsonStructure(['*' => ['foo', 'bar']]);
+            $failed = false;
+        } catch (AssertionFailedError $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+
+        $response->assertExactJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
+    }
+
     public function testAssertJsonCount()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
If an API route returns the following response
```json
{
    "data": {
        "id": 1,
        "firstname": "Taylor",
        "lastname": "Otwell"
    }
}
```
then the following assertion will succeed
```php
$response->assertJsonStructure([
    'data' => [
        'firstname',
        'lastname',
    ],
]);
```
But what if that API response should not include the "id" key? The `assertJsonStructure()` method does not allow you to assert that.

That is were this new `assertExactJsonStructure()` method comes in:
```php
// This fails
$response->assertExactJsonStructure([
    'data' => [
        'firstname',
        'lastname',
    ],
]);

// This succeeds
$response->assertExactJsonStructure([
    'data' => [
        'id',
        'firstname',
        'lastname',
    ],
]);
```