### PR TITLE
Fix #52456, Unique rule silently discard when invalid/non-exist column is provided #52499

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -969,7 +969,7 @@ trait ValidatesAttributes
 
         $columns = array_merge($availableColumns, $availableQualifyColumns);
 
-        if (!in_array($column, $columns)) {
+        if (! in_array($column, $columns)) {
             $errorMsg = sprintf(
                 'The [%s] column doesnt exists in [%s] the table. Available columns: %s',
                 $column,

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -970,8 +970,12 @@ trait ValidatesAttributes
         $columns = array_merge($availableColumns, $availableQualifyColumns);
 
         if (!in_array($column, $columns)) {
-            $columnsList = implode(',', $columns);
-            $errorMsg = sprintf("The [%s] column doesnt exists in [%s] the table. Available columns: {$columnsList}", $column, $table);
+            $errorMsg = sprintf(
+                "The [%s] column doesnt exists in [%s] the table. Available columns: %s",
+                $column,
+                $table,
+                implode(',', $columns)
+            );
             throw new InvalidArgumentException($errorMsg);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -971,7 +971,7 @@ trait ValidatesAttributes
 
         if (!in_array($column, $columns)) {
             $errorMsg = sprintf(
-                "The [%s] column doesnt exists in [%s] the table. Available columns: %s",
+                'The [%s] column doesnt exists in [%s] the table. Available columns: %s',
                 $column,
                 $table,
                 implode(',', $columns)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
@@ -958,6 +959,21 @@ trait ValidatesAttributes
         // be verified as unique. If this parameter isn't specified we will just
         // assume that this column to be verified shares the attribute's name.
         $column = $this->getQueryColumn($parameters, $attribute);
+
+        $model = new class extends Model {};
+        $model->setTable($table);
+
+        // Get columns of $table
+        $availableColumns = Schema::getColumnListing($table);
+        $availableQualifyColumns = $model->qualifyColumns($availableColumns);
+
+        $columns = array_merge($availableColumns, $availableQualifyColumns);
+
+        if (!in_array($column, $columns)) {
+            $columnsList = implode(',', $columns);
+            $errorMsg = sprintf("The [%s] column doesnt exists in [%s] the table. Available columns: {$columnsList}", $column, $table);
+            throw new InvalidArgumentException($errorMsg);
+        }
 
         $id = null;
 

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -46,7 +46,7 @@ class ValidatorTest extends DatabaseTestCase
         $this->assertTrue($validator->passes());
 
         $validator = $this->getValidator(['first_name' => 'Taylor'], ['first_name' => 'unique:'.User::class.',no_column']);
-        $this->assertThrows(fn() => $validator->passes(), \InvalidArgumentException::class);
+        $this->assertThrows(fn () => $validator->passes(), \InvalidArgumentException::class);
     }
 
     public function testUniqueWithCustomModelKey()

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -44,6 +44,9 @@ class ValidatorTest extends DatabaseTestCase
 
         $validator = $this->getValidator(['first_name' => 'Taylor'], ['first_name' => 'unique:'.User::class]);
         $this->assertTrue($validator->passes());
+
+        $validator = $this->getValidator(['first_name' => 'Taylor'], ['first_name' => 'unique:'.User::class.',no_column']);
+        $this->assertThrows(fn() => $validator->passes(), \InvalidArgumentException::class);
     }
 
     public function testUniqueWithCustomModelKey()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Exceptions\MathException;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Stringable;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
@@ -4031,6 +4032,10 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateUnique()
     {
+        Schema::shouldReceive('getColumnListing')
+            ->with('users')
+            ->andReturn(['email', 'email_addr']);
+
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
@@ -4079,6 +4084,10 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays()
     {
+        Schema::shouldReceive('getColumnListing')
+            ->with('users')
+            ->andReturn(['email']);
+
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
             '*.email' => 'unique:users', '*.type' => 'exists:user_types',


### PR DESCRIPTION
This fix the issue of #52456. Issue is about unique rule pass when invalid column/non-exist is provided.

Explanation:

Imagine you have a users table with the columns id and first_name. You want to ensure that first_name is unique, so you define a validation rule like this:

```php
$rules = ['first_name' => [Rule::unique('users', 'name')]];
```
Now, suppose you mistakenly specify name as the column to be unique instead of first_name. This rule would incorrectly pass for any value of name, potentially leading to unexpected behavior. If not properly tested, this oversight could cause significant issues.