### PR TITLE
[11.x] Add Description for `EntryNotFoundException`

### DIFF
--- a/src/Illuminate/Container/EntryNotFoundException.php
+++ b/src/Illuminate/Container/EntryNotFoundException.php
@@ -7,5 +7,15 @@ use Psr\Container\NotFoundExceptionInterface;
 
 class EntryNotFoundException extends Exception implements NotFoundExceptionInterface
 {
-    //
+    /**
+     * Create a new exception instance.
+     *
+     * @param  string  $id
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($id, $code, $previous)
+    {
+        parent::__construct("No container bind defined for: {$id}.", $code, $previous);
+    }
 }

--- a/src/Illuminate/Container/EntryNotFoundException.php
+++ b/src/Illuminate/Container/EntryNotFoundException.php
@@ -12,6 +12,7 @@ class EntryNotFoundException extends Exception implements NotFoundExceptionInter
      *
      * @param  string  $id
      * @param  int  $code
+     * @param  \Throwable|null  $previous
      * @return void
      */
     public function __construct($id, $code, $previous)

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -650,7 +650,7 @@ class ContainerTest extends TestCase
     public function testUnknownEntryThrowsExceptionWithExpectedMessage()
     {
         $this->expectException(EntryNotFoundException::class);
-        $this->expectExceptionMessage("No container bind defined for: Taylor.");
+        $this->expectExceptionMessage('No container bind defined for: Taylor.');
 
         $container = new Container;
         $container->get('Taylor');

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -647,6 +647,15 @@ class ContainerTest extends TestCase
         $container->get('Taylor');
     }
 
+    public function testUnknownEntryThrowsExceptionWithExpectedMessage()
+    {
+        $this->expectException(EntryNotFoundException::class);
+        $this->expectExceptionMessage("No container bind defined for: Taylor.");
+
+        $container = new Container;
+        $container->get('Taylor');
+    }
+
     public function testBoundEntriesThrowsContainerExceptionWhenNotResolvable()
     {
         $this->expectException(ContainerExceptionInterface::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When trying to get a bind from the container via `app()->get('...')`, if the bind is not found, no descriptive message will be displayed in the exception

![CleanShot 2024-08-19 at 18 39 24](https://github.com/user-attachments/assets/273f225f-4830-4564-9f2c-c03b6ea13e1a)

⬆️  In this example, I tried `app()->get('mixpanel')`

This PR implements a basic description to make understanding clear to anyone reading the exception. 

As the name is generic (EntryNotFoundException), people who work analyzing error tracking services (Sentry, NewRelic, and others) have difficulty understanding it and end up associating it with other problems.


