### PR TITLE
Add RefreshDatabaseWhenNecessary trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabaseWhenNecessary.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabaseWhenNecessary.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+trait RefreshDatabaseWhenNecessary
+{
+    use RefreshDatabase {
+        refreshTestDatabase as baseRefreshTestDatabase;
+    }
+
+    protected function refreshTestDatabase(): void
+    {
+        if (! $this->shouldMigrate()) {
+            RefreshDatabaseState::$migrated = true;
+        }
+
+        $this->baseRefreshTestDatabase();
+    }
+
+    /**
+     * Checks whether there are any migration files that have not yet run.
+     *
+     * @return bool
+     */
+    protected function shouldMigrate(): bool
+    {
+        $migrator = $this->app->make('migrator');
+
+        if (! $migrator->repositoryExists()) {
+            return true;
+        }
+
+        $migrationDirectories = array_merge($migrator->paths(), [database_path('migrations')]);
+        $migrationFiles       = $migrator->getMigrationFiles($migrationDirectories);
+
+        return count($migrationFiles) !== count($migrator->getRepository()->getRan());
+    }
+}


### PR DESCRIPTION
# Explanation
The `RefreshDatabase` trait always initially runs a `migrate:fresh` when a test run is started, even when no new migrations have been added. This is despite the documentation stating the following:

> The Illuminate\Foundation\Testing\RefreshDatabase trait does not migrate your database if your schema is up to date.

When dealing with a large set of migrations this can make test driven development quite tedious, having to wait for the migrations to run every time you run a test.

The `RefreshDatabaseWhenNecessary` trait is a drop-in replacement for the `RefreshDatabase` trait, that only runs `migrate:fresh` when necessary. It has taken inspiration from the `migrate:status` artisan command for the logic of determining whether new migrations have been added. In my use case this change makes about a 16 second difference, as the running of migrations can be completely skipped when the database is already up-to-date.

![image](https://github.com/user-attachments/assets/fbfc939a-5558-492c-8aaf-22edb25d68e8)
![image](https://github.com/user-attachments/assets/1356b940-8568-4b04-adfb-87ce89b482d3)
