### PR TITLE
11.x Add a environment filter to the Schedule List Command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -8,6 +8,7 @@ use DateTimeZone;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\App;
 use ReflectionClass;
 use ReflectionFunction;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -24,6 +25,7 @@ class ScheduleListCommand extends Command
     protected $signature = 'schedule:list
         {--timezone= : The timezone that times should be displayed in}
         {--next : Sort the listed tasks by their next due date}
+        {--all : Show all the listed tasks}
     ';
 
     /**
@@ -51,6 +53,10 @@ class ScheduleListCommand extends Command
     public function handle(Schedule $schedule)
     {
         $events = collect($schedule->events());
+
+        if (! $this->option('all')) {
+            $events = $events->filter(fn(Event $event) => $event->runsInEnvironment(App::environment()));
+        }
 
         if ($events->isEmpty()) {
             $this->components->info('No scheduled tasks have been defined.');

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -133,7 +133,7 @@ class ScheduleListCommandTest extends TestCase
     public function testDisplayScheduleCurrentEnvironment()
     {
         $this->schedule->command('inspire')->environments(['testing'])->weekly();
-        $this->schedule->command('inspire')->environments(['staging'])->weekly();
+        $this->schedule->command('inspire')->environments(['staging'])->daily();
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
             ->expectsOutput('  0 0 * * 0  php artisan inspire ................... Next Due: 1 week from now');
@@ -142,12 +142,12 @@ class ScheduleListCommandTest extends TestCase
     public function testDisplayScheduleAllEnvironments()
     {
         $this->schedule->command('inspire')->environments(['testing'])->weekly();
-        $this->schedule->command('inspire')->environments(['staging'])->weekly();
+        $this->schedule->command('inspire')->environments(['staging'])->daily();
 
         $this->artisan(ScheduleListCommand::class, ['--all' => true])
             ->assertSuccessful()
             ->expectsOutput('  0 0 * * 0  php artisan inspire ................... Next Due: 1 week from now')
-            ->expectsOutput('  0 0 * * 0  php artisan inspire ................... Next Due: 1 week from now');
+            ->expectsOutput('  0 0 * * *  php artisan inspire .................... Next Due: 1 day from now');
     }
 
     public function testClosureCommandsMayBeScheduled()

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -130,6 +130,26 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * * * * * 30s  php artisan inspire ........... Next Due: 30 seconds from now');
     }
 
+    public function testDisplayScheduleCurrentEnvironment()
+    {
+        $this->schedule->command('inspire')->environments(['testing'])->weekly();
+        $this->schedule->command('inspire')->environments(['staging'])->weekly();
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('  0 0 * * 0  php artisan inspire ................... Next Due: 1 week from now');
+    }
+
+    public function testDisplayScheduleAllEnvironments()
+    {
+        $this->schedule->command('inspire')->environments(['testing'])->weekly();
+        $this->schedule->command('inspire')->environments(['staging'])->weekly();
+
+        $this->artisan(ScheduleListCommand::class, ['--all' => true])
+            ->assertSuccessful()
+            ->expectsOutput('  0 0 * * 0  php artisan inspire ................... Next Due: 1 week from now')
+            ->expectsOutput('  0 0 * * 0  php artisan inspire ................... Next Due: 1 week from now');
+    }
+
     public function testClosureCommandsMayBeScheduled()
     {
         $closure = function () {


### PR DESCRIPTION
Display only the scheduled tasks for a environment. If you want to check what command are scheduled on a environment you can run scheduled list, but it will actually show all tasks without taking the environment filter into account.

# Old behaviour
When you schedule a command with an environment filter on it like so:

```php
$schedule->command('horizon:snapshot')
    ->everyFiveMinutes()
    ->environments(['staging']);
    
$schedule->command('inspire')
    ->everyFiveMinutes();
```

and you call `php artisan schedule:list`

It will still output as schedule even though the env is set to `APP_ENV=local`:

```shell
  */5 *  * * *  php artisan horizon:snapshot ................................ Next Due: 4 minutes from now
  */5 *  * * *  php artisan inspire ......................................... Next Due: 4 minutes from now
```

# New behaviour

## Default
Calling `php artisan schedule:list` with `APP_ENV=local` and the following schedule:
 
```php
$schedule->command('horizon:snapshot')
    ->everyFiveMinutes()
    ->environments(['staging']);
    
$schedule->command('inspire')
    ->everyFiveMinutes();
```

Output:

```shell
  */5 *  * * *  php artisan inspire ................................................. Next Due: 4 minutes from now
```

## Checking specific environment
Calling `php artisan schedule:list --env=staging` and the following schedule:
 
```php
$schedule->command('horizon:snapshot')
    ->everyFiveMinutes()
    ->environments(['staging']);
    
$schedule->command('inspire')
    ->everyFiveMinutes();
```

Output:

```shell
  */5 *  * * *  php artisan horizon:snapshot ................................ Next Due: 4 minutes from now
  */5 *  * * *  php artisan inspire ......................................... Next Due: 4 minutes from now
```

## Show all option

Calling `php artisan schedule:list --all` with `APP_ENV=local` and the following schedule:
 
```php
$schedule->command('horizon:snapshot')
    ->everyFiveMinutes()
    ->environments(['staging']);
    
$schedule->command('inspire')
    ->everyFiveMinutes();
```

Output:

```shell
  */5 *  * * *  php artisan horizon:snapshot ................................ Next Due: 4 minutes from now
  */5 *  * * *  php artisan inspire ......................................... Next Due: 4 minutes from now
```


The original discussion I started: #49143 