### PR TITLE
[11.x] Cache: Redis store does not flush locks while file store does

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -246,6 +246,7 @@ class RedisStore extends TaggableStore implements LockProvider
     public function flush()
     {
         $this->connection()->flushdb();
+        $this->lockConnection()->flushdb();
 
         return true;
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -132,8 +132,8 @@ class CacheRedisStoreTest extends TestCase
     public function testFlushesCached()
     {
         $redis = $this->getRedis();
-        $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('flushdb')->once()->andReturn('ok');
+        $redis->getRedis()->shouldReceive('connection')->twice()->with('default')->andReturn($redis->getRedis());
+        $redis->getRedis()->shouldReceive('flushdb')->twice()->andReturn('ok');
         $result = $redis->flush();
         $this->assertTrue($result);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
While exploring the problem behind issue #52344 (and will fix #52344) we found, that the drop of the locks is a expected thing to happen, when flushing the redis connection. It is done by most of the other drivers, basically because that is how the other drivers are work. But when we flush all the data inside the redis, we also want to flush all the locks of them.
Ah psosible thing to do, is to only execute a flushdb on the locked connection when it is different from the cache connection. But I would leave that to the mainter that is reviewing that to leave an opinion