### PR TITLE
[11.x] Add middleware to stack before sending the request

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1265,12 +1265,11 @@ class PendingRequest
     public function pushHandlers($handlerStack)
     {
         return tap($handlerStack, function ($stack) {
-            $stack->push($this->buildBeforeSendingHandler());
-
             $this->middleware->each(function ($middleware) use ($stack) {
                 $stack->push($middleware);
             });
 
+            $stack->push($this->buildBeforeSendingHandler());
             $stack->push($this->buildRecorderHandler());
             $stack->push($this->buildStubHandler());
         });


### PR DESCRIPTION
**Backstory**
[See my comment.](https://github.com/laravel/framework/issues/51980#issuecomment-2257040730)

**Problem**

The problem is that we currently do not initialise the middleware before sending the request which causes an issue further described in https://github.com/laravel/framework/issues/51980.

```
Http::globalRequestMiddleware(fn ($request) => $request->withHeader(
    'User-Agent', 'Example Application/1.0'
));
```

**Solution**
We should always first add the middleware to the stack and then build any follow-up handler.

This now causes our middleware to be initialised at the right time and the user-agent is now correctly set when listening to the RequestSending event.