### PR TITLE
Add functionality to the framework to customize service providers loading process

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -123,9 +123,10 @@ interface Application extends Container
     /**
      * Register all of the configured providers.
      *
+     * @param  \Illuminate\Foundation\ProviderRepository|null  $providerRepository
      * @return void
      */
-    public function registerConfiguredProviders();
+    public function registerConfiguredProviders($providerRepository);
 
     /**
      * Register a service provider with the application.

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -133,9 +133,10 @@ interface Application extends Container
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
      * @param  bool  $force
+     * @param  bool  $boot
      * @return \Illuminate\Support\ServiceProvider
      */
-    public function register($provider, $force = false);
+    public function register($provider, $force = false, $boot = true);
 
     /**
      * Register a deferred provider and service.
@@ -160,6 +161,14 @@ interface Application extends Container
      * @return void
      */
     public function boot();
+
+    /**
+     * Boot the given service provider.
+     *
+     * @param  \Illuminate\Support\ServiceProvider  $provider
+     * @return void
+     */
+    public function bootProvider($provider);
 
     /**
      * Register a new boot listener.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -830,17 +830,21 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Register all of the configured providers.
      *
+     * @param  \Illuminate\Foundation\ProviderRepository|null  $providerRepository
      * @return void
      */
-    public function registerConfiguredProviders()
+    public function registerConfiguredProviders($providerRepository = null)
     {
         $providers = Collection::make($this->make('config')->get('app.providers'))
                         ->partition(fn ($provider) => str_starts_with($provider, 'Illuminate\\'));
 
         $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);
 
-        (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load($providers->collapse()->toArray());
+        if ($providerRepository == null) {
+            $providerRepository = new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath());
+        }
+
+        $providerRepository->load($providers->collapse()->toArray());
 
         $this->fireAppCallbacks($this->registeredCallbacks);
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -854,9 +854,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
      * @param  bool  $force
+     * @param  bool  $boot
      * @return \Illuminate\Support\ServiceProvider
      */
-    public function register($provider, $force = false)
+    public function register($provider, $force = false, $boot = true)
     {
         if (($registered = $this->getProvider($provider)) && ! $force) {
             return $registered;
@@ -893,7 +894,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // If the application has already booted, we will call this boot method on
         // the provider class so it has an opportunity to do its boot logic and
         // will be ready for any usage by this developer's application logic.
-        if ($this->isBooted()) {
+        if ($this->isBooted() && $boot) {
             $this->bootProvider($provider);
         }
 
@@ -1115,7 +1116,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  \Illuminate\Support\ServiceProvider  $provider
      * @return void
      */
-    protected function bootProvider(ServiceProvider $provider)
+    public function bootProvider($provider)
     {
         $provider->callBootingCallbacks();
 


### PR DESCRIPTION
Add ability to the framework to optionally alter service providers loading process by providing custom providerRepository and adding more control to the Application's register and bootProvider methods.

This is second part of the solution, please refer to the [PR](https://github.com/laravel/octane/pull/938) in laravel/octane.