### PR TITLE
[11.x] Automatically generate markdown file name via `Str::kebab` for notification command

### DIFF
--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\text;
 
 #[AsCommand(name: 'make:notification')]
 class NotificationMakeCommand extends GeneratorCommand

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -143,7 +144,7 @@ class NotificationMakeCommand extends GeneratorCommand
         $wantsMarkdownView = confirm('Would you like to create a markdown view?');
 
         if ($wantsMarkdownView) {
-            $markdownView = text('What should the markdown view be named?', 'E.g. invoice-paid');
+            $markdownView = Str::kebab($this->argument('name'));
             $input->setOption('markdown', $markdownView);
         }
     }

--- a/tests/Integration/Generators/NotificationMakeCommandTest.php
+++ b/tests/Integration/Generators/NotificationMakeCommandTest.php
@@ -68,7 +68,6 @@ class NotificationMakeCommandTest extends TestCase
         $this->artisan('make:notification')
             ->expectsQuestion('What should the notification be named?', 'FooNotification')
             ->expectsQuestion('Would you like to create a markdown view?', true)
-            ->expectsQuestion('What should the markdown view be named?', 'foo-notification')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Notifications/FooNotification.php');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR improves the step for `Notification Make Command` when no initial inputs are provided (Refer to #52355). It would generate the markdown file name using `Str::kebab` instead of manual input.

The automatically generated approach also refers to the `Mail Make Command`, which similarly generates the markdown file name.

https://github.com/user-attachments/assets/4e3263c0-629d-4ec0-98dd-0976acc7650a

Refers to `Mail Make Command`:

https://github.com/user-attachments/assets/4b26f1cc-1f8d-4678-92c9-655caa2c1663

