### PR TITLE
[10.x] Dispatch failed notification event

### DIFF
--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -31,11 +31,11 @@ class NotificationFailed
     public $channel;
 
     /**
-     * The data needed to process this failure.
+     * The exception that caused the failure.
      *
-     * @var array
+     * @var \Throwable
      */
-    public $data = [];
+    public $throwable;
 
     /**
      * Create a new event instance.
@@ -43,12 +43,12 @@ class NotificationFailed
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
      * @param  string  $channel
-     * @param  array  $data
+     * @param  \Throwable  $throwable
      * @return void
      */
-    public function __construct($notifiable, $notification, $channel, $data = [])
+    public function __construct($notifiable, $notification, $channel, $throwable)
     {
-        $this->data = $data;
+        $this->throwable = $throwable;
         $this->channel = $channel;
         $this->notifiable = $notifiable;
         $this->notification = $notification;

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -157,6 +157,7 @@ class NotificationSender
             $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, $channel, $e)
             );
+            throw $e;
         }
     }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications;
 
+use Throwable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Collection as ModelCollection;
@@ -12,7 +13,6 @@ use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Localizable;
-use Throwable;
 
 class NotificationSender
 {
@@ -147,7 +147,7 @@ class NotificationSender
             return;
         }
 
-        try{
+        try {
             $response = $this->manager->driver($channel)->send($notifiable, $notification);
 
             $this->events->dispatch(

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Notifications;
 
-use Throwable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Collection as ModelCollection;
@@ -13,6 +12,7 @@ use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Localizable;
+use Throwable;
 
 class NotificationSender
 {

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
@@ -16,7 +17,6 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Exception;
 
 class NotificationChannelManagerTest extends TestCase
 {

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -114,10 +114,15 @@ class NotificationChannelManagerTest extends TestCase
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
         $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
         $manager->shouldReceive('driver')->once()->andReturn($driver = m::mock());
-        $driver->shouldReceive('send')->once()->andThrow(new Exception());
+        $driver->shouldReceive('send')->once()->andThrow(new Exception('Mail exception'));
         $events->shouldReceive('dispatch')->once()->with(m::type(NotificationFailed::class));
 
-        $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotCancelledNotification);
+        try {
+            $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotCancelledNotification);
+            $this->fail('Should fail');
+        } catch(Exception $e) {
+            $this->assertEquals('Mail exception', $e->getMessage());
+        }
     }
 }
 


### PR DESCRIPTION
The event `NotificationFailed` existed but was never used.

There is a small difference in how the code will behave with this error caching. For example, before if the first channel failed, the rest of them would fail too, now others will be processed.