### PR TITLE
[10.x] Fix `Factory::afterCreating` callable argument type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -676,7 +676,7 @@ abstract class Factory
     /**
      * Add a new "after creating" callback to the model definition.
      *
-     * @param  \Closure(\Illuminate\Database\Eloquent\Model|TModel): mixed  $callback
+     * @param  \Closure(\Illuminate\Database\Eloquent\Model|TModel, \Illuminate\Database\Eloquent\Model|null): mixed  $callback
      * @return static
      */
     public function afterCreating(Closure $callback)


### PR DESCRIPTION
The callback passed as an argument to `afterCreating()` is always invoked with 2 parameters, the 2nd parameter being the parent model (see `callAfterCreating()`).

Before this change, PHPStan could raise this kind of error:
```
 Parameter #1 $callback of method Illuminate\Database\Eloquent\Factories\Factory<Illuminate\Database\Eloquent\Model>::afterCreating() expects Closure(Illuminate\Database\Eloquent\Model): mixed, Closure(App\Models\MyModel, mixed): void given.  
 🪪  argument.type                                                                                                                                                                                                                                  
 💡 Parameter #2 $parent of passed callable is required but accepting callable does not have that parameter. It will be called without it. 
```

Here're some reproducers:
- Before: https://phpstan.org/r/8943ed79-f8b5-4b24-89af-76d82e044977
- After: https://phpstan.org/r/8120c644-077f-4e92-8113-749f41aa00d4