### PR TITLE
[11.x] Adding `envOrFail()` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -150,6 +150,20 @@ if (! function_exists('env')) {
     }
 }
 
+if (! function_exists('envOrFail')) {
+    /**
+     * Gets the value of an environment variable
+     * or fails if it does not exist
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    function envOrFail($key)
+    {
+        return Env::getOrFail($key);
+    }
+}
+
 if (! function_exists('filled')) {
     /**
      * Determine if a value is "filled".

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -153,7 +153,7 @@ if (! function_exists('env')) {
 if (! function_exists('envOrFail')) {
     /**
      * Gets the value of an environment variable
-     * or fails if it does not exist
+     * or fails if it does not exist.
      *
      * @param  string  $key
      * @return mixed

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1173,6 +1173,16 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('some-value', Env::getOrFail('required-exists'));
     }
 
+    public function testEnvOrFail()
+    {
+        $_SERVER['foo'] = 'bar';
+        $this->assertSame('bar', envOrFail('foo'));
+        $this->assertSame('bar', Env::getOrFail('foo'));
+        $this->expectException(RuntimeException::class);
+        envOrFail('baz');
+        Env::getOrFail('baz');
+    }
+
     public function testLiteral(): void
     {
         $this->assertEquals(1, literal(1));


### PR DESCRIPTION
Oussama [posted a tweet](https://x.com/OussamaMater/status/1822356482349814114) today about the `Env::getOrFail()` method, which allows a developer to ensure that if an environment variable is missing, the app will hard fail.  This can be extremely useful in cases where the env var is an API key and you need to ensure that it's been set correctly, and based on the replies to the tweet, it seems like I'm not the only one who didn't know it exists but would find it helpful.

I wanted to add this helper method so that I don't have to import the `Illuminate\Support\Env` class in every config file where I have API keys being loaded.

Following the current convention, where `env()` actually proxies the `Env::get()` method, I created `envOrFail()` which proxies the `Env::getOrFail()` method.  I'm happy to rename this to something else if requested.

If this PR is accepted, I will also add an entry in the docs publicizing this helper.
