### PR TITLE
[11.x] add depth to Arr mapWithKeys

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -622,9 +622,10 @@ class Arr
      *
      * @param  array<TKey, TValue>  $array
      * @param  callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue>  $callback
+     * @param  int  $depth
      * @return array
      */
-    public static function mapWithKeys(array $array, callable $callback)
+    public static function mapWithKeys(array $array, callable $callback, $depth = 1)
     {
         $result = [];
 
@@ -632,6 +633,9 @@ class Arr
             $assoc = $callback($value, $key);
 
             foreach ($assoc as $mapKey => $mapValue) {
+                if (is_array($mapValue) && $depth > 1) {
+                    $mapValue = self::mapWithKeys($mapValue, $callback, $depth - 1);
+                }
                 $result[$mapKey] = $mapValue;
             }
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -788,19 +789,52 @@ class SupportArrTest extends TestCase
 
     public function testMapWithKeys()
     {
-        $data = [
+        $depthOneData = [
             ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
             ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
             ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
         ];
+        $depthTwoData = [
+            'Pikachu' => [
+                'Type' => 'Electric',
+                'Level' => 25,
+                'Moves' => ['Thunder Shock', 'Quick Attack', 'Iron Tail', 'Electro Ball'],
+            ],
+            'Charmander' => [
+                'Type' => 'Fire',
+                'Level' => 15,
+                'Moves' => ['Ember', 'Scratch', 'Growl', 'Smokescreen'],
+            ],
+        ];
 
-        $data = Arr::mapWithKeys($data, function ($pokemon) {
+        $expectedDepthOneData = ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'];
+        $expectedDepthTwoData = [
+            'PIKACHU' => [
+                'TYPE' => 'Electric',
+                'LEVEL' => 25,
+                'MOVES' => ['Thunder Shock', 'Quick Attack', 'Iron Tail', 'Electro Ball'],
+            ],
+            'CHARMANDER' => [
+                'TYPE' => 'Fire',
+                'LEVEL' => 15,
+                'MOVES' => ['Ember', 'Scratch', 'Growl', 'Smokescreen'],
+            ],
+        ];
+
+        $depthOneResult = Arr::mapWithKeys($depthOneData, function ($pokemon) {
             return [$pokemon['name'] => $pokemon['type']];
         });
+        $depthTwoResult = Arr::mapWithKeys($depthTwoData, function ($value, $key) {
+            return [Str::upper($key) => $value];
+        }, 2);
 
         $this->assertEquals(
-            ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
-            $data
+            $expectedDepthOneData,
+            $depthOneResult
+        );
+        $this->assertEquals(
+            $expectedDepthTwoData,
+            $depthTwoResult
         );
     }
 


### PR DESCRIPTION
Hey folks,

This adds a $depth param to the `Arr::mapWithKeys` method.
It defaults to 1, thus does not change the previous behaviour. 

Example usage:
```php
$data = ["hello_laravel" => ["hello" => "world"]];

Arr::mapWithKeys($data, function ($value, $key) {
    return [Str::upper($key) => $value];
}, 2);
// ["HELLO_LARAVEL" => ["HELLO" => "world"]];
```

Greetings from Germany,
Sascha
