### PR TITLE
[11.x] Add upsertUsing functionality

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -118,6 +118,7 @@ class Builder implements BuilderContract
         'insertorignore',
         'insertusing',
         'insertorignoreusing',
+        'upsertusing',
         'max',
         'min',
         'raw',

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3916,14 +3916,18 @@ class Builder implements BuilderContract
      *
      * @param  array  $columns
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
+     * @param  array|string  $uniqueBy
+     * @param  array|null  $update
      * @return int
      */
     public function upsertUsing(array $columns, $query, $uniqueBy, $update = null)
     {
+        if ($update === []) {
+            return $this->insertUsing($columns, $query);
+        }
+
         if (is_null($update)) {
             $update = $columns;
-        } elseif (! is_array($update)) {
-            $update = [$update];
         }
 
         $this->applyBeforeQueryCallbacks();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3920,9 +3920,9 @@ class Builder implements BuilderContract
      */
     public function upsertUsing(array $columns, $query, $uniqueBy, $update = null)
     {
-        if(is_null($update)) {
+        if (is_null($update)) {
             $update = $columns;
-        } else if (! is_array($update)) {
+        } elseif (! is_array($update)) {
             $update = [$update];
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3912,6 +3912,31 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Upsert new records into the table using a subquery.
+     *
+     * @param  array  $columns
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
+     * @return int
+     */
+    public function upsertUsing(array $columns, $query, $uniqueBy, $update = null)
+    {
+        if(is_null($update)) {
+            $update = $columns;
+        } else if (! is_array($update)) {
+            $update = [$update];
+        }
+
+        $this->applyBeforeQueryCallbacks();
+
+        [$sql, $bindings] = $this->createSub($query);
+
+        return $this->connection->affectingStatement(
+            $this->grammar->compileUpsertUsing($this, $columns, $sql, (array) $uniqueBy, $update),
+            $this->cleanBindings($bindings)
+        );
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1332,6 +1332,8 @@ class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $columns
      * @param  string  $sql
+     * @param  array  $uniqueBy
+     * @param  array  $update
      * @return string
      */
     public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1327,6 +1327,19 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an upsert statement using a subquery into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @param  string  $sql
+     * @return string
+     */
+    public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)
+    {
+        throw new RuntimeException('This database engine does not support upserts.');
+    }
+
+    /**
      * Prepare the bindings for an update statement.
      *
      * @param  array  $bindings

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -378,7 +378,8 @@ class MySqlGrammar extends Grammar
      * Compile an upsert statement using a subquery into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $values
+     * @param  array  $columns
+     * @param  string  $sql
      * @param  array  $uniqueBy
      * @param  array  $update
      * @return string

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -375,6 +375,32 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile an upsert statement using a subquery into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  array  $update
+     * @return string
+     */
+    public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)
+    {
+        $sql = $this->compileInsertUsing($query, $columns, $sql);
+
+        $sql .= ' on duplicate key update ';
+
+        $columns = collect($update)->map(function ($value, $key) {
+            if (! is_numeric($key)) {
+                return $this->wrap($key).' = '.$this->parameter($value);
+            }
+
+            return $this->wrap($value).' = values('.$this->wrap($value).')';
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Compile a "lateral join" clause.
      *
      * @param  \Illuminate\Database\Query\JoinLateralClause  $join

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -427,6 +427,31 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an upsert statement using a subquery into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @param  string  $sql
+     * @param  array  $uniqueBy
+     * @param  array  $update
+     * @return string
+     */
+    public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)
+    {
+        $sql = $this->compileInsertUsing($query, $columns, $sql);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect($update)->map(function ($value, $key) {
+            return is_numeric($key)
+                ? $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value)
+                : $this->wrap($key).' = '.$this->parameter($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Compile a "lateral join" clause.
      *
      * @param  \Illuminate\Database\Query\JoinLateralClause  $join

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -324,6 +324,31 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile an upsert statement using a subquery into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @param  string  $sql
+     * @param  array  $uniqueBy
+     * @param  array  $update
+     * @return string
+     */
+    public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)
+    {
+        $sql = $this->compileInsertUsing($query, $columns, $sql);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect($update)->map(function ($value, $key) {
+            return is_numeric($key)
+                ? $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value)
+                : $this->wrap($key).' = '.$this->parameter($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Group the nested JSON columns.
      *
      * @param  array  $values

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -983,6 +983,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('foo', $builder->insertUsing(['bar'], 'baz'));
 
         $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('upsertUsing')->once()->with(['bar'], 'baz', 'foobar')->andReturn('foo');
+
+        $this->assertSame('foo', $builder->upsertUsing(['bar'], 'baz', 'foobar'));
+
+        $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('raw')->once()->with('bar')->andReturn('foo');
 
         $this->assertSame('foo', $builder->raw('bar'));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3558,6 +3558,21 @@ class DatabaseQueryBuilderTest extends TestCase
         );
 
         $this->assertEquals(1, $result);
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->getConnection()
+            ->shouldReceive('affectingStatement')->once()->with('insert into "table1" ("foo") select "bar" from "table2" where "foreign_id" = ? on conflict ("id") do update set "foo" = "excluded"."foo"', [5])->andReturn(1);
+
+        $result = $builder->from('table1')->upsertUsing(
+            ['foo'],
+            function (Builder $query) {
+                $query->select(['bar'])->from('table2')->where('foreign_id', '=', 5);
+            },
+            'id'
+        );
+
+        $this->assertEquals(1, $result);
     }
 
     public function testUpsertUsingWithEmptyColumns()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3528,6 +3528,50 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(2, $result);
     }
 
+    public function testUpsertUsingMethod()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->getConnection()
+            ->shouldReceive('affectingStatement')->once()->with('insert into `table1` (`foo`) select `bar` from `table2` where `foreign_id` = ? on duplicate key update `foo` = values(`foo`)', [5])->andReturn(1);
+
+        $result = $builder->from('table1')->upsertUsing(
+            ['foo'],
+            function (Builder $query) {
+                $query->select(['bar'])->from('table2')->where('foreign_id', '=', 5);
+            },
+            'id'
+        );
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUpsertUsingWithEmptyColumns()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `table1` select * from `table2` where `foreign_id` = ? on duplicate key update `foo` = values(`foo`)', [5])->andReturn(1);
+
+        $result = $builder->from('table1')->upsertUsing(
+            [],
+            function (Builder $query) {
+                $query->from('table2')->where('foreign_id', '=', 5);
+            },
+            'id',
+            ['foo']
+        );
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUpsertUsingInvalidSubquery()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('table1')->upsertUsing(['foo'], ['bar'], 'id');
+    }
+
     public function testUpdateMethodWithJoins()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**Overview**

This branch is based on an idea in the discussions - https://github.com/laravel/framework/discussions/46589

It adds an `upsertUsing` method which is similar to the `insertUsing` method and allows developers to upsert data using a subquery.

I've implemented it only for MySql for now.

**Benefits**

Really it's an extension of `insertUsing` bringing the power of upserts. The alternative currently would be to either write a raw statement or to load records into memory and use the upsert method to enter them into the new table. Obviously, keeping it in MySQL is much faster and this method makes that easier to do for devs.

My use case is syncing data from a staging table to the live table.

**Breaking Changes**

None! It's a new method and doesn't change any existing functionality!

**Notes**

One thing to note - I don't use the `laravel_upsert_alias` because it's difficult to implement with a subquery. I could nest the subquery like so:
```sql
insert into `table1` (`foo`) select * from (select `bar` from `table2` where `foreign_id` = ?) as laravel_upsert_alias on duplicate key update `foo` = `laravel_upsert_alias`.`foo`
```
However, this would result in an error since the column `foo` doesn't exist in the subquery. If anyone has a good solution for this let me know! Although I'm not sure the alias would provide any benefit in this scenario anyway.