### PR TITLE
[11.x] Add `sometimeDaily()` to scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -2,11 +2,20 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use DateInterval;
+use DateTime;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 
 trait ManagesFrequencies
 {
+    /**
+     * The next timestamp to use in sometimeDaily().
+     *
+     * @var string
+     */
+    protected static string $nextSometimeDaily = '00:05';
+
     /**
      * The Cron expression representing the event's frequency.
      *
@@ -348,6 +357,21 @@ trait ManagesFrequencies
             count($segments) === 2 ? (int) $segments[1] : '0',
             (int) $segments[0]
         );
+    }
+
+    /**
+     * Schedule the event to at some time during the day. Each call picks a different time.
+     *
+     * @return $this
+     */
+    public function sometimeDaily()
+    {
+        $at = static::$nextSometimeDaily;
+        $next = DateTime::createFromFormat('H:i', $at)->add(new DateInterval('PT5M'));
+
+        static::$nextSometimeDaily = $next->format('H:i');
+
+        return $this->dailyAt($at);
     }
 
     /**


### PR DESCRIPTION
Often times you have scheduled commands that you want to run every day, but you don't particularly care **when** during the day they run. For apps that have many scheduled tasks, this can unintentionally cause a huge spike in command execution every midnight—the default for `daily()`.

This PR introduces a `sometimeDaily()` method that incrementally schedules tasks 5 minutes apart from each other throughout the day:

```php
$schedule->command('model:prune')->sometimeDaily();       // scheduled at 00:05
$schedule->command('telescope:prune')->sometimeDaily();   // scheduled at 00:10
$schedule->command('cloudflare:reload')->sometimeDaily(); // scheduled at 00:15
```

If, somehow, you manage to fill out every 5-minute increment, it will reset back to midnight and start again.