### PR TITLE
[11.x] Fix docblock for the event dispatcher

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -80,8 +80,8 @@ class Dispatcher implements DispatcherContract
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Closure|string|array  $events
-     * @param  \Closure|string|array|null  $listener
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $events
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array|null  $listener
      * @return void
      */
     public function listen($events, $listener = null)

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Testing\Fakes\EventFake;
 
 /**
- * @method static void listen(\Closure|string|array $events, \Closure|string|array|null $listener = null)
+ * @method static void listen(\Illuminate\Events\QueuedClosure|\Closure|string|array $events, \Illuminate\Events\QueuedClosure|\Closure|string|array|null $listener = null)
  * @method static bool hasListeners(string $eventName)
  * @method static bool hasWildcardListeners(string $eventName)
  * @method static void push(string $event, object|array $payload = [])


### PR DESCRIPTION
`Events\Dispatcher::listen` method can accept `$event` as `\Illuminate\Events\QueuedClosure`, similar to `$listener`.