### PR TITLE
[11.x] Rework `Context::stackContains` with Closures.

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -333,7 +333,7 @@ class Repository
         }
 
         if ($value instanceof Closure) {
-            return $value($this->data[$key]);
+            return collect($this->data[$key])->contains($value);
         }
 
         return in_array($value, $this->data[$key], $strict);
@@ -360,7 +360,7 @@ class Repository
         }
 
         if ($value instanceof Closure) {
-            return $value($this->data[$key]);
+            return collect($this->hidden[$key])->contains($value);
         }
 
         return in_array($value, $this->hidden[$key], $strict);

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -217,8 +217,10 @@ class ContextTest extends TestCase
     public function test_it_can_check_if_value_is_in_context_stack_with_closures()
     {
         Context::push('foo', 'bar', ['lorem'], 123);
+        Context::pushHidden('baz');
 
-        $this->assertTrue(Context::stackContains('foo', fn ($stack) => in_array('bar', $stack, true)));
+        $this->assertTrue(Context::stackContains('foo', fn ($value) => $value === 'bar'));
+        $this->assertFalse(Context::stackContains('foo', fn ($value) => $value === 'baz'));
     }
 
     public function test_it_can_check_if_value_is_in_hidden_context_stack()
@@ -228,6 +230,15 @@ class ContextTest extends TestCase
         $this->assertTrue(Context::hiddenStackContains('foo', 'bar'));
         $this->assertTrue(Context::hiddenStackContains('foo', 'lorem'));
         $this->assertFalse(Context::hiddenStackContains('foo', 'doesNotExist'));
+    }
+
+    public function test_it_can_check_if_value_is_in_hidden_context_stack_with_closures()
+    {
+        Context::pushHidden('foo', 'baz');
+        Context::push('foo', 'bar', ['lorem'], 123);
+
+        $this->assertTrue(Context::hiddenStackContains('foo', fn ($value) => $value === 'baz'));
+        $this->assertFalse(Context::hiddenStackContains('foo', fn ($value) => $value === 'bar'));
     }
 
     public function test_it_cannot_check_if_hidden_value_is_in_non_hidden_context_stack()


### PR DESCRIPTION
This PR re-works how `Context::stackContains` works with closures to make it line up with how `Collection::contains` works.

Before, the closure passed to `Context::stackContains` would receive the entire stack. I believe it should be passed each individual item and have a truth test performed on the item.

```php
Context::push('stack-name', 'value-1');
Context::push('stack-name', 'value-2');
Context::push('stack-name', 'value-3');

Context::stackContains('stack-name', function (string $value) {
    // $value will be "value-1" then "value-2" then "value-3"

    return str_ends_with($value, '-2');
});
```

Previously, the closure received the entire stack.

```php
Context::stackContains('stack-name', function (array $stack) {
    // $value is ["value-1",  "value-2", "value-3"]
});
```