### PR TITLE
Add `prod` Method to Collections for Calculating Product of Elements

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -551,6 +551,22 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the product of the given values.
+     *
+     * @param  (callable(TValue): mixed)|string|null  $callback
+     * @return mixed
+     */
+    public function prod($callback = null)
+    {
+        $callback = is_null($callback)
+            ? $this->identity()
+            : $this->valueRetriever($callback);
+
+        // Initial value is 1 since we are multiplying
+        return $this->reduce(fn ($carry, $item) => $carry * $callback($item), 1);
+    }
+
+    /**
      * Apply the callback if the collection is empty.
      *
      * @template TWhenEmptyReturnType

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5506,6 +5506,21 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(0.0, $collection->percentage(fn ($value) => $value === 5));
     }
 
+    public function testGettingProductFromCollection()
+    {
+        $numbers = collect([1, 2, 3, 4, 5]);
+        $this->assertEquals(120, $numbers->prod());
+
+        $numbers = collect([-1, 2, -3, 4]);
+        $this->assertEquals(24, $numbers->prod());
+
+        $numbers = collect([['value' => 2], ['value' => 3], ['value' => 4]]);
+        $callback = function ($item) {
+            return $item['value'];
+        };
+        $this->assertEquals(24, $numbers->prod($callback));
+    }
+
     #[DataProvider('collectionClassProvider')]
     public function testPercentageWithNestedCollection($collection)
     {


### PR DESCRIPTION
This pull request adds a handy method to the Laravel collections for calculating the product of the given collection. This method is useful in various scenarios, such as calculating compound interest, probability, and more.

Here is an example of how to use this new method:
```php
$growthRates = collect([1.05, 1.07, 1.03, 1.08]);
$totalGrowth = $growthRates->prod();
echo $totalGrowth;  // Output: 1.271944 (This represents the overall growth factor)
```