### PR TITLE
[11.x] More specific parameter type in CastsInboundAttributes

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
@@ -12,7 +12,7 @@ interface CastsInboundAttributes
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
      * @param  mixed  $value
-     * @param  array  $attributes
+     * @param  array<string, mixed>  $attributes
      * @return mixed
      */
     public function set(Model $model, string $key, mixed $value, array $attributes);


### PR DESCRIPTION
In the [documentation about inbound casting](https://laravel.com/docs/11.x/eloquent-mutators#inbound-casting), the `$attributes` parameter is (correctly) defined as `array<string, mixed>`, and likewise in the stubs created with `php artisan make:cast --inbound`. However, in the `CastsInboundAttributes` interface, it's a simple `array`. This PR aligns the interface source code with docs and stubs, and with a more precise definition - similarly to `CastsAttributes`, too.