### PR TITLE
Add `CommandErrored` to listen the `ConsoleErrorEvent`

### DIFF
--- a/src/Illuminate/Console/Events/CommandErrored.php
+++ b/src/Illuminate/Console/Events/CommandErrored.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+class CommandErrored
+{
+    /**
+     * The command name.
+     *
+     * @var string
+     */
+    public $command;
+
+    /**
+     * The console input implementation.
+     *
+     * @var \Symfony\Component\Console\Input\InputInterface|null
+     */
+    public $input;
+
+    /**
+     * The command output implementation.
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface|null
+     */
+    public $output;
+
+    /**
+     * The error that was thrown.
+     *
+     * @var \Throwable
+     */
+    public $error;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $command
+     * @param  \Symfony\Component\Console\Input\InputInterface|null  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface|null  $output
+     * @param  \Throwable  $error
+     * @return void
+     */
+    public function __construct($command, InputInterface $input, OutputInterface $output, Throwable $error) {
+        $this->command = $command;
+        $this->input = $input;
+        $this->output = $output;
+        $this->error = $error;
+    }
+}

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -7,6 +7,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Command;
+use Illuminate\Console\Events\CommandErrored;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Console\Scheduling\Schedule;
@@ -24,6 +25,7 @@ use ReflectionClass;
 use SplFileInfo;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
@@ -169,6 +171,12 @@ class Kernel implements KernelContract
             $this->symfonyDispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) {
                 $this->events->dispatch(
                     new CommandFinished($event->getCommand()->getName(), $event->getInput(), $event->getOutput(), $event->getExitCode())
+                );
+            });
+
+            $this->symfonyDispatcher->addListener(ConsoleEvents::ERROR, function (ConsoleErrorEvent $event) {
+                $this->events->dispatch(
+                    new CommandErrored($event->getCommand()->getName(), $event->getInput(), $event->getOutput(), $event->getError())
                 );
             });
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Sometimes, we need to take additional action when a command fails, such as reporting it to our monitoring platform. However, currently, the CommandFinishedEvent is triggered whether the command is successful or not. Although the CommandFinishedEvent contains the exit code, we want to capture the reason for the command failure. Therefore, I created a CommandErroredEvent.