### PR TITLE
Add `between` to `AssertableJson`

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -41,15 +41,16 @@ trait Has
     }
 
     /**
-     * Asserts that the value is between 2 specified values.
+     * Assert that the prop size is between a given minimum and maximum.
      *
      * @param  int|string  $lowestValue
      * @param  int|string  $highestValue
      * @return $this
      */
-    public function between(int|string $lowestValue, int|string $highestValue): self
+    public function countBetween(int|string $lowestValue, int|string $highestValue): self
     {
         $path = $this->dotPath();
+
         $prop = $this->prop();
 
         PHPUnit::assertGreaterThanOrEqual(

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -41,7 +41,7 @@ trait Has
     }
 
     /**
-     * Asserts that the value is between 2 specified values
+     * Asserts that the value is between 2 specified values.
      *
      * @param  int|string  $lowestValue
      * @param  int|string  $highestValue

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -41,6 +41,37 @@ trait Has
     }
 
     /**
+     * Asserts that the value is between 2 specified values
+     *
+     * @param  int|string  $lowestValue
+     * @param  int|string  $highestValue
+     * @return $this
+     */
+    public function between(int|string $lowestValue, int|string $highestValue): self
+    {
+        $path = $this->dotPath();
+        $prop = $this->prop();
+
+        PHPUnit::assertGreaterThanOrEqual(
+            $lowestValue,
+            count($prop),
+            $path
+                ? sprintf('Property [%s] size is not greater than or equal to [%s].', $path, $lowestValue)
+                : sprintf('Root level size is not greater than or equal to [%s].', $lowestValue)
+        );
+
+        PHPUnit::assertLessThanOrEqual(
+            $highestValue,
+            count($prop),
+            $path
+                ? sprintf('Property [%s] size is not less than or equal to [%s].', $path, $highestValue)
+                : sprintf('Root level size is not less than or equal to [%s].', $highestValue)
+        );
+
+        return $this;
+    }
+
+    /**
      * Ensure that the given prop exists.
      *
      * @param  string|int  $key

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -43,30 +43,30 @@ trait Has
     /**
      * Assert that the prop size is between a given minimum and maximum.
      *
-     * @param  int|string  $lowestValue
-     * @param  int|string  $highestValue
+     * @param  int|string  $min
+     * @param  int|string  $max
      * @return $this
      */
-    public function countBetween(int|string $lowestValue, int|string $highestValue): self
+    public function countBetween(int|string $min, int|string $max): self
     {
         $path = $this->dotPath();
 
         $prop = $this->prop();
 
         PHPUnit::assertGreaterThanOrEqual(
-            $lowestValue,
+            $min,
             count($prop),
             $path
-                ? sprintf('Property [%s] size is not greater than or equal to [%s].', $path, $lowestValue)
-                : sprintf('Root level size is not greater than or equal to [%s].', $lowestValue)
+                ? sprintf('Property [%s] size is not greater than or equal to [%s].', $path, $min)
+                : sprintf('Root level size is not greater than or equal to [%s].', $min)
         );
 
         PHPUnit::assertLessThanOrEqual(
-            $highestValue,
+            $max,
             count($prop),
             $path
-                ? sprintf('Property [%s] size is not less than or equal to [%s].', $path, $highestValue)
-                : sprintf('Root level size is not less than or equal to [%s].', $highestValue)
+                ? sprintf('Property [%s] size is not less than or equal to [%s].', $path, $max)
+                : sprintf('Root level size is not less than or equal to [%s].', $max)
         );
 
         return $this;

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -295,7 +295,7 @@ class AssertTest extends TestCase
 
         $assert->between(1, 3);
     }
-    
+
     public function testAssertBetweenFails()
     {
         $assert = AssertableJson::fromArray([
@@ -309,7 +309,7 @@ class AssertTest extends TestCase
 
         $assert->between(1, 2);
     }
-    
+
     public function testAssertBetweenLowestValueFails()
     {
         $assert = AssertableJson::fromArray([
@@ -323,7 +323,7 @@ class AssertTest extends TestCase
 
         $assert->between(4, 3);
     }
-    
+
     public function testAssertBetweenFailsScoped()
     {
         $assert = AssertableJson::fromArray([
@@ -341,7 +341,7 @@ class AssertTest extends TestCase
             $bar->between(1, 2);
         });
     }
-    
+
     public function testAssertMissing()
     {
         $assert = AssertableJson::fromArray([

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -285,6 +285,63 @@ class AssertTest extends TestCase
         });
     }
 
+    public function testAssertBetween()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $assert->between(1, 3);
+    }
+    
+    public function testAssertBetweenFails()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Root level size is not less than or equal to [2].');
+
+        $assert->between(1, 2);
+    }
+    
+    public function testAssertBetweenLowestValueFails()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Root level size is not greater than or equal to [4].');
+
+        $assert->between(4, 3);
+    }
+    
+    public function testAssertBetweenFailsScoped()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+                'foo' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] size is not less than or equal to [2].');
+
+        $assert->has('bar', function (AssertableJson $bar) {
+            $bar->between(1, 2);
+        });
+    }
+    
     public function testAssertMissing()
     {
         $assert = AssertableJson::fromArray([

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -293,7 +293,7 @@ class AssertTest extends TestCase
             'baz',
         ]);
 
-        $assert->between(1, 3);
+        $assert->countBetween(1, 3);
     }
 
     public function testAssertBetweenFails()
@@ -307,7 +307,7 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Root level size is not less than or equal to [2].');
 
-        $assert->between(1, 2);
+        $assert->countBetween(1, 2);
     }
 
     public function testAssertBetweenLowestValueFails()
@@ -321,7 +321,7 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Root level size is not greater than or equal to [4].');
 
-        $assert->between(4, 3);
+        $assert->countBetween(4, 3);
     }
 
     public function testAssertBetweenFailsScoped()
@@ -338,7 +338,7 @@ class AssertTest extends TestCase
         $this->expectExceptionMessage('Property [bar] size is not less than or equal to [2].');
 
         $assert->has('bar', function (AssertableJson $bar) {
-            $bar->between(1, 2);
+            $bar->countBetween(1, 2);
         });
     }
 


### PR DESCRIPTION
This PR adds between method to AssertableJson class.

Sometimes it is not possible to determine the exact number of items.
In this case, you are force to break the chain.

This PR allows you to continue using the arrow function:

```php
$response->assertJson(fn (AssertableJson $json) => $json
    ->between(10, 30)
    ->etc(),
);
```