### PR TITLE
[11.x] Fix for #52436 artisan schema:dump infinite recursion

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -151,7 +151,7 @@ class MySqlSchemaState extends SchemaState
     protected function executeDumpProcess(Process $process, $output, array $variables, int $depth = 0)
     {
         if ($depth > 30) {
-            throw new Exception('Dump execution exceeded maximum depth of '.$maxDepth.'.');
+            throw new Exception('Dump execution exceeded maximum depth of 30.');
         }
 
         try {

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -145,23 +145,30 @@ class MySqlSchemaState extends SchemaState
      * @param  \Symfony\Component\Process\Process  $process
      * @param  callable  $output
      * @param  array  $variables
+     * @param  int  $depth
      * @return \Symfony\Component\Process\Process
      */
-    protected function executeDumpProcess(Process $process, $output, array $variables)
+    protected function executeDumpProcess(Process $process, $output, array $variables, int $depth = 0)
     {
+        $maxDepth = 10;
+
+        if ($depth > $maxDepth) {
+            throw new Exception('Dump execution exceeded maximum depth of '.$maxDepth);
+        }
+
         try {
             $process->setTimeout(null)->mustRun($output, $variables);
         } catch (Exception $e) {
             if (Str::contains($e->getMessage(), ['column-statistics', 'column_statistics'])) {
                 return $this->executeDumpProcess(Process::fromShellCommandLine(
                     str_replace(' --column-statistics=0', '', $process->getCommandLine())
-                ), $output, $variables);
+                ), $output, $variables, $depth + 1);
             }
 
             if (str_contains($e->getMessage(), 'set-gtid-purged')) {
                 return $this->executeDumpProcess(Process::fromShellCommandLine(
                     str_replace(' --set-gtid-purged=OFF', '', $process->getCommandLine())
-                ), $output, $variables);
+                ), $output, $variables, $depth + 1);
             }
 
             throw $e;

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -150,10 +150,8 @@ class MySqlSchemaState extends SchemaState
      */
     protected function executeDumpProcess(Process $process, $output, array $variables, int $depth = 0)
     {
-        $maxDepth = 10;
-
-        if ($depth > $maxDepth) {
-            throw new Exception('Dump execution exceeded maximum depth of '.$maxDepth);
+        if ($depth > 30) {
+            throw new Exception('Dump execution exceeded maximum depth of '.$maxDepth.'.');
         }
 
         try {

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
+use Exception;
 use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
+use Symfony\Component\Process\Process;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -83,5 +85,31 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'unix_socket' => '/tmp/mysql.sock',
             ],
         ];
+    }
+
+    public function testExecuteDumpProcessForDepth()
+    {
+        $mockProcess = $this->createMock(Process::class);
+        $mockProcess->method('setTimeout')->willReturnSelf();
+        $mockProcess->method('mustRun')->will(
+            $this->throwException(new Exception('column-statistics'))
+        );
+
+        $mockOutput = $this->createMock(\stdClass::class);
+        $mockVariables = [];
+
+        $schemaState = $this->getMockBuilder(MySqlSchemaState::class)
+                            ->disableOriginalConstructor()
+                            ->onlyMethods(['makeProcess'])
+                            ->getMock();
+
+        $schemaState->method('makeProcess')->willReturn($mockProcess);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Dump execution exceeded maximum depth of 10');
+
+        // test executeDumpProcess
+        $method = new ReflectionMethod(get_class($schemaState), 'executeDumpProcess');
+        $method->invoke($schemaState, $mockProcess, $mockOutput, $mockVariables, 11);
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -6,10 +6,10 @@ use Exception;
 use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
-use Symfony\Component\Process\Process;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use Symfony\Component\Process\Process;
 
 class DatabaseMySqlSchemaStateTest extends TestCase
 {

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -106,10 +106,10 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $schemaState->method('makeProcess')->willReturn($mockProcess);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Dump execution exceeded maximum depth of 10');
+        $this->expectExceptionMessage('Dump execution exceeded maximum depth of 30.');
 
         // test executeDumpProcess
         $method = new ReflectionMethod(get_class($schemaState), 'executeDumpProcess');
-        $method->invoke($schemaState, $mockProcess, $mockOutput, $mockVariables, 11);
+        $method->invoke($schemaState, $mockProcess, $mockOutput, $mockVariables, 31);
     }
 }


### PR DESCRIPTION
This PR fix the issue of potential infinite recursion when executing the `schema:dump` command in Laravel, as reported in [#52436](https://github.com/laravel/framework/issues/52436). This happens because the `executeDumpProcess` method can recursively call itself without a clear termination condition under certain error conditions, such as encountering `column-statistics` or `set-gtid-purged` exceptions (https://github.com/laravel/framework/issues/52436#issuecomment-2286679516https://github.com/laravel/framework/issues/52436#issuecomment-2286679516). Without a limit on the recursion depth, this can lead to an infinite loop, causing the process to hang or crash.

To improve this, a maximum recursion depth is to be introduced to ensure that the recursion terminates after a certain number of attempts, preventing the infinite loop and making the code more robust.