### PR TITLE
[11.x] revert #52510 which added a unneeded function call

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -475,7 +475,7 @@ if (! function_exists('transform')) {
             return $default($value);
         }
 
-        return value($default);
+        return $default;
     }
 }
 


### PR DESCRIPTION
This PR reverts PR #52510

PR #52510 introduced a call to the `value()` helper on the `transform()` helper's last return. 

The `value()` helper only checks if the `$value` argument is a `\Closure`, and if so, invokes it. Otherwise, it returns the plain `$value` without any changes:

https://github.com/laravel/framework/blob/81a0b5b60ff83d7a47177675741c41c1dfe78967/src/Illuminate/Collections/helpers.php#L234-L237

The `transform()` helper already checks if the `$default` value is a callable (which includes the `\Closure` case), before the modified line: 

https://github.com/laravel/framework/blob/81a0b5b60ff83d7a47177675741c41c1dfe78967/src/Illuminate/Support/helpers.php#L468-L479

Therefore, when execution reaches the modified line on PR #52510 we already know `$default` is not a callable, and thus, not a `\Closure`.

Which renders the modification unneeded, as it only adds a useless function call, and a ternary check, that will always evaluate to `false` and return the unmodified value the `value()` helper receives.

This PR:

- Reverts the line modified by PR #52510 to remove the unneeded `value()` call.