### PR TITLE
[11.x] Add `withoutHeaders` method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -104,6 +104,21 @@ trait MakesHttpRequests
     }
 
     /**
+     * Remove headers from the request.
+     *
+     * @param  array  $headers
+     * @return $this
+     */
+    public function withoutHeaders(array $headers)
+    {
+        foreach ($headers as $name) {
+            $this->withoutHeader($name);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add an authorization token for the request.
      *
      * @param  string  $token

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -30,6 +30,17 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('http://localhost/previous/url', $this->app['session']->previousUrl());
     }
 
+    public function testFromRemoveHeader()
+    {
+        $this->withHeader('name', 'Milwad')->from('previous/url');
+
+        $this->assertEquals('Milwad', $this->defaultHeaders['name']);
+
+        $this->withoutHeader('name')->from('previous/url');
+
+        $this->assertArrayNotHasKey('name', $this->defaultHeaders);
+    }
+
     public function testWithTokenSetsAuthorizationHeader()
     {
         $this->withToken('foobar');

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -41,6 +41,22 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertArrayNotHasKey('name', $this->defaultHeaders);
     }
 
+    public function testFromRemoveHeaders()
+    {
+        $this->withHeaders([
+            'name' => 'Milwad',
+            'foo' => 'bar'
+        ])->from('previous/url');
+
+        $this->assertEquals('Milwad', $this->defaultHeaders['name']);
+        $this->assertEquals('bar', $this->defaultHeaders['foo']);
+
+        $this->withoutHeaders(['name', 'foo'])->from('previous/url');
+
+        $this->assertArrayNotHasKey('name', $this->defaultHeaders);
+        $this->assertArrayNotHasKey('foo', $this->defaultHeaders);
+    }
+
     public function testWithTokenSetsAuthorizationHeader()
     {
         $this->withToken('foobar');

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -45,7 +45,7 @@ class MakesHttpRequestsTest extends TestCase
     {
         $this->withHeaders([
             'name' => 'Milwad',
-            'foo' => 'bar'
+            'foo' => 'bar',
         ])->from('previous/url');
 
         $this->assertEquals('Milwad', $this->defaultHeaders['name']);


### PR DESCRIPTION
https://github.com/laravel/framework/pull/52321

I've added tests for `withoutHeaders` and `withHeaders`.

```php
Before:
$this->withoutHeader('name')->withoutHeader('foo')->from('previous/url');

After: 
$this->withoutHeaders(['name', 'foo'])->from('previous/url');
```