### PR TITLE
[11.x] Handle circular references in model serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php
@@ -44,7 +44,7 @@ trait PreventsCircularRecursion
      * @param  mixed  $default
      * @return mixed
      */
-    protected function once($callback, $default = null)
+    protected function withoutRecursion($callback, $default = null)
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
 
@@ -53,13 +53,12 @@ trait PreventsCircularRecursion
         $object = $onceable->object ?? $this;
         $stack = static::getRecursiveCallStack($object);
 
-        if (isset($stack[$onceable->hash])) {
+        if (array_key_exists($onceable->hash, $stack)) {
             return $stack[$onceable->hash];
         }
 
         try {
-            // Set the default first to prevent recursion
-            $stack[$onceable->hash] = $default;
+            $stack[$onceable->hash] = is_callable($default) ? call_user_func($default) : $default;
             static::getRecursionCache()->offsetSet($object, $stack);
 
             return call_user_func($onceable->callable);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1084,7 +1084,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function push()
     {
-        return $this->once(function () {
+        return $this->withoutRecursion(function () {
             if (! $this->save()) {
                 return false;
             }
@@ -1647,9 +1647,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function toArray()
     {
-        return $this->once(
+        return $this->withoutRecursion(
             fn () => array_merge($this->attributesToArray(), $this->relationsToArray()),
-            $this->attributesToArray(),
+            fn () => $this->attributesToArray(),
         );
     }
 
@@ -1997,7 +1997,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getQueueableRelations()
     {
-        return $this->once(function () {
+        return $this->withoutRecursion(function () {
             $relations = [];
 
             foreach ($this->getRelations() as $key => $relation) {

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Concerns\PreventsCircularRecursion;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        PreventsCircularRecursionWithRecursiveMethod::$globalStack = 0;
+    }
+
+    public function testRecursiveCallsArePreventedWithoutPreventingSubsequentCalls()
+    {
+        $instance = new PreventsCircularRecursionWithRecursiveMethod();
+
+        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(0, $instance->instanceStack);
+
+        $this->assertEquals(0, $instance->callStack());
+        $this->assertEquals(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(1, $instance->instanceStack);
+
+        $this->assertEquals(1, $instance->callStack());
+        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(2, $instance->instanceStack);
+    }
+
+    public function testRecursiveCallsAreLimitedToIndividualInstances()
+    {
+        $instance = new PreventsCircularRecursionWithRecursiveMethod();
+        $other = $instance->other;
+
+        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(0, $instance->instanceStack);
+        $this->assertEquals(0, $other->instanceStack);
+
+        $instance->callStack();
+        $this->assertEquals(1, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(1, $instance->instanceStack);
+        $this->assertEquals(0, $other->instanceStack);
+
+        $instance->callStack();
+        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(2, $instance->instanceStack);
+        $this->assertEquals(0, $other->instanceStack);
+
+        $other->callStack();
+        $this->assertEquals(3, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(2, $instance->instanceStack);
+        $this->assertEquals(1, $other->instanceStack);
+
+        $other->callStack();
+        $this->assertEquals(4, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(2, $instance->instanceStack);
+        $this->assertEquals(2, $other->instanceStack);
+    }
+
+    public function testRecursiveCallsToCircularReferenceCallsOtherInstanceOnce()
+    {
+        $instance = new PreventsCircularRecursionWithRecursiveMethod();
+        $other = $instance->other;
+
+        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(0, $instance->instanceStack);
+        $this->assertEquals(0, $other->instanceStack);
+
+        $instance->callOtherStack();
+        $this->assertEquals(2, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(1, $instance->instanceStack);
+        $this->assertEquals(1, $other->instanceStack);
+
+        $instance->callOtherStack();
+        $this->assertEquals(4, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(2, $instance->instanceStack);
+        $this->assertEquals(2, $other->instanceStack);
+
+        $other->callOtherStack();
+        $this->assertEquals(6, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(3, $other->instanceStack);
+        $this->assertEquals(3, $instance->instanceStack);
+
+        $other->callOtherStack();
+        $this->assertEquals(8, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(4, $other->instanceStack);
+        $this->assertEquals(4, $instance->instanceStack);
+    }
+
+    public function testRecursiveCallsToCircularLinkedListCallsEachInstanceOnce()
+    {
+        $instance = new PreventsCircularRecursionWithRecursiveMethod();
+        $second = $instance->other;
+        $third = new PreventsCircularRecursionWithRecursiveMethod($second);
+        $instance->other = $third;
+
+        $this->assertEquals(0, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(0, $instance->instanceStack);
+        $this->assertEquals(0, $second->instanceStack);
+        $this->assertEquals(0, $third->instanceStack);
+
+        $instance->callOtherStack();
+        $this->assertEquals(3, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(1, $instance->instanceStack);
+        $this->assertEquals(1, $second->instanceStack);
+        $this->assertEquals(1, $third->instanceStack);
+
+        $second->callOtherStack();
+        $this->assertEquals(6, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(2, $instance->instanceStack);
+        $this->assertEquals(2, $second->instanceStack);
+        $this->assertEquals(2, $third->instanceStack);
+
+        $third->callOtherStack();
+        $this->assertEquals(9, PreventsCircularRecursionWithRecursiveMethod::$globalStack);
+        $this->assertEquals(3, $instance->instanceStack);
+        $this->assertEquals(3, $second->instanceStack);
+        $this->assertEquals(3, $third->instanceStack);
+    }
+}
+
+class PreventsCircularRecursionWithRecursiveMethod
+{
+    use PreventsCircularRecursion;
+
+    public function __construct(
+        public ?PreventsCircularRecursionWithRecursiveMethod $other = null,
+    ) {
+        $this->other ??= new PreventsCircularRecursionWithRecursiveMethod($this);
+    }
+
+    public static int $globalStack = 0;
+    public int $instanceStack = 0;
+
+    public function callStack(): int
+    {
+        return $this->once(
+            function () {
+                static::$globalStack++;
+                $this->instanceStack++;
+
+                return $this->callStack();
+            },
+            $this->instanceStack
+        );
+    }
+
+    public function callOtherStack(): int
+    {
+        return $this->once(
+            function () {
+                $this->other->callStack();
+
+                return $this->other->callOtherStack();
+            },
+            $this->instanceStack
+        );
+    }
+}

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -137,7 +137,7 @@ class PreventsCircularRecursionWithRecursiveMethod
 
     public function callStack(): int
     {
-        return $this->once(
+        return $this->withoutRecursion(
             function () {
                 static::$globalStack++;
                 $this->instanceStack++;
@@ -150,7 +150,7 @@ class PreventsCircularRecursionWithRecursiveMethod
 
     public function callOtherStack(): int
     {
-        return $this->once(
+        return $this->withoutRecursion(
             function () {
                 $this->other->callStack();
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1156,6 +1156,28 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([2, 3], $model->relationMany->pluck('id')->all());
     }
 
+    public function testPushCircularRelations()
+    {
+        $parent = new EloquentModelWithRecursiveRelationshipsStub(['id' => 1, 'parent_id' => null]);
+        $lastId = $parent->id;
+        $parent->setRelation('self', $parent);
+
+        $children = new Collection();
+        for ($count = 0; $count < 2; $count++) {
+            $child = new EloquentModelWithRecursiveRelationshipsStub(['id' => ++$lastId, 'parent_id' => $parent->id]);
+            $child->setRelation('parent', $parent);
+            $child->setRelation('self', $child);
+            $children->push($child);
+        }
+        $parent->setRelation('children', $children);
+
+        try {
+            $this->assertTrue($parent->push());
+        } catch (\RuntimeException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
     public function testNewQueryReturnsEloquentQueryBuilder()
     {
         $conn = m::mock(Connection::class);
@@ -1229,6 +1251,79 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setAppends(['appendable']);
         $array = $model->toArray();
         $this->assertSame('appended', $array['appendable']);
+    }
+
+    public function testToArrayWithCircularRelations()
+    {
+        $parent = new EloquentModelWithRecursiveRelationshipsStub(['id' => 1, 'parent_id' => null]);
+        $lastId = $parent->id;
+        $parent->setRelation('self', $parent);
+
+        $children = new Collection();
+        for ($count = 0; $count < 2; $count++) {
+            $child = new EloquentModelWithRecursiveRelationshipsStub(['id' => ++$lastId, 'parent_id' => $parent->id]);
+            $child->setRelation('parent', $parent);
+            $child->setRelation('self', $child);
+            $children->push($child);
+        }
+        $parent->setRelation('children', $children);
+
+        try {
+            $this->assertSame(
+                [
+                    'id' => 1,
+                    'parent_id' => null,
+                    'self' => ['id' => 1, 'parent_id' => null],
+                    'children' => [
+                        [
+                            'id' => 2,
+                            'parent_id' => 1,
+                            'parent' => ['id' => 1, 'parent_id' => null],
+                            'self' => ['id' => 2, 'parent_id' => 1],
+                        ],
+                        [
+                            'id' => 3,
+                            'parent_id' => 1,
+                            'parent' => ['id' => 1, 'parent_id' => null],
+                            'self' => ['id' => 3, 'parent_id' => 1],
+                        ],
+                    ],
+                ],
+                $parent->toArray()
+            );
+        } catch (\RuntimeException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    public function testGetQueueableRelationsWithCircularRelations()
+    {
+        $parent = new EloquentModelWithRecursiveRelationshipsStub(['id' => 1, 'parent_id' => null]);
+        $lastId = $parent->id;
+        $parent->setRelation('self', $parent);
+
+        $children = new Collection();
+        for ($count = 0; $count < 2; $count++) {
+            $child = new EloquentModelWithRecursiveRelationshipsStub(['id' => ++$lastId, 'parent_id' => $parent->id]);
+            $child->setRelation('parent', $parent);
+            $child->setRelation('self', $child);
+            $children->push($child);
+        }
+        $parent->setRelation('children', $children);
+
+        try {
+            $this->assertSame(
+                [
+                    'self',
+                    'children',
+                    'children.parent',
+                    'children.self',
+                ],
+                $parent->getQueueableRelations()
+            );
+        } catch (\RuntimeException $e) {
+            $this->fail($e->getMessage());
+        }
     }
 
     public function testVisibleCreatesArrayWhitelist()
@@ -3681,5 +3776,97 @@ class Address implements Castable
                 ];
             }
         };
+    }
+}
+
+class EloquentModelWithRecursiveRelationshipsStub extends Model
+{
+    public $fillable = ['id', 'parent_id'];
+
+    protected static \WeakMap $recursionDetectionCache;
+
+    public function getQueueableRelations()
+    {
+        try {
+            $this->stepIn();
+
+            return parent::getQueueableRelations();
+        } finally {
+            $this->stepOut();
+        }
+    }
+
+    public function push()
+    {
+        try {
+            $this->stepIn();
+
+            return parent::push();
+        } finally {
+            $this->stepOut();
+        }
+    }
+
+    public function save(array $options = [])
+    {
+        return true;
+    }
+
+    public function relationsToArray()
+    {
+        try {
+            $this->stepIn();
+
+            return parent::relationsToArray();
+        } finally {
+            $this->stepOut();
+        }
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(static::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(static::class, 'parent_id');
+    }
+
+    public function self(): BelongsTo
+    {
+        return $this->belongsTo(static::class, 'id');
+    }
+
+    protected static function getRecursionDetectionCache()
+    {
+        return static::$recursionDetectionCache ??= new \WeakMap;
+    }
+
+    protected function getRecursionDepth(): int
+    {
+        $cache = static::getRecursionDetectionCache();
+
+        return $cache->offsetExists($this) ? $cache->offsetGet($this) : 0;
+    }
+
+    protected function stepIn(): void
+    {
+        $depth = $this->getRecursionDepth();
+
+        if ($depth > 1) {
+            throw new \RuntimeException('Recursion detected');
+        }
+        static::getRecursionDetectionCache()->offsetSet($this, $depth + 1);
+    }
+
+    protected function stepOut(): void
+    {
+        $cache = static::getRecursionDetectionCache();
+        if ($depth = $this->getRecursionDepth()) {
+            $cache->offsetSet($this, $depth - 1);
+        } else {
+            $cache->offsetUnset($this);
+        }
     }
 }


### PR DESCRIPTION
_This is a companion PR to #51582 which resolves the issues raised around serialization of models that have circular references in relations._

# TL;DR:
This PR makes some minor changes to how the main recursive operations on Models work to prevent getting into infintite recursion down a stack of circular references, which leads to a stack overflow. It does this by preventing recursive calls to the same method on an object.

# What are circular references?
Put simply - circular references occur when two objects hold a reference to each other. In the context of this PR, it's when a model holds a relationship to another model which in turn holds a relationship back to the first _instance_. For example, if you had a user with multiple posts, and you wanted to give each post a reference back to the original user, you might do something like this:
```php
$user->posts->each->setRelation('user', $user);
```
This would mean that each post has a link back to the original user, not to another _copy_ of the user.

## Why would you want to do this?
There are many reasons, but the most common reason that I encounter is authorization. What if you had a policy similar to this for posts:
```php
class PostPolicy
{
    // ...
    public function view(User $user, Post $post): bool
    {
        return $post->published_at?->greaterThan(now()) || $post->user->is($user);
    }
    //...
}
```
Note that the post references it's own copy of the user object. When you're looping through posts on an index page you can easily eager-load the user (`Post::with(['user'])->get()`), but if you're pulling the posts for a _particular_ user, you either have to:

* Eager-load the user on the posts (`$user->load(['posts.user']);`) which leaves you with multiple copies of the user that you already had.
* Deal with N+1 queries as each post runs a query to pull out its user - again, something that you had already pulled out of the database.
* Set the relation to the existing model, and end up with a circular reference.

Setting the relation is the most memory efficient, database efficient, and has some other benefits like being able to naviagate back and forth between the user and posts without generating more queries, e.g.
```html
<!-- user/post-index.blade.php -->
@foreach($user->posts as $idx => $post)
  <x-post :$post :position="$idx + 1" />
@endforeach

<!-- components/post.blade.php -->
<a href="{{ route('user.posts.edit', [$post->user, $post]) }}">{{ $post->title }}</a>
({{ $position }} / {{ $post->user->posts->count() }})
```
## How does this cause problems?
For the most part, it doesn't. I've used this pattern many times on many projects, and PR #51582 would make it possible to set the inverse relation automatically in a number of situations.

The issue is when it comes to serializing a model that has circular relations. When you call `toJson()` or `toArray()` on a model with circular relations, or you attempt to send that model to a queue, or you simply want to just call `push()` to save the model and any of it's dependent children. Essentially any time where it tries to walk down the stack of relations recursively, you'll end up in this loop:
```php
>>> dump($user->toArray());
[
    'id' => 1,
    'posts' => [
        0 => [
            'id' => 1234,
            'user' => [
                'id' => 1,
                'posts' => [
                    0 => [
                        'id' => 1234,
                        'user' => [
                            'id' => 1,
                            'posts' => [// ... all the way to a stack overflow
```
I don't know how many people have experienced a SegFault in PHP, but it's... not a fun issue to diagnose.

## How does this PR fix that issue?
This adds a new internal method to models called ~~`once()`~~ `withoutRecursion()`. This keeps track of the call stack and will prevent the same method from being called on the same _instance_ of an object more than once _within that stack_. So instead of that call stack above, you end up with something like this:
```php
>>> dump($user->toArray());
[
    'id' => 1,
    'posts' => [
        0 => [
            'id' => 1234,
            'user' => [
                'id' => 1,
            ],
        ],
        1 => [
            'id' => 2345,
            'user' => [
                'id' => 1,
            ],
        ],
        2 => [
            'id' => 3456,
            'user' => [
                'id' => 1,
            ],
        ],
    ]
];
```
Because `toArray()` was called on `$user` at the top level, it doesn't get called again, so it doesn't dig down again, but because each _post_ is a unique object, `toArray()` can get called on each of them.

# A Couple Of Questions That You Might Want Answered
### Is this backwards compatible?
Yes. This won't break any existing code because any code that would have encoutnered this problem wouldn't be working. ~~The only concerns are if someone has already defined a `once()` method on a model (in which case I'm happy to change this method name if you'd prefer - I was just keeping consistency with the other existing functionality for the `once()` helper)~~.

### Why not use the `once()` helper?
For two major reasons:

1. **It's not recursion safe**

It expects a call to complete so that it can store the value before it can prevent subsequent calls to the method. This means that if the method is recursive, it will never complete. The change that I've made here accepts a "default" value which will be stored as the return value _before_ the method is called, meaning that any recursion will return early with the default value instead of continuing to dig itself deeper.

2. **`once()` would keep the result for the rest of the request, even if the model changed**

We don't want to prevent `->toArray()` from changing its result if the models or relations change. Each time it gets called we want to actually pull the result at that point in time. We only want the "once" behaviour to persist _within the context of that one call stack_. This is particularly important for `->push()` - you don't want to store the result of `$model->push()` and never actually call it again.

### Has anyone other than you even encoutnered this?
Yep! @reinink has talked about [Optimizing circular relationships in Laravel](https://reinink.ca/articles/optimizing-circular-relationships-in-laravel), @stancl made a package to add [`hasManyWithInverse()`](https://github.com/archtechx/laravel-hasmanywithinverse), and @stayallive extended that, with an specific note about [dealing with recursion](https://github.com/stayallive/laravel-inverse-relations?tab=readme-ov-file#caveats).

Even if the `inverse()` pull request never gets merged, I believe that this would still be a valuable fix for models.