### PR TITLE
[11.x] Rename the method `whereNone` to `whereNotAny` in the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2238,7 +2238,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where" clause to the query for multiple columns with "and" conditions between them.
      *
-     * @param  string[]  $columns
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -2262,8 +2262,8 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query for multiple columns with "and" conditions between them.
      *
-     * @param  string[]  $columns
-     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
      */
@@ -2275,8 +2275,8 @@ class Builder implements BuilderContract
     /**
      * Add a "where" clause to the query for multiple columns with "or" conditions between them.
      *
-     * @param  string[]  $columns
-     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
@@ -2299,8 +2299,8 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query for multiple columns with "or" conditions between them.
      *
-     * @param  string[]  $columns
-     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
      */
@@ -2312,8 +2312,8 @@ class Builder implements BuilderContract
     /**
      * Add a "where not" clause to the query for multiple columns where none of the conditions should be true.
      *
-     * @param  string[]  $columns
-     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
@@ -2326,8 +2326,8 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not" clause to the query for multiple columns where none of the conditions should be true.
      *
-     * @param  string[]  $columns
-     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2339,6 +2339,8 @@ class Builder implements BuilderContract
     /**
      * Add a "where not" clause to the query for multiple columns where none of the conditions should be true.
      *
+     * @deprecated Will be removed in a future Laravel version. Use whereNotAny instead.
+     *
      * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
      * @param  mixed  $operator
      * @param  mixed  $value
@@ -2347,11 +2349,13 @@ class Builder implements BuilderContract
      */
     public function whereNone($columns, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereAny($columns, $operator, $value, $boolean.' not');
+        return $this->whereNotAny($columns, $operator, $value, $boolean);
     }
 
     /**
      * Add an "or where not" clause to the query for multiple columns where none of the conditions should be true.
+     *
+     * @deprecated Will be removed in a future Laravel version. Use orWhereNotAny instead.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
      * @param  mixed  $operator
@@ -2360,7 +2364,7 @@ class Builder implements BuilderContract
      */
     public function orWhereNone($columns, $operator = null, $value = null)
     {
-        return $this->whereNone($columns, $operator, $value, 'or');
+        return $this->orWhereNotAny($columns, $operator, $value);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2310,6 +2310,33 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where not" clause to the query for multiple columns with "or" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotAny($columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->whereAny($columns, $operator, $value, $boolean.' not');
+    }
+
+    /**
+     * Add an "or where not" clause to the query for multiple columns with "or" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereNotAny($columns, $operator = null, $value = null)
+    {
+        return $this->whereNotAny($columns, $operator, $value, 'or');
+    }
+
+    /**
      * Add a "where not" clause to the query for multiple columns where none of the conditions should be true.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression[]|string[]  $columns

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1376,6 +1376,52 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
+    public function testWhereNotAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAny(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAny(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where not ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testOrWhereNotAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAny(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" = ? or "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAny(['last_name', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAny(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
     public function testWhereNone()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1454,11 +1454,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereNone(['last_name', 'email'], 'Otwell');
         $this->assertSame('select * from "users" where not ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['Otwell', 'Otwell'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNone(['last_name', 'email'], 'like', '%Otwell%');
-        $this->assertSame('select * from "users" where "first_name" like ? and not ("last_name" like ? or "email" like ?)', $builder->toSql());
-        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
     public function testOrWhereNone()
@@ -1471,11 +1466,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNone(['last_name', 'email'], 'like', '%Otwell%', 'or');
         $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? or "email" like ?)', $builder->toSql());
-        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNone(['last_name', 'email'], '%Otwell%');
-        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1325,6 +1325,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereAll(['last_name', 'email'], 'not like', '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" not like ? and "email" not like ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAll(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where ("email_verified_at" is null and "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testOrWhereAll()
@@ -1343,6 +1348,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll(['last_name', 'email'], '%Otwell%');
         $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? and "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAll(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where ("email_verified_at" is null and "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testWhereAny()
@@ -1356,6 +1366,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereAny(['last_name', 'email'], '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testOrWhereAny()
@@ -1374,6 +1389,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['last_name', 'email'], '%Otwell%');
         $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? or ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
     }
 
     public function testWhereNotAny()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1390,7 +1390,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
 
-
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['email_verified_at', 'deleted_at'], null);
         $this->assertSame('select * from "users" where "first_name" like ? or ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());


### PR DESCRIPTION
The [PR#52361](https://github.com/laravel/framework/pull/52361) suggests the introduction of the negated version for `whereAll` called  `whereNotAll`. This got me thinking about the naming of the `whereNone` query that was published in the last release, which is the negated version of `whereAny`. With the introduction of `whereNotAll`, I realized we might want to reconsider the name of `whereNone` for clarity and consistency, as none is the opposite to both "any" and "all".

I propose renaming `whereNone` to `whereNotAny`. Here's why:
1. It's clearer what the method does in relation to `whereAny`.
2. It follows the naming pattern of `whereNotAll`, and most of the other queries in the framework, for example; `whereIn`/`whereNotIn`, `whereLike`/`whereNotLike`, `whereBetween`/`whereNotBetween` and so on...
3. It would be easier for developers to understand the relationship between all these methods.

If we make this change, our method names would be:
* `whereAll`: Return rows where all conditions are true
* `whereNotAll`: Return rows excluding where all conditions are true
* `whereAny`: Return rows where at least one condition is true
* `whereNotAny`: Return rows excluding where at least one condition is true (currently `whereNone`)

The name whereNotAny might be a bit clunkier, but I think it provides a clearer developer experience, especially when considered alongside whereNotAll.

This PR adds the @deprecated tag to the docblocks of whereNone (since users might already started using it), and makes whereNone forward all arguments to whereNotAny, so that we in the future can remove the whereNone methods safely. Also the tests have been updated with tests for the new naming.

The docblocks are updated to accept \Illuminate\Contracts\Database\Query\Expression[], since the user can pass in column names from the DB::raw() method, also the `$operator` is changed from string to mixed, to match the signature in the `where` method.