### PR TITLE
[11.x] Auto-secure cookies

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -224,7 +224,7 @@ class StartSession
                 $this->getCookieExpirationDate(),
                 $config['path'],
                 $config['domain'],
-                $config['secure'] ?? false,
+                $config['secure'],
                 $config['http_only'] ?? true,
                 false,
                 $config['same_site'] ?? null,

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -90,6 +90,24 @@ class HttpResponseTest extends TestCase
         $this->assertSame('bar', $cookies[0]->getValue());
     }
 
+    public function testResponseCookiesInheritRequestSecureState()
+    {
+        $cookie = Cookie::create('foo', 'bar');
+
+        $response = new Response('foo');
+        $response->headers->setCookie($cookie);
+
+        $request = Request::create('/', 'GET');
+        $response->prepare($request);
+
+        $this->assertFalse($cookie->isSecure());
+
+        $request = Request::create('https://localhost/', 'GET');
+        $response->prepare($request);
+
+        $this->assertTrue($cookie->isSecure());
+    }
+
     public function testGetOriginalContent()
     {
         $arr = ['foo' => 'bar'];

--- a/tests/Integration/Session/CookieSessionHandlerTest.php
+++ b/tests/Integration/Session/CookieSessionHandlerTest.php
@@ -20,6 +20,25 @@ class CookieSessionHandlerTest extends TestCase
         $this->assertEquals(0, $sessionValueCookie->getExpiresTime());
     }
 
+    public function testCookieSessionInheritsRequestSecureState()
+    {
+        Route::get('/', fn () => '')->middleware('web');
+
+        $unsecureResponse = $this->get('/');
+        $unsecureSessionIdCookie = $unsecureResponse->getCookie('laravel_session');
+        $unsecureSessionValueCookie = $unsecureResponse->getCookie($unsecureSessionIdCookie->getValue());
+
+        $this->assertFalse($unsecureSessionIdCookie->isSecure());
+        $this->assertFalse($unsecureSessionValueCookie->isSecure());
+
+        $secureResponse = $this->get('https://localhost/');
+        $secureSessionIdCookie = $secureResponse->getCookie('laravel_session');
+        $secureSessionValueCookie = $secureResponse->getCookie($secureSessionIdCookie->getValue());
+
+        $this->assertTrue($secureSessionIdCookie->isSecure());
+        $this->assertTrue($secureSessionValueCookie->isSecure());
+    }
+
     protected function defineEnvironment($app)
     {
         $app['config']->set('app.key', Str::random(32));


### PR DESCRIPTION
This PR auto-secures cookies as implemented in https://github.com/symfony/symfony/pull/28447. `VerifyCsrfToken` middleware already auto-secures cookies since it doesn't pass a fallback value `false` to the Cookie's `secure` attribute. 

By passing `null`, the `secureDefault` value from the Cookie takes over.

In the `prepare` method of `Illuminate\Http\Response` (`Symfony\Component\HttpFoundation\Response`) , the cookies inherit the "secure" attribute from the request:

```
if ($request->isSecure()) {
    foreach ($headers->getCookies() as $cookie) {
        $cookie->setSecureDefault(true);
    }
}
```
This behavior would be a good balance between making applications "safe by default" and not breaking existing ones. It further provides a solution to the discussion in https://github.com/laravel/laravel/pull/6437 