### PR TITLE
[11.x] Add `in()` and `inHidden()` functions to Context Stacks

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -312,6 +312,50 @@ class Repository
     }
 
     /**
+     * Checks if the given value is in the stack.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
+    public function in(string $key, mixed $value): bool
+    {
+        if (! $this->isStackable($key)) {
+            throw new RuntimeException("Given value is not a stack for key [{$key}].");
+        }
+
+        if (! array_key_exists($key, $this->data)) {
+            return false;
+        }
+
+        return in_array($value, $this->data[$key], true);
+    }
+
+    /**
+     * Checks if the given value is in the hidden stack.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
+    public function inHidden(string $key, mixed $value): bool
+    {
+        if (! $this->isHiddenStackable($key)) {
+            throw new RuntimeException("Given value is not a hidden stack for key [{$key}].");
+        }
+
+        if (! array_key_exists($key, $this->hidden)) {
+            return false;
+        }
+
+        return in_array($value, $this->hidden[$key], true);
+    }
+
+    /**
      * Determine if a given key can be used as a stack.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -21,6 +21,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Log\Context\Repository addHiddenIf(string $key, mixed $value)
  * @method static \Illuminate\Log\Context\Repository push(string $key, mixed ...$values)
  * @method static \Illuminate\Log\Context\Repository pushHidden(string $key, mixed ...$values)
+ * @method static bool in(string $key, mixed $value)
+ * @method static bool inHidden(string $key, mixed $value)
  * @method static bool isEmpty()
  * @method static \Illuminate\Log\Context\Repository dehydrating(callable $callback)
  * @method static \Illuminate\Log\Context\Repository hydrated(callable $callback)

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -206,6 +206,31 @@ class ContextTest extends TestCase
         $this->assertFalse(Context::has('unset'));
     }
 
+    public function test_it_can_check_if_value_is_in_context_stack()
+    {
+        Context::push('foo', 'bar', 'lorem');
+
+        $this->assertTrue(Context::in('foo', 'bar'));
+        $this->assertTrue(Context::in('foo', 'lorem'));
+        $this->assertFalse(Context::in('foo', 'doesNotExist'));
+    }
+
+    public function test_it_can_check_if_value_is_in_hidden_context_stack()
+    {
+        Context::pushHidden('foo','bar', 'lorem');
+
+        $this->assertTrue(Context::inHidden('foo', 'bar'));
+        $this->assertTrue(Context::inHidden('foo', 'lorem'));
+        $this->assertFalse(Context::inHidden('foo', 'doesNotExist'));
+    }
+
+    public function test_it_cannot_check_if_hidden_value_is_in_non_hidden_context_stack()
+    {
+        Context::pushHidden('foo', 'bar', 'lorem');
+
+        $this->assertFalse(Context::in('foo', 'bar'));
+    }
+
     public function test_it_can_get_all_values()
     {
         Context::add('foo', 'bar');


### PR DESCRIPTION
I'm really liking the addition of Context and the support for stacks. But I was missing a function where you could easily check if a certain value actually is within a stack. It's basically just adding` in_array()` support for the stacks.

You could use it as follows:
```php
# Normal
Context::push('foo', 'bar', 'lorem');

Context::in('foo', 'bar'); # true
Context::in('foo', 'doesNotExist'); # false

# Hidden
Context::pushHidden('foo', 'bar', 'lorem');

Context::inHidden('foo', 'bar'); # true
Context::inHidden('foo', 'doesNotExist'); # false
```