### PR TITLE
[11.x] Enhanced typing for `HigherOrderCollectionProxy`

### DIFF
--- a/src/Illuminate/Collections/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Collections/HigherOrderCollectionProxy.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support;
 /**
  * @template TKey of array-key
  *
- * @template-covariant TValue of mixed
+ * @template-covariant TValue
  *
  * @mixin \Illuminate\Support\Enumerable<TKey, TValue>
  * @mixin TValue

--- a/src/Illuminate/Collections/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Collections/HigherOrderCollectionProxy.php
@@ -3,14 +3,19 @@
 namespace Illuminate\Support;
 
 /**
- * @mixin \Illuminate\Support\Enumerable
+ * @template TKey of array-key
+ *
+ * @template-covariant TValue of mixed
+ *
+ * @mixin \Illuminate\Support\Enumerable<TKey, TValue>
+ * @mixin TValue
  */
 class HigherOrderCollectionProxy
 {
     /**
      * The collection being operated on.
      *
-     * @var \Illuminate\Support\Enumerable
+     * @var \Illuminate\Support\Enumerable<TKey, TValue>
      */
     protected $collection;
 
@@ -24,7 +29,7 @@ class HigherOrderCollectionProxy
     /**
      * Create a new proxy instance.
      *
-     * @param  \Illuminate\Support\Enumerable  $collection
+     * @param  \Illuminate\Support\Enumerable<TKey, TValue>  $collection
      * @param  string  $method
      * @return void
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -24,35 +24,35 @@ use WeakMap;
  *
  * @template-covariant TValue
  *
- * @property-read HigherOrderCollectionProxy $average
- * @property-read HigherOrderCollectionProxy $avg
- * @property-read HigherOrderCollectionProxy $contains
- * @property-read HigherOrderCollectionProxy $doesntContain
- * @property-read HigherOrderCollectionProxy $each
- * @property-read HigherOrderCollectionProxy $every
- * @property-read HigherOrderCollectionProxy $filter
- * @property-read HigherOrderCollectionProxy $first
- * @property-read HigherOrderCollectionProxy $flatMap
- * @property-read HigherOrderCollectionProxy $groupBy
- * @property-read HigherOrderCollectionProxy $keyBy
- * @property-read HigherOrderCollectionProxy $map
- * @property-read HigherOrderCollectionProxy $max
- * @property-read HigherOrderCollectionProxy $min
- * @property-read HigherOrderCollectionProxy $partition
- * @property-read HigherOrderCollectionProxy $percentage
- * @property-read HigherOrderCollectionProxy $reject
- * @property-read HigherOrderCollectionProxy $skipUntil
- * @property-read HigherOrderCollectionProxy $skipWhile
- * @property-read HigherOrderCollectionProxy $some
- * @property-read HigherOrderCollectionProxy $sortBy
- * @property-read HigherOrderCollectionProxy $sortByDesc
- * @property-read HigherOrderCollectionProxy $sum
- * @property-read HigherOrderCollectionProxy $takeUntil
- * @property-read HigherOrderCollectionProxy $takeWhile
- * @property-read HigherOrderCollectionProxy $unique
- * @property-read HigherOrderCollectionProxy $unless
- * @property-read HigherOrderCollectionProxy $until
- * @property-read HigherOrderCollectionProxy $when
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $average
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $avg
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $contains
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $doesntContain
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $each
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $every
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $filter
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $first
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $flatMap
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $groupBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $keyBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $map
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $max
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $min
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $partition
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $percentage
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $reject
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $skipUntil
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $skipWhile
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $some
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sortBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sortByDesc
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sum
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $takeUntil
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $takeWhile
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $unique
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $unless
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $until
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $when
  */
 trait EnumeratesValues
 {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1112,3 +1112,34 @@ class Zoo
 $zoo = new Zoo();
 
 assertType('Illuminate\Support\Collection<int, Animal>', $zoo->getWithoutZebras());
+
+$coll = $zoo->getWithoutZebras();
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->average);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->avg);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->contains);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->doesntContain);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->each);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->every);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->filter);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->first);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->flatMap);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->groupBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->keyBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->map);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->max);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->min);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->partition);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->percentage);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->reject);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->skipUntil);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->skipWhile);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->some);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->sortBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->sortByDesc);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->sum);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->takeUntil);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->takeWhile);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->unique);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->unless);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->until);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->when);

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 
 use function PHPStan\Testing\assertType;
@@ -856,3 +857,77 @@ foreach ($collection as $int => $user) {
     assertType('int', $int);
     assertType('User', $user);
 }
+
+
+class LazyAnimal
+{
+}
+class LazyTiger extends LazyAnimal
+{
+}
+class LazyLion extends LazyAnimal
+{
+}
+class LazyZebra extends LazyAnimal
+{
+}
+
+class LazyZoo
+{
+    /**
+     * @var \Illuminate\Support\Collection<int, LazyAnimal>
+     */
+    private Collection $animals;
+
+    public function __construct()
+    {
+        $this->animals = collect([
+            new LazyTiger,
+            new LazyLion,
+            new LazyZebra,
+        ]);
+    }
+
+    /**
+     * @return \Illuminate\Support\LazyCollection<int, LazyAnimal>
+     */
+    public function getWithoutZebras(): LazyCollection
+    {
+        return $this->animals->lazy()->filter(fn (LazyAnimal $animal) => ! $animal instanceof LazyZebra);
+    }
+}
+
+$zoo = new LazyZoo();
+
+$coll = $zoo->getWithoutZebras();
+
+assertType('Illuminate\Support\LazyCollection<int, LazyAnimal>', $coll);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->average);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->avg);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->contains);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->doesntContain);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->each);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->every);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->filter);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->first);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->flatMap);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->groupBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->keyBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->map);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->max);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->min);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->partition);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->percentage);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->reject);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->skipUntil);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->skipWhile);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->some);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->sortBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->sortByDesc);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->sum);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->takeUntil);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->takeWhile);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->unique);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->unless);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->until);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->when);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`HigherOrderCollectionProxy` is a great feature of Laravel that helps reduce boilerplate code. Sadly there is no out-of-the-box decent auto-completion for it.

This PR makes `HigherOrderCollectionProxy` a templated type (as is `Enumerable`, `Collection` and `EnumeratesValues`) that aims to help IDEs provide auto-completion based on the collection's value type.

- **What's been added:** Nothing
- **What's been modified:** Docblocks to add and use the template type parameters
- **Tests:** none needed, no changes in code; auto-completion changes were tested in PHPStorm
- **Hard breaking changes:** none, no changes in code
- **Soft breaking changes:** Library authors that use `HigherOrderCollectionProxy` might want to update docblocks to include the correct template type parameters
- **Room for improvement:** As of now, this PR cannot properly type chains of `HigherOrderCollectionProxy` like `$coll->keyBy->id->map->value->toArray()`