### PR TITLE
[11.x] Simple scoped bindings container registration

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -867,12 +867,20 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         $provider->register();
 
-        // If there are bindings / singletons set as properties on the provider we
+        // If there are (scoped) bindings / singletons set as properties on the provider we
         // will spin through them and register them with the application, which
         // serves as a convenience layer while registering a lot of bindings.
         if (property_exists($provider, 'bindings')) {
             foreach ($provider->bindings as $key => $value) {
                 $this->bind($key, $value);
+            }
+        }
+
+        if (property_exists($provider, 'scopedBindings')) {
+            foreach ($provider->scopedBindings as $key => $value) {
+                $key = is_int($key) ? $value : $key;
+
+                $this->scoped($key, $value);
             }
         }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -88,7 +88,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertInstanceOf(NonContractBackedClass::class, $instance);
         $this->assertSame($instance, $app->make(NonContractBackedClass::class));
         $app->forgetScopedInstances();
-        $this->assertNotSame($instance, $app->make(AbstractClass::class));
+        $this->assertNotSame($instance, $app->make(NonContractBackedClass::class));
     }
 
     public function testSingletonsAreCreatedWhenServiceProviderIsRegistered()

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -63,6 +63,34 @@ class FoundationApplicationTest extends TestCase
         $this->assertNotSame($instance, $app->make(AbstractClass::class));
     }
 
+    public function testScopedBindingsAreCreatedWhenServiceProviderIsRegistered()
+    {
+        $app = new Application;
+        $app->register($provider = new class($app) extends ServiceProvider
+        {
+            public $scopedBindings = [
+                NonContractBackedClass::class,
+                AbstractClass::class => ConcreteClass::class,
+            ];
+        });
+
+        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
+
+        $instance = $app->make(AbstractClass::class);
+
+        $this->assertInstanceOf(ConcreteClass::class, $instance);
+        $this->assertSame($instance, $app->make(AbstractClass::class));
+        $app->forgetScopedInstances();
+        $this->assertNotSame($instance, $app->make(AbstractClass::class));
+
+        $instance = $app->make(NonContractBackedClass::class);
+
+        $this->assertInstanceOf(NonContractBackedClass::class, $instance);
+        $this->assertSame($instance, $app->make(NonContractBackedClass::class));
+        $app->forgetScopedInstances();
+        $this->assertNotSame($instance, $app->make(AbstractClass::class));
+    }
+
     public function testSingletonsAreCreatedWhenServiceProviderIsRegistered()
     {
         $app = new Application;


### PR DESCRIPTION
In #37521, Laravel introduced "scoped" binding. This PR adds support for a `$scopedBindings` property on service providers to allow for the registration of simple scoped bindings. It also has support for tersely binding classes that don't have a backing contract, as was introduced for simple singleton bindings in #43469.

For "regular" bindings and singletons, there already exist convenient properties (`$bindings` and `$singletons` respectively), that can be used to simplify registration of bindings.

When using Laravel Octane, you regularly encounter situations where you might want to use a scoped binding, but currently you need to implement the `register()` method when you want to do this.

Before:
```php
class AppServiceProvider extends ServiceProvider
{
    public array $bindings = [
        ServerProvider::class => DigitalOceanServerProvider::class,
    ];
 
    public array $singletons = [
        DowntimeNotifier::class => PingdomDowntimeNotifier::class,
    ];

    public function register()
    {
        $this->app->scoped(RequestScopedClassContract::class, RequestScopedClass::class)
    }
}
```

When skimming the code above, it feels like there is a fundamental difference between the different types of bindings.

When looking at the code below, the connection between the three types of bindings is more obvious.

After:
```php
class AppServiceProvider extends ServiceProvider
{
    public array $bindings = [
        ServerProvider::class => DigitalOceanServerProvider::class,
    ];
 
    public array $scopedBindings = [
        RequestScopedClassContract::class => RequestScopedClass::class,
    ];
 
    public array $singletons = [
        DowntimeNotifier::class => PingdomDowntimeNotifier::class,
    ];
}
```