### PR TITLE
Run prepareNestedBatches on append/prependToChain & chain

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -5,7 +5,6 @@ namespace Illuminate\Bus;
 use Closure;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -230,6 +230,7 @@ trait Queueable
     public function appendToChain($job)
     {
         $jobs = ChainedBatch::prepareNestedBatches(collect([$job]));
+
         $this->chained = array_merge($this->chained, [$this->serializeJob($jobs->first())]);
 
         return $this;

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Bus;
 use Closure;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 
@@ -212,7 +213,9 @@ trait Queueable
      */
     public function prependToChain($job)
     {
-        $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
+        $jobs = ChainedBatch::prepareNestedBatches(collect([$job]));
+
+        $this->chained = Arr::prepend($this->chained, $this->serializeJob($jobs->first()));
 
         return $this;
     }
@@ -225,7 +228,8 @@ trait Queueable
      */
     public function appendToChain($job)
     {
-        $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
+        $jobs = ChainedBatch::prepareNestedBatches(collect([$job]));
+        $this->chained = array_merge($this->chained, [$this->serializeJob($jobs->first())]);
 
         return $this;
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -197,7 +197,9 @@ trait Queueable
      */
     public function chain($chain)
     {
-        $this->chained = collect($chain)->map(function ($job) {
+        $jobs = ChainedBatch::prepareNestedBatches(collect($chain));
+
+        $this->chained = $jobs->map(function ($job) {
             return $this->serializeJob($job);
         })->all();
 


### PR DESCRIPTION
# The issue with appending/prepending a batch from within a job

Currently, when appending or prepending a batch from within a job, you get the following error:

```
Serialization of 'Closure' is not allowed 
```

Diving into the Queuable class, this is because prepend/appendToChain fails to turn the `PendingBatch` into a `ChainedBatch`. The workaround for this is by creating a ChainedBatch manually as described here:
https://github.com/laravel/framework/issues/52468

# Proposal

Run `ChainedBatch::prepareNestedBatches` when appending or prepending a job from within another job, so you can add a batch onto a current chain as follows:

```
<?php

namespace App\Jobs;

use Illuminate\Bus\ChainedBatch;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Foundation\Queue\Queueable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;
use Illuminate\Support\Facades\Bus;

class Chainer implements ShouldQueue
{
    use Queueable;

    public function __construct() {}

    public function handle(): void {
        $batch = Bus::batch([
            new Logger('From batch'),
            new Logger('From batch'),
            new Logger('From batch'),
            Bus::batch([
                new Logger('From nested batch'),
            ]),
            new Logger('From batch'),
        ]);
        $this->appendToChain($batch);
    }
}
```

# Discussion

Currently, my implementation of appendToChain/prependToChain wraps the single job in a collection to match the expected format of `ChainedBatch::prepareNestedBatches()` - this feels kinda unnecessary, so this could be further improved by either:
- allowing an array of jobs to be appended/prepended
- refactoring `prepareNestedBatches` and creating a method that accepts a single job (in addition to the currently available method that accepts a collection)

Happy to make the necessary changes if needed.