### PR TITLE
[11.x] Unify exception renderer

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -837,12 +837,8 @@ class Handler implements ExceptionHandlerContract
     protected function renderExceptionContent(Throwable $e)
     {
         try {
-            if (config('app.debug')) {
-                if (app()->has(ExceptionRenderer::class)) {
-                    return $this->renderExceptionWithCustomRenderer($e);
-                } elseif ($this->container->bound(Renderer::class)) {
-                    return $this->container->make(Renderer::class)->render(request(), $e);
-                }
+            if (config('app.debug') && app()->has(ExceptionRenderer::class)) {
+                return $this->renderExceptionWithCustomRenderer($e);
             }
 
             return $this->renderExceptionWithSymfony($e, config('app.debug'));

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -19,7 +19,6 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
-use Illuminate\Foundation\Exceptions\Renderer\Renderer;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;

--- a/src/Illuminate/Foundation/Exceptions/Renderer/LaravelRenderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/LaravelRenderer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions\Renderer;
+
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
+use Illuminate\Http\Request;
+
+class LaravelRenderer implements ExceptionRenderer
+{
+    /**
+     * The renderer instance.
+     *
+     * @var \Illuminate\Foundation\Exceptions\Renderer\Renderer
+     */
+    protected $renderer;
+
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
+
+    /**
+     * Create a new default Laravel exception renderer instance.
+     *
+     * @param  \Illuminate\Foundation\Exceptions\Renderer\Renderer  $renderer
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function __construct(Renderer $renderer, Request $request)
+    {
+        $this->renderer = $renderer;
+        $this->request = $request;
+    }
+
+    /**
+     * Renders the given exception as HTML.
+     *
+     * @param  \Throwable  $throwable
+     * @return string
+     */
+    public function render($throwable)
+    {
+        return $this->renderer->render($this->request, $throwable);
+    }
+
+    /**
+     * Get the request instance.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Set the request instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return $this
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -7,11 +7,13 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Grammar;
 use Illuminate\Foundation\Console\CliDumper;
+use Illuminate\Foundation\Exceptions\Renderer\LaravelRenderer;
 use Illuminate\Foundation\Exceptions\Renderer\Listener;
 use Illuminate\Foundation\Exceptions\Renderer\Mappers\BladeMapper;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
@@ -135,8 +137,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * Register the "validate" macro on the request.
      *
      * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
      */
     public function registerRequestValidation()
     {
@@ -238,6 +238,10 @@ class FoundationServiceProvider extends AggregateServiceProvider
         });
 
         $this->app->singleton(Listener::class);
+
+        $this->app->singleton(ExceptionRenderer::class, function ($app) {
+            return new LaravelRenderer($app[Renderer::class], $app['request']);
+        });
     }
 
     /**


### PR DESCRIPTION
Nuno's changed the default exception renderer since https://github.com/laravel/framework/pull/51261. Now, there are two ways to customize how Laravel renders an exception.

```php
// Bind/rebind the \Illuminate\Contracts\Foundation\ExceptionRenderer interface.
$this->app->singleton(Illuminate\Contracts\Foundation\ExceptionRenderer::class, function () {
    return new SomeExceptionRendererImpl;
});

// Or bind/rebind the \Illuminate\Foundation\Exceptions\Renderer class.
// It doesn't implement the ExceptionRenderer interface.
$this->app->singleton(Illuminate\Foundation\Exceptions\Renderer\Renderer::class, function () {
    return new SomeRendererSubClass;
});
```

I think it's complex, inconsistent and introduces more additional checks when actual displaying exceptions because both of them refer to the same thing/category. They defines how an exception should be rendered, right?

Therefore, we can create `LaravelRenderer` class which implements the `ExceptionRenderer` interface to unify the concept of rendering exceptions.

Then, inside `FoundationServiceProvider`, we'll bind the `ExceptionRenderer` interface to an instance of `LaravelRenderer` class by default. People can rebind it later.
```php
use Illuminate\Foundation\Exceptions\Renderer\Renderer;

$this->app->singleton(ExceptionRenderer::class, function ($app) {
    return new LaravelRenderer(
        $app[Renderer::class], $app['request']
    );
});

// It's really clear, isn't it?
$this->app->singleton(ExceptionRenderer::class, IgnitionExceptionRenderer::class);
$this->app->singleton(ExceptionRenderer::class, WhoopsExceptionRenderer::class);
$this->app->singleton(ExceptionRenderer::class, AnotherCustomExceptionRenderer::class);
```

The `renderExceptionContent` method looks simple as it did before.

```php
protected function renderExceptionContent(Throwable $e)
{
    try {
        if (config('app.debug') && app()->has(ExceptionRenderer::class)) {
            return $this->renderExceptionWithCustomRenderer($e);
        }

        return $this->renderExceptionWithSymfony($e, config('app.debug'));
    } catch (Throwable $e) {
        return $this->renderExceptionWithSymfony($e, config('app.debug'));
    }
}
```
