### PR TITLE
Add same_size validation rule.

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -145,6 +145,7 @@ return [
     'required_without' => 'The :attribute field is required when :values is not present.',
     'required_without_all' => 'The :attribute field is required when none of :values are present.',
     'same' => 'The :attribute field must match :other.',
+    'same_size' => 'The :attribute field size must match the :other size.',
     'size' => [
         'array' => 'The :attribute field must contain :size items.',
         'file' => 'The :attribute field must be :size kilobytes.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -716,6 +716,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the same size rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceSameSize($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':other', $this->getDisplayableAttribute($parameters[0]), $message);
+    }
+
+    /**
      * Replace all place-holders for the before rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2370,7 +2370,7 @@ trait ValidatesAttributes
         return $value === $other;
     }
 
-     /**
+    /**
      * Validate that the size of two attributes match.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2370,6 +2370,23 @@ trait ValidatesAttributes
         return $value === $other;
     }
 
+     /**
+     * Validate that the size of two attributes match.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateSameSize($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'same_size');
+
+        $other = Arr::get($this->data, $parameters[0]);
+
+        return BigNumber::of($this->getSize($attribute, $value))->isEqualTo($this->getSize($parameters[0], $other));
+    }
+
     /**
      * Validate the size of an attribute.
      *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -272,6 +272,7 @@ class Validator implements ValidatorContract
         'MissingWith',
         'MissingWithAll',
         'Same',
+        'SameSize',
         'Unique',
     ];
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2158,6 +2158,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => [1], 'baz' => [2, 3]], ['foo' => 'same_size:baz']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['bar'], 'baz' => ['bar']], ['foo.*' => 'same_size:baz.*']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['bar', 'boo'], 'baz' => ['bar', 'boom']], ['foo.*' => 'same_size:baz.*']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateDifferent()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2129,6 +2129,37 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateSameSize()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'same_size:baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'same_size:baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'bar'], ['foo' => 'same_size:baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1e2', 'baz' => '100'], ['foo' => 'same_size:baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => null, 'baz' => null], ['foo' => 'same_size:baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 1, 'baz' => 2], ['foo' => 'same_size:baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 1, 'baz' => 2], ['foo' => 'same_size:baz', 'baz' => 'numeric']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1], 'baz' => [2]], ['foo' => 'same_size:baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1], 'baz' => [2, 3]], ['foo' => 'same_size:baz']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateDifferent()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a simple `same_size` validation rule, allowing developers to ensure that two fields share the same size.

For example, when posting files to the server you may also wish to associate metadata with those files. Currently, developers must write a custom rule to ensure the `metadata` array contains an entry for each of the `files` being uploaded.

With this PR, the validation can be applied as:

```
'files' => ['array'],
'files.* => ['file'],
'metadata' => ['array', 'same_size:files`],
```

The logic for calculating field size is that of the existing `size` rule, meaning the rule can be applied (less helpfully, but consistently) to strings, numbers and files.