### PR TITLE
[12.x] Fixes for cron expressions when using `between()`

### DIFF
--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -227,4 +227,19 @@ class FrequencyTest extends TestCase
 
         $this->assertSame('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
     }
+
+    public function testBetweenOnDifferentHoursEveryTwoMinutes()
+    {
+        $this->assertSame('*/2 06-23 * * *', $this->event->everyTwoMinutes()->between('06:00', '23:00')->getExpression());
+    }
+
+    public function testBetweenOnEveryTwoMinutesDuringSpecificMinutesInSameHour()
+    {
+        $this->assertSame('17-37/2 06 * * *', $this->event->everyTwoMinutes()->between('06:17', '06:37')->getExpression());
+    }
+
+    public function testBetweenEveryTwoMinutesFromDuringHourToEndOfHour()
+    {
+        $this->assertSame('30-59/2 19-20 * * *', $this->event->everyTwoMinutes()->between('19:30', '20:00')->getExpression());
+    }
 }


### PR DESCRIPTION
> [!NOTE]  
> As part of #50670 I was [asked by @driesvints](https://github.com/laravel/framework/issues/50670#issuecomment-2176247928) to reattempt my previous PR (https://github.com/laravel/framework/pull/47983) for Laravel 12, so here we go! PR body is the same so I've copied it over

 Hey,

I noticed something weird with some of the expressions of my scheduled commands when I run  run `php artisan schedule list`, so I decided to do some digging. It seems like if you're using `->between()`, this doesn't get included in the cron expression that shows.

For example, let's take a scheduled command that's meant to run every minute between 10pm and 11pm:

```php
$schedule->command('example')
    ->everyMinute()
    ->timezone('BST')
    ->between('22:00', '23:00');
```

If I run `php artisan schedule:list` before 10pm, for example at the time of typing this, it's 21:21, I get:

```bash
 * * * * *  php artisan example ............................... Next Due: 20 seconds from now
``` 

But that's not correct, because it's actually next due in 36 minutes.  With the changes in this PR, if I run `php artisan schedule:list` again, I get:

```bash
* 22-23 * * *  php artisan example ........................ Next Due: 36 minutes from now
```

I also noticed that if you try and be more specific about the minutes you want to run, e.g.:

```php
$schedule->command('example')
    ->everyMinute()
    ->timezone('BST')
    ->between('22:30', '23:00');
```

You get the same as before, where it will give me the wrong expression and count down:

```bash
 * * * * *  php artisan example ............................... Next Due: 20 seconds from now
```

But with this PR, it changes it to the below, which includes the hours and minutes.
```bash
30-59 22-23 * * *  php artisan example ........................ Next Due: 1 hour from now
```

I've also amended the output to show if, for example, you've specified it to run every 2 minutes, 10 minutes etc...:

```bash
30-35/2 22-23 * * *  php artisan example ..................... Next Due: 1 hour from now
```

I haven't really delved into this part of the code in the framework before so I'm definitely open to being educated 😄 

I've added some supporting tests to cover this new behaviour. 

Thanks!
