### PR TITLE
Query Builder - standardise array key as alias name in selects

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -281,7 +281,7 @@ class Builder implements BuilderContract
                 if ($this->isQueryable($column)) {
                     $this->selectSub($column, $as);
                 } elseif (is_string($column)) {
-                    $this->columns[] = $column . ' as ' . $as;
+                    $this->columns[] = $column.' as '.$as;
                 }
             } else {
                 $this->columns[] = $column;
@@ -436,11 +436,11 @@ class Builder implements BuilderContract
             if (is_string($as)) {
                 if ($this->isQueryable($column)) {
                     if (\is_null($this->columns)) {
-                        $this->select($this->from . '.*');
+                        $this->select($this->from.'.*');
                     }
                     $this->selectSub($column, $as);
                 } elseif (is_string($column)) {
-                    $this->columns[] = $column . ' as ' . $as;
+                    $this->columns[] = $column.' as '.$as;
                 }
             } else {
                 if (is_array($this->columns) && in_array($column, $this->columns, true)) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -277,8 +277,12 @@ class Builder implements BuilderContract
         $columns = is_array($columns) ? $columns : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && $this->isQueryable($column)) {
-                $this->selectSub($column, $as);
+            if (is_string($as)) {
+                if ($this->isQueryable($column)) {
+                    $this->selectSub($column, $as);
+                } elseif (is_string($column)) {
+                    $this->columns[] = $column . ' as ' . $as;
+                }
             } else {
                 $this->columns[] = $column;
             }
@@ -429,12 +433,15 @@ class Builder implements BuilderContract
         $columns = is_array($column) ? $column : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && $this->isQueryable($column)) {
-                if (is_null($this->columns)) {
-                    $this->select($this->from.'.*');
+            if (is_string($as)) {
+                if ($this->isQueryable($column)) {
+                    if (\is_null($this->columns)) {
+                        $this->select($this->from . '.*');
+                    }
+                    $this->selectSub($column, $as);
+                } elseif (is_string($column)) {
+                    $this->columns[] = $column . ' as ' . $as;
                 }
-
-                $this->selectSub($column, $as);
             } else {
                 if (is_array($this->columns) && in_array($column, $this->columns, true)) {
                     continue;


### PR DESCRIPTION
Add support for column alias in array key when supplying string values. This pull request allows the column alias argument to be specified in the same format as a column alias for an expression currently is.

Pull request allows: `$query->select(['aliasName' => 'columnName'])`


Which follows the same format as an expression select: `$query->select(['aliasName' => new Expression(...)])`



Currently the query builder requires the alias to be baked in as part of the string `$query->select('columnName as aliasName') `, which can be confusing as the way to alias a column is inconsistent

