### PR TITLE
[11.x] Ask about markdown template for notification command with no initial input

### DIFF
--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -147,10 +147,9 @@ class NotificationMakeCommand extends GeneratorCommand
 
         $wantsMarkdownView = confirm('Would you like to create a markdown view?');
 
-        if($wantsMarkdownView) {
+        if ($wantsMarkdownView) {
             $markdownView = text('What should the markdown view be named?', 'E.g. invoice-paid');
             $input->setOption('markdown', $markdownView);
         }
     }
-
 }

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -127,18 +127,12 @@ class NotificationMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command options.
+     * Perform actions after the user was prompted for missing arguments.
      *
-     * @return array
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
      */
-    protected function getOptions()
-    {
-        return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the notification already exists'],
-            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification'],
-        ];
-    }
-
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         if ($this->didReceiveOptions($input)) {
@@ -151,5 +145,18 @@ class NotificationMakeCommand extends GeneratorCommand
             $markdownView = text('What should the markdown view be named?', 'E.g. invoice-paid');
             $input->setOption('markdown', $markdownView);
         }
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the notification already exists'],
+            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -5,7 +5,11 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\text;
 
 #[AsCommand(name: 'make:notification')]
 class NotificationMakeCommand extends GeneratorCommand
@@ -134,4 +138,19 @@ class NotificationMakeCommand extends GeneratorCommand
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification'],
         ];
     }
+
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $wantsMarkdownView = confirm('Would you like to create a markdown view?');
+
+        if($wantsMarkdownView) {
+            $markdownView = text('What should the markdown view be named?', 'E.g. invoice-paid');
+            $input->setOption('markdown', $markdownView);
+        }
+    }
+
 }

--- a/tests/Integration/Generators/NotificationMakeCommandTest.php
+++ b/tests/Integration/Generators/NotificationMakeCommandTest.php
@@ -55,23 +55,23 @@ class NotificationMakeCommandTest extends TestCase
     public function testItCanGenerateNotificationFileWithNotInitialInput()
     {
         $this->artisan('make:notification')
-            ->expectsQuestion('What should the notification be named?', 'ExportFinishedNotification')
+            ->expectsQuestion('What should the notification be named?', 'FooNotification')
             ->expectsQuestion('Would you like to create a markdown view?', false)
             ->assertExitCode(0);
 
-        $this->assertFilenameExists('app/Notifications/ExportFinishedNotification.php');
-        $this->assertFileDoesNotExist('resources/views/export.blade.php');
+        $this->assertFilenameExists('app/Notifications/FooNotification.php');
+        $this->assertFileDoesNotExist('resources/views/foo-notification.blade.php');
     }
 
     public function testItCanGenerateNotificationFileWithMarkdownTemplateWithNotInitialInput()
     {
         $this->artisan('make:notification')
-            ->expectsQuestion('What should the notification be named?', 'ExportFinishedNotification')
+            ->expectsQuestion('What should the notification be named?', 'FooNotification')
             ->expectsQuestion('Would you like to create a markdown view?', true)
-            ->expectsQuestion('What should the markdown view be named?', 'export')
+            ->expectsQuestion('What should the markdown view be named?', 'foo-notification')
             ->assertExitCode(0);
 
-        $this->assertFilenameExists('app/Notifications/ExportFinishedNotification.php');
-        $this->assertFilenameExists('resources/views/export.blade.php');
+        $this->assertFilenameExists('app/Notifications/FooNotification.php');
+        $this->assertFilenameExists('resources/views/foo-notification.blade.php');
     }
 }

--- a/tests/Integration/Generators/NotificationMakeCommandTest.php
+++ b/tests/Integration/Generators/NotificationMakeCommandTest.php
@@ -51,4 +51,27 @@ class NotificationMakeCommandTest extends TestCase
         $this->assertFilenameNotExists('resources/views/foo-notification.blade.php');
         $this->assertFilenameExists('tests/Feature/Notifications/FooNotificationTest.php');
     }
+
+    public function testItCanGenerateNotificationFileWithNotInitialInput()
+    {
+        $this->artisan('make:notification')
+            ->expectsQuestion('What should the notification be named?', 'ExportFinishedNotification')
+            ->expectsQuestion('Would you like to create a markdown view?', false)
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Notifications/ExportFinishedNotification.php');
+        $this->assertFileDoesNotExist('resources/views/export.blade.php');
+    }
+
+    public function testItCanGenerateNotificationFileWithMarkdownTemplateWithNotInitialInput()
+    {
+        $this->artisan('make:notification')
+            ->expectsQuestion('What should the notification be named?', 'ExportFinishedNotification')
+            ->expectsQuestion('Would you like to create a markdown view?', true)
+            ->expectsQuestion('What should the markdown view be named?', 'export')
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Notifications/ExportFinishedNotification.php');
+        $this->assertFilenameExists('resources/views/export.blade.php');
+    }
 }


### PR DESCRIPTION
This PR lets the `Notification Make Command` ask you about creating a `markdown template` when no initial inputs are provided.

![CleanShot 2024-08-01 at 17 38 38@2x](https://github.com/user-attachments/assets/fad0d623-1fb1-4e0c-adda-370558e3cbb1)

This PR is similar to my last one about the `Mail Make Command`: https://github.com/laravel/framework/pull/52057
