### PR TITLE
Enhance `throw` Method to Use Typed `Closure` in `Response`

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
@@ -277,17 +278,16 @@ class Response implements ArrayAccess, Stringable
     /**
      * Throw an exception if a server or client error occurred.
      *
+     * @param  \Closure|null  $callback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throw()
+    public function throw(?Closure $callback = null)
     {
-        $callback = func_get_args()[0] ?? null;
-
         if ($this->failed()) {
             throw tap($this->toException(), function ($exception) use ($callback) {
-                if ($callback && is_callable($callback)) {
+                if ($callback) {
                     $callback($this, $exception);
                 }
             });

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
-use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
@@ -278,12 +277,12 @@ class Response implements ArrayAccess, Stringable
     /**
      * Throw an exception if a server or client error occurred.
      *
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throw(?Closure $callback = null)
+    public function throw(?callable $callback = null)
     {
         if ($this->failed()) {
             throw tap($this->toException(), function ($exception) use ($callback) {


### PR DESCRIPTION
This PR refines the throw method in the ClassName class by typing the $callback parameter as ?Closure.

- **Previous Implementation:** The original throw method used func_get_args() to handle callback arguments flexibly but included redundant checks for callability and argument presence.
- **New Implementation:** The updated method directly uses a ?Closure type hint for the $callback parameter and removes the extra is_callable() check. This results in cleaner and more readable code.

### Changes Made:

1. **Parameter Typing:** The $callback parameter is now explicitly typed as ?Closure. This type hinting ensures that the parameter is either a Closure or null.
2. **Simplified Callback Handling:** Removed the redundant check for callability, as the type hint ensures the argument is either a valid closure or null.

### Benefits:

1. **Improved Clarity:** Explicitly typing $callback as ?Closure simplifies the code by making the intended use clear and removing redundant checks.
2. **Enhanced Readability:** The code is cleaner and more readable without the extra callability checks.

