### PR TITLE
[11.x] Improved Email Verification Hash Security

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -85,7 +85,7 @@ class VerifyEmail extends Notification
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             [
                 'id' => $notifiable->getKey(),
-                'hash' => sha1($notifiable->getEmailForVerification() . $notifiable->created_at),
+                'hash' => sha1($notifiable->getEmailForVerification().$notifiable->created_at),
             ]
         );
     }

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -85,7 +85,7 @@ class VerifyEmail extends Notification
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             [
                 'id' => $notifiable->getKey(),
-                'hash' => sha1($notifiable->getEmailForVerification()),
+                'hash' => sha1($notifiable->getEmailForVerification() . $notifiable->created_at),
             ]
         );
     }

--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -19,7 +19,7 @@ class EmailVerificationRequest extends FormRequest
             return false;
         }
 
-        if (! hash_equals(sha1($this->user()->getEmailForVerification()), (string) $this->route('hash'))) {
+        if (! hash_equals(sha1($this->user()->getEmailForVerification() . $this->user()->created_at), (string) $this->route('hash'))) {
             return false;
         }
 

--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -19,7 +19,7 @@ class EmailVerificationRequest extends FormRequest
             return false;
         }
 
-        if (! hash_equals(sha1($this->user()->getEmailForVerification() . $this->user()->created_at), (string) $this->route('hash'))) {
+        if (! hash_equals(sha1($this->user()->getEmailForVerification().$this->user()->created_at), (string) $this->route('hash'))) {
             return false;
         }
 

--- a/tests/Hashing/HashTest.php
+++ b/tests/Hashing/HashTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Hashing;
+
+use Carbon\Carbon;
+use Orchestra\Testbench\TestCase;
+
+class HashTest extends TestCase
+{
+    public function testSha1HashIsConsistentForSameInput()
+    {
+        $email = 'taylor@laravel.com';
+        $timeStamp = Carbon::now();
+
+        $firstHash = sha1($email . $timeStamp);
+        $secondHash= sha1($email . $timeStamp);
+
+        $this->assertTrue(hash_equals($firstHash, $secondHash));
+    }
+}

--- a/tests/Hashing/HashTest.php
+++ b/tests/Hashing/HashTest.php
@@ -12,8 +12,8 @@ class HashTest extends TestCase
         $email = 'taylor@laravel.com';
         $timeStamp = Carbon::now();
 
-        $firstHash = sha1($email . $timeStamp);
-        $secondHash= sha1($email . $timeStamp);
+        $firstHash = sha1($email.$timeStamp);
+        $secondHash = sha1($email.$timeStamp);
 
         $this->assertTrue(hash_equals($firstHash, $secondHash));
     }


### PR DESCRIPTION
**Description**

Hey all !!
This pull request enhances the security of the email verification process in Laravel by incorporating a timestamp into the hash generation.

While working on a project, I realized that if someone bypasses Laravel's signed routes and relies solely on EmailVerificationRequest for validation, a hash created with just the user's email could be easily replicated by anyone who knows the email. By adding a timestamp to the hash, we significantly strengthen its security.

Additionally, if an organisation uses signed routes, a former employee with knowledge of the app key might try to exploit their previous access. By including a timestamp in the hash, we add an extra layer of security, making it significantly harder for such individuals to misuse their former access. If this idea is approved, my next proposal will be to improve the security of signed routes further.

**Backward Compatibility**

Existing users and routes remain unaffected, as the changes are internal to the hash generation and validation logic.

**Testing**

A new unit test is added to ensure the consistency and correctness of the hash when both the email and timestamp are used. This test verifies that the hash generation is deterministic and produces the same hash for the same input values.

**Thank You**

Thanks for reviewing my PR and for all the efforts you are making to provide the Laravel community with a strong and feature-rich framework.

Hadees Ahmed
