### PR TITLE
[11.x] Fix using closure controller bug

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -921,7 +921,7 @@ class Route
 
         return $this->setAction(array_merge($this->action, $this->parseAction([
             'uses' => $action,
-            'controller' => $action,
+            'controller' => is_string($action) ? $action : null,
         ])));
     }
 


### PR DESCRIPTION
# Controller name when using closure
Controller name should be a string value, but laravel save the actual Closure instead of null

## Description
When controller is a closure, this line set the controller name to an closure (expected string) and the getActionName method returns not a string! This bug break the exception viewer too
This edit fix that unexpected logic by setting controller to null when using a closure

## Bug 

**This is what i saw when using packages like livewire/volt:**

![Screenshot from 2024-08-18 18-04-28](https://github.com/user-attachments/assets/941c4efa-3a55-414e-968f-37632035daf9)

**And this i what is see after the changes:**

![Screenshot from 2024-08-18 18-07-31](https://github.com/user-attachments/assets/211af039-4a0c-4308-bc33-1dbceed930bb)

![Screenshot from 2024-08-18 18-08-42](https://github.com/user-attachments/assets/da8ddfed-8f9c-45b8-92fe-e009cacbf3b2)
