### PR TITLE
[12.x] Switch models to UUID v7

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -34,7 +34,7 @@ trait HasUuids
      */
     public function newUniqueId()
     {
-        return (string) Str::orderedUuid();
+        return (string) Str::uuid7();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasVersion4Uuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasVersion4Uuids.php
@@ -4,17 +4,17 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Support\Str;
 
-trait HasVersion7Uuids
+trait HasVersion4Uuids
 {
     use HasUuids;
 
     /**
-     * Generate a new UUID (version 7) for the model.
+     * Generate a new UUID (version 4) for the model.
      *
      * @return string
      */
     public function newUniqueId()
     {
-        return (string) Str::uuid7();
+        return (string) Str::orderedUuid();
     }
 }


### PR DESCRIPTION
Based on #52029, I'm proposing to switch the `HasUuids` trait to UUID v7.

This change is similar to the reverted #44210 but addresses its [privacy concerns](https://github.com/laravel/framework/pull/44210#issuecomment-1256833746): While #44210 switched _all_ UUIDs to v7, this PR only targets model UUIDs and they already contain a timestamp in the current implementation. 

v7 is a standardized format, while the UUIDs generated by `Str::orderedUuid()` at the moment are only a custom variant of the v4 standard.

At least on PostgreSQL, v7 UUIDs also seem to [perform much better](https://x.com/maciejwalkowiak/status/1809164757959938376).

# Upgrade

This is a [breaking change](https://github.com/laravel/framework/pull/44210#issuecomment-1373385979) for users of the trait that rely on the sortability of UUIDs. The affected models need to continue generating UUIDs with `Str::orderedUuid()`. I added a legacy `HasVersion4Uuids` trait because that's the most convenient solution, IMO.

I removed the `HasVersion7Uuids` trait from #52029 because it's redundant now. We could also deprecate it and remove it later.