### PR TITLE
[11.x] Handle listener after transaction when it implements ShouldHandleEventsAfterCommit

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -663,7 +663,7 @@ class Dispatcher implements DispatcherContract
         return tap($job, function ($job) use ($listener) {
             $data = array_values($job->data);
 
-            if ($listener instanceof ShouldQueueAfterCommit) {
+            if ($listener instanceof ShouldQueueAfterCommit || $listener instanceof ShouldHandleEventsAfterCommit) {
                 $job->afterCommit = true;
             } else {
                 $job->afterCommit = property_exists($listener, 'afterCommit') ? $listener->afterCommit : null;


### PR DESCRIPTION
I came across an issue with a [queued listener that should be handled after transaction](https://laravel.com/docs/11.x/events#queued-event-listeners-and-database-transactions). It just dispatches the listener regardless whether it implements the interface or no.

Look at bug report to understand the issue better: https://github.com/laravel/framework/issues/52440

---

Upd: I feel like that might not be a bug but rather a mistake [in the docs](https://laravel.com/docs/11.x/events#queued-event-listeners-and-database-transactions) and it should use `ShouldQueueAfterCommit` instead. If so, `ShouldHandleEventsAfterCommit` is supposed to be added to listeners that don't implement `ShouldQueue` [since it won't simply work](https://github.com/laravel/framework/blob/0e39947275707a82c63465e91c132d38152b8fc9/src/Illuminate/Events/Dispatcher.php#L498). What's the use case for `ShouldHandleEventsAfterCommit` then?