### PR TITLE
Add `orderByPriority` Method for Custom Sorting in Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2615,6 +2615,35 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param  string  $column
+     * @param  array  $priority
+     * @param  string  $direction
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $direction = strtolower($direction);
+
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
+        }
+
+        if (empty($priority)) {
+            throw new InvalidArgumentException('Order priority must not be empty.');
+        }
+
+        $placeholders = implode(',', array_fill(0, count($priority), '?'));
+
+        $this->orderByRaw("FIELD($column, $placeholders) $direction", $priority);
+
+        return $this;
+    }
+
+    /**
      * Add a descending "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1777,6 +1777,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" order by "name" desc', $builder->toSql());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('select * from "users" order by FIELD(name, ?,?) asc', $builder->toSql());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('public', 1)
             ->unionAll($this->getBuilder()->select('*')->from('videos')->where('public', 1))
             ->orderByRaw('field(category, ?, ?) asc', ['news', 'opinion']);


### PR DESCRIPTION
### Explanation:
This commit introduces the `orderByPriority` method to Laravel's query builder, enabling developers to sort query results based on a custom priority array. For example, you can now order records by specific IDs in a preferred sequence like this:

```php
Model::whereIn('id', [2, 4, 6, 1, 3, 5])->orderByPriority('id', [2, 4, 6, 1, 3, 5])->get();
```

This method leverages SQL's FIELD() function, allowing developers to easily display results in a user-defined order rather than the default ascending or descending order.

### Impact:
This feature greatly enhances the flexibility of data retrieval, particularly when a specific order of items is crucial for the application's logic or user interface.