### PR TITLE
[11.x] `ShouldBeSingleton` interface as an alternative syntax to registering singletons

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use Illuminate\Contracts\Container\ShouldBeSingleton;
 use LogicException;
 use ReflectionAttribute;
 use ReflectionClass;
@@ -825,7 +826,7 @@ class Container implements ArrayAccess, ContainerContract
         // If the requested type is registered as a singleton we'll want to cache off
         // the instances in "memory" so we can return it later without creating an
         // entirely new instance of an object on each subsequent request for it.
-        if ($this->isShared($abstract) && ! $needsContextualBuild) {
+        if (($this->isShared($abstract) || $object instanceof ShouldBeSingleton) && ! $needsContextualBuild) {
             $this->instances[$abstract] = $object;
         }
 

--- a/src/Illuminate/Contracts/Container/ShouldBeSingleton.php
+++ b/src/Illuminate/Contracts/Container/ShouldBeSingleton.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Container;
+
+interface ShouldBeSingleton
+{
+    //
+}


### PR DESCRIPTION
Working on an enterprise-level application, the AppServiceProvider gets pretty large. Almost every service we have created really should be bound as a singleton, but sometimes we either don't want to pollute the AppServiceProvider, or we simply forget.

This is a slightly cleaner syntax. We simply add `implements ShouldBeSingleton` to the classes.

```php
class CreatePodcastAction implements ShouldBeSingleton
{
    public function __construct(
        private readonly AwsService $awsService,
        private readonly SomeOtherService $anotherService,
        // ... more complex objects to resolve
    ) {
    }
}
```

As an alternative to adding:
```php
// AppServiceProvider
// ... all of the other singletons we have bound
$this->app->singleton(CreatePodcastAction::class);
```

## Followup
Add a `ShouldBeScopedSingleton` interface so we can leverage this and place nice with Laravel Octane.