### PR TITLE
Add fillNull Method to Collection for Filling Null Values

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1902,4 +1902,26 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Fill null values in specified fields of a collection.
+     *
+     * @param  mixed  $value  Default value to fill in the fields
+     * @param  string  ...$fields  Field names to be filled with the default value
+     * @return static
+     */
+    public function fillNull($value = 0, ...$fields)
+    {
+        return $this->map(function ($item) use ($fields, $value) {
+            $fieldsToFill = empty($fields) ? array_keys($item) : $fields;
+
+            foreach ($fieldsToFill as $field) {
+                if (array_key_exists($field, $item) && $item[$field] === null) {
+                    $item[$field] = $value;
+                }
+            }
+
+            return $item;
+        });
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5522,6 +5522,37 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(0.0, $collection->percentage(fn ($value) => $value['foo'] === 'test'));
     }
 
+    public function testFillNullCollection()
+    {
+        $collection = new Collection([
+            ['name' => 'Item 1', 'value' => null],
+            ['name' => 'Item 2', 'value' => 10, 'meta' => null],
+            ['name' => 'Item 4', 'value' => 25],
+            ['name' => null, 'value' => null],
+        ]);
+
+        $this->assertEquals([
+            ['name' => 'Item 1', 'value' => 0],
+            ['name' => 'Item 2', 'value' => 10, 'meta' => 0],
+            ['name' => 'Item 4', 'value' => 25],
+            ['name' => 0, 'value' => 0],
+        ], $collection->fillNull()->toArray());
+
+        $this->assertEquals([
+            ['name' => 'Item 1', 'value' => 'Default'],
+            ['name' => 'Item 2', 'value' => 10, 'meta' => 'Default'],
+            ['name' => 'Item 4', 'value' => 25],
+            ['name' => 'Default', 'value' => 'Default'],
+        ], $collection->fillNull('Default')->toArray());
+
+        $this->assertEquals([
+            ['name' => 'Item 1', 'value' => 0],
+            ['name' => 'Item 2', 'value' => 10, 'meta' => 0],
+            ['name' => 'Item 4', 'value' => 25],
+            ['name' => null, 'value' => 0],
+        ], $collection->fillNull(0, 'value', 'meta')->toArray());
+    }
+
     #[DataProvider('collectionClassProvider')]
     public function testHighOrderPercentage($collection)
     {


### PR DESCRIPTION
The pandas library in Python provides a useful method called fillna that fills NaN values in a DataFrame. Inspired by this functionality, this pull request introduces a similar method for Laravel collections called fillNull.

The fillNull method allows you to replace null values in a collection with a specified default value. This method provides flexibility to either fill all null values in the collection or target specific fields.

```php
$collection = collect([
    ['name' => 'Item 1', 'value' => null],
    ['name' => 'Item 2', 'value' => 10, 'meta' => null],
    ['name' => 'Item 4', 'value' => 25],
    ['name' => null, 'value' => null],
]);

// Fill all null values with 0
$collection->fillNull(); 

// Fill all null values with 'default'
$collection->fillNull('default');

// Fill only 'name' and 'meta' fields with 'default'
$collection->fillNull('default', 'name', 'meta');
```

**Details:**

- **No Fields Provided:** If no specific fields are provided, all null values in the collection are replaced with the default value.
- **Specific Fields:** When one or more fields are specified, only the null values in those fields are replaced with the default value.

**Benefits:**

- **Flexibility:** Allows for selective or comprehensive filling of null values.
- **Consistency:** Aligns with familiar functionality from pandas, making it easier for users coming from a data science background.