### PR TITLE
Improve `Lock->block` method

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -112,14 +112,17 @@ abstract class Lock implements LockContract
      */
     public function block($seconds, $callback = null)
     {
-        $starting = $this->currentTime();
+        $starting = ((int) now()->format('Uu')) / 1000;
+        $milliseconds = $seconds * 1000;
 
         while (! $this->acquire()) {
-            Sleep::usleep($this->sleepMilliseconds * 1000);
+            $now = ((int) now()->format('Uu')) / 1000;
 
-            if ($this->currentTime() - $seconds >= $starting) {
+            if ($now + $this->sleepMilliseconds - $milliseconds >= $starting) {
                 throw new LockTimeoutException;
             }
+
+            Sleep::usleep($this->sleepMilliseconds * 1000);
         }
 
         if (is_callable($callback)) {

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -113,12 +113,13 @@ abstract class Lock implements LockContract
     public function block($seconds, $callback = null)
     {
         $starting = ((int) now()->format('Uu')) / 1000;
+
         $milliseconds = $seconds * 1000;
 
         while (! $this->acquire()) {
             $now = ((int) now()->format('Uu')) / 1000;
 
-            if ($now + $this->sleepMilliseconds - $milliseconds >= $starting) {
+            if (($now + $this->sleepMilliseconds - $milliseconds) >= $starting) {
                 throw new LockTimeoutException;
             }
 


### PR DESCRIPTION
Small improvement to the block method of the default cache driver. While developing my own cache layer for Laravel, I figured that that the block method on a cache lock didn't quite cover the work it should do in my opinion. This is because the while loop, which attempts to acquire the lock every 250 miliseconds, has a heavy ordering problem of executing the `usleep` and the timeout test. While failing to acquire the lock, it should immediately check if there will be a timeout after the following nap. Currently, if the method will end up in a timeout, it will unnecessarily execute another `usleep`.

The Lock will now use the `now()` method to do time management instead of using the InteractsWithTime trait. I don't know if that is out of line with the idea of the code, but it sure works without any issues. 

Currently i am using this own block implementation, but would love to work with the improvement within the framework itself.

And, thanks for the amazing framework!

Chears!
