### PR TITLE
[11.x] Add PDO subclass support for PHP 8.4

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -62,7 +62,7 @@ class Connector
      */
     protected function createPdoConnection($dsn, $username, $password, $options)
     {
-        return (version_compare(phpversion(), '8.4.0', '<'))
+        return version_compare(phpversion(), '8.4.0', '<')
             ? new PDO($dsn, $username, $password, $options)
             : PDO::connect($dsn, $username, $password, $options);
     }

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -62,7 +62,9 @@ class Connector
      */
     protected function createPdoConnection($dsn, $username, $password, $options)
     {
-        return new PDO($dsn, $username, $password, $options);
+        return (version_compare(phpversion(), '8.4.0', '<'))
+            ? new PDO($dsn, $username, $password, $options)
+            : PDO::connect($dsn, $username, $password, $options);
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -64,7 +64,7 @@ class Connector
     {
         return version_compare(phpversion(), '8.4.0', '<')
             ? new PDO($dsn, $username, $password, $options)
-            : PDO::connect($dsn, $username, $password, $options);
+            : PDO::connect($dsn, $username, $password, $options); /** @phpstan-ignore staticMethod.notFound (PHP 8.4) */
     }
 
     /**


### PR DESCRIPTION
### Description

In PHP 8.4 there will be [PDO driver specific subclasses](https://wiki.php.net/rfc/pdo_driver_specific_subclasses). PHP will introduce classes for each database driver it supports. It allows for driver specific methods. I don't think this will be a huge improvement for most, but it does allow SQLite users to load extensions for example. This is not available in PDO at the moment.

If you're not using Laravel this would look like this:

```php
$pdo = PDO::connect('sqlite:database.sqlite');
$pdo->loadExtension('sqlean.dylib');

$query = "select regexp_replace(company_name, '[^a-zA-Z0-9]', '') from customers";
$query = $pdo->query($query)->fetchAll();
```

I'm not sure what your policy is for features that are only in 8.4, so please let me know what I could do to improve on this. I've targeted this at 11.x as it's backwards compatible with older PHP versions.

### Backwards compatibility

`PDO::connect` returns a subclass of [PDO](https://github.com/php/php-src/blob/69d9c12df64e829befd843175bfc9617aabb7450/ext/pdo_sqlite/pdo_sqlite.stub.php). It will pick the correct subclass for you based on the DSN. As the subclass extends PDO, the return type does not need to change and is backwards compatible.

As `PDO::connect` is not compatible with versions prior to 8.4. This PR is backwards compatible by using `new PDO` for other PHP versions instead.

### Tests

I haven't included any new tests. `PDO::connect` is a PHP function so it should not require testing in userland. The method itself is already covered by the test suite and its functionality remains the same.

Edit: static analysis failed because it runs on 8.2 where `PDO::connect` does not exist yet.

### References

- https://github.com/php/php-src/blob/php-8.4.0alpha1/UPGRADING#L299
- https://wiki.php.net/rfc/pdo_driver_specific_subclasses