### PR TITLE
[11.x] Added `ModelExists` rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
@@ -13,6 +15,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\ModelExists;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
@@ -104,6 +107,17 @@ class Rule
     public static function exists($table, $column = 'NULL')
     {
         return new Exists($table, $column);
+    }
+
+    /**
+     * Get an exists constraint builder instance.
+     *
+     * @param  Builder<TModel>|TModel|class-string<TModel>  $model
+     * @return \Illuminate\Validation\Rules\ModelExists<Builder<TModel>>
+     */
+    public static function modelExists(Builder|Model|string $model, ?string $column = null): ModelExists
+    {
+        return ModelExists::make($model, $column);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -110,7 +110,7 @@ class Rule
     }
 
     /**
-     * Get an exists constraint builder instance.
+     * Get an ModelExists constraint builder instance.
      *
      * @param  Builder<TModel>|TModel|class-string<TModel>  $model
      * @return \Illuminate\Validation\Rules\ModelExists<Builder<TModel>>

--- a/src/Illuminate/Validation/Rules/ModelExists.php
+++ b/src/Illuminate/Validation/Rules/ModelExists.php
@@ -28,6 +28,8 @@ class ModelExists implements ValidationRule
     }
 
     /**
+     * Create a new rule instance with the given Builder, Model, or class name.
+     *
      * @template TModel of Model
      *
      * @param  Builder<TModel>|TModel|class-string<TModel>  $model

--- a/src/Illuminate/Validation/Rules/ModelExists.php
+++ b/src/Illuminate/Validation/Rules/ModelExists.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * @template TModel of Model
+ *
+ * @mixin Builder<TModel>
+ */
+class ModelExists implements ValidationRule
+{
+    use ForwardsCalls;
+
+    /**
+     * Create a new rule instance.
+     */
+    public function __construct(
+        protected Builder $query,
+        protected ?string $column
+    ) {
+        //
+    }
+
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>|TModel|class-string<TModel>  $model
+     * @return ModelExists<TModel>
+     */
+    public static function make(Builder|Model|string $model, ?string $column = null): self
+    {
+        $builder = match (true) {
+            $model instanceof Builder => $model,
+            $model instanceof Model => $model->query(),
+            default => $model::query(),
+        };
+
+        return new self($builder, $column);
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $this->column
+            ? $this->query->where($this->column, $value)
+            : $this->query->whereKey($value);
+
+        if (! $this->query->exists()) {
+            $fail('validation.exists')->translate(['attribute' => $attribute]);
+        }
+    }
+
+    /**
+     * Get the underlying query builder instance.
+     *
+     * @return Builder<TModel>
+     */
+    public function getQueryBuilder(): Builder
+    {
+        return $this->query;
+    }
+
+    /**
+     * Dynamically handle calls into the query instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $this->forwardCallTo($this->query, $method, $parameters);
+
+        return $this;
+    }
+}

--- a/tests/Validation/ValidationModelExistsRuleTest.php
+++ b/tests/Validation/ValidationModelExistsRuleTest.php
@@ -75,6 +75,21 @@ class ValidationModelExistsRuleTest extends TestCase
         $this->assertSame('The selected id is invalid.', $v->errors()->first('id'));
     }
 
+    public function testPassesWhenRecordExistsWithScope()
+    {
+        $rule = Rule::modelExists(UserModel::class)->typeFoo();
+
+        UserModel::create(['id' => 1, 'type' => 'foo']);
+        UserModel::create(['id' => 2, 'type' => 'bar']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['id' => 1], ['id' => $rule]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['id' => 2], ['id' => $rule]);
+        $this->assertFalse($v->passes());
+    }
+
     public function testPassesWhenRecordExistsWithColumn()
     {
         $rule = Rule::modelExists(UserModel::class, 'type');
@@ -153,4 +168,9 @@ class UserModel extends Eloquent
     protected $guarded = [];
 
     public $timestamps = false;
+
+    public function scopeTypeFoo($query)
+    {
+        $query->where('type', 'foo');
+    }
 }

--- a/tests/Validation/ValidationModelExistsRuleTest.php
+++ b/tests/Validation/ValidationModelExistsRuleTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationModelExistsRuleTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    public function testItCanPassAnEloquentBuilderInstance()
+    {
+        $rule = Rule::modelExists(UserModel::query());
+        $this->assertInstanceOf(Builder::class, $rule->getQueryBuilder());
+        $this->assertInstanceOf(UserModel::class, $rule->getQueryBuilder()->getModel());
+    }
+
+    public function testItCanPassAModelInstance()
+    {
+        $rule = Rule::modelExists(new UserModel);
+        $this->assertInstanceOf(Builder::class, $rule->getQueryBuilder());
+        $this->assertInstanceOf(UserModel::class, $rule->getQueryBuilder()->getModel());
+    }
+
+    public function testItCanPassAModelClassName()
+    {
+        $rule = Rule::modelExists(UserModel::class);
+        $this->assertInstanceOf(Builder::class, $rule->getQueryBuilder());
+        $this->assertInstanceOf(UserModel::class, $rule->getQueryBuilder()->getModel());
+    }
+
+    public function testItForwardsCallsToTheQueryBuilder()
+    {
+        $rule = Rule::modelExists(UserModel::class);
+        $rule->where('foo', 'bar');
+        $this->assertSame('select * from "users" where "foo" = ?', $rule->getQueryBuilder()->toSql());
+    }
+
+    public function testPassesWhenRecordExists()
+    {
+        $rule = Rule::modelExists(UserModel::class);
+
+        UserModel::create(['id' => 1, 'type' => 'foo']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.exists' => 'The selected :attribute is invalid.'], 'en');
+        $v = new Validator($trans, ['id' => 1], ['id' => $rule]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['id' => 2], ['id' => $rule]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The selected id is invalid.', $v->errors()->first('id'));
+    }
+
+    public function testPassesWhenRecordExistsWithColumn()
+    {
+        $rule = Rule::modelExists(UserModel::class, 'type');
+
+        UserModel::create(['id' => 1, 'type' => 'foo']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['id' => 'foo'], ['id' => $rule]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['id' => 'bar'], ['id' => $rule]);
+        $this->assertFalse($v->passes());
+    }
+
+    protected function createSchema()
+    {
+        $this->schema('default')->create('users', function ($table) {
+            $table->unsignedInteger('id');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return $this->getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get connection resolver.
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected function getConnectionResolver()
+    {
+        return Eloquent::getConnectionResolver();
+    }
+
+    /**
+     * Tear down the database schema.
+     */
+    protected function tearDown(): void
+    {
+        $this->schema('default')->drop('users');
+    }
+
+    public function getIlluminateArrayTranslator()
+    {
+        return new Translator(
+            new ArrayLoader, 'en'
+        );
+    }
+}
+
+/**
+ * Eloquent Models.
+ */
+class UserModel extends Eloquent
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}


### PR DESCRIPTION
There is an `exists` rule to check the existence of a record in the database. You can already pass an Eloquent Model class as the table argument in the `Rule::exists()` method, but that just extracts the table and connection from the Model. You can apply additional constraints by chaining the `where()` method, but under the hood, it uses the `Illuminate\Database\Query\Builder`, not the `Illuminate\Database\Eloquent\Builder`, so you can't use scopes, for instance.

What we have found in our application is that we are repeating code by writing `exists` rules and reimplementing the constraints for which we actually already have scopes defined.

This new `Rule::modelExists()` rule lets you use scopes and other Eloquent Builder features:

```php
Rule::modelExists(User::class)->active()->admin();
```

By default, it checks the model key (using `whereKey()`), but you can change that with the optional second argument:

```php
Rule::modelExists(User::class, 'email');
```

Besides the Model class string, you can also pass a Builder or Model instance:

```php
Rule::modelExists(new User);
Rule::modelExists(User::query()->active());
```