### PR TITLE
[11.x] Fix Http Client Pool requests that have no response

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1029,7 +1029,7 @@ class PendingRequest
                 });
             })
             ->otherwise(function (OutOfBoundsException|TransferException $e) {
-                if ($e instanceof ConnectException) {
+                if ($e instanceof ConnectException || ($e instanceof RequestException && ! $e->hasResponse())) {
                     $exception = new ConnectionException($e->getMessage(), 0, $e);
 
                     $this->dispatchConnectionFailedEvent(new Request($e->getRequest()), $exception);


### PR DESCRIPTION
Fixes an issue when a HTTP Client Pool is used and a request throws a RequestException and there is no response body, such as an SSL verify error.

Previously this would still return a Response class, with no response code or body. This now considers it a ConnectionException.

Looks to be a regression of https://github.com/laravel/framework/pull/41412 