### PR TITLE
Query Builder - add more support for column aliases in array keys

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -281,7 +281,7 @@ class Builder implements BuilderContract
                 if ($this->isQueryable($column)) {
                     $this->selectSub($column, $as);
                 } elseif (is_string($column)) {
-                    $this->columns[] = $column . ' as ' . $as;
+                    $this->columns[] = $column.' as '.$as;
                 }
             } else {
                 $this->columns[] = $column;
@@ -436,11 +436,11 @@ class Builder implements BuilderContract
             if (is_string($as)) {
                 if ($this->isQueryable($column)) {
                     if (\is_null($this->columns)) {
-                        $this->select($this->from . '.*');
+                        $this->select($this->from.'.*');
                     }
                     $this->selectSub($column, $as);
                 } elseif (is_string($column)) {
-                    $this->columns[] = $column . ' as ' . $as;
+                    $this->columns[] = $column.' as '.$as;
                 }
             } else {
                 if (is_array($this->columns) && in_array($column, $this->columns, true)) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -277,8 +277,12 @@ class Builder implements BuilderContract
         $columns = is_array($columns) ? $columns : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && $this->isQueryable($column)) {
-                $this->selectSub($column, $as);
+            if (is_string($as)) {
+                if ($this->isQueryable($column)) {
+                    $this->selectSub($column, $as);
+                } elseif (is_string($column)) {
+                    $this->columns[] = $column . ' as ' . $as;
+                }
             } else {
                 $this->columns[] = $column;
             }
@@ -429,12 +433,15 @@ class Builder implements BuilderContract
         $columns = is_array($column) ? $column : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && $this->isQueryable($column)) {
-                if (is_null($this->columns)) {
-                    $this->select($this->from.'.*');
+            if (is_string($as)) {
+                if ($this->isQueryable($column)) {
+                    if (\is_null($this->columns)) {
+                        $this->select($this->from . '.*');
+                    }
+                    $this->selectSub($column, $as);
+                } elseif (is_string($column)) {
+                    $this->columns[] = $column . ' as ' . $as;
                 }
-
-                $this->selectSub($column, $as);
             } else {
                 if (is_array($this->columns) && in_array($column, $this->columns, true)) {
                     continue;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -103,6 +103,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
     }
 
+    public function testAliasInArrayKey()
+    {
+        $builder = $this->getBuilder();
+        $builder->select(['foo.bar' => 'x.y'])->from('baz');
+        $this->assertSame('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
+    }
+
     public function testAliasWrappingWithSpacesInDatabaseName()
     {
         $builder = $this->getBuilder();
@@ -115,6 +122,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->addSelect('bar')->from('users');
         $this->assertSame('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
+    }
+
+    public function testAddingSelectsWithAlias()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('foo')->addSelect(['baz' => 'bar'])->addSelect(['bust' => 'boom'])->from('users');
+        $this->assertSame('select "foo", "bar" as "baz", "boom" as "bust" from "users"', $builder->toSql());
     }
 
     public function testBasicSelectWithPrefix()


### PR DESCRIPTION
Adds support for string values when supplying a column alias in array key. Currently an array key to define a select alias is only allowed when the value is a Builder|EloquentBuilder|Relation|Closure.

This pull request allows: `$query->select(['aliasName' => 'columnName'])`

Currently, the only way to specify a select alias with a column name is by concatenating the string: `$query->select('columnName as aliasName')`. Requiring this format makes the api inconsistent with other permitted types of select e.g. `$query->select(['aliasName' => $query2])`



