### PR TITLE
Add orderByPriority Method for Custom Sorting in Query Builder V2

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2638,7 +2638,7 @@ class Builder implements BuilderContract
 
         $grammar = $this->getGrammar();
 
-        if (!method_exists($grammar, 'orderByPriority')) {
+        if (! method_exists($grammar, 'orderByPriority')) {
             throw new RuntimeException('The "orderByPriority" function is not supported by this database.');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2615,6 +2615,39 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param  string  $column
+     * @param  array  $priority
+     * @param  string  $direction
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $direction = strtolower($direction);
+
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
+        }
+
+        if (count($priority) === 0) {
+            throw new InvalidArgumentException('Order priority array must not be empty.');
+        }
+
+        $grammar = $this->getGrammar();
+
+        if (!method_exists($grammar, 'orderByPriority')) {
+            throw new RuntimeException('The "orderByPriority" function is not supported by this database.');
+        }
+
+        $this->orderByRaw($grammar->orderByPriority($column, $priority, $direction), $priority);
+
+        return $this;
+    }
+
+    /**
      * Add a descending "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -53,19 +53,4 @@ class MariaDbGrammar extends MySqlGrammar
     {
         return false;
     }
-
-    /**
-     * Apply custom ordering to a query based on a priority array.
-     *
-     * @param  $column
-     * @param  array  $priority
-     * @param  $direction
-     * @return string
-     */
-    public function orderByPriority($column, array $priority, $direction = 'asc')
-    {
-        $placeholders = implode(',', array_fill(0, count($priority), '?'));
-
-        return "FIELD($column, $placeholders) $direction";
-    }
 }

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -53,4 +53,19 @@ class MariaDbGrammar extends MySqlGrammar
     {
         return false;
     }
+
+    /**
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param $column
+     * @param array $priority
+     * @param $direction
+     * @return string
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $placeholders = implode(',', array_fill(0, count($priority), '?'));
+
+        return "FIELD($column, $placeholders) $direction";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -57,9 +57,9 @@ class MariaDbGrammar extends MySqlGrammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param $column
-     * @param array $priority
-     * @param $direction
+     * @param  $column
+     * @param  array $priority
+     * @param  $direction
      * @return string
      */
     public function orderByPriority($column, array $priority, $direction = 'asc')

--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -58,7 +58,7 @@ class MariaDbGrammar extends MySqlGrammar
      * Apply custom ordering to a query based on a priority array.
      *
      * @param  $column
-     * @param  array $priority
+     * @param  array  $priority
      * @param  $direction
      * @return string
      */

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -537,8 +537,14 @@ class MySqlGrammar extends Grammar
     {
         $column = $this->wrap($column);
 
-        $placeholders = implode(',', array_fill(0, count($priority), '?'));
+        $cases = [];
 
-        return 'field('.$column.', '.$placeholders.') '.$direction;
+        foreach ($priority as $index => $value) {
+            $cases[] = "when {$column} = ? then {$index}";
+        }
+
+        $caseStatement = 'case '.implode(' ', $cases).' else '.count($priority).' end';
+
+        return "{$caseStatement} {$direction}";
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -528,9 +528,9 @@ class MySqlGrammar extends Grammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param $column
-     * @param array $priority
-     * @param $direction
+     * @param  $column
+     * @param  array $priority
+     * @param  $direction
      * @return string
      */
     public function orderByPriority($column, array $priority, $direction = 'asc')

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -529,7 +529,7 @@ class MySqlGrammar extends Grammar
      * Apply custom ordering to a query based on a priority array.
      *
      * @param  $column
-     * @param  array $priority
+     * @param  array  $priority
      * @param  $direction
      * @return string
      */

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -524,4 +524,19 @@ class MySqlGrammar extends Grammar
 
         return 'json_extract('.$field.$path.')';
     }
+
+    /**
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param $column
+     * @param array $priority
+     * @param $direction
+     * @return string
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $placeholders = implode(',', array_fill(0, count($priority), '?'));
+
+        return "FIELD($column, $placeholders) $direction";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -528,15 +528,17 @@ class MySqlGrammar extends Grammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param  $column
+     * @param  string  $column
      * @param  array  $priority
-     * @param  $direction
+     * @param  string  $direction
      * @return string
      */
