### PR TITLE
[11.x] Allow enums to be passed to AssertableJson where methods

### DIFF
--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -496,6 +496,33 @@ class AssertTest extends TestCase
             ]);
     }
 
+    public function testAssertWhereUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => BackedEnum::test->value,
+        ]);
+
+        $assert->where('bar', BackedEnum::test);
+
+        $assert = AssertableJson::fromArray([
+            'bar' => BackedEnum::test_empty->value,
+        ]);
+
+        $assert->where('bar', BackedEnum::test_empty);
+    }
+
+    public function testAssertWhereFailsUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => BackedEnum::test->value,
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+
+        $assert->where('bar', BackedEnum::test_empty);
+    }
+
     public function testAssertWhereContainsFailsWithEmptyValue()
     {
         $assert = AssertableJson::fromArray([]);
@@ -690,6 +717,33 @@ class AssertTest extends TestCase
         $assert->whereContains('foo', null);
     }
 
+    public function testAssertWhereContainsUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [BackedEnum::test->value],
+        ]);
+
+        $assert->whereContains('bar', BackedEnum::test);
+
+        $assert = AssertableJson::fromArray([
+            'bar' => [BackedEnum::test_empty->value],
+        ]);
+
+        $assert->whereContains('bar', BackedEnum::test_empty);
+    }
+
+    public function testAssertWhereContainsFailsUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [BackedEnum::test_empty->value],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not contain [test].');
+
+        $assert->whereContains('bar', BackedEnum::test);
+    }
+
     public function testAssertNestedWhereMatchesValue()
     {
         $assert = AssertableJson::fromArray([
@@ -713,6 +767,31 @@ class AssertTest extends TestCase
         $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
 
         $assert->where('example.nested', 'another-value');
+    }
+
+    public function testAssertNestedWhereUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'example' => [
+                'nested' => BackedEnum::test->value,
+            ],
+        ]);
+
+        $assert->where('example.nested', BackedEnum::test);
+    }
+
+    public function testAssertNestedWhereFailsUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'example' => [
+                'nested' => BackedEnum::test_empty->value,
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
+
+        $assert->where('example.nested', BackedEnum::test);
     }
 
     public function testAssertWhereDoesNotMatchValue()
@@ -771,6 +850,27 @@ class AssertTest extends TestCase
         $assert->whereNot('bar', function ($value) {
             return $value === 'baz';
         });
+    }
+
+    public function testAssertWhereNotUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => BackedEnum::test->value,
+        ]);
+
+        $assert->whereNot('bar', BackedEnum::test_empty);
+    }
+
+    public function testAssertWhereNotFailsUsingBackedEnum()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => BackedEnum::test->value,
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] contains a value that should be missing: [bar, test]');
+
+        $assert->whereNot('bar', BackedEnum::test);
     }
 
     public function testScope()

--- a/tests/Testing/Fluent/BackedEnum.php
+++ b/tests/Testing/Fluent/BackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Fluent;
+
+enum BackedEnum: string
+{
+    case test = 'test';
+    case test_empty = '';
+}


### PR DESCRIPTION
Like a lot of developers, I hate strings. Strings are for users.

Enums give me type safety for speling mistakes, and generally make me feel more comfortable about the world and my code.

This PR brings the `where`, `whereNot` and `whereContains` methods of the `AssertableJson` class in to line with their Eloquent cousins by accepting enums.

This change is backward compatible.

```php
$this->getJson('/users/1')
    ->assertJson(fn (AssertableJson $json) => $json->where('role', UserRole::Developer->value))

// becomes
$this->getJson('/users/1')
    ->assertJson(fn (AssertableJson $json) => $json->where('role', UserRole::Developer))
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
