### PR TITLE
[12.x] `Model::hashUsing()`

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -76,7 +76,7 @@ trait CreatesUserProviders
      */
     protected function createEloquentProvider($config)
     {
-        return new EloquentUserProvider($this->app['hash'], $config['model']);
+        return new EloquentUserProvider($config['model']);
     }
 
     /**

--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -39,4 +39,12 @@ interface Hasher
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = []);
+
+    /**
+     * Determine if a given string is already hashed.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public function isHashed(#[\SensitiveParameter] $value);
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -184,6 +184,13 @@ trait HasAttributes
     public static $encrypter;
 
     /**
+     * The hasher instance that is used to hash attributes.
+     *
+     * @var \Illuminate\Contracts\Hashing\Hasher|null
+     */
+    public static $hasher;
+
+    /**
      * Initialize the trait.
      *
      * @return void
@@ -1392,15 +1399,37 @@ trait HasAttributes
             return null;
         }
 
-        if (! Hash::isHashed($value)) {
-            return Hash::make($value);
+        if (! static::currentHasher()->isHashed($value)) {
+            return static::currentHasher()->make($value);
         }
 
-        if (! Hash::verifyConfiguration($value)) {
+        if (method_exists(static::currentHasher(), 'verifyConfiguration') &&
+            ! static::currentHasher()->verifyConfiguration($value)) {
             throw new RuntimeException("Could not verify the hashed value's configuration.");
         }
 
         return $value;
+    }
+
+    /**
+     * Set the hasher instance that will be used to hash attributes.
+     *
+     * @param  \Illuminate\Contracts\Hashing\Hasher|null  $hasher
+     * @return void
+     */
+    public static function hashUsing($hasher)
+    {
+        static::$hasher = $hasher;
+    }
+
+    /**
+     * Get the current hasher being used by the model.
+     *
+     * @return \Illuminate\Contracts\Hashing\Hasher
+     */
+    protected static function currentHasher()
+    {
+        return static::$hasher ?? Hash::getFacadeRoot()->driver();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1427,7 +1427,7 @@ trait HasAttributes
      *
      * @return \Illuminate\Contracts\Hashing\Hasher
      */
-    protected static function currentHasher()
+    public static function currentHasher()
     {
         return static::$hasher ?? Hash::getFacadeRoot()->driver();
     }

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -31,4 +31,15 @@ abstract class AbstractHasher
 
         return password_verify($value, $hashedValue);
     }
+
+    /**
+     * Determine if a given string is already hashed.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public function isHashed(#[\SensitiveParameter] $value)
+    {
+        return $this->info($value)['algo'] !== null;
+    }
 }

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -96,7 +96,7 @@ class HashManager extends Manager implements Hasher
      */
     public function isHashed(#[\SensitiveParameter] $value)
     {
-        return $this->driver()->info($value)['algo'] !== null;
+        return $this->driver()->isHashed($value);
     }
 
     /**

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -270,7 +270,7 @@ class AuthenticationTest extends TestCase
 
     public function testAuthViaAttemptRemembering()
     {
-        $provider = new EloquentUserProvider(app('hash'), AuthenticationTestUser::class);
+        $provider = new EloquentUserProvider(AuthenticationTestUser::class);
 
         $user = AuthenticationTestUser::create([
             'username' => 'username2',


### PR DESCRIPTION
The Eloquent model class has an `encryptUsing()` method that allows you to customize the encrypter used by the `encrypted` cast (https://github.com/laravel/framework/pull/35080). This PR adds a similar method called `hashUsing`  that allows you to customize the hasher used by the `hashed` cast.

I targeted the master branch because I had to update the `Hasher` interface. I needed to add the `isHashed` method as that method currently only existed on the `HashManager` class. I did not add the `verifyConfiguration` method to the interface because that method is marked as `@internal` on the existing hashers so I thought that may be an optional method on a hasher class.