### PR TITLE
[11.x]  Add `resource()` method to Illuminate\Http\Client\Response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -106,11 +106,11 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Get the body of the response as a php resource.
+     * Get the body of the response as a PHP resource.
      *
      * @return resource
      *
-     * @throws \InvalidArgumentException if stream is not readable or writable
+     * @throws \InvalidArgumentException
      */
     public function resource()
     {

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
@@ -102,6 +103,18 @@ class Response implements ArrayAccess, Stringable
     public function collect($key = null)
     {
         return Collection::make($this->json($key));
+    }
+
+    /**
+     * Get the body of the response as a php resource.
+     *
+     * @return resource
+     *
+     * @throws \InvalidArgumentException if stream is not readable or writable
+     */
+    public function resource()
+    {
+        return StreamWrapper::getResource($this->response->getBody());
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -327,6 +327,18 @@ class HttpClientTest extends TestCase
         $this->assertSame('bar', $response->object()->result->foo);
     }
 
+    public function testResponseCanBeReturnedAsResource()
+    {
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api');
+
+        $this->assertIsResource($response->resource());
+        $this->assertSame('{"result":{"foo":"bar"}}', stream_get_contents($response->resource()));
+    }
+
     public function testResponseCanBeReturnedAsCollection()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR introduces a new `resource()` method to the `Response` class in Laravel. This method allows users to directly obtain a PHP stream resource from the response body, simplifying workflows that involve stream operations.

**Motivation**
Working with stream resources in Laravel, especially when dealing with external services or large datasets, can sometimes be verbose and require multiple steps. This new method aims to simplify this process, making it more intuitive and reducing the amount of boilerplate code needed.

**Changes**
- Added a new `resource()` method to the `Response` class.
- Implemented a corresponding test case to ensure the new functionality works as expected.

**New Functionality**
The `resource()` method returns a PHP stream resource from the response body. It uses the amazing `GuzzleHttp\Psr7\StreamWrapper` that comes with the `guzzlehttp/psr7` package, that is required by the framework as a requirement in `guzzlehttp/guzzle`:

```php
use GuzzleHttp\Psr7\StreamWrapper;

/**
 * Get the body of the response as a PHP stream resource.
 *
 * @return resource
 *
 * @throws \InvalidArgumentException if stream is not readable or writable
 */
public function resource()
{
    return StreamWrapper::getResource($this->response->getBody());
}
```

## Usage Examples

### Writing to S3

Before:
```php
use GuzzleHttp\Psr7\StreamWrapper;

$response = Http::get($imageUrl);
Storage::disk('s3')->writeStream(
    'thumbnail.png',
    StreamWrapper::getResource($response->toPsrResponse()->getBody()),
);
```

After:
```php
$response = Http::get($imageUrl);
Storage::disk('s3')->writeStream('thumbnail.png', $response->resource());
```

### Streaming large JSON responses

My favorite way to work with JSON data from external api's, using [halaxa/json-machine](https://github.com/halaxa/json-machine/blob/master/examples/guzzleHttp.php). 

Before:
```php
use GuzzleHttp\Psr7\StreamWrapper;
use JsonMachine\Items;

$response = Http::get('https://jsonplaceholder.typicode.com/todos/1');
$phpStream = StreamWrapper::getResource($response->toPsrResponse()->getBody());

foreach (Items::fromStream($phpStream) as $key => $value) {
    var_dump($value);
}
```

After:
```php
use JsonMachine\Items;

$response = Http::get('https://jsonplaceholder.typicode.com/todos/1');

foreach (Items::fromStream($response->resource()) as $key => $value) {
    var_dump($value);
}
```

I'll make a PR to the docs to include information about the new `resource()` method.