### PR TITLE
[11.x] Don't touch BelongsTo relationship when it doesn't exist

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -177,6 +177,18 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Touch all of the related models for the relationship.
+     *
+     * @return void
+     */
+    public function touch()
+    {
+        if (! is_null($this->getParentKey())) {
+            parent::touch();
+        }
+    }
+
+    /**
      * Associate the model instance to the given parent.
      *
      * @param  TRelatedModel|int|string|null  $model

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -177,18 +177,6 @@ class BelongsTo extends Relation
     }
 
     /**
-     * Touch all of the related models for the relationship.
-     *
-     * @return void
-     */
-    public function touch()
-    {
-        if (! is_null($this->getParentKey())) {
-            parent::touch();
-        }
-    }
-
-    /**
      * Associate the model instance to the given parent.
      *
      * @param  TRelatedModel|int|string|null  $model
@@ -229,6 +217,18 @@ class BelongsTo extends Relation
     public function disassociate()
     {
         return $this->dissociate();
+    }
+
+    /**
+     * Touch all of the related models for the relationship.
+     *
+     * @return void
+     */
+    public function touch()
+    {
+        if (! is_null($this->getParentKey())) {
+            parent::touch();
+        }
     }
 
     /** @inheritDoc */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -263,7 +263,7 @@ class MorphTo extends BelongsTo
      */
     public function touch()
     {
-        if (! is_null($this->child->{$this->foreignKey})) {
+        if (! is_null($this->getParentKey())) {
             parent::touch();
         }
     }


### PR DESCRIPTION
Currently, `MorphTo` and `BelongsToMany` check for relation existence before sending the update query to the database.

This adds that check to the `BelongsTo` relationship.

I found this when trawling through query logs. Nullable belongs to relationship were producing a lot of unnecessary update queries

```sql
update
  `table`
set
  `table`.`updated_at` = '2024-08-07 02:46:18'
where
  `table`.`id` is null
```

Additionally, `getParentKey()` can be used to find the child foreign key value.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