-    public function orderByPriority($column, array $priority, $direction = 'asc')
+    public function orderByPriority(string $column, array $priority, string $direction = 'asc')
     {
+        $column = $this->wrap($column);
+
         $placeholders = implode(',', array_fill(0, count($priority), '?'));
 
-        return "FIELD($column, $placeholders) $direction";
+        return 'field('.$column.', '.$placeholders.') '.$direction;
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -777,7 +777,7 @@ class PostgresGrammar extends Grammar
      * Apply custom ordering to a query based on a priority array.
      *
      * @param  $column
-     * @param  array $priority
+     * @param  array  $priority
      * @param  $direction
      * @return string
      */

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -776,20 +776,22 @@ class PostgresGrammar extends Grammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param  $column
+     * @param  string  $column
      * @param  array  $priority
-     * @param  $direction
+     * @param  string  $direction
      * @return string
      */
-    public function orderByPriority($column, array $priority, $direction = 'asc')
+    public function orderByPriority(string $column, array $priority,string $direction = 'asc')
     {
+        $column = $this->wrap($column);
+
         $cases = [];
 
         foreach ($priority as $index => $value) {
-            $cases[] = "WHEN {$column} = ? THEN {$index}";
+            $cases[] = "when {$column} = ? then {$index}";
         }
 
-        $caseStatement = 'CASE '.implode(' ', $cases).' ELSE '.count($priority).' END';
+        $caseStatement = 'case '.implode(' ', $cases).' else '.count($priority).' end';
 
         return "{$caseStatement} {$direction}";
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -776,9 +776,9 @@ class PostgresGrammar extends Grammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param $column
-     * @param array $priority
-     * @param $direction
+     * @param  $column
+     * @param  array $priority
+     * @param  $direction
      * @return string
      */
     public function orderByPriority($column, array $priority, $direction = 'asc')
@@ -789,7 +789,7 @@ class PostgresGrammar extends Grammar
             $cases[] = "WHEN {$column} = ? THEN {$index}";
         }
 
-        $caseStatement = "CASE " . implode(' ', $cases) . " ELSE " . count($priority) . " END";
+        $caseStatement = 'CASE '.implode(' ', $cases).' ELSE '.count($priority).' END';
 
         return "{$caseStatement} {$direction}";
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -781,7 +781,7 @@ class PostgresGrammar extends Grammar
      * @param  string  $direction
      * @return string
      */
-    public function orderByPriority(string $column, array $priority,string $direction = 'asc')
+    public function orderByPriority(string $column, array $priority, string $direction = 'asc')
     {
         $column = $this->wrap($column);
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -772,4 +772,25 @@ class PostgresGrammar extends Grammar
 
         return $query;
     }
+
+    /**
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param $column
+     * @param array $priority
+     * @param $direction
+     * @return string
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $cases = [];
+
+        foreach ($priority as $index => $value) {
+            $cases[] = "WHEN {$column} = ? THEN {$index}";
+        }
+
+        $caseStatement = "CASE " . implode(' ', $cases) . " ELSE " . count($priority) . " END";
+
+        return "{$caseStatement} {$direction}";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -460,20 +460,22 @@ class SQLiteGrammar extends Grammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param  $column
+     * @param  string  $column
      * @param  array  $priority
-     * @param  $direction
+     * @param  string  $direction
      * @return string
      */
-    public function orderByPriority($column, array $priority, $direction = 'asc')
+    public function orderByPriority(string $column, array $priority,string $direction = 'asc')
     {
+        $column = $this->wrap($column);
+
         $cases = [];
 
         foreach ($priority as $index => $value) {
-            $cases[] = "WHEN {$column} = ? THEN {$index}";
+            $cases[] = "when {$column} = ? then {$index}";
         }
 
-        $caseStatement = 'CASE '.implode(' ', $cases).' ELSE '.count($priority).' END';
+        $caseStatement = 'case '.implode(' ', $cases).' else '.count($priority).' end';
 
         return "{$caseStatement} {$direction}";
     }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -461,7 +461,7 @@ class SQLiteGrammar extends Grammar
      * Apply custom ordering to a query based on a priority array.
      *
      * @param  $column
-     * @param  array $priority
+     * @param  array  $priority
      * @param  $direction
      * @return string
      */

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -460,9 +460,9 @@ class SQLiteGrammar extends Grammar
     /**
      * Apply custom ordering to a query based on a priority array.
      *
-     * @param $column
-     * @param array $priority
-     * @param $direction
+     * @param  $column
+     * @param  array $priority
+     * @param  $direction
      * @return string
      */
     public function orderByPriority($column, array $priority, $direction = 'asc')
@@ -473,7 +473,7 @@ class SQLiteGrammar extends Grammar
             $cases[] = "WHEN {$column} = ? THEN {$index}";
         }
 
