### PR TITLE
[11.x] Add `withoutHeaders` method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -104,6 +104,19 @@ trait MakesHttpRequests
     }
 
     /**
+     * Remove headers from the request.
+     *
+     * @param  array  $headers
+     * @return $this
+     */
+    public function withoutHeaders(array $headers)
+    {
+        $this->defaultHeaders = array_diff($this->defaultHeaders, $headers);
+
+        return $this;
+    }
+
+    /**
      * Add an authorization token for the request.
      *
      * @param  string  $token


### PR DESCRIPTION
We have the `withoutHeader` method and I think it is a good idea to add a new method called the `withoutHeaders` method to remove headers from requests.

Also, I want to add the `withoutHeader` method to docs, but I saw the `withHeaders` method in docs.

https://github.com/laravel/framework/pull/52309