### PR TITLE
[11.x] Constrain key when asserting database has a model

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -26,6 +26,13 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            $data = [
+                $table->getKeyName() => $table->getKey(),
+                ...$data,
+            ];
+        }
+
         $this->assertThat(
             $this->getTable($table), new HasInDatabase($this->getConnection($connection, $table), $data)
         );
@@ -43,6 +50,13 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            $data = [
+                $table->getKeyName() => $table->getKey(),
+                ...$data,
+            ];
+        }
+
         $constraint = new ReverseConstraint(
             new HasInDatabase($this->getConnection($connection, $table), $data)
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -24,7 +24,7 @@ trait InteractsWithDatabase
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseHas($table, array $data, $connection = null)
+    protected function assertDatabaseHas($table, array $data = [], $connection = null)
     {
         if ($table instanceof Model) {
             $data = [
@@ -48,7 +48,7 @@ trait InteractsWithDatabase
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseMissing($table, array $data, $connection = null)
+    protected function assertDatabaseMissing($table, array $data = [], $connection = null)
     {
         if ($table instanceof Model) {
             $data = [
@@ -171,11 +171,7 @@ trait InteractsWithDatabase
      */
     protected function assertModelExists($model)
     {
-        return $this->assertDatabaseHas(
-            $model->getTable(),
-            [$model->getKeyName() => $model->getKey()],
-            $model->getConnectionName()
-        );
+        return $this->assertDatabaseHas($model);
     }
 
     /**
@@ -186,11 +182,7 @@ trait InteractsWithDatabase
      */
     protected function assertModelMissing($model)
     {
-        return $this->assertDatabaseMissing(
-            $model->getTable(),
-            [$model->getKeyName() => $model->getKey()],
-            $model->getConnectionName()
-        );
+        return $this->assertDatabaseMissing($model);
     }
 
     /**

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -52,6 +52,20 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas(new ProductStub, $this->data);
     }
 
+    public function testAssertDatabaseHasConstrainsToModel()
+    {
+        $data = $this->data;
+
+        $this->data = [
+            'id' => 1,
+            ...$this->data,
+        ];
+
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHas(new ProductStub(['id' => 1]), $data);
+    }
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -108,6 +122,20 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $this->assertDatabaseMissing(ProductStub::class, $this->data);
         $this->assertDatabaseMissing(new ProductStub, $this->data);
+    }
+
+    public function testAssertDatabaseMissingConstrainsToModel()
+    {
+        $data = $this->data;
+
+        $this->data = [
+            'id' => 1,
+            ...$this->data,
+        ];
+
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseMissing(new ProductStub(['id' => 1]), $data);
     }
 
     public function testDontSeeInDatabaseFindsResults()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -44,12 +44,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    public function testAssertDatabaseHasSupportModels()
+    public function testAssertDatabaseHasSupportsModelClass()
     {
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseHas(ProductStub::class, $this->data);
-        $this->assertDatabaseHas(new ProductStub, $this->data);
     }
 
     public function testAssertDatabaseHasConstrainsToModel()
@@ -116,12 +115,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    public function testAssertDatabaseMissingSupportModels()
+    public function testAssertDatabaseMissingSupportsModelClass()
     {
         $this->mockCountBuilder(0);
 
         $this->assertDatabaseMissing(ProductStub::class, $this->data);
-        $this->assertDatabaseMissing(new ProductStub, $this->data);
     }
 
     public function testAssertDatabaseMissingConstrainsToModel()


### PR DESCRIPTION
There are currently three options to pass as the first argument to `assertDatabaseHas()` and `assertDatabaseMissing()`

* the table name (string)
* the class (string)
* a model (instance)

```php
$pat = User::factory()->create(['name' => 'Pat']);

$this->assertDatabaseHas('users', ['name' => 'Pat']); // pass
$this->assertDatabaseHas(User::class, ['name' => 'Pat']); // pass

$cinderella = User::factory()->create(['name' => 'Cinderella']);

$this->assertDatabaseHas($cinderella, ['name' => 'Pat']); // pass
```

This PR adds a constraint on the model's key when an eloquent model is used so the last assertion above would fail.

### Breaking Change

Like the above example, if a test suite currently asserts a database row contains data against a different model instance that test will now fail. However, I would argue that the test gives a false positive and should change to use the class string or the correct model instance. 

```php
$this->assertDatabaseHas(User::class, ['name' => 'Pat']); // pass

$this->assertDatabaseHas($pat, ['name' => 'Pat']); // pass
```

Additionally, passing an empty model instance is an anti-pattern as until it is saved, the database does not have that model.

Currently the following test would pass:

```php
$pat = User::query()->find(1);
$cinderella = new User(['name' => 'Cinderella']);

$this->assertDatabaseHas($cinderella, ['name' => 'Pat']); // pass
$this->assertDatabaseMissing($pat, ['name' => 'Cinderella']); // pass

// Using User::class for these has a clearer intention.
$this->assertDatabaseHas(new User, ['name' => 'Pat']); // pass
$this->assertDatabaseMissing(new User, ['name' => 'Cinderella']); // pass
```

This change will _only_ break those specific tests _not_ the application logic. 