### PR TITLE
[11.x] incrementEach and decrementEach on a model instance should only update the same record in database

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1183,6 +1183,22 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Increment the given column's values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function incrementEach($columns, array $extra = [])
+    {
+        return $this->toBase()->incrementEach(
+            $columns, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
      * Decrement a column's value by a given amount.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
@@ -1194,6 +1210,22 @@ class Builder implements BuilderContract
     {
         return $this->toBase()->decrement(
             $column, $amount, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
+     * Decrement the given column's values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function decrementEach($columns, array $extra = [])
+    {
+        return $this->toBase()->decrementEach(
+            $columns, $this->addUpdatedAtColumn($extra)
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1027,7 +1027,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Run the incrementEach or decrementEach method on the model.
      *
-     * @param array<string, float|int|numeric-string> $columns
+     * @param  array<string, float|int|numeric-string>  $columns
      * @param  array  $extra
      * @param  string  $method
      * @return int

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -118,7 +118,7 @@ class EloquentUpdateTest extends DatabaseTestCase
         TestUpdateModel3::increment('wallet_1');
         TestUpdateModel3::incrementEach([
             'wallet_1' => 10,
-            'wallet_2' => -20
+            'wallet_2' => -20,
         ]);
 
         $models = TestUpdateModel3::withoutGlobalScopes()->orderBy('id')->get();

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -28,8 +28,8 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         Schema::create('test_model3', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('wallet_1');
-            $table->unsignedInteger('wallet_2');
+            $table->integer('wallet_1');
+            $table->integer('wallet_2');
             $table->softDeletes();
             $table->timestamps();
         });


### PR DESCRIPTION
incrementEach() and decrementEach() on a model instance will only update the same record in the database.

```php
$user = User::where('shop_id', 1)->first();
$user->decrementEach(['counter' => 1, 'balance' => 100]);
// counter and balance of $user will be decremented.
// All other records will not change.
```

Please note that the expected behavior of `Illuminate\Database\Eloquent\Model`, `Illuminate\Database\Query\Builder`, and `Illuminate\Database\Eloquent\Builder` is unchanged.
```php
// Decrements all record's counter and balance
User::decrementEach(['counter' => 1, 'balance' => 100]);
DB::table('users')->decrementEach(['counter' => 1, 'balance' => 100]);

// Decrements only user with shop_id = 1
User::where('shop_id', 1)->decrementEach(['counter' => 1, 'balance' => 100]);
DB::table('users')->where('shop_id', 1)->decrementEach(['counter' => 1, 'balance' => 100]);
```

Related: https://github.com/laravel/framework/issues/49009, https://github.com/laravel/framework/pull/45577 and https://github.com/laravel/framework/issues/48595.