### PR TITLE
[11.x] Feat: `requires` Helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -87,6 +87,28 @@ if (! function_exists('class_basename')) {
     }
 }
 
+if (! function_exists('required')) {
+    /**
+     * Return the required value or the default value.
+     *
+     * @template TValue
+     * @template TArgs
+     *
+     * @param  TValue|\Closure(TArgs): TValue  $callback
+     * @param  TValue  $require
+     * @param  mixed  $default
+     * @return TValue
+     */
+    function required($callback, $require, $default)
+    {
+        if ($callback($require) === $require) {
+            return $require;
+        }
+
+        return value($default);
+    }
+}
+
 if (! function_exists('class_uses_recursive')) {
     /**
      * Returns all traits used by a class, its parent classes and trait of their traits.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -87,7 +87,7 @@ if (! function_exists('class_basename')) {
     }
 }
 
-if (! function_exists('required')) {
+if (! function_exists('requires')) {
     /**
      * Returns a non-null value of the given closure or the fallback value.
      *
@@ -98,7 +98,7 @@ if (! function_exists('required')) {
      * @param  mixed  $fallback
      * @return TValue
      */
-    function required($callback, $fallback)
+    function requires($callback, $fallback)
     {
         $result = $callback();
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -89,23 +89,24 @@ if (! function_exists('class_basename')) {
 
 if (! function_exists('required')) {
     /**
-     * Return the required value or the default value.
+     * Return the required value or the fallback value.
      *
      * @template TValue
      * @template TArgs
      *
      * @param  TValue|\Closure(TArgs): TValue  $callback
-     * @param  TValue  $require
-     * @param  mixed  $default
+     * @param  mixed  $fallback
      * @return TValue
      */
-    function required($callback, $require, $default)
+    function required($callback, $fallback = null)
     {
-        if ($callback($require) === $require) {
-            return $require;
+        $result = $callback();
+
+        if (! is_null($result)) {
+            return $result;
         }
 
-        return value($default);
+        return value($fallback);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -89,7 +89,7 @@ if (! function_exists('class_basename')) {
 
 if (! function_exists('required')) {
     /**
-     * Return the required value or the fallback value.
+     * Returns a non-null value of the given closure or the fallback value.
      *
      * @template TValue
      * @template TArgs

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -98,7 +98,7 @@ if (! function_exists('required')) {
      * @param  mixed  $fallback
      * @return TValue
      */
-    function required($callback, $fallback = null)
+    function required($callback, $fallback)
     {
         $result = $callback();
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1207,6 +1207,19 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testRequired()
+    {
+        // Nullables
+        $this->assertEquals(10, required(fn () => null,10));
+        $this->assertEquals(true, required(fn () => null,true));
+        $this->assertEquals(false, required(fn () => null,false));
+
+        // Non-nullables
+        $this->assertEquals(10, required(fn () => 10,5));
+        $this->assertEquals(true, required(fn () => true,false));
+        $this->assertEquals(false, required(fn () => false,true));
+    }
 }
 
 trait SupportTestTraitOne

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1211,14 +1211,14 @@ class SupportHelpersTest extends TestCase
     public function testRequired()
     {
         // Nullables
-        $this->assertEquals(10, required(fn () => null,10));
-        $this->assertEquals(true, required(fn () => null,true));
-        $this->assertEquals(false, required(fn () => null,false));
+        $this->assertEquals(10, required(fn () => null, 10));
+        $this->assertEquals(true, required(fn () => null, true));
+        $this->assertEquals(false, required(fn () => null, false));
 
         // Non-nullables
-        $this->assertEquals(10, required(fn () => 10,5));
-        $this->assertEquals(true, required(fn () => true,false));
-        $this->assertEquals(false, required(fn () => false,true));
+        $this->assertEquals(10, required(fn () => 10, 5));
+        $this->assertEquals(true, required(fn () => true, false));
+        $this->assertEquals(false, required(fn () => false, true));
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1208,17 +1208,17 @@ class SupportHelpersTest extends TestCase
         );
     }
 
-    public function testRequired()
+    public function testRequires()
     {
         // Nullables
-        $this->assertEquals(10, required(fn () => null, 10));
-        $this->assertEquals(true, required(fn () => null, true));
-        $this->assertEquals(false, required(fn () => null, false));
+        $this->assertEquals(10, requires(fn () => null, 10));
+        $this->assertEquals(true, requires(fn () => null, true));
+        $this->assertEquals(false, requires(fn () => null, false));
 
         // Non-nullables
-        $this->assertEquals(10, required(fn () => 10, 5));
-        $this->assertEquals(true, required(fn () => true, false));
-        $this->assertEquals(false, required(fn () => false, true));
+        $this->assertEquals(10, requires(fn () => 10, 5));
+        $this->assertEquals(true, requires(fn () => true, false));
+        $this->assertEquals(false, requires(fn () => false, true));
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Although we have helpers like `value`, which in addition to being widely used and useful, deals with standard value situations, the `requires` helper introduced by this PR aims to perform a different task. Given a closure, if the value as the result of the closure is null, then we return the fallback value, hence the name `requires` - for situations where we want to work with a value, not null.

When `null`:

```php
requires(fn () => null, 'Taylor Otwell'); // Taylor Otwell
```

When non-null:

```php
requires(fn () => true, 'Taylor Otwell'); // true
```

According to the helper concept, the second parameter of the helper is not optional, but mandatory to determine the fallback value when the callable result is not null.