### PR TITLE
[11.x] Add `whereNotAll` method to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2337,6 +2337,33 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where not" clause to the query for multiple columns with "and" conditions between them.
+     *
+     * @param  string[]  $columns
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotAll($columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->whereAll($columns, $operator, $value, $boolean.' not');
+    }
+
+    /**
+     * Add an "or where not" clause to the query for multiple columns with "and" conditions between them.
+     *
+     * @param  string[]  $columns
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereNotAll($columns, $operator = null, $value = null)
+    {
+        return $this->whereNotAll($columns, $operator, $value, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|\Illuminate\Contracts\Database\Query\Expression|string  ...$groups

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1412,6 +1412,42 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
+    public function testWhereNotAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAll(['last_name', 'email'], ['Otwell', 'taylor@larave.com']);
+        $this->assertSame('select * from "users" where not ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['Otwell', 'Otwell'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAll(['last_name', 'email'], 'not like', '%Otwell%');
+        $this->assertSame('select * from "users" where not ("last_name" not like ? and "email" not like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAll(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAll(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
## Overview

In [PR #50344](https://github.com/laravel/framework/pull/50344), the `whereAll` and `whereAny` methods were introduced to enhance the framework's querying capabilities. Subsequently, [PR #52260](https://github.com/laravel/framework/pull/52260) introduced the `whereNone` method, which complements `whereAny` by providing a negated alternative.

To further complete the logical set, this pull request introduces the `whereNotAll` method. This method serves as the opposite of `whereAll` and allows users to query for records where not all of the specified columns meet the given condition. By including `whereNotAll`, we finalize the logical quartet of "any," "all," "none," and "notAll."

This addition provides a comprehensive set of methods for handling complex constraints across multiple columns, enhancing the flexibility of the query builder.


### Usage

The `whereNoAll` method works as follows:

```php
$jobs = DB::table('jobs')
    ->where('active', true)
    ->whereNotAll(['job_type', 'employment_type'], 'LIKE', ['Remote', 'Part-Time'])
    ->get();
```
  
  ```sql
SELECT *
FROM jobs
WHERE active = true AND NOT (
    job_type LIKE 'Remote' AND
    employment_type LIKE 'Part-Time'
)
  ```