### PR TITLE
[11.x] Enhance DB inspection commands

### DIFF
--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -162,7 +162,7 @@ class ShowCommand extends DatabaseInspectionCommand
         $this->newLine();
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform['name'].'</>', $platform['version']);
-        $this->components->twoColumnDetail('Connection', Arr::get($platform['config'], 'connection'));
+        $this->components->twoColumnDetail('Connection', $platform['connection']);
         $this->components->twoColumnDetail('Database', Arr::get($platform['config'], 'database'));
         $this->components->twoColumnDetail('Host', Arr::get($platform['config'], 'host'));
         $this->components->twoColumnDetail('Port', Arr::get($platform['config'], 'port'));
@@ -186,13 +186,11 @@ class ShowCommand extends DatabaseInspectionCommand
             );
 
             $tables->each(function ($table) {
-                if ($tableSize = $table['size']) {
-                    $tableSize = Number::fileSize($tableSize, 2);
-                }
+                $tableSize = is_null($table['size']) ? null : Number::fileSize($table['size'], 2);
 
                 $this->components->twoColumnDetail(
                     ($table['schema'] ? $table['schema'].' <fg=gray;options=bold>/</> ' : '').$table['table'].($this->output->isVerbose() ? ' <fg=gray>'.$table['engine'].'</>' : null),
-                    ($tableSize ?: '—').($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>'.Number::format($table['rows']).'</>' : '')
+                    ($tableSize ?? '—').($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>'.Number::format($table['rows']).'</>' : '')
                 );
 
                 if ($this->output->isVerbose()) {

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -80,7 +80,7 @@ class ShowCommand extends DatabaseInspectionCommand
             'schema' => $table['schema'],
             'size' => $table['size'],
             'rows' => $this->option('counts')
-                ? $connection->table($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name'])->count()
+                ? ($connection->table($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name'])->count())
                 : null,
             'engine' => $table['engine'],
             'collation' => $table['collation'],

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -103,7 +103,6 @@ class ShowCommand extends DatabaseInspectionCommand
                 'view' => $view['name'],
                 'schema' => $view['schema'],
                 'rows' => $connection->table($view['schema'] ? $view['schema'].'.'.$view['name'] : $view['name'])->count(),
-
             ]);
     }
 

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -79,7 +79,9 @@ class ShowCommand extends DatabaseInspectionCommand
             'table' => $table['name'],
             'schema' => $table['schema'],
             'size' => $table['size'],
-            'rows' => $this->option('counts') ? $connection->table($table['name'])->count() : null,
+            'rows' => $this->option('counts')
+                ? $connection->table($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name'])->count()
+                : null,
             'engine' => $table['engine'],
             'collation' => $table['collation'],
             'comment' => $table['comment'],
@@ -100,7 +102,8 @@ class ShowCommand extends DatabaseInspectionCommand
             ->map(fn ($view) => [
                 'view' => $view['name'],
                 'schema' => $view['schema'],
-                'rows' => $connection->table($view->getName())->count(),
+                'rows' => $connection->table($view['schema'] ? $view['schema'].'.'.$view['name'] : $view['name'])->count(),
+
             ]);
     }
 

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -204,11 +204,11 @@ class TableCommand extends DatabaseInspectionCommand
 
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name']).'</>', $table['comment']);
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name']).'</>', $table['comment'] ? '<fg=gray>'.$table['comment'].'</>' : null);
         $this->components->twoColumnDetail('Columns', $table['columns']);
 
-        if ($size = $table['size']) {
-            $this->components->twoColumnDetail('Size', Number::fileSize($size, 2));
+        if (! is_null($table['size'])) {
+            $this->components->twoColumnDetail('Size', Number::fileSize($table['size'], 2));
         }
 
         if ($table['engine']) {

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -56,9 +56,7 @@ class TableCommand extends DatabaseInspectionCommand
             return 1;
         }
 
-        $tableName = $table['schema']
-            ? $table['schema'].'.'.$this->withoutTablePrefix($connection, $table['name'])
-            : $this->withoutTablePrefix($connection, $table['name']);
+        $tableName = ($table['schema'] ? $table['schema'].'.' : '').$this->withoutTablePrefix($connection, $table['name']);
 
         $columns = $this->columns($schema, $tableName);
         $indexes = $this->indexes($schema, $tableName);
@@ -70,6 +68,9 @@ class TableCommand extends DatabaseInspectionCommand
                 'name' => $table['name'],
                 'columns' => count($columns),
                 'size' => $table['size'],
+                'comment' => $table['comment'],
+                'collation' => $table['collation'],
+                'engine' => $table['engine'],
             ],
             'columns' => $columns,
             'indexes' => $indexes,
@@ -108,6 +109,7 @@ class TableCommand extends DatabaseInspectionCommand
     {
         return collect([
             $column['type_name'],
+            $column['generation'] ? $column['generation']['type'] : null,
             $column['auto_increment'] ? 'autoincrement' : null,
             $column['nullable'] ? 'nullable' : null,
             $column['collation'],
@@ -202,11 +204,19 @@ class TableCommand extends DatabaseInspectionCommand
 
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name']).'</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name']).'</>', $table['comment']);
         $this->components->twoColumnDetail('Columns', $table['columns']);
 
         if ($size = $table['size']) {
             $this->components->twoColumnDetail('Size', Number::fileSize($size, 2));
+        }
+
+        if ($table['engine']) {
+            $this->components->twoColumnDetail('Engine', $table['engine']);
+        }
+
+        if ($table['collation']) {
+            $this->components->twoColumnDetail('Collation', $table['collation']);
         }
 
         $this->newLine();


### PR DESCRIPTION
This PR enhances DB inspection commands:

* On `db:show` command:
  * Fixes connection name hadn't been displayed.
  * Fixes zero table's size hadn't been displayed.
  * Fixes #52496: the `db:show --counts` command was failing when table is not on the default schema.
  * Fixes `db:show --views` wasn't showing views' rows counts.
* On `db:table` command:
  * Adds support for schema names (pgsql and sqlsrv), now lists full table names: `schema.table`.
  * Displays more table info when available: table's comment (pgsql and mysql), engine (mysql), and collation (mysql).
  * Displays column's generation type for generated columns, "stored" or "virtual" (all DBs)
  * Fixes zero table's size hadn't been displayed.
