### PR TITLE
[11.x] Add `forceDestroy` to `SoftDeletes`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1475,6 +1475,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Force a hard destroy on a soft deleted model.
+     *
+     * This method protects developers from running forceDestroy when the trait is missing.
+     *
+     * @return bool|null
+     */
+    public static function forceDestroy($ids)
+    {
+        return static::destroy($ids);
+    }
+
+    /**
      * Perform the actual delete query on this model instance.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1479,6 +1479,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * This method protects developers from running forceDestroy when the trait is missing.
      *
+     * @param  \Illuminate\Support\Collection|array|int|string  $ids
      * @return bool|null
      */
     public static function forceDestroy($ids)

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -243,6 +243,68 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertTrue($user->exists);
     }
 
+    public function testForceDestroyFullyDeletesRecord()
+    {
+        $this->createUsers();
+        $deleted = SoftDeletesTestUser::forceDestroy(2);
+
+        $this->assertSame(1, $deleted);
+
+        $users = SoftDeletesTestUser::withTrashed()->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(1, $users->first()->id);
+        $this->assertNull(SoftDeletesTestUser::find(2));
+    }
+
+    public function testForceDestroyDeletesAlreadyDeletedRecord()
+    {
+        $this->createUsers();
+        $deleted = SoftDeletesTestUser::forceDestroy(1);
+
+        $this->assertSame(1, $deleted);
+
+        $users = SoftDeletesTestUser::withTrashed()->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(2, $users->first()->id);
+        $this->assertNull(SoftDeletesTestUser::find(1));
+    }
+
+    public function testForceDestroyDeletesMultipleRecords()
+    {
+        $this->createUsers();
+        $deleted = SoftDeletesTestUser::forceDestroy([1, 2]);
+
+        $this->assertSame(2, $deleted);
+
+        $this->assertTrue(SoftDeletesTestUser::withTrashed()->get()->isEmpty());
+    }
+
+    public function testForceDestroyDeletesRecordsFromCollection()
+    {
+        $this->createUsers();
+        $deleted = SoftDeletesTestUser::forceDestroy(collect([1, 2]));
+
+        $this->assertSame(2, $deleted);
+
+        $this->assertTrue(SoftDeletesTestUser::withTrashed()->get()->isEmpty());
+    }
+
+    public function testForceDestroyDeletesRecordsFromEloquentCollection()
+    {
+        $this->createUsers();
+        $deleted = SoftDeletesTestUser::forceDestroy(SoftDeletesTestUser::all());
+
+        $this->assertSame(1, $deleted);
+
+        $users = SoftDeletesTestUser::withTrashed()->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(1, $users->first()->id);
+        $this->assertNull(SoftDeletesTestUser::find(2));
+    }
+
     public function testRestoreRestoresRecords()
     {
         $this->createUsers();


### PR DESCRIPTION
When working with a soft deleted model the other day, I reached for `forceDestroy` but it wasn't there. I thought this might be a good addition to the `SoftDeletes` trait.

**Before**
```php
$comment = Comment::find(1);
$comment->forceDelete();
```

**After**
```php
Comment::forceDestroy(1);
```

Similar to `Model::destroy()`, you may also pass `forceDestroy` an array or collection of ids, as well as an Eloquent collection of models to force destroy.