### PR TITLE
[11.x] Support attributes in `app()->call()`

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -63,7 +63,9 @@ class BoundMethod
         }
 
         return static::call(
-            $container, [$container->make($segments[0]), $method], $parameters
+            $container,
+            [$container->make($segments[0]), $method],
+            $parameters
         );
     }
 
@@ -159,34 +161,47 @@ class BoundMethod
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected static function addDependencyForCallParameter($container, $parameter,
-                                                            array &$parameters, &$dependencies)
-    {
+    protected static function addDependencyForCallParameter(
+        $container,
+        $parameter,
+        array &$parameters,
+        &$dependencies
+    ) {
+        $pendingDependencies = [];
+
         if (array_key_exists($paramName = $parameter->getName(), $parameters)) {
-            $dependencies[] = $parameters[$paramName];
+            $pendingDependencies[] = $parameters[$paramName];
 
             unset($parameters[$paramName]);
+        } elseif ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
+            $pendingDependencies[] = $container->resolveFromAttribute($attribute);
         } elseif (! is_null($className = Util::getParameterClassName($parameter))) {
             if (array_key_exists($className, $parameters)) {
-                $dependencies[] = $parameters[$className];
+                $pendingDependencies[] = $parameters[$className];
 
                 unset($parameters[$className]);
             } elseif ($parameter->isVariadic()) {
                 $variadicDependencies = $container->make($className);
 
-                $dependencies = array_merge($dependencies, is_array($variadicDependencies)
+                $pendingDependencies = array_merge($pendingDependencies, is_array($variadicDependencies)
                             ? $variadicDependencies
                             : [$variadicDependencies]);
             } else {
-                $dependencies[] = $container->make($className);
+                $pendingDependencies[] = $container->make($className);
             }
         } elseif ($parameter->isDefaultValueAvailable()) {
-            $dependencies[] = $parameter->getDefaultValue();
+            $pendingDependencies[] = $parameter->getDefaultValue();
         } elseif (! $parameter->isOptional() && ! array_key_exists($paramName, $parameters)) {
             $message = "Unable to resolve dependency [{$parameter}] in class {$parameter->getDeclaringClass()->getName()}";
 
             throw new BindingResolutionException($message);
         }
+
+        foreach ($pendingDependencies as $dependency) {
+            $container->fireAfterResolvingAttributeCallbacks($parameter->getAttributes(), $dependency);
+        }
+
+        $dependencies = array_merge($dependencies, $pendingDependencies);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1010,7 +1010,7 @@ class Container implements ArrayAccess, ContainerContract
 
             $result = null;
 
-            if (! is_null($attribute = $this->getContextualAttributeFromDependency($dependency))) {
+            if (! is_null($attribute = Util::getContextualAttributeFromDependency($dependency))) {
                 $result = $this->resolveFromAttribute($attribute);
             }
 
@@ -1065,17 +1065,6 @@ class Container implements ArrayAccess, ContainerContract
     protected function getLastParameterOverride()
     {
         return count($this->with) ? end($this->with) : [];
-    }
-
-    /**
-     * Get a contextual attribute from a dependency.
-     *
-     * @param  ReflectionParameter  $dependency
-     * @return \ReflectionAttribute|null
-     */
-    protected function getContextualAttributeFromDependency($dependency)
-    {
-        return $dependency->getAttributes(ContextualAttribute::class, ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
     }
 
     /**
@@ -1164,7 +1153,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \ReflectionAttribute  $attribute
      * @return mixed
      */
-    protected function resolveFromAttribute(ReflectionAttribute $attribute)
+    public function resolveFromAttribute(ReflectionAttribute $attribute)
     {
         $handler = $this->contextualAttributes[$attribute->getName()] ?? null;
 
@@ -1363,7 +1352,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  mixed  $object
      * @return void
      */
-    protected function fireAfterResolvingAttributeCallbacks(array $attributes, $object)
+    public function fireAfterResolvingAttributeCallbacks(array $attributes, $object)
     {
         foreach ($attributes as $attribute) {
             if (is_a($attribute->getName(), ContextualAttribute::class, true)) {

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Container;
 
 use Closure;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use ReflectionAttribute;
 use ReflectionNamedType;
 
 /**
@@ -70,5 +72,16 @@ class Util
         }
 
         return $name;
+    }
+
+    /**
+     * Get a contextual attribute from a dependency.
+     *
+     * @param  ReflectionParameter  $dependency
+     * @return \ReflectionAttribute|null
+     */
+    public static function getContextualAttributeFromDependency($dependency)
+    {
+        return $dependency->getAttributes(ContextualAttribute::class, ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
     }
 }

--- a/src/Illuminate/Routing/ResolvesRouteDependencies.php
+++ b/src/Illuminate/Routing/ResolvesRouteDependencies.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Container\Util;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
 use ReflectionClass;
@@ -57,6 +58,8 @@ trait ResolvesRouteDependencies
                       $parameter->isDefaultValueAvailable()) {
                 $this->spliceIntoParameters($parameters, $key, $parameter->getDefaultValue());
             }
+
+            $this->container->fireAfterResolvingAttributeCallbacks($parameter->getAttributes(), $instance);
         }
 
         return $parameters;
@@ -73,6 +76,10 @@ trait ResolvesRouteDependencies
     protected function transformDependency(ReflectionParameter $parameter, $parameters, $skippableValue)
     {
         $className = Reflector::getParameterClassName($parameter);
+
+        if ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
+            return $this->container->resolveFromAttribute($attribute);
+        }
 
         // If the parameter has a type-hinted class, we will check to see if it is already in
         // the list of parameters. If it is we will just skip it as it is probably a model

--- a/tests/Container/AfterResolvingAttributeCallbackTest.php
+++ b/tests/Container/AfterResolvingAttributeCallbackTest.php
@@ -57,6 +57,21 @@ class AfterResolvingAttributeCallbackTest extends TestCase
         $this->assertInstanceOf(ContainerTestHasSelfConfiguringAttributeAndConstructor::class, $instance);
         $this->assertEquals('the-right-value', $instance->value);
     }
+
+    public function testCallbackIsCalledOnAppCall()
+    {
+        $container = new Container();
+
+        $container->afterResolvingAttribute(ContainerTestOnTenant::class, function (ContainerTestOnTenant $attribute, HasTenantImpl $hasTenantImpl, Container $container) {
+            $hasTenantImpl->onTenant($attribute->tenant);
+        });
+
+        $tenant = $container->call(function (#[ContainerTestOnTenant(Tenant::TenantA)] HasTenantImpl $property) {
+            return $property->tenant;
+        });
+
+        $this->assertEquals(Tenant::TenantA, $tenant);
+    }
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -208,6 +208,33 @@ class ContextualAttributeBindingTest extends TestCase
 
         $container->make(StorageTest::class);
     }
+
+    public function testInjectionWithAttributeOnAppCall()
+    {
+        $container = new Container;
+
+        $person = $container->call(function (ContainerTestHasConfigValueWithResolvePropertyAndAfterCallback $hasAttribute) {
+            return $hasAttribute->person;
+        });
+
+        $this->assertEquals('Taylor', $person->name);
+    }
+
+    public function testAttributeOnAppCall()
+    {
+        $container = new Container;
+        $container->singleton('config', fn () => new Repository([
+            'app' => [
+                'timezone' => 'Europe/Paris',
+            ],
+        ]));
+
+        $value = $container->call(function (#[Config('app.timezone')] string $value) {
+            return $value;
+        });
+
+        $this->assertEquals('Europe/Paris', $value);
+    }
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1125,7 +1125,7 @@ class RoutingRouteTest extends TestCase
             'middleware' => SubstituteBindings::class,
             'uses' => function (#[Config('app.timezone')] string $value) {
                 return $value;
-            }
+            },
         ]);
 
         $this->assertSame('Europe/Paris', $router->dispatch(Request::create('foo', 'GET'))->getContent());
@@ -1146,7 +1146,7 @@ class RoutingRouteTest extends TestCase
             'middleware' => SubstituteBindings::class,
             'uses' => function (#[RoutingTestOnTenant(RoutingTestTenant::TenantA)] RoutingTestHasTenantImpl $property) {
                 return $property->tenant->name;
-            }
+            },
         ]);
 
         $this->assertSame('TenantA', $router->dispatch(Request::create('foo', 'GET'))->getContent());
