### PR TITLE
Fix `Model->isRelation` Method to Accurately Identify Relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -570,13 +570,13 @@ trait HasAttributes
         }
 
         if (method_exists($this, $key)) {
-            $methodReturnType = (new ReflectionMethod($this, $key))->getReturnType()->getName();
+            $methodReturnType = (new ReflectionMethod($this, $key))->getReturnType()?->getName();
             if (is_subclass_of($methodReturnType, Relation::class)) {
                 return true;
             }
         }
 
-        return $this->relationResolver(static::class, $key);
+        return !!$this->relationResolver(static::class, $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -569,8 +569,14 @@ trait HasAttributes
             return false;
         }
 
-        return method_exists($this, $key) ||
-               $this->relationResolver(static::class, $key);
+        if (method_exists($this, $key)) {
+            $methodReturnType = (new ReflectionMethod($this, $key))->getReturnType()->getName();
+            if (is_subclass_of($methodReturnType, Relation::class)) {
+                return true;
+            }
+        }
+
+        return $this->relationResolver(static::class, $key);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentNoRelationsTest.php
+++ b/tests/Database/DatabaseEloquentNoRelationsTest.php
@@ -71,6 +71,16 @@ class DatabaseEloquentDynamicRelationsTest extends TestCase
         $this->assertTrue($model->isRelation('hardCodedRelation'));
     }
 
+    public function testNotDetectRegularFunctionAsRelation()
+    {
+        $model = new NoRelationModel;
+
+        if (!isset($model->comment)) {
+            $model->comment();
+        }
+        $this->assertTrue(true);
+    }
+
     public function testRelationResolvers()
     {
         $model1 = new DynamicRelationModel;
@@ -136,4 +146,10 @@ class FakeHasManyRel extends HasMany
     {
         return ['many' => 'related'];
     }
+}
+
+class NoRelationModel extends Model
+{
+    public function comment(): void
+    {}
 }


### PR DESCRIPTION
This PR addresses an issue in the isRelation method of the HasAttributes trait, where the method would incorrectly return true for any key that exists as a method on the model. This caused issues when determining whether a given key represents a relation.

Previously, isRelation could mistakenly identify non-relationship methods as relationships, leading to unexpected behavior in Eloquent models. This fix ensures that only methods returning a Relation subclass are treated as relations, improving the reliability and accuracy of relationship handling in Eloquent models.