### PR TITLE
[11.x] Made `list` validation rule as array for "size rules" in validation messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -221,7 +221,7 @@ trait FormatsMessages
         // list doesn't have it we'll just consider it a string by elimination.
         return match (true) {
             $this->hasRule($attribute, $this->numericRules) => 'numeric',
-            $this->hasRule($attribute, ['Array']) => 'array',
+            $this->hasRule($attribute, ['Array', 'List']) => 'array',
             $this->getValue($attribute) instanceof UploadedFile,
             $this->getValue($attribute) instanceof File => 'file',
             default => 'string',


### PR DESCRIPTION
Right now it's detected as "string" and it's not correct

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
