### PR TITLE
[11.x] Replace dead link in Security Policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,7 +15,7 @@ If you discover a security vulnerability within Laravel, please send an email to
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: OpenPGP v2.0.8
-Comment: https://sela.io/pgp/
+Comment: Report Security Vulnerabilities to taylor@laravel.com
 
 xsFNBFugFSQBEACxEKhIY9IoJzcouVTIYKJfWFGvwFgbRjQWBiH3QdHId5vCrbWo
 s2l+4Rv03gMG+yHLJ3rWElnNdRaNdQv59+lShrZF7Bvu7Zvc0mMNmFOM/mQ/K2Lt


### PR DESCRIPTION
Seems like a dead link is used in the PGP Key Comment in the Security Policy: https://sela.io/pgp/

So I replaced it with a meaningful comment instead. Please check internally if the PGP Key is still valid for usage.

It would also be possible to simply delete the Comment itself.