### PR TITLE
[11.x] Removed null safe operator from whereNotMorphedTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -505,12 +505,12 @@ trait QueriesRelationships
                 $model = array_search($model, $morphMap, true);
             }
 
-            return $this->whereNot($relation->qualifyColumn($relation->getMorphType()), '<=>', $model, $boolean);
+            return $this->whereNot($relation->qualifyColumn($relation->getMorphType()), $model, $boolean);
         }
 
         return $this->whereNot(function ($query) use ($relation, $model) {
-            $query->where($relation->qualifyColumn($relation->getMorphType()), '<=>', $model->getMorphClass())
-                ->where($relation->qualifyColumn($relation->getForeignKeyName()), '<=>', $model->getKey());
+            $query->where($relation->qualifyColumn($relation->getMorphType()), $model->getMorphClass())
+                ->where($relation->qualifyColumn($relation->getForeignKeyName()), $model->getKey());
         }, null, null, $boolean);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -505,12 +505,12 @@ trait QueriesRelationships
                 $model = array_search($model, $morphMap, true);
             }
 
-            return $this->whereNot($relation->qualifyColumn($relation->getMorphType()), $model, $boolean);
+            return $this->whereNot($relation->qualifyColumn($relation->getMorphType()), '=', $model, $boolean);
         }
 
         return $this->whereNot(function ($query) use ($relation, $model) {
-            $query->where($relation->qualifyColumn($relation->getMorphType()), $model->getMorphClass())
-                ->where($relation->qualifyColumn($relation->getForeignKeyName()), $model->getKey());
+            $query->where($relation->qualifyColumn($relation->getMorphType()), '=', $model->getMorphClass())
+                ->where($relation->qualifyColumn($relation->getForeignKeyName()), '=', $model->getKey());
         }, null, null, $boolean);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -509,8 +509,8 @@ trait QueriesRelationships
         }
 
         return $this->whereNot(function ($query) use ($relation, $model) {
-            $query->where($relation->qualifyColumn($relation->getMorphType()), '=', $model->getMorphClass())
-                ->where($relation->qualifyColumn($relation->getForeignKeyName()), '=', $model->getKey());
+            $query->where($relation->qualifyColumn($relation->getMorphType()), $model->getMorphClass())
+                ->where($relation->qualifyColumn($relation->getForeignKeyName()), $model->getKey());
         }, null, null, $boolean);
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1797,7 +1797,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->whereNotMorphedTo('morph', $relatedModel);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not ("eloquent_builder_test_model_parent_stubs"."morph_type" <=> ? and "eloquent_builder_test_model_parent_stubs"."morph_id" <=> ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not ("eloquent_builder_test_model_parent_stubs"."morph_type" = ? and "eloquent_builder_test_model_parent_stubs"."morph_id" = ?)', $builder->toSql());
         $this->assertEquals([$relatedModel->getMorphClass(), $relatedModel->getKey()], $builder->getBindings());
     }
 
@@ -1836,7 +1836,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->where('bar', 'baz')->orWhereNotMorphedTo('morph', $relatedModel);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not ("eloquent_builder_test_model_parent_stubs"."morph_type" <=> ? and "eloquent_builder_test_model_parent_stubs"."morph_id" <=> ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not ("eloquent_builder_test_model_parent_stubs"."morph_type" = ? and "eloquent_builder_test_model_parent_stubs"."morph_id" = ?)', $builder->toSql());
         $this->assertEquals(['baz', $relatedModel->getMorphClass(), $relatedModel->getKey()], $builder->getBindings());
     }
 
@@ -1858,7 +1858,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->whereNotMorphedTo('morph', EloquentBuilderTestModelCloseRelatedStub::class);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not "eloquent_builder_test_model_parent_stubs"."morph_type" <=> ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not "eloquent_builder_test_model_parent_stubs"."morph_type" = ?', $builder->toSql());
         $this->assertEquals([EloquentBuilderTestModelCloseRelatedStub::class], $builder->getBindings());
     }
 
@@ -1880,7 +1880,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->where('bar', 'baz')->orWhereNotMorphedTo('morph', EloquentBuilderTestModelCloseRelatedStub::class);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not "eloquent_builder_test_model_parent_stubs"."morph_type" <=> ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not "eloquent_builder_test_model_parent_stubs"."morph_type" = ?', $builder->toSql());
         $this->assertEquals(['baz', EloquentBuilderTestModelCloseRelatedStub::class], $builder->getBindings());
     }
 


### PR DESCRIPTION
Issue Summary:
We identified an issue with the whereNotMorphedTo method in the Laravel framework. The issue stems from the use of the null safe operator <=>, which is not compatible with SQLite and PostgreSQL databases. This operator, while functioning correctly in MySQL, causes errors when used with other database systems.

The following error message was encountered during execution:

`PDOException: SQLSTATE[HY000]: General error: 1 near ">": syntax error
in vendor/laravel/framework/src/Illuminate/Database/Connection.php:407
`

Solution:
To ensure cross-database compatibility and to avoid unexpected errors, we propose removing or replacing the null safe operator <=> in the whereNotMorphedTo method. This change will enhance the framework's reliability across different database systems.

References:
This issue was discussed and partially addressed in a previous PR: [#42878](https://github.com/laravel/framework/pull/42878), which initially proposed the use of the null safe operator.