### PR TITLE
Add `deduplicate` to strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -342,6 +342,18 @@ class Str
     }
 
     /**
+     * Replace consecutive characters with character in the given string.
+     *
+     * @param  string  $string
+     * @param  string  $character
+     * @return string
+     */
+    public static function dedup(string $string, string $character = ' ')
+    {
+        return preg_replace('/'.preg_quote($character, '/').'+/u', $character, $string);
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -342,13 +342,13 @@ class Str
     }
 
     /**
-     * Replace consecutive characters with character in the given string.
+     * Replace consecutive instances of a given character with a single character in the given string.
      *
      * @param  string  $string
      * @param  string  $character
      * @return string
      */
-    public static function dedup(string $string, string $character = ' ')
+    public static function deduplicate(string $string, string $character = ' ')
     {
         return preg_replace('/'.preg_quote($character, '/').'+/u', $character, $string);
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -236,6 +236,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Replace consecutive characters with character in a string.
+     *
+     * @param  string  $character
+     * @return static
+     */
+    public function dedup(string $character = ' ')
+    {
+        return new static(Str::dedup($this->value, $character));
+    }
+
+    /**
      * Get the parent directory's path.
      *
      * @param  int  $levels

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -236,14 +236,14 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Replace consecutive characters with character in a string.
+     * Replace consecutive instances of a given character with a single character.
      *
      * @param  string  $character
      * @return static
      */
-    public function dedup(string $character = ' ')
+    public function deduplicate(string $character = ' ')
     {
-        return new static(Str::dedup($this->value, $character));
+        return new static(Str::deduplicate($this->value, $character));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -400,6 +400,14 @@ class SupportStrTest extends TestCase
         Str::convertCase('Hello', -1);
     }
 
+    public function testDedup()
+    {
+        $this->assertSame(' laravel php framework ', Str::dedup(' laravel   php  framework '));
+        $this->assertSame('what', Str::dedup('whaaat', 'a'));
+        $this->assertSame('/some/odd/path/', Str::dedup('/some//odd//path/', '/'));
+        $this->assertSame('ムだム', Str::dedup('ムだだム', 'だ'));
+    }
+
     public function testParseCallback()
     {
         $this->assertEquals(['Class', 'method'], Str::parseCallback('Class@method'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -402,10 +402,10 @@ class SupportStrTest extends TestCase
 
     public function testDedup()
     {
-        $this->assertSame(' laravel php framework ', Str::dedup(' laravel   php  framework '));
-        $this->assertSame('what', Str::dedup('whaaat', 'a'));
-        $this->assertSame('/some/odd/path/', Str::dedup('/some//odd//path/', '/'));
-        $this->assertSame('ムだム', Str::dedup('ムだだム', 'だ'));
+        $this->assertSame(' laravel php framework ', Str::deduplicate(' laravel   php  framework '));
+        $this->assertSame('what', Str::deduplicate('whaaat', 'a'));
+        $this->assertSame('/some/odd/path/', Str::deduplicate('/some//odd//path/', '/'));
+        $this->assertSame('ムだム', Str::deduplicate('ムだだム', 'だ'));
     }
 
     public function testParseCallback()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -214,10 +214,10 @@ class SupportStringableTest extends TestCase
 
     public function testDedup()
     {
-        $this->assertSame(' laravel php framework ', (string) $this->stringable(' laravel   php  framework ')->dedup());
-        $this->assertSame('what', (string) $this->stringable('whaaat')->dedup('a'));
-        $this->assertSame('/some/odd/path/', (string) $this->stringable('/some//odd//path/')->dedup('/'));
-        $this->assertSame('ムだム', (string) $this->stringable('ムだだム')->dedup('だ'));
+        $this->assertSame(' laravel php framework ', (string) $this->stringable(' laravel   php  framework ')->deduplicate());
+        $this->assertSame('what', (string) $this->stringable('whaaat')->deduplicate('a'));
+        $this->assertSame('/some/odd/path/', (string) $this->stringable('/some//odd//path/')->deduplicate('/'));
+        $this->assertSame('ムだム', (string) $this->stringable('ムだだム')->deduplicate('だ'));
     }
 
     public function testDirname()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -212,6 +212,14 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testDedup()
+    {
+        $this->assertSame(' laravel php framework ', (string) $this->stringable(' laravel   php  framework ')->dedup());
+        $this->assertSame('what', (string) $this->stringable('whaaat')->dedup('a'));
+        $this->assertSame('/some/odd/path/', (string) $this->stringable('/some//odd//path/')->dedup('/'));
+        $this->assertSame('ムだム', (string) $this->stringable('ムだだム')->dedup('だ'));
+    }
+
     public function testDirname()
     {
         $this->assertSame('/framework/tests', (string) $this->stringable('/framework/tests/Support')->dirname());


### PR DESCRIPTION
This adds a convenience method to replace consecutive occurrences of a character with character. Or, more commonly, _deduplicate_ characters within a string.

```php
Str::dedup('random  double  spaces'); // 'random double spaces'
Str::dedup('/some//odd/path//', '/'); // '/some/odd/path/'
Str::dedup('zondaaaa', 'a');          // 'zonda'
```

---

Note: While a second parameter might have been added to `squish`, their primary intention felt different. `squish` also exists in other languages. So creating a separate, new method seemed more appropriate than expanding the `squish` behavior within Laravel.