### PR TITLE
[11.x] Introduce MixFileNotFoundException for handling missing Mix files

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation;
 
-use Exception;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
@@ -15,7 +14,7 @@ class Mix
      * @param  string  $manifestDirectory
      * @return \Illuminate\Support\HtmlString|string
      *
-     * @throws \Illuminate\Foundation\MixManifestNotFoundException
+     * @throws \Illuminate\Foundation\MixManifestNotFoundException|\Illuminate\Foundation\MixFileNotFoundException
      */
     public function __invoke($path, $manifestDirectory = '')
     {
@@ -58,7 +57,7 @@ class Mix
         $manifest = $manifests[$manifestPath];
 
         if (! isset($manifest[$path])) {
-            $exception = new Exception("Unable to locate Mix file: {$path}.");
+            $exception = new MixFileNotFoundException("Unable to locate Mix file: {$path}.");
 
             if (! app('config')->get('app.debug')) {
                 report($exception);

--- a/src/Illuminate/Foundation/MixFileNotFoundException.php
+++ b/src/Illuminate/Foundation/MixFileNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Exception;
+
+class MixFileNotFoundException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Foundation/MixFileNotFoundException.php
+++ b/src/Illuminate/Foundation/MixFileNotFoundException.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation;
 
-use RuntimeException;
+use Exception;
 
-class MixFileNotFoundException extends RuntimeException
+class MixFileNotFoundException extends Exception
 {
     //
 }

--- a/src/Illuminate/Foundation/MixFileNotFoundException.php
+++ b/src/Illuminate/Foundation/MixFileNotFoundException.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation;
 
-use Exception;
+use RuntimeException;
 
-class MixFileNotFoundException extends Exception
+class MixFileNotFoundException extends RuntimeException
 {
     //
 }


### PR DESCRIPTION
This PR introduces a new MixFileNotFoundException to specifically handle missing Mix files. This custom exception extends the base \Exception class and provides a more precise error handling mechanism for scenarios where the Mix file cannot be found.

It will be usefull when you want to suppress specific errors report went the application in maintenance mode.