-        $caseStatement = "CASE " . implode(' ', $cases) . " ELSE " . count($priority) . " END";
+        $caseStatement = 'CASE '.implode(' ', $cases).' ELSE '.count($priority).' END';
 
         return "{$caseStatement} {$direction}";
     }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -465,7 +465,7 @@ class SQLiteGrammar extends Grammar
      * @param  string  $direction
      * @return string
      */
-    public function orderByPriority(string $column, array $priority,string $direction = 'asc')
+    public function orderByPriority(string $column, array $priority, string $direction = 'asc')
     {
         $column = $this->wrap($column);
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -456,4 +456,25 @@ class SQLiteGrammar extends Grammar
 
         return 'json_extract('.$field.$path.')';
     }
+
+    /**
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param $column
+     * @param array $priority
+     * @param $direction
+     * @return string
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $cases = [];
+
+        foreach ($priority as $index => $value) {
+            $cases[] = "WHEN {$column} = ? THEN {$index}";
+        }
+
+        $caseStatement = "CASE " . implode(' ', $cases) . " ELSE " . count($priority) . " END";
+
+        return "{$caseStatement} {$direction}";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -583,20 +583,24 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * @param  $column
+     * Apply custom ordering to a query based on a priority array.
+     *
+     * @param  string  $column
      * @param  array  $priority
-     * @param  $direction
+     * @param  string  $direction
      * @return string
      */
-    public function orderByPriority($column, array $priority, $direction = 'asc')
+    public function orderByPriority(string $column, array $priority,string $direction = 'asc')
     {
+        $column = $this->wrap($column);
+
         $cases = [];
 
         foreach ($priority as $index => $value) {
-            $cases[] = "WHEN {$column} = ? THEN {$index}";
+            $cases[] = "when {$column} = ? then {$index}";
         }
 
-        $caseStatement = 'CASE '.implode(' ', $cases).' ELSE '.count($priority).' END';
+        $caseStatement = 'case '.implode(' ', $cases).' else '.count($priority).' end';
 
         return "{$caseStatement} {$direction}";
     }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -583,9 +583,9 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * @param $column
-     * @param array $priority
-     * @param $direction
+     * @param  $column
+     * @param  array $priority
+     * @param  $direction
      * @return string
      */
     public function orderByPriority($column, array $priority, $direction = 'asc')
@@ -596,7 +596,7 @@ class SqlServerGrammar extends Grammar
             $cases[] = "WHEN {$column} = ? THEN {$index}";
         }
 
-        $caseStatement = "CASE " . implode(' ', $cases) . " ELSE " . count($priority) . " END";
+        $caseStatement = 'CASE '.implode(' ', $cases).' ELSE '.count($priority).' END';
 
         return "{$caseStatement} {$direction}";
     }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -581,4 +581,23 @@ class SqlServerGrammar extends Grammar
 
         return $table;
     }
+
+    /**
+     * @param $column
+     * @param array $priority
+     * @param $direction
+     * @return string
+     */
+    public function orderByPriority($column, array $priority, $direction = 'asc')
+    {
+        $cases = [];
+
+        foreach ($priority as $index => $value) {
+            $cases[] = "WHEN {$column} = ? THEN {$index}";
+        }
+
+        $caseStatement = "CASE " . implode(' ', $cases) . " ELSE " . count($priority) . " END";
+
+        return "{$caseStatement} {$direction}";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -590,7 +590,7 @@ class SqlServerGrammar extends Grammar
      * @param  string  $direction
      * @return string
      */
-    public function orderByPriority(string $column, array $priority,string $direction = 'asc')
+    public function orderByPriority(string $column, array $priority, string $direction = 'asc')
     {
         $column = $this->wrap($column);
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -584,7 +584,7 @@ class SqlServerGrammar extends Grammar
 
     /**
      * @param  $column
-     * @param  array $priority
+     * @param  array  $priority
      * @param  $direction
      * @return string
      */

--- a/tests/Database/DatabaseMariaDbQueryGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseMariaDbQueryGrammarTest extends TestCase
     {
         $grammar = new MariaDbGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('FIELD(name, ?,?) asc', $queryString);
+        $this->assertSame('field(`name`, ?,?) asc', $queryString);
     }
 }

--- a/tests/Database/DatabaseMariaDbQueryGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbQueryGrammarTest.php
@@ -28,4 +28,11 @@ class DatabaseMariaDbQueryGrammarTest extends TestCase
 
         $this->assertSame('select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
     }
+
+    public function testOrderByPriority()
+    {
+        $grammar = new MariaDbGrammar;
+        $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('FIELD(name, ?,?) asc', $queryString);
+    }
 }

--- a/tests/Database/DatabaseMariaDbQueryGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseMariaDbQueryGrammarTest extends TestCase
     {
         $grammar = new MariaDbGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('field(`name`, ?,?) asc', $queryString);
+        $this->assertSame('case when `name` = ? then 0 when `name` = ? then 1 else 2 end asc', $queryString);
     }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
     {
         $grammar = new MySqlGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('FIELD(name, ?,?) asc', $queryString);
+        $this->assertSame('field(`name`, ?,?) asc', $queryString);
     }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -28,4 +28,11 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
 
         $this->assertSame('select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
     }
+
+    public function testOrderByPriority()
+    {
+        $grammar = new MySqlGrammar;
+        $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('FIELD(name, ?,?) asc', $queryString);
+    }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
     {
         $grammar = new MySqlGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('case when "name" = ? then 0 when "name" = ? then 1 else 2 end asc', $queryString);
+        $this->assertSame('case when `name` = ? then 0 when "name" = ? then 1 else 2 end asc', $queryString);
     }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
     {
         $grammar = new MySqlGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('case when `name` = ? then 0 when "name" = ? then 1 else 2 end asc', $queryString);
+        $this->assertSame('case when `name` = ? then 0 when `name` = ? then 1 else 2 end asc', $queryString);
     }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
     {
         $grammar = new MySqlGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('field(`name`, ?,?) asc', $queryString);
+        $this->assertSame('case when "name" = ? then 0 when "name" = ? then 1 else 2 end asc', $queryString);
     }
 }

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabasePostgresQueryGrammarTest extends TestCase
     {
         $grammar = new PostgresGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 ELSE 2 END asc', $queryString);
+        $this->assertSame('case when "name" = ? then 0 when "name" = ? then 1 else 2 end asc', $queryString);
     }
 }

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -28,4 +28,11 @@ class DatabasePostgresQueryGrammarTest extends TestCase
 
         $this->assertSame('select * from "users" where \'{}\' ? \'Hello\\\'\\\'World?\' AND "email" = \'foo\'', $query);
     }
+
+    public function testOrderByPriority()
+    {
+        $grammar = new PostgresGrammar;
+        $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 ELSE 2 END asc', $queryString);
+    }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1792,7 +1792,7 @@ class DatabaseQueryBuilderTest extends TestCase
             m::mock(Processor::class),
         ]);
         $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('select * from `users` order by field(`name`, ?,?) asc', $builder->toSql());
+        $this->assertSame('select * from `users` order by case when `name` = ? then 0 when `name` = ? then 1 else 2 end asc', $builder->toSql());
 
         $builder = m::mock(Builder::class.'[where,exists,insert]', [
             m::mock(ConnectionInterface::class),
@@ -1800,7 +1800,7 @@ class DatabaseQueryBuilderTest extends TestCase
             m::mock(Processor::class),
         ]);
         $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('select * from `users` order by field(`name`, ?,?) asc', $builder->toSql());
+        $this->assertSame('select * from `users` order by case when `name` = ? then 0 when `name` = ? then 1 else 2 end asc', $builder->toSql());
 
         $builder = m::mock(Builder::class.'[where,exists,insert]', [
             m::mock(ConnectionInterface::class),

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1784,6 +1784,58 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
+    public function testOrderByPriority()
+    {
+        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+            m::mock(ConnectionInterface::class),
+            new MySqlGrammar,
+            m::mock(Processor::class),
+        ]);
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('select * from `users` order by field(`name`, ?,?) asc', $builder->toSql());
+
+        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+            m::mock(ConnectionInterface::class),
+            new MariaDbGrammar,
+            m::mock(Processor::class),
+        ]);
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('select * from `users` order by field(`name`, ?,?) asc', $builder->toSql());
+
+        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+            m::mock(ConnectionInterface::class),
+            new PostgresGrammar,
+            m::mock(Processor::class),
+        ]);
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('select * from "users" order by case when "name" = ? then 0 when "name" = ? then 1 else 2 end asc', $builder->toSql());
+
+        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+            m::mock(ConnectionInterface::class),
+            new SqlServerGrammar,
+            m::mock(Processor::class),
+        ]);
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('select * from [users] order by case when [name] = ? then 0 when [name] = ? then 1 else 2 end asc', $builder->toSql());
+
+        $builder = m::mock(Builder::class.'[where,exists,insert]', [
+            m::mock(ConnectionInterface::class),
+            new SQLiteGrammar,
+            m::mock(Processor::class),
+        ]);
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('select * from "users" order by case when "name" = ? then 0 when "name" = ? then 1 else 2 end asc', $builder->toSql());
+    }
+
+    public function testOrderByPriorityThrowsRuntimeExceptionForUnsupportedDatabase()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "orderByPriority" function is not supported by this database.');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe']);
+    }
+
     public function testLatest()
     {
         $builder = $this->getBuilder();
@@ -1928,6 +1980,24 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('age', 'asec');
+    }
+
+    public function testOrderByPriorityInvalidDirectionParam()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Order direction must be "asc" or "desc".');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByPriority('name', ['john', 'doe'], 'asec');
+    }
+
+    public function testOrderByPriorityInvalidEmptyPriorityParam()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Order priority array must not be empty.');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByPriority('name', []);
     }
 
     public function testHavings()

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseSQLiteQueryGrammarTest extends TestCase
     {
         $grammar = new SQLiteGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 ELSE 2 END asc', $queryString);
+        $this->assertSame('case when "name" = ? then 0 when "name" = ? then 1 else 2 end asc', $queryString);
     }
 }

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -28,4 +28,11 @@ class DatabaseSQLiteQueryGrammarTest extends TestCase
 
         $this->assertSame('select * from "users" where \'Hello\'\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
     }
+
+    public function testOrderByPriority()
+    {
+        $grammar = new SQLiteGrammar;
+        $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 ELSE 2 END asc', $queryString);
+    }
 }

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -28,4 +28,11 @@ class DatabaseSqlServerQueryGrammarTest extends TestCase
 
         $this->assertSame("select * from [users] where 'Hello''World?' IS NOT NULL AND [email] = 'foo'", $query);
     }
+
+    public function testOrderByPriority()
+    {
+        $grammar = new SqlServerGrammar;
+        $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
+        $this->assertSame('CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 ELSE 2 END asc', $queryString);
+    }
 }

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -33,6 +33,6 @@ class DatabaseSqlServerQueryGrammarTest extends TestCase
     {
         $grammar = new SqlServerGrammar;
         $queryString = $grammar->orderByPriority('name', ['john', 'doe']);
-        $this->assertSame('CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 ELSE 2 END asc', $queryString);
+        $this->assertSame('case when [name] = ? then 0 when [name] = ? then 1 else 2 end asc', $queryString);
     }
 }


### PR DESCRIPTION
Building upon the work done in PR #52483

**Explanation:**
This commit introduces the orderByPriority method to Laravel's query builder, enabling developers to sort query results based on a custom priority array. For example, you can now order records by specific IDs in a preferred sequence like this:

Model::whereIn('id', [2, 4, 6, 1, 3, 5])->orderByPriority('id', [2, 4, 6, 1, 3, 5])->get();

For MYSQL and Mariadb
This method leverages SQL's FIELD() function, allowing developers to easily display results in a user-defined order.

For Postgres, Sqlite and SQL server, the CASE() function was used to achieve the same result.

Compared to the previous PR, I have placed the logic in the corresponding grammar class as suggested to allow for flexibility of implementation depending on the database server.

**Impact:**
This feature greatly enhances the flexibility of data retrieval, particularly when a specific order of items is crucial for the application's logic or user interface.
We have to note that if the larger the array of priority, we might introduce performance issues

For reference:
- https://mariadb.com/docs/skysql-dbaas/ref/xpand/functions/FIELD/
- https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#function_field
 