### PR TITLE
[11.x] Inverse Fake Queue Interactions: `assertNotDeleted`, `assertNotFailed`, and `assertNotReleased`

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -112,6 +112,23 @@ trait InteractsWithQueue
     }
 
     /**
+     * Assert that the job was not deleted from the queue.
+     *
+     * @return $this
+     */
+    public function assertNotDeleted()
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            ! $this->job->isDeleted(),
+            'Job was expected to be not deleted, but was.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the job was manually failed.
      *
      * @return $this
@@ -123,6 +140,23 @@ trait InteractsWithQueue
         PHPUnit::assertTrue(
             $this->job->hasFailed(),
             'Job was expected to be manually failed, but was not.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the job was not manually failed.
+     *
+     * @return $this
+     */
+    public function assertNotFailed()
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            ! $this->job->hasFailed(),
+            'Job was expected to be not manually failed, but was.'
         );
 
         return $this;
@@ -154,6 +188,23 @@ trait InteractsWithQueue
                 "Expected job to be released with delay of [{$delay}] seconds, but was released with delay of [{$this->job->releaseDelay}] seconds."
             );
         }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the job was not released back onto the queue.
+     *
+     * @return $this
+     */
+    public function assertNotReleased()
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            ! $this->job->isReleased(),
+            'Job was expected to not be released, but was.'
+        );
 
         return $this;
     }

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -122,7 +122,7 @@ trait InteractsWithQueue
 
         PHPUnit::assertTrue(
             ! $this->job->isDeleted(),
-            'Job was expected to be not deleted, but was.'
+            'Job was unexpectedly deleted.'
         );
 
         return $this;
@@ -156,7 +156,7 @@ trait InteractsWithQueue
 
         PHPUnit::assertTrue(
             ! $this->job->hasFailed(),
-            'Job was expected to be not manually failed, but was.'
+            'Job was unexpectedly failed manually.'
         );
 
         return $this;
@@ -203,7 +203,7 @@ trait InteractsWithQueue
 
         PHPUnit::assertTrue(
             ! $this->job->isReleased(),
-            'Job was expected to not be released, but was.'
+            'Job was unexpectedly released.'
         );
 
         return $this;


### PR DESCRIPTION
You can easily assert that a job has been deleted, failed, or released back onto the queue:
```php
public function test_job_is_released(): void
{
    $job = (new TestJob)->withFakeQueueInteractions();

    $job->handle();

    $job->assertReleased();

    // $job->assertDeleted();
    // $job->assertFailed();
}
```
but there is currently no easy way to assert that the job was not deleted, failed, or released back onto the queue. This PR fixes that by adding extra methods for those assertions:

```php
public function test_job_is_not_released(): void
{
    $job = (new TestJob)->withFakeQueueInteractions();

    $job->handle();

    $job->assertNotReleased();

    // $job->assertNotDeleted();
    // $job->assertNotFailed();
}
```