### PR TITLE
[11.x] Update signature of the where(All|Any) methods, make $operator argument required

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2244,7 +2244,7 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereAll($columns, $operator = null, $value = null, $boolean = 'and')
+    public function whereAll($columns, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
@@ -2267,7 +2267,7 @@ class Builder implements BuilderContract
      * @param  mixed  $value
      * @return $this
      */
-    public function orWhereAll($columns, $operator = null, $value = null)
+    public function orWhereAll($columns, $operator, $value = null)
     {
         return $this->whereAll($columns, $operator, $value, 'or');
     }
@@ -2281,7 +2281,7 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereAny($columns, $operator = null, $value = null, $boolean = 'and')
+    public function whereAny($columns, $operator, $value = null, $boolean = 'and')
     {
         [$value, $operator] = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
@@ -2304,7 +2304,7 @@ class Builder implements BuilderContract
      * @param  mixed  $value
      * @return $this
      */
-    public function orWhereAny($columns, $operator = null, $value = null)
+    public function orWhereAny($columns, $operator, $value = null)
     {
         return $this->whereAny($columns, $operator, $value, 'or');
     }
@@ -2318,7 +2318,7 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNone($columns, $operator = null, $value = null, $boolean = 'and')
+    public function whereNone($columns, $operator, $value = null, $boolean = 'and')
     {
         return $this->whereAny($columns, $operator, $value, $boolean.' not');
     }
@@ -2331,7 +2331,7 @@ class Builder implements BuilderContract
      * @param  mixed  $value
      * @return $this
      */
-    public function orWhereNone($columns, $operator = null, $value = null)
+    public function orWhereNone($columns, $operator, $value = null)
     {
         return $this->whereNone($columns, $operator, $value, 'or');
     }


### PR DESCRIPTION
This PR proposes to update the signature of the where(All|Any) methods, and potentially the whereNot(All|Any) methods as well. The current implementation has an unintuitive default behavior that may lead to unexpected results.

Current issue:
The `$operator` argument is optional and defaults to `null`. This default leads to an unexpected IS NULL condition in the generated SQL when no arguments are provided. Intuitively, one might expect a WHERE EXISTS statement or an equality check (=) if no argument was passed, rather than the current IS NULL behavior.

For example:

```php
$builder->select('*')->from('users')->whereAll(['first_name', 'last_name']);
```
will generate
```sql
SELECT * FROM "users" WHERE ("first_name" IS NULL AND "last_name" IS NULL)
```

Proposed change:
Modify the method signature to require the $operator argument. This change would align the method behavior with developer expectations and prevent unintended IS NULL conditions.


Note: This PR is currently in draft status pending the resolution of the following related PRs:
- https://github.com/laravel/framework/pull/52383
- https://github.com/laravel/framework/pull/52361