### PR TITLE
[11.x] Use correct pluralization rules in trans_choice for fallback strings

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -217,15 +217,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     protected function localeForChoice($key, $locale)
     {
-        if ($locale && $this->hasForLocale($key, $locale)) {
-            return $locale;
-        }
+        $locale = $locale ?: $this->locale;
 
-        if ($this->hasForLocale($key, $this->locale)) {
-            return $this->locale;
-        }
-
-        return $this->fallback;
+        return $this->hasForLocale($key, $locale) ? $locale : $this->fallback;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -191,7 +191,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     public function choice($key, $number, array $replace = [], $locale = null)
     {
         $line = $this->get(
-            $key, $replace, $locale = $this->localeForChoice($locale)
+            $key, $replace, $locale = $this->localeForChoice($key, $locale)
         );
 
         // If the given "number" is actually an array or countable we will simply count the
@@ -211,12 +211,21 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Get the proper locale for a choice operation.
      *
+     * @param  string  $key
      * @param  string|null  $locale
      * @return string
      */
-    protected function localeForChoice($locale)
+    protected function localeForChoice($key, $locale)
     {
-        return $locale ?: $this->locale ?: $this->fallback;
+        if ($locale && $this->hasForLocale($key, $locale)) {
+            return $locale;
+        }
+
+        if ($this->hasForLocale($key, $this->locale)) {
+            return $this->locale;
+        }
+
+        return $this->fallback;
     }
 
     /**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -125,8 +125,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItemForAnInt()
     {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
@@ -135,8 +136,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItemForAFloat()
     {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 1.2, 'en')->andReturn('choiced');
 
@@ -145,8 +147,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->exactly(2))->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
 
@@ -155,6 +158,18 @@ class TranslationTranslatorTest extends TestCase
 
         $values = new Collection(['foo', 'bar', 'baz']);
         $t->choice('foo', $values, ['replace']);
+    }
+
+    public function testChoiceMethodProperlySelectsLocaleForChoose()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'hasForLocale'])->setConstructorArgs([$this->getLoader(), 'cs'])->getMock();
+        $t->setFallback('en');
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->once())->method('hasForLocale')->with($this->equalTo('foo'), $this->equalTo('cs'))->willReturn(false);
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
+
+        $t->choice('foo', 10, ['replace']);
     }
 
     public function testGetJson()


### PR DESCRIPTION
The `trans_choice` function uses the pluralization rules of the preferred language. If the preferred language and the fallback language have different rules, and the key is not found in the preferred language, the fallback language is used but with the pluralization rules of the preferred language, causing unexpected results. See issue #52341 for an example.

This PR updates `Translator::localeForChoice()` so that it returns the fallback locale if the preferred language does not have a translation for the given key.