### PR TITLE
[11.x] Fix tests in wrong file

### DIFF
--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -71,4 +71,38 @@ class MailMakeCommandTest extends TestCase
         $this->assertFilenameNotExists('resources/views/foo-mail.blade.php');
         $this->assertFilenameExists('tests/Feature/Mail/FooMailTest.php');
     }
+
+    public function testItCanGenerateMailWithNoInitialInput()
+    {
+        $this->artisan('make:mail')
+            ->expectsQuestion('What should the mailable be named?', 'FooMail')
+            ->expectsQuestion('Would you like to create a view?', 'none')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Mail/FooMail.php');
+        $this->assertFilenameDoesNotExists('resources/views/mail/foo-mail.blade.php');
+    }
+
+    public function testItCanGenerateMailWithViewWithNoInitialInput()
+    {
+        $this->artisan('make:mail')
+            ->expectsQuestion('What should the mailable be named?', 'MyFooMail')
+            ->expectsQuestion('Would you like to create a view?', 'view')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Mail/MyFooMail.php');
+        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
+    }
+
+    public function testItCanGenerateMailWithMarkdownViewWithNoInitialInput()
+    {
+        $this->artisan('make:mail')
+
+            ->expectsQuestion('What should the mailable be named?', 'FooMail')
+            ->expectsQuestion('Would you like to create a view?', 'markdown')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Mail/MyFooMail.php');
+        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
+    }
 }

--- a/tests/Integration/Generators/ViewMakeCommandTest.php
+++ b/tests/Integration/Generators/ViewMakeCommandTest.php
@@ -26,38 +26,4 @@ class ViewMakeCommandTest extends TestCase
         $this->assertFilenameExists('resources/views/foo.blade.php');
         $this->assertFilenameExists('tests/Feature/View/FooTest.php');
     }
-
-    public function testItCanGenerateMailWithNoInitialInput()
-    {
-        $this->artisan('make:mail')
-            ->expectsQuestion('What should the mailable be named?', 'FooMail')
-            ->expectsQuestion('Would you like to create a view?', 'none')
-            ->assertExitCode(0);
-
-        $this->assertFilenameExists('app/Mail/FooMail.php');
-        $this->assertFilenameDoesNotExists('resources/views/mail/foo-mail.blade.php');
-    }
-
-    public function testItCanGenerateMailWithViewWithNoInitialInput()
-    {
-        $this->artisan('make:mail')
-            ->expectsQuestion('What should the mailable be named?', 'MyFooMail')
-            ->expectsQuestion('Would you like to create a view?', 'view')
-            ->assertExitCode(0);
-
-        $this->assertFilenameExists('app/Mail/MyFooMail.php');
-        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
-    }
-
-    public function testItCanGenerateMailWithMarkdownViewWithNoInitialInput()
-    {
-        $this->artisan('make:mail')
-
-            ->expectsQuestion('What should the mailable be named?', 'FooMail')
-            ->expectsQuestion('Would you like to create a view?', 'markdown')
-            ->assertExitCode(0);
-
-        $this->assertFilenameExists('app/Mail/MyFooMail.php');
-        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
-    }
 }


### PR DESCRIPTION
This PR moves the `MailMakeCommand tests` to the correct file. It seems I put them in the wrong one during my last PR. (https://github.com/laravel/framework/pull/52057)