@@ -2684,7 +2684,6 @@ class ExampleMiddleware implements ExampleMiddlewareContract
         return $next($request);
     }
 }
-
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 final class RoutingTestOnTenant

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2,11 +2,14 @@
 
 namespace Illuminate\Tests\Routing;
 
+use Attribute;
 use Closure;
 use DateTime;
 use Exception;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\Authorize;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Attributes\Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
@@ -1105,6 +1108,48 @@ class RoutingRouteTest extends TestCase
         }]);
         $router->model('bar', RouteModelInterface::class);
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testRouteDependenciesCanBeResolvedThroughAttributes()
+    {
+        $container = new Container;
+        $container->singleton('config', fn () => new Repository([
+            'app' => [
+                'timezone' => 'Europe/Paris',
+            ],
+        ]));
+        $router = new Router(new Dispatcher, $container);
+        $container->instance(Registrar::class, $router);
+        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $router->get('foo', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (#[Config('app.timezone')] string $value) {
+                return $value;
+            }
+        ]);
+
+        $this->assertSame('Europe/Paris', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
+    public function testAfterResolvingAttributeCallbackIsCalledOnRouteDependenciesResolution()
+    {
+        $container = new Container();
+        $router = new Router(new Dispatcher, $container);
+        $container->instance(Registrar::class, $router);
+        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+
+        $container->afterResolvingAttribute(RoutingTestOnTenant::class, function (RoutingTestOnTenant $attribute, RoutingTestHasTenantImpl $hasTenantImpl, Container $container) {
+            $hasTenantImpl->onTenant($attribute->tenant);
+        });
+
+        $router->get('foo', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (#[RoutingTestOnTenant(RoutingTestTenant::TenantA)] RoutingTestHasTenantImpl $property) {
+                return $property->tenant->name;
+            }
+        ]);
+
+        $this->assertSame('TenantA', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
     public function testGroupMerging()
@@ -2637,5 +2682,31 @@ class ExampleMiddleware implements ExampleMiddlewareContract
     public function handle($request, Closure $next)
     {
         return $next($request);
+    }
+}
+
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class RoutingTestOnTenant
+{
+    public function __construct(
+        public readonly RoutingTestTenant $tenant
+    ) {
+    }
+}
+
+enum RoutingTestTenant
+{
+    case TenantA;
+    case TenantB;
+}
+
+final class RoutingTestHasTenantImpl
+{
+    public ?RoutingTestTenant $tenant = null;
+
+    public function onTenant(RoutingTestTenant $tenant): void
+    {
+        $this->tenant = $tenant;
     }
 }


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/laravel/framework/pull/51934. It adds support for the same features on `app()->call()`, therefore supporting parameters injected to routes, `handle` methods, etc.

### Important note
Since the resolution of the dependencies of closures happens outside of the container itself (in `BoundMethod`), we don't have access to methods that are needed for this to work.

Specifically:
- `resolveFromAttribute`
- `fireAfterResolvingAttributeCallbacks`

These cannot be copied to `BoundMethod` because they depend on properties of the container (`contextualAttributes` and `afterResolvingAttributeCallbacks`).

I couldn't find a clean solution for this that didn't involve a bigger refactor. For now, I made these methods public, but the pull request cannot be merged as-is, as we do not want them to be available to the public API.

### Possible solutions

- I thought of refactoring `BoundMethod#addDependencyForCallParameter` to use `Container#resolveDependencies`, but it doesn't support the `$parameters` array and its behavior is slightly different.
- `BoundMethod` could be integrated into the `Container` itself (but we can't get rid of the class entirely, it is not marked as `@internal`, projects like Livewire use it).
- We could invade methods of the container, but this is slow and hacky.

Any suggestion?