### PR TITLE
[11.x] Use Command::fail() method for single error messages

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -33,9 +33,7 @@ class ConfigShowCommand extends Command
         $config = $this->argument('config');
 
         if (! config()->has($config)) {
-            $this->components->error("Configuration file or key <comment>{$config}</comment> does not exist.");
-
-            return Command::FAILURE;
+            $this->fail("Configuration file or key <comment>{$config}</comment> does not exist.");
         }
 
         $this->newLine();

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -63,9 +63,7 @@ class EnvironmentDecryptCommand extends Command
         $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
 
         if (! $key) {
-            $this->components->error('A decryption key is required.');
-
-            return Command::FAILURE;
+            $this->fail('A decryption key is required.');
         }
 
         $cipher = $this->option('cipher') ?: 'AES-256-CBC';
@@ -79,21 +77,15 @@ class EnvironmentDecryptCommand extends Command
         $outputFile = $this->outputFilePath();
 
         if (Str::endsWith($outputFile, '.encrypted')) {
-            $this->components->error('Invalid filename.');
-
-            return Command::FAILURE;
+            $this->fail('Invalid filename.');
         }
 
         if (! $this->files->exists($encryptedFile)) {
-            $this->components->error('Encrypted environment file not found.');
-
-            return Command::FAILURE;
+            $this->fail('Encrypted environment file not found.');
         }
 
         if ($this->files->exists($outputFile) && ! $this->option('force')) {
-            $this->components->error('Environment file already exists.');
-
-            return Command::FAILURE;
+            $this->fail('Environment file already exists.');
         }
 
         try {
@@ -104,9 +96,7 @@ class EnvironmentDecryptCommand extends Command
                 $encrypter->decrypt($this->files->get($encryptedFile))
             );
         } catch (Exception $e) {
-            $this->components->error($e->getMessage());
-
-            return Command::FAILURE;
+            $this->fail($e->getMessage());
         }
 
         $this->components->info('Environment successfully decrypted.');

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -75,15 +75,11 @@ class EnvironmentEncryptCommand extends Command
         }
 
         if (! $this->files->exists($environmentFile)) {
-            $this->components->error('Environment file not found.');
-
-            return Command::FAILURE;
+            $this->fail('Environment file not found.');
         }
 
         if ($this->files->exists($encryptedFile) && ! $this->option('force')) {
-            $this->components->error('Encrypted environment file already exists.');
-
-            return Command::FAILURE;
+            $this->fail('Encrypted environment file already exists.');
         }
 
         try {
@@ -94,9 +90,7 @@ class EnvironmentEncryptCommand extends Command
                 $encrypter->encrypt($this->files->get($environmentFile))
             );
         } catch (Exception $e) {
-            $this->components->error($e->getMessage());
-
-            return Command::FAILURE;
+            $this->fail($e->getMessage());
         }
 
         if ($this->option('prune')) {


### PR DESCRIPTION
Command::fail() was introduced in https://github.com/laravel/framework/pull/51435. We can use it for these cases instead of manually printing single error messages and returning 1 as exit code. Actual results aren't changed but code is more readable.