### PR TITLE
[11.x] fix: Update text email template

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,7 +39,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards'),<br>
+@lang('Regards,')<br>
 {{ config('app.name') }}
 @endif
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR is used to have a good way for multiple languages in email.

I know that all sentences include: **punctuation**

```
  return (new MailMessage)
            ->subject(Lang::get('Verify Email Address'))
            ->line(Lang::get('Please click the button below to verify your email address.'))
            ->action(Lang::get('Verify Email Address'), $url)
            ->line(Lang::get('If you did not create an account, no further action is required.'));
```
So I tried with: ```"Regards,"``` and it doesn't work.
--> I need to search alot to find the issue -> the email template is: ```@lang('Regards')```
--> I created this PR to hope other developers don't lose time to customizing the language for their emails and **Consistency**

 ```@lang('Thanks,')``` not  ```@lang('Thanks'),```