### PR TITLE
exlude the primary key on getDirtyForUpdate method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2126,7 +2126,11 @@ trait HasAttributes
      */
     protected function getDirtyForUpdate()
     {
-        return $this->getDirty();
+        return array_filter(
+            $this->getDirty(),
+            fn ($key) => !($this->incrementing && $key === $this->getKeyName()),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2128,7 +2128,7 @@ trait HasAttributes
     {
         return array_filter(
             $this->getDirty(),
-            fn ($key) => !($this->incrementing && $key === $this->getKeyName()),
+            fn ($key) => ! ($this->incrementing && $key === $this->getKeyName()),
             ARRAY_FILTER_USE_KEY
         );
     }

--- a/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
+++ b/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
@@ -34,6 +34,7 @@ class DatabaseEloquentGeneratedAsFillTest extends TestCase
     {
         $this->schema()->create('users', function ($table) {
             $table->id()->generatedAs()->always();
+            $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamps();

--- a/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
+++ b/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-use BadMethodCallException;
-use Exception;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
@@ -78,7 +76,6 @@ class DatabaseEloquentGeneratedAsFillTest extends TestCase
  */
 class TestUserWithIdendityId extends Eloquent
 {
-
     protected $table = 'users';
     protected $guarded = [];
 
@@ -95,6 +92,7 @@ class TestUserWithIdendityId extends Eloquent
             $user->forceFill([
                 'trials_end_at' => now()->addDays(7),
             ])->save();
+            
             return $user;
         });
     }

--- a/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
+++ b/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
@@ -92,7 +92,7 @@ class TestUserWithIdendityId extends Eloquent
             $user->forceFill([
                 'trials_end_at' => now()->addDays(7),
             ])->save();
-            
+
             return $user;
         });
     }

--- a/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
+++ b/tests/Database/DatabaseEloquentGeneratedAsIdentityIdUpdateTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use BadMethodCallException;
+use Exception;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentGeneratedAsFillTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->id()->generatedAs()->always();
+            $table->string('email')->unique();
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function testForceFillAfterCreationNotThrowsException()
+    {
+        $user = TestUserWithIdendityId::create([
+            'email' => 'matteo@email.it',
+            'name' => 'Matteo',
+        ]);
+
+        $this->assertNotNull($user->trial_ends_at);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class TestUserWithIdendityId extends Eloquent
+{
+
+    protected $table = 'users';
+    protected $guarded = [];
+
+    public function casts()
+    {
+        return [
+            'trial_ends_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted()
+    {
+        static::created(function ($user) {
+            $user->forceFill([
+                'trials_end_at' => now()->addDays(7),
+            ])->save();
+            return $user;
+        });
+    }
+}


### PR DESCRIPTION
### What
Request to update the method `getDirtyForUpdate` on `HasAttributes` Eloquent Model trait.

### Why
When migration declares the id as identity (best practice for Postgres) and forceFill is called on created lifecycle hook (like on Spark package on billable trait) the primary key is not excluded from the dirty keys of the attributes to be updated.

### How
Simply remove the primaryKey from the $dirty attributes when model is incrementing.

Not sure if the test I created is acceptable but fix is working and verified.


