### PR TITLE
[11.x] Add support for verbose exception messages in RequestException

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -14,16 +14,26 @@ class RequestException extends HttpClientException
     public $response;
 
     /**
+     * Determine if the exception message should be verbose.
+     *
+     * @var bool
+     */
+    protected bool $isVerbose = false;
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Illuminate\Http\Client\Response  $response
+     * @param  bool  $isVerbose
      * @return void
      */
-    public function __construct(Response $response)
+    public function __construct(Response $response, $isVerbose = false)
     {
-        parent::__construct($this->prepareMessage($response), $response->status());
-
         $this->response = $response;
+
+        $this->isVerbose = $isVerbose;
+
+        parent::__construct($this->prepareMessage($response), $response->status());
     }
 
     /**
@@ -36,8 +46,12 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = Message::bodySummary($response->toPsrResponse());
+        if (! $this->isVerbose) {
+            $psrResponse = Message::bodySummary($response->toPsrResponse());
+        } else {
+            $psrResponse = $response->toPsrResponse()->getBody()->getContents();
+        }
 
-        return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
+        return is_null($psrResponse) ? $message : $message .= ":\n{$psrResponse}\n";
     }
 }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -33,6 +33,13 @@ class Response implements ArrayAccess, Stringable
     protected $decoded;
 
     /**
+     * Determine the output verbosity state.
+     *
+     * @var bool
+     */
+    protected $withVerboseException = false;
+
+    /**
      * The request cookies.
      *
      * @var \GuzzleHttp\Cookie\CookieJar
@@ -286,7 +293,7 @@ class Response implements ArrayAccess, Stringable
     public function toException()
     {
         if ($this->failed()) {
-            return new RequestException($this);
+            return new RequestException($this, $this->withVerboseException);
         }
     }
 
@@ -310,6 +317,18 @@ class Response implements ArrayAccess, Stringable
         }
 
         return $this;
+    }
+
+    /**
+     * Enable verbose exception messages.
+     *
+     * @return $this
+     */
+    public function withVerboseException()
+    {
+        return tap($this, function () {
+            $this->withVerboseException = true;
+        });
     }
 
     /**
@@ -453,7 +472,7 @@ class Response implements ArrayAccess, Stringable
     public function __call($method, $parameters)
     {
         return static::hasMacro($method)
-                    ? $this->macroCall($method, $parameters)
-                    : $this->response->{$method}(...$parameters);
+            ? $this->macroCall($method, $parameters)
+            : $this->response->{$method}(...$parameters);
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1162,6 +1162,22 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $resp->toException());
     }
 
+    public function testExceptionMessageOnFailure()
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit');
+
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+
+        throw new RequestException(new Response($response), true);
+    }
+
     public function testRequestExceptionSummary()
     {
         $this->expectException(RequestException::class);


### PR DESCRIPTION
### Context:
In the current implementation, when a third-party service returns a long response message, Laravel's HTTP client automatically truncates the message in exceptions. While this is useful in many cases, it can be limiting when detailed information from the response is needed for debugging or logging purposes.

### Changes Introduced:
This PR introduces a new feature that allows developers to choose whether they want the full response message or a truncated version when handling exceptions thrown by the HTTP client. The main changes include:

1. New Attribute isVerbose:
Added a boolean attribute isVerbose to the RequestException class, which determines if the exception message should include the full response body or a truncated summary.

2. New Method enableVerboseMessage in Response:
Introduced a method enableVerboseMessage() in the Response class, which allows developers to enable the verbose exception message mode.

3. Modified toException Method:
The toException() method in the Response class now passes the isVerbose flag when creating a RequestException instance, allowing the exception to contain the full message if verbosity is enabled.

4. Enhanced Exception Message Preparation:
Updated the prepareMessage() method in RequestException to conditionally include either a truncated summary or the full response body based on the isVerbose attribute.