### PR TITLE
[11.x] Add optional ability to array wrap associative arrays

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -941,14 +941,19 @@ class Arr
      * If the given value is not an array and not null, wrap it in one.
      *
      * @param  mixed  $value
+     * @param  bool  $wrapIfAssoc
      * @return array
      */
-    public static function wrap($value)
+    public static function wrap($value, $wrapIfAssoc = false)
     {
         if (is_null($value)) {
             return [];
         }
 
-        return is_array($value) ? $value : [$value];
+        if (is_array($value)) {
+            return array_is_list($value) ? $value : ($wrapIfAssoc ? [$value] : $value);
+        }
+
+        return [$value];
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1337,10 +1337,13 @@ class SupportArrTest extends TestCase
     {
         $string = 'a';
         $array = ['a'];
+        $assocArray = ['a' => 'b'];
         $object = new stdClass;
         $object->value = 'a';
         $this->assertEquals(['a'], Arr::wrap($string));
         $this->assertEquals($array, Arr::wrap($array));
+        $this->assertEquals($assocArray, Arr::wrap($assocArray));
+        $this->assertEquals([$assocArray], Arr::wrap($assocArray, true));
         $this->assertEquals([$object], Arr::wrap($object));
         $this->assertEquals([], Arr::wrap(null));
         $this->assertEquals([null], Arr::wrap([null]));


### PR DESCRIPTION
These additions allow array wrapping for associative arrays. Currently, `Arr::wrap()` does not wrap an associative array, but simply returns that same array. This feature is fully backwards compatible because the wrapping of associative arrays is opt in.. by passing `true` to `Arr::wrap` as the `$wrapIfAssoc` argument. This defaults to `false` which maintains current wrapping behavior.

### Use Case

Functions that define an array parameter could be passed a list or an associative array. Also, many users implement functions that could be used on 1 data set or many data sets.. i.e. associative arrays. Being able to wrap associative arrays produces slightly more concise code and convenience. 

Here, `$params` could either be `['id' => 1]` or `[['id' => 1], ['id' => 2]]`...

Before
```php

function (array $params) {
    $params = array_is_list($params) ? $params : [$params];

    foreach ($params as $param) {
        // process param
    }
}
```

After
```php
function (array $params) {
    foreach (Arr::wrap($params, true) as $param) {
        // process param
    }
}

```

