### PR TITLE
[11.x] Make `expectsChoice` assertion more intuitive with associative arrays.

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -397,7 +397,7 @@ class PendingCommand
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
                     if (isset($this->test->expectedChoices[$question[0]])) {
-                        $this->test->expectedChoices[$question[0]]['actual'] = $argument->getAutocompleterValues();
+                        $this->test->expectedChoices[$question[0]]['actual'] = $argument->getChoices();
                     }
 
                     return $argument->getQuestion() == $question[0];

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class PendingCommand
 {
@@ -397,7 +398,9 @@ class PendingCommand
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
                     if (isset($this->test->expectedChoices[$question[0]])) {
-                        $this->test->expectedChoices[$question[0]]['actual'] = $argument->getChoices();
+                        $this->test->expectedChoices[$question[0]]['actual'] = $argument instanceof ChoiceQuestion
+                            ? $argument->getChoices()
+                            : $argument->getAutocompleterValues();
                     }
 
                     return $argument->getQuestion() == $question[0];

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -398,7 +398,7 @@ class PendingCommand
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
                     if (isset($this->test->expectedChoices[$question[0]])) {
-                        $this->test->expectedChoices[$question[0]]['actual'] = $argument instanceof ChoiceQuestion
+                        $this->test->expectedChoices[$question[0]]['actual'] = $argument instanceof ChoiceQuestion && ! array_is_list($this->test->expectedChoices[$question[0]]['expected'])
                             ? $argument->getChoices()
                             : $argument->getAutocompleterValues();
                     }

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -10,6 +10,7 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
+use function Laravel\Prompts\suggest;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\textarea;
 
@@ -57,6 +58,28 @@ class PromptsAssertionTest extends TestCase
             ->artisan('test:textarea')
             ->expectsQuestion('What is your name?', 'Jane')
             ->expectsOutput('Jane');
+    }
+
+    public function testAssertionForSuggestPrompt()
+    {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:suggest';
+
+                public function handle()
+                {
+                    $name = suggest('What is your name?', ['John', 'Jane']);
+
+                    $this->line($name);
+                }
+            }
+        );
+
+        $this
+            ->artisan('test:suggest')
+            ->expectsChoice('What is your name?', 'Joe', ['John', 'Jane'])
+            ->expectsOutput('Joe');
     }
 
     public function testAssertionForPasswordPrompt()

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -185,6 +185,31 @@ class PromptsAssertionTest extends TestCase
             ->expectsOutput('Your name is jane.');
     }
 
+    public function testAlternativeAssertionForSelectPromptWithAnAssociativeArray()
+    {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:select';
+
+                public function handle()
+                {
+                    $name = select(
+                        label: 'What is your name?',
+                        options: ['john' => 'John', 'jane' => 'Jane']
+                    );
+
+                    $this->line("Your name is $name.");
+                }
+            }
+        );
+
+        $this
+            ->artisan('test:select')
+            ->expectsChoice('What is your name?', 'jane', ['john', 'jane', 'John', 'Jane'])
+            ->expectsOutput('Your name is jane.');
+    }
+
     public function testAssertionForRequiredMultiselectPrompt()
     {
         $this->app[Kernel::class]->registerCommand(

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -112,7 +112,7 @@ class PromptsAssertionTest extends TestCase
             ->expectsOutput('Your name is John.');
     }
 
-    public function testAssertionForSelectPrompt()
+    public function testAssertionForSelectPromptWithAList()
     {
         $this->app[Kernel::class]->registerCommand(
             new class extends Command
@@ -135,6 +135,31 @@ class PromptsAssertionTest extends TestCase
             ->artisan('test:select')
             ->expectsChoice('What is your name?', 'Jane', ['John', 'Jane'])
             ->expectsOutput('Your name is Jane.');
+    }
+
+    public function testAssertionForSelectPromptWithAnAssociativeArray()
+    {
+        $this->app[Kernel::class]->registerCommand(
+            new class extends Command
+            {
+                protected $signature = 'test:select';
+
+                public function handle()
+                {
+                    $name = select(
+                        label: 'What is your name?',
+                        options: ['john' => 'John', 'jane' => 'Jane']
+                    );
+
+                    $this->line("Your name is $name.");
+                }
+            }
+        );
+
+        $this
+            ->artisan('test:select')
+            ->expectsChoice('What is your name?', 'jane', ['john' => 'John', 'jane' => 'Jane'])
+            ->expectsOutput('Your name is jane.');
     }
 
     public function testAssertionForRequiredMultiselectPrompt()


### PR DESCRIPTION
Currently, the `expectsChoice` test method behaves in an unusual way when passing an associative array to the `choice` method (or the `select` prompt).

For example, imagine the following scenario:

```php
$this->choice('Choose an option', [
    'one' => 'One',
    'two' => 'Two',
    'three' => 'Three',
]);

// or

select('Choose an option', [
    'one' => 'One',
    'two' => 'Two',
    'three' => 'Three',
]);
```

To use `expectsChoice`, you would need to write the test like this:

```php
$this->expectsChoice('Choose an option', 'one', [
    'one',
    'two',
    'three',
    'One',
    'Two',
    'Three',
]);
```

This is because the available options are retrieved from Symfony using the `getAutocompleterValues` method. Technically, this could be considered correct because with Symfony, the user must type a value to select an option, and they can either type a key or a value. However, I don't think it's very intuitive, and with the `select` prompt, it's even less intuitive because the keys are never exposed to the user.

This PR addresses this by detecting the available options using the `getChoices` method instead, which allows an associative array to be used in the `expectsChoice` method like so:

```php
$this->expectsChoice('Choose an option', 'one', [
    'one' => 'One',
    'two' => 'Two',
    'three' => 'Three',
]);
```

To avoid breaking backwards compatibility for anyone relying on the current behaviour, this only uses the `getChoice` method when an associative array is passed to `expectsChoice`, meaning that passing a list will continue to function as it currently does.

Fixes https://github.com/laravel/prompts/issues/158