### PR TITLE
[11.x] Fix route controller name when closure passed (included tests)

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -921,7 +921,7 @@ class Route
 
         return $this->setAction(array_merge($this->action, $this->parseAction([
             'uses' => $action,
-            'controller' => is_string($action) ? $action : null,
+            'controller' => $action,
         ])));
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -921,7 +921,7 @@ class Route
 
         return $this->setAction(array_merge($this->action, $this->parseAction([
             'uses' => $action,
-            'controller' => $action,
+            'controller' => is_string($action) ? $action : null,
         ])));
     }
 

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -47,6 +47,10 @@ class RouteAction
             $action['uses'] = static::makeInvokable($action['uses']);
         }
 
+        if (isset($action['controller']) && !is_string($action['controller'])) {
+            $action['controller'] = null;
+        }
+
         return $action;
     }
 

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -47,7 +47,7 @@ class RouteAction
             $action['uses'] = static::makeInvokable($action['uses']);
         }
 
-        if (isset($action['controller']) && !is_string($action['controller'])) {
+        if (isset($action['controller']) && ! is_string($action['controller'])) {
             $action['controller'] = null;
         }
 

--- a/tests/Routing/RouteActionTest.php
+++ b/tests/Routing/RouteActionTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Routing;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteAction;
 use Illuminate\Routing\Router;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -35,19 +34,21 @@ class RouteActionTest extends TestCase
 
         $route = $router->get('/', ['FooController', 'index']);
 
-        $this->assertSame($route->getActionName(), 'FooController@index');
+        $this->assertSame('FooController@index', $route->getActionName());
 
-        $route = $router->get('/', function() {});
+        $route = $router->get('/', function () {
+        });
 
-        $this->assertSame($route->getActionName(), 'Closure');
+        $this->assertSame('Closure', $route->getActionName());
 
         $route = $router->get('/')->uses(['FooController', 'index']);
 
-        $this->assertSame($route->getActionName(), 'FooController@index');
+        $this->assertSame('FooController@index', $route->getActionName());
 
-        $route = $router->get('/')->uses(function() {});
+        $route = $router->get('/')->uses(function () {
+        });
 
-        $this->assertSame($route->getActionName(), 'Closure');
+        $this->assertSame('Closure', $route->getActionName());
     }
 }
 

--- a/tests/Routing/RouteActionTest.php
+++ b/tests/Routing/RouteActionTest.php
@@ -29,7 +29,7 @@ class RouteActionTest extends TestCase
         $this->assertFalse(RouteAction::containsSerializedClosure($action));
     }
 
-    public function test_action_name_is_a_string_or_null()
+    public function test_action_name_is_a_string()
     {
         $router = new Router(new Dispatcher());
 

--- a/tests/Routing/RouteActionTest.php
+++ b/tests/Routing/RouteActionTest.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteAction;
+use Illuminate\Routing\Router;
 use Laravel\SerializableClosure\SerializableClosure;
 use PHPUnit\Framework\TestCase;
 
@@ -24,6 +27,27 @@ class RouteActionTest extends TestCase
         $action = ['uses' => 'FooController@index'];
 
         $this->assertFalse(RouteAction::containsSerializedClosure($action));
+    }
+
+    public function test_action_name_is_a_string_or_null()
+    {
+        $router = new Router(new Dispatcher());
+
+        $route = $router->get('/', ['FooController', 'index']);
+
+        $this->assertSame($route->getActionName(), 'FooController@index');
+
+        $route = $router->get('/', function() {});
+
+        $this->assertSame($route->getActionName(), 'Closure');
+
+        $route = $router->get('/')->uses(['FooController', 'index']);
+
+        $this->assertSame($route->getActionName(), 'FooController@index');
+
+        $route = $router->get('/')->uses(function() {});
+
+        $this->assertSame($route->getActionName(), 'Closure');
     }
 }
 


### PR DESCRIPTION
## About the bug
There was a bug in Laravel that if we gave the action in the router with the help of the `uses` function and that action was of the Closure type, Laravel would place it directly in the `'controller'` index, which should be of the string|null type.
This caused errors that expected a string when getting the name of the controller through the `getActionName` function, but received a closure.
- _This bug has broken the livewire/volt_

## Changes
- I put a condition in the `RouteAction::parse` method, which has the role of checking actions, to prevent Closure from being placed in the `'controller'` index.
- Also, in this regard, I put tests that were not successful before the changes but became successful after the changes