### PR TITLE
[11.x] Ask about job should be synchronous for job command with no initial input

### DIFF
--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -6,6 +6,10 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\confirm;
 
 #[AsCommand(name: 'make:job')]
 class JobMakeCommand extends GeneratorCommand
@@ -67,6 +71,24 @@ class JobMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Jobs';
+    }
+
+    /**
+     * Perform actions after the user was prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $wantsSync = confirm('Do you want the job to be synchronous?', false);
+
+        $input->setOption('sync', $wantsSync);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -5,8 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\confirm;

--- a/tests/Integration/Generators/JobMakeCommandTest.php
+++ b/tests/Integration/Generators/JobMakeCommandTest.php
@@ -56,4 +56,42 @@ class JobMakeCommandTest extends TestCase
         $this->assertFilenameExists('app/Jobs/FooCreated.php');
         $this->assertFilenameExists('tests/Feature/Jobs/FooCreatedTest.php');
     }
+
+    public function testItCanGenerateJobFileWithNotInitialInput()
+    {
+        $this->artisan('make:job')
+            ->expectsQuestion('What should the job be named?', 'FooCreated')
+            ->expectsQuestion('Do you want the job to be synchronous?', false)
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Jobs;',
+            'use Illuminate\Contracts\Queue\ShouldQueue;',
+            'use Illuminate\Foundation\Bus\Dispatchable;',
+            'use Illuminate\Foundation\Queue\Queueable;',
+            'use Illuminate\Queue\InteractsWithQueue;',
+            'use Illuminate\Queue\SerializesModels;',
+            'class FooCreated implements ShouldQueue',
+            'use Queueable;',
+        ], 'app/Jobs/FooCreated.php');
+
+        $this->assertFilenameExists('app/Jobs/FooCreated.php');
+    }
+
+    public function testItCanGenerateJobFileWithsynchronousWithNotInitialInput()
+    {
+        $this->artisan('make:job')
+            ->expectsQuestion('What should the job be named?', 'FooCreated')
+            ->expectsQuestion('Do you want the job to be synchronous?', true)
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Jobs;',
+            'use Illuminate\Foundation\Bus\Dispatchable;',
+            'class FooCreated',
+            'use Dispatchable;',
+        ], 'app/Jobs/FooCreated.php');
+
+        $this->assertFilenameExists('app/Jobs/FooCreated.php');
+    }
 }


### PR DESCRIPTION
This PR lets the `Job Make Command` ask you about job should be synchronous when no initial inputs are provided.