### PR TITLE
[11.x] Fix `Factory::afterCreating` callable argument type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -678,7 +678,7 @@ abstract class Factory
     /**
      * Add a new "after creating" callback to the model definition.
      *
-     * @param  \Closure(TModel): mixed  $callback
+     * @param  \Closure(TModel, \Illuminate\Database\Eloquent\Model|null): mixed  $callback
      * @return static
      */
     public function afterCreating(Closure $callback)


### PR DESCRIPTION
For some reason, #52335 was documented as part of [the v11.20.0 release](https://github.com/laravel/framework/releases/tag/v11.20.0), even though the changes were not backported to the `11.x` branch.