### PR TITLE
Add `path` to strings (Returns platform independent path)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -925,6 +925,36 @@ class Str
     }
 
     /**
+     * Convert to a universal file path
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function path(string $value)
+    {
+        $value = trim($value);
+
+        // If path separator is hardcoded make it platform independent
+        $value =  preg_replace('/(^[\/\\\\]+)|([\/\\\\]+$)|[\/\\\\]+/', DIRECTORY_SEPARATOR, $value);
+
+        // Remove the leading/trailing separators
+        $value = trim($value, DIRECTORY_SEPARATOR);
+
+        // Remove special characters (:,*,?,",<,>,|) that aren't allowed in some os
+        $value = preg_replace('/[:\*\?\"\<\>\|]/', '', $value);
+
+        // Trim paths
+        $value = implode(
+            DIRECTORY_SEPARATOR,
+            collect(explode(DIRECTORY_SEPARATOR, $value))
+                ->transform(fn ($value) => trim($value))
+                ->toArray()
+        );
+
+        return $value;
+    }
+
+    /**
      * Get the plural form of an English word.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -925,7 +925,7 @@ class Str
     }
 
     /**
-     * Convert to a universal file path
+     * Convert to a universal file path.
      *
      * @param  string  $value
      * @param  string  $replace  Special characters are replaced with this param default empty

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -928,9 +928,10 @@ class Str
      * Convert to a universal file path
      *
      * @param  string  $value
+     * @param  string  $replace Special characters are replaced with this param default empty
      * @return string
      */
-    public static function path(string $value)
+    public static function path(string $value, string $replace = '')
     {
         $value = trim($value);
 
@@ -941,7 +942,7 @@ class Str
         $value = trim($value, DIRECTORY_SEPARATOR);
 
         // Remove special characters (:,*,?,",<,>,|) that aren't allowed in some os
-        $value = preg_replace('/[:\*\?\"\<\>\|]/', '', $value);
+        $value = preg_replace('/[:\*\?\"\<\>\|]/', $replace, $value);
 
         // Trim paths
         $value = implode(

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -928,7 +928,7 @@ class Str
      * Convert to a universal file path
      *
      * @param  string  $value
-     * @param  string  $replace Special characters are replaced with this param default empty
+     * @param  string  $replace  Special characters are replaced with this param default empty
      * @return string
      */
     public static function path(string $value, string $replace = '')
@@ -936,7 +936,7 @@ class Str
         $value = trim($value);
 
         // If path separator is hardcoded make it platform independent
-        $value =  preg_replace('/(^[\/\\\\]+)|([\/\\\\]+$)|[\/\\\\]+/', DIRECTORY_SEPARATOR, $value);
+        $value = preg_replace('/(^[\/\\\\]+)|([\/\\\\]+$)|[\/\\\\]+/', DIRECTORY_SEPARATOR, $value);
 
         // Remove the leading/trailing separators
         $value = trim($value, DIRECTORY_SEPARATOR);

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -602,13 +602,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
 
     /**
      * Convert to a universal file path
-     *
-     * @param  string  $value
+     * @param  string  $replace  Special characters are replaced with this param default empty
      * @return static
      */
-    public function path()
+    public function path($replace = '')
     {
-        return new static(Str::path($this->value));
+        return new static(Str::path($this->value, $replace));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -602,6 +602,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
 
     /**
      * Convert to a universal file path.
+     *
      * @param  string  $replace  Special characters are replaced with this param default empty
      * @return static
      */

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -601,7 +601,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Convert to a universal file path
+     * Convert to a universal file path.
      * @param  string  $replace  Special characters are replaced with this param default empty
      * @return static
      */

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -601,6 +601,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Convert to a universal file path
+     *
+     * @param  string  $value
+     * @return static
+     */
+    public function path()
+    {
+        return new static(Str::path($this->value));
+    }
+
+    /**
      * Call the given callback and return a new string.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1152,13 +1152,17 @@ class SupportStrTest extends TestCase
 
     public function testPath()
     {
-        $path = sprintf('x%sy%sz', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+        $ds = DIRECTORY_SEPARATOR;
+        $path = sprintf('x%sy%sz', $ds, $ds);
 
         $this->assertSame("$path", Str::path(' x/  y/z/ '));
         $this->assertSame("$path", Str::path('///x/y/z//'));
         $this->assertSame("$path", Str::path(' | " ?:x/\>>**y/\<<z//'));
         $this->assertSame("$path", Str::path('x////y///z'));
         $this->assertSame("$path", Str::path('x\\\\y\\z'));
+
+        $this->assertSame("users{$ds}davejohn", Str::path('users/dave:john'));
+        $this->assertSame("users{$ds}dave_john", Str::path('users/dave_john', '_'));
     }
 
     public function testSwapKeywords(): void

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1150,6 +1150,17 @@ class SupportStrTest extends TestCase
         $this->assertSame('❤MultiByte☆❤☆❤☆❤', Str::padRight('❤MultiByte☆', 16, '❤☆'));
     }
 
+    public function testPath()
+    {
+        $path = sprintf('x%sy%sz', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+
+        $this->assertSame("$path", Str::path(' x/  y/z/ '));
+        $this->assertSame("$path", Str::path('///x/y/z//'));
+        $this->assertSame("$path", Str::path(' | " ?:x/\>>**y/\<<z//'));
+        $this->assertSame("$path", Str::path('x////y///z'));
+        $this->assertSame("$path", Str::path('x\\\\y\\z'));
+    }
+
     public function testSwapKeywords(): void
     {
         $this->assertSame(

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1078,6 +1078,17 @@ class SupportStringableTest extends TestCase
         $this->assertSame('     ❤MultiByte☆', (string) $this->stringable('❤MultiByte☆')->padLeft(16));
     }
 
+    public function testPath()
+    {
+        $path = sprintf('x%sy%sz', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+
+        $this->assertSame("$path", (string) $this->stringable(' x/  y/z/ ')->path());
+        $this->assertSame("$path", (string) $this->stringable('///x/y/z//')->path());
+        $this->assertSame("$path", (string) $this->stringable(' | " ?:x/\>>**y/\<<z//')->path());
+        $this->assertSame("$path", (string) $this->stringable('x////y///z')->path());
+        $this->assertSame("$path", (string) $this->stringable('x\\\\y\\z')->path());
+    }
+
     public function testPadRight()
     {
         $this->assertSame('Alien-----', (string) $this->stringable('Alien')->padRight(10, '-'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
@@ -1080,13 +1081,17 @@ class SupportStringableTest extends TestCase
 
     public function testPath()
     {
-        $path = sprintf('x%sy%sz', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+        $ds = DIRECTORY_SEPARATOR;
+        $path = sprintf('x%sy%sz', $ds, $ds);
 
         $this->assertSame("$path", (string) $this->stringable(' x/  y/z/ ')->path());
         $this->assertSame("$path", (string) $this->stringable('///x/y/z//')->path());
         $this->assertSame("$path", (string) $this->stringable(' | " ?:x/\>>**y/\<<z//')->path());
         $this->assertSame("$path", (string) $this->stringable('x////y///z')->path());
         $this->assertSame("$path", (string) $this->stringable('x\\\\y\\z')->path());
+
+        $this->assertSame("users{$ds}davejohn", (string) $this->stringable('users/dave:john')->path());
+        $this->assertSame("users{$ds}dave_john", (string) $this->stringable('users/dave_john')->path('_'));
     }
 
     public function testPadRight()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;


### PR DESCRIPTION
This string helper returns a platform-independent path.

Here’s why this is useful:

1). In a Linux environment, if a user is named **dave:junior**. we need to create a directory for each user by their name, the directory for this user would be `users/@dave:junior`. If there is developer who use windows can't open it since Windows does not allow colons (:) in filenames, so this helper returns `users/davejunior` or `users/dave_junior` to ensure compatibility.

2). Developers working in a Windows environment might use `users\davejunior` as the path separator. Issues arise when deploying to a Linux environment. This helper converts the path to use the appropriate platform path separator.

3). Sometimes, paths might have additional separator characters, such as `users//davejunior`. This helper consolidates them to `users/davejunior`.

Practical example here https://github.com/Lakshan-Madushanka/laravel-comments-admin-panel/issues/5

List can be much longer but I hope this would enough to perceive the potentiality of this helper.