### PR TITLE
[11.x] adds formatKeysWith method to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -321,6 +321,28 @@ class Arr
     }
 
     /**
+     * Format the key names of an associative array.
+     *
+     * @param  array  $array
+     * @param  callable  $formatter
+     * @param  int  $depth
+     * @return array
+     */
+    public static function formatKeysWith(array $array, callable $formatter, int $depth = PHP_INT_MAX): array
+    {
+        $result = [];
+        foreach ($array as $key => $value) {
+            $newKey = $formatter($key);
+            if (is_array($value) && $depth > 1) {
+                $value = self::formatKeysWith($value, $formatter, $depth - 1);
+            }
+            $result[$newKey] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -420,6 +421,39 @@ class SupportArrTest extends TestCase
 
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
+    }
+
+    public function testFormatKeysWith()
+    {
+        $inputArray = [
+            'snake_case' => true,
+            'camelCase' => true,
+            'sub_array' => [
+                'snake_case' => true,
+                'camelCase' => true,
+            ],
+        ];
+
+        $uppercaseArray = [
+            'SNAKE_CASE' => true,
+            'CAMELCASE' => true,
+            'SUB_ARRAY' => [
+                'SNAKE_CASE' => true,
+                'CAMELCASE' => true,
+            ],
+        ];
+
+        $camelCaseDepthOneArray = [
+            'snakeCase' => true,
+            'camelCase' => true,
+            'subArray' => [
+                'snake_case' => true,
+                'camelCase' => true,
+            ],
+        ];
+
+        $this->assertEquals(Arr::formatKeysWith($inputArray, [Str::class, 'upper']), $uppercaseArray);
+        $this->assertEquals(Arr::formatKeysWith($inputArray, [Str::class, 'camel'], 1), $camelCaseDepthOneArray);
     }
 
     public function testGet()


### PR DESCRIPTION
Hey folks,

this PR adds makes it possible to format the key names of an associative Array with any given callable.

```php
  $formatedArray = Arr::formatKeysWith(["hello_laravel" => true ], [Str::class, 'camel']); 
  // ["helloLaravel" => true ];
```

I've also added a third $depth parameter, which defaults to the maximum integer

Greetings from Germany,
Sascha