### PR TITLE
[11.x] Fix FoundationServiceProvider docblock

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -135,8 +135,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * Register the "validate" macro on the request.
      *
      * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
      */
     public function registerRequestValidation()
     {


### PR DESCRIPTION
The `FoundationServiceProvider::registerRequestValidation` just registers the "validate" macro on the Request class. It does not throw any exceptions.