### PR TITLE
[11.x] Remove undefined class PreventRequestsDuringMaintenance

### DIFF
--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -11,7 +11,6 @@ use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
-use Orchestra\Testbench\Http\Middleware\PreventRequestsDuringMaintenance as TestbenchPreventRequestsDuringMaintenance;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -24,8 +23,6 @@ class MaintenanceModeTest extends TestCase
         });
 
         parent::setUp();
-
-        $this->withoutMiddleware(TestbenchPreventRequestsDuringMaintenance::class);
     }
 
     public function testBasicMaintenanceModeResponse()


### PR DESCRIPTION
The `Orchestra\Testbench\Http\Middleware\PreventRequestsDuringMaintenance` class is undefined, we can remove it in `MaintenanceModeTest` and all tests still pass.