### PR TITLE
Non-utf8 input on `fulltext` query in BOOLEAN mode

### DIFF
--- a/tests/Integration/Database/MySql/FulltextTest.php
+++ b/tests/Integration/Database/MySql/FulltextTest.php
@@ -53,7 +53,7 @@ class FulltextTest extends MySqlTestCase
 
     public function testWhereFulltextWithNonUtf8Input()
     {
-        $articles = DB::table('articles')->whereFulltext(['title', 'body'], '😊😊')->get();
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], '+😊*', ['mode' => 'boolean'])->get();
 
         $this->assertCount(0, $articles);
     }

--- a/tests/Integration/Database/MySql/FulltextTest.php
+++ b/tests/Integration/Database/MySql/FulltextTest.php
@@ -51,6 +51,13 @@ class FulltextTest extends MySqlTestCase
         $this->assertSame('MySQL vs. YourSQL', $articles[1]->title);
     }
 
+    public function testWhereFulltextWithNonUtf8Input()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], '😊😊')->get();
+
+        $this->assertCount(0, $articles);
+    }
+
     /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html */
     public function testWhereFulltextWithBooleanMode()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


Getting the following error when having some UTF-16 chars on a fulltext boolean query:

```
Illuminate\Database\QueryException  SQLSTATE[42000]: Syntax error or access violation: 1064 syntax error, unexpected $end (Connection: mysql, SQL: select * from `table` where match (`fulltext`) against ('+😊' in boolean mode) limit 1).
```

I am not sure this is a problem on Laravel/Eloquent itself, although I think it could maybe give some help to the developer in case this happens.

The "bad" fulltext boolean query used breaks because part of its mult-byte content is a fulltext operator itself.

Interestingly enough, running the same query via a client i.e TablePlus, the query runs properly - so it must be something on Eloquent <> PHP MySQL Driver <> MySQL to blame here.

```
> $s = '😊'

> strlen($s)
= 4

> mb_strlen($s)
= 1

> $s[0]
= b"ð"

> $s[1]
= b"Ÿ"

> $s[2]
= b"˜"

> $s[3]
= b"Š"
```

Assuming that because one of the multi-byte composing bytes is a tilde (`~`) that is messing with MySQL query interpretation.