### PR TITLE
[11.x] Add ResponseInterface mixin to `Illuminate\Http\Client\Response`

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -8,6 +8,9 @@ use Illuminate\Support\Traits\Macroable;
 use LogicException;
 use Stringable;
 
+/**
+ * @mixin \Psr\Http\Message\ResponseInterface
+ */
 class Response implements ArrayAccess, Stringable
 {
     use Concerns\DeterminesStatusCode, Macroable {


### PR DESCRIPTION
This PR adds the `Psr\Http\Message\ResponseInterface` interface as a mixin to the Response class. This will make our IDE completion better.

```
/**
 * @mixin \Psr\Http\Message\ResponseInterface
 */
```

The Response class is using the magic `__call` method and forwards it calls to the $response property, therefore all the methods on the `$response` property is available for the developer.

```
    /**
     * The underlying PSR response.
     *
     * @var \Psr\Http\Message\ResponseInterface
     */
    protected $response;

    public function __call($method, $parameters)
    {
        return static::hasMacro($method)
                    ? $this->macroCall($method, $parameters)
                    : $this->response->{$method}(...$parameters);
    }
```
