### PR TITLE
[11.x] Applying `value` Function into the `$default` value of `transform` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -475,7 +475,7 @@ if (! function_exists('transform')) {
             return $default($value);
         }
 
-        return $default;
+        return value($default);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `$default` value of the `transform` function does not pass through the `value` to allow the execution of a closure to obtain the default value, for example. This PR fixes this by passing `$default` through the `value` helper.