### PR TITLE
[10.x] fix: prevent casting empty string to array from triggering json error

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1271,7 +1271,11 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        return Json::decode($value ?? '', ! $asObject);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return Json::decode($value, ! $asObject);
     }
 
     /**

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -21,6 +21,14 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $attributes = $instance->getMutatedAttributes();
         $this->assertEquals(['some_attribute'], $attributes);
     }
+
+    public function testCastingEmptyStringToArrayDoesNotError()
+    {
+        $instance = new HasAttributesWithArrayCast();
+        $this->assertEquals(['foo' => null], $instance->attributesToArray());
+
+        $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
+    }
 }
 
 class HasAttributesWithoutConstructor
@@ -38,5 +46,25 @@ class HasAttributesWithConstructorArguments extends HasAttributesWithoutConstruc
 {
     public function __construct($someValue)
     {
+    }
+}
+
+class HasAttributesWithArrayCast
+{
+    use HasAttributes;
+
+    public function getArrayableAttributes(): array
+    {
+        return ['foo' => ''];
+    }
+
+    public function getCasts(): array
+    {
+        return ['foo' => 'array'];
+    }
+
+    public function usesTimestamps(): bool
+    {
+        return false;
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

Please see https://github.com/laravel/framework/pull/52293#issuecomment-2273290823 for context.

This PR prevents json errors being triggered when trying to cast Model attributes with empty strings (invalid json) to an array.

Thanks!