### PR TITLE
[11.x] Add NullableIf Validation Rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -15,6 +15,7 @@ return [
 
     'accepted' => 'The :attribute field must be accepted.',
     'accepted_if' => 'The :attribute field must be accepted when :other is :value.',
+    'nullable_if' => 'The :attribute field must be nullable when :other is :value.',
     'active_url' => 'The :attribute field must be a valid URL.',
     'after' => 'The :attribute field must be a date after :date.',
     'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -626,6 +626,22 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the nullable_if rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceNullableIf($message, $attribute, $rule, $parameters)
+    {
+        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
+
+        return str_replace([':other'], $parameters, $message);
+    }
+
+    /**
      * Replace all place-holders for the required_unless rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1764,6 +1764,31 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is nullable based on a condition.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateNullableIf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'nullable_if');
+
+        if (! Arr::has($this->data, $parameters[0])) {
+            return true;
+        }
+
+        [$values, $other] = $this->parseDependentRuleParameters($parameters);
+
+        if (in_array($other, $values, is_bool($other) || is_null($other))) {
+            return true; // The attribute is nullable
+        }
+
+        return false; // The attribute is not nullable
+    }
+
+    /**
      * Validate an attribute is not contained within a list of values.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -14,10 +14,10 @@ use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\NullableIf;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
-use Illuminate\Validation\Rules\NullableIf;
 
 class Rule
 {
@@ -26,8 +26,8 @@ class Rule
     /**
      * Get a can constraint builder instance.
      *
-     * @param  string  $ability
-     * @param  mixed  ...$arguments
+     * @param string $ability
+     * @param mixed ...$arguments
      * @return \Illuminate\Validation\Rules\Can
      */
     public static function can($ability, ...$arguments)
@@ -38,9 +38,9 @@ class Rule
     /**
      * Apply the given rules if the given condition is truthy.
      *
-     * @param  callable|bool  $condition
-     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $rules
-     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $defaultRules
+     * @param callable|bool $condition
+     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $rules
+     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
     public static function when($condition, $rules, $defaultRules = [])
@@ -51,9 +51,9 @@ class Rule
     /**
      * Apply the given rules if the given condition is falsy.
      *
-     * @param  callable|bool  $condition
-     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $rules
-     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $defaultRules
+     * @param callable|bool $condition
+     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $rules
+     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
     public static function unless($condition, $rules, $defaultRules = [])
@@ -64,7 +64,7 @@ class Rule
     /**
      * Get an array rule builder instance.
      *
-     * @param  array|null  $keys
+     * @param array|null $keys
      * @return \Illuminate\Validation\Rules\ArrayRule
      */
     public static function array($keys = null)
@@ -75,7 +75,7 @@ class Rule
     /**
      * Create a new nested rule set.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return \Illuminate\Validation\NestedRules
      */
     public static function forEach($callback)
@@ -86,8 +86,8 @@ class Rule
     /**
      * Get a unique constraint builder instance.
      *
-     * @param  string  $table
-     * @param  string  $column
+     * @param string $table
+     * @param string $column
      * @return \Illuminate\Validation\Rules\Unique
      */
     public static function unique($table, $column = 'NULL')
@@ -98,8 +98,8 @@ class Rule
     /**
      * Get an exists constraint builder instance.
      *
-     * @param  string  $table
-     * @param  string  $column
+     * @param string $table
+     * @param string $column
      * @return \Illuminate\Validation\Rules\Exists
      */
     public static function exists($table, $column = 'NULL')
@@ -110,7 +110,7 @@ class Rule
     /**
      * Get an in rule builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string $values
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in($values)
@@ -125,7 +125,7 @@ class Rule
     /**
      * Get a not_in rule builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn($values)
@@ -140,7 +140,7 @@ class Rule
     /**
      * Get a required_if rule builder instance.
      *
-     * @param  callable|bool  $callback
+     * @param callable|bool $callback
      * @return \Illuminate\Validation\Rules\RequiredIf
      */
     public static function requiredIf($callback)
@@ -151,7 +151,7 @@ class Rule
     /**
      * Get a nullable_if rule builder instance.
      *
-     * @param  callable|bool  $callback
+     * @param callable|bool $callback
      * @return \Illuminate\Validation\Rules\NullableIf
      */
     public static function nullableIf($callback)
@@ -162,7 +162,7 @@ class Rule
     /**
      * Get a exclude_if rule builder instance.
      *
-     * @param  callable|bool  $callback
+     * @param callable|bool $callback
      * @return \Illuminate\Validation\Rules\ExcludeIf
      */
     public static function excludeIf($callback)
@@ -173,7 +173,7 @@ class Rule
     /**
      * Get a prohibited_if rule builder instance.
      *
-     * @param  callable|bool  $callback
+     * @param callable|bool $callback
      * @return \Illuminate\Validation\Rules\ProhibitedIf
      */
     public static function prohibitedIf($callback)
@@ -184,7 +184,7 @@ class Rule
     /**
      * Get an enum rule builder instance.
      *
-     * @param  class-string  $type
+     * @param class-string $type
      * @return \Illuminate\Validation\Rules\Enum
      */
     public static function enum($type)
@@ -215,7 +215,7 @@ class Rule
     /**
      * Get a dimensions rule builder instance.
      *
-     * @param  array  $constraints
+     * @param array $constraints
      * @return \Illuminate\Validation\Rules\Dimensions
      */
     public static function dimensions(array $constraints = [])

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -17,6 +17,7 @@ use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\NullableIf;
 
 class Rule
 {

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -26,8 +26,8 @@ class Rule
     /**
      * Get a can constraint builder instance.
      *
-     * @param string $ability
-     * @param mixed ...$arguments
+     * @param  string  $ability
+     * @param  mixed  ...$arguments
      * @return \Illuminate\Validation\Rules\Can
      */
     public static function can($ability, ...$arguments)
@@ -38,9 +38,9 @@ class Rule
     /**
      * Apply the given rules if the given condition is truthy.
      *
-     * @param callable|bool $condition
-     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $rules
-     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $defaultRules
+     * @param  callable|bool  $condition
+     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $rules
+     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
     public static function when($condition, $rules, $defaultRules = [])
@@ -51,9 +51,9 @@ class Rule
     /**
      * Apply the given rules if the given condition is falsy.
      *
-     * @param callable|bool $condition
-     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $rules
-     * @param \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string $defaultRules
+     * @param  callable|bool  $condition
+     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $rules
+     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
     public static function unless($condition, $rules, $defaultRules = [])
@@ -64,7 +64,7 @@ class Rule
     /**
      * Get an array rule builder instance.
      *
-     * @param array|null $keys
+     * @param  array|null  $keys
      * @return \Illuminate\Validation\Rules\ArrayRule
      */
     public static function array($keys = null)
@@ -75,7 +75,7 @@ class Rule
     /**
      * Create a new nested rule set.
      *
-     * @param callable $callback
+     * @param  callable  $callback
      * @return \Illuminate\Validation\NestedRules
      */
     public static function forEach($callback)
@@ -86,8 +86,8 @@ class Rule
     /**
      * Get a unique constraint builder instance.
      *
-     * @param string $table
-     * @param string $column
+     * @param  string  $table
+     * @param  string  $column
      * @return \Illuminate\Validation\Rules\Unique
      */
     public static function unique($table, $column = 'NULL')
@@ -98,8 +98,8 @@ class Rule
     /**
      * Get an exists constraint builder instance.
      *
-     * @param string $table
-     * @param string $column
+     * @param  string  $table
+     * @param  string  $column
      * @return \Illuminate\Validation\Rules\Exists
      */
     public static function exists($table, $column = 'NULL')
@@ -110,7 +110,7 @@ class Rule
     /**
      * Get an in rule builder instance.
      *
-     * @param \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in($values)
@@ -125,7 +125,7 @@ class Rule
     /**
      * Get a not_in rule builder instance.
      *
-     * @param \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn($values)
@@ -140,7 +140,7 @@ class Rule
     /**
      * Get a required_if rule builder instance.
      *
-     * @param callable|bool $callback
+     * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\RequiredIf
      */
     public static function requiredIf($callback)
@@ -151,7 +151,7 @@ class Rule
     /**
      * Get a nullable_if rule builder instance.
      *
-     * @param callable|bool $callback
+     * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\NullableIf
      */
     public static function nullableIf($callback)
@@ -162,7 +162,7 @@ class Rule
     /**
      * Get a exclude_if rule builder instance.
      *
-     * @param callable|bool $callback
+     * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\ExcludeIf
      */
     public static function excludeIf($callback)
@@ -173,7 +173,7 @@ class Rule
     /**
      * Get a prohibited_if rule builder instance.
      *
-     * @param callable|bool $callback
+     * @param  callable|bool  $callback
      * @return \Illuminate\Validation\Rules\ProhibitedIf
      */
     public static function prohibitedIf($callback)
@@ -184,7 +184,7 @@ class Rule
     /**
      * Get an enum rule builder instance.
      *
-     * @param class-string $type
+     * @param  class-string  $type
      * @return \Illuminate\Validation\Rules\Enum
      */
     public static function enum($type)
@@ -215,7 +215,6 @@ class Rule
     /**
      * Get a dimensions rule builder instance.
      *
-     * @param array $constraints
      * @return \Illuminate\Validation\Rules\Dimensions
      */
     public static function dimensions(array $constraints = [])

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -148,6 +148,17 @@ class Rule
     }
 
     /**
+     * Get a nullable_if rule builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\NullableIf
+     */
+    public static function nullableIf($callback)
+    {
+        return new NullableIf($callback);
+    }
+
+    /**
      * Get a exclude_if rule builder instance.
      *
      * @param  callable|bool  $callback

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -22,11 +22,11 @@ class NullableIf implements Stringable
      */
     public function __construct($condition)
     {
-        if (! is_string($condition)) {
-            $this->condition = $condition;
-        } else {
+        if (! is_callable($condition) && ! is_bool($condition)) {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
         }
+
+        $this->condition = $condition;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -37,6 +37,6 @@ class NullableIf implements Stringable
     public function __toString()
     {
         $result = is_callable($this->condition) ? call_user_func($this->condition) : $this->condition;
-        return $result ? 'nullable' : 'required';
+        return $result ? 'nullable' : '';
     }
 }

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -17,12 +17,12 @@ class NullableIf implements Stringable
     /**
      * Create a new required validation rule based on a condition.
      *
-     * @param  callable|bool  $condition
+     * @param callable|bool $condition
      * @return void
      */
     public function __construct($condition)
     {
-        if (! is_callable($condition) && ! is_bool($condition)) {
+        if (!is_callable($condition) && !is_bool($condition)) {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
         }
 
@@ -36,10 +36,7 @@ class NullableIf implements Stringable
      */
     public function __toString()
     {
-        if (is_callable($this->condition)) {
-            return call_user_func($this->condition) ? 'nullable' : '';
-        }
-
-        return $this->condition ? 'nullable' : '';
+        $result = is_callable($this->condition) ? call_user_func($this->condition) : $this->condition;
+        return $result ? 'nullable' : 'required';
     }
 }

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+use Stringable;
+
+class NullableIf implements Stringable
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'nullable' : '';
+        }
+
+        return $this->condition ? 'nullable' : '';
+    }
+}

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -17,12 +17,12 @@ class NullableIf implements Stringable
     /**
      * Create a new required validation rule based on a condition.
      *
-     * @param callable|bool $condition
+     * @param  callable|bool  $condition
      * @return void
      */
     public function __construct($condition)
     {
-        if (!is_callable($condition) && !is_bool($condition)) {
+        if (! is_callable($condition) && ! is_bool($condition)) {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
         }
 
@@ -37,6 +37,7 @@ class NullableIf implements Stringable
     public function __toString()
     {
         $result = is_callable($this->condition) ? call_user_func($this->condition) : $this->condition;
+
         return $result ? 'nullable' : '';
     }
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -227,6 +227,7 @@ class Validator implements ValidatorContract
         'RequiredWithAll',
         'RequiredWithout',
         'RequiredWithoutAll',
+        'NullableIf',
     ];
 
     /**
@@ -273,6 +274,7 @@ class Validator implements ValidatorContract
         'MissingWithAll',
         'Same',
         'Unique',
+        'NullableIf',
     ];
 
     /**

--- a/tests/Validation/ValidationNullableIfTest.php
+++ b/tests/Validation/ValidationNullableIfTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\NullableIf;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationNullableIfTest extends TestCase
+{
+    public function testItClosureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new NullableIf(function () {
+            return true;
+        });
+
+        $this->assertSame('nullable', (string) $rule);
+
+        $rule = new NullableIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new NullableIf(true);
+
+        $this->assertSame('nullable', (string) $rule);
+
+        $rule = new NullableIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new NullableIf(false);
+
+        $rule = new NullableIf(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new NullableIf('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new NullableIf(function () {
+            return true;
+        }));
+    }
+
+    public function testNullableIfValidationMessage()
+    {
+        $validator = Validator::make(
+            ['field' => 'value'],
+            ['field' => ['nullable_if:other,1']]
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertEquals(
+            'The field field must be nullable when other is 1.',
+            $validator->errors()->first('field')
+        );
+    }
+}

--- a/tests/Validation/ValidationNullableIfTest.php
+++ b/tests/Validation/ValidationNullableIfTest.php
@@ -33,17 +33,6 @@ class ValidationNullableIfTest extends TestCase
         $this->assertSame('', (string) $rule);
     }
 
-    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
-    {
-        $rule = new NullableIf(false);
-
-        $rule = new NullableIf(true);
-
-        $this->expectException(InvalidArgumentException::class);
-
-        $rule = new NullableIf('phpinfo');
-    }
-
     public function testItReturnedRuleIsNotSerializable()
     {
         $this->expectException(Exception::class);
@@ -51,19 +40,5 @@ class ValidationNullableIfTest extends TestCase
         $rule = serialize(new NullableIf(function () {
             return true;
         }));
-    }
-
-    public function testNullableIfValidationMessage()
-    {
-        $validator = Validator::make(
-            ['field' => 'value'],
-            ['field' => ['nullable_if:other,1']]
-        );
-
-        $this->assertTrue($validator->fails());
-        $this->assertEquals(
-            'The field field must be nullable when other is 1.',
-            $validator->errors()->first('field')
-        );
     }
 }

--- a/tests/Validation/ValidationNullableIfTest.php
+++ b/tests/Validation/ValidationNullableIfTest.php
@@ -14,21 +14,21 @@ class ValidationNullableIfTest extends TestCase
             return true;
         });
 
-        $this->assertSame('nullable', (string)$rule);
+        $this->assertSame('nullable', (string) $rule);
 
         $rule = new NullableIf(function () {
             return false;
         });
 
-        $this->assertSame('', (string)$rule);
+        $this->assertSame('', (string) $rule);
 
         $rule = new NullableIf(true);
 
-        $this->assertSame('nullable', (string)$rule);
+        $this->assertSame('nullable', (string) $rule);
 
         $rule = new NullableIf(false);
 
-        $this->assertSame('', (string)$rule);
+        $this->assertSame('', (string) $rule);
     }
 
     public function testItReturnedRuleIsNotSerializable()

--- a/tests/Validation/ValidationNullableIfTest.php
+++ b/tests/Validation/ValidationNullableIfTest.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\NullableIf;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ValidationNullableIfTest extends TestCase
@@ -16,21 +14,21 @@ class ValidationNullableIfTest extends TestCase
             return true;
         });
 
-        $this->assertSame('nullable', (string) $rule);
+        $this->assertSame('nullable', (string)$rule);
 
         $rule = new NullableIf(function () {
             return false;
         });
 
-        $this->assertSame('', (string) $rule);
+        $this->assertSame('', (string)$rule);
 
         $rule = new NullableIf(true);
 
-        $this->assertSame('nullable', (string) $rule);
+        $this->assertSame('nullable', (string)$rule);
 
         $rule = new NullableIf(false);
 
-        $this->assertSame('', (string) $rule);
+        $this->assertSame('', (string)$rule);
     }
 
     public function testItReturnedRuleIsNotSerializable()


### PR DESCRIPTION
This pull request introduces a new validation rule, NullableIf, to the Laravel framework. The NullableIf rule allows an attribute to be nullable based on a condition. If the condition evaluates to true, the attribute can be null.

Details:

File Modified: src/Illuminate/Validation/Rules/NullableIf.php
Functionality:
Constructor: Accepts a callable or boolean condition.
__toString Method: Converts the rule to a validation string based on the condition.
Usage Example:

In a request validation rule:
`'field' => [
    Rule::nullableIf(true),
    'string'
],`
