### PR TITLE
[11.x] Add middleware before sending request and dispatching events

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1265,12 +1265,11 @@ class PendingRequest
     public function pushHandlers($handlerStack)
     {
         return tap($handlerStack, function ($stack) {
-            $stack->push($this->buildBeforeSendingHandler());
-
             $this->middleware->each(function ($middleware) use ($stack) {
                 $stack->push($middleware);
             });
 
+            $stack->push($this->buildBeforeSendingHandler());
             $stack->push($this->buildRecorderHandler());
             $stack->push($this->buildStubHandler());
         });

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -2,12 +2,29 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase;
 
 class HttpClientTest extends TestCase
 {
+    public function testGlobalMiddlewarePersistsBeforeWeDispatchEvent(): void
+    {
+        Event::fake();
+        Http::fake();
+
+        Http::globalRequestMiddleware(fn ($request) => $request->withHeader('User-Agent', 'Facade/1.0'));
+
+        Http::get('laravel.com');
+
+        Event::assertDispatched(RequestSending::class, function (RequestSending $event) {
+            return Collection::make($event->request->header('User-Agent'))->contains('Facade/1.0');
+        });
+    }
+
     public function testGlobalMiddlewarePersistsAfterFacadeFlush(): void
     {
         Http::macro('getGlobalMiddleware', fn () => $this->globalMiddleware);


### PR DESCRIPTION
**Backstory**
[See my comment.](https://github.com/laravel/framework/issues/51980#issuecomment-2257040730)

**Problem**

The problem is that we currently do not initialise the middleware before sending the request which causes an issue further described in https://github.com/laravel/framework/issues/51980.

```
Http::globalRequestMiddleware(fn ($request) => $request->withHeader(
    'User-Agent', 'Example Application/1.0'
));
```

**Solution**
We should always first add the middleware to the stack and then build any follow-up handler.

This now causes our middleware to be initialised at the right time and the user-agent is now correctly set when listening to the RequestSending event.

Please let me know if there is a way I could improve this test! :)