### PR TITLE
[12.x] Add missing methods to the Illuminate\Contracts\Container\Container interface

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -216,4 +216,23 @@ interface Container extends ContainerInterface
      * @return void
      */
     public function afterResolving($abstract, ?Closure $callback = null);
+
+    /**
+     * Refresh an instance on the given target and method.
+     *
+     * @param  string  $abstract
+     * @param  mixed  $target
+     * @param  string  $method
+     * @return mixed
+     */
+    public function refresh($abstract, $target, $method);
+
+    /**
+     * Bind a new callback to an abstract's rebind event.
+     *
+     * @param  string  $abstract
+     * @param  \Closure  $callback
+     * @return mixed
+     */
+    public function rebinding($abstract, Closure $callback);
 }


### PR DESCRIPTION
1. `refresh($abstract, $target, $method)`
2. `rebinding($abstract, Closure $callback)`
## Proposed Changes
The changes have been made to the `src/Illuminate/Contracts/Container/Container.php` file, where the new methods have been added to the `Illuminate\Contracts\Container\Container` interface.

## Potential Impact
These changes are intended to be backward-compatible and should not break existing code that relies on the `Illuminate\Contracts\Container\Container` interface. They provide additional capabilities that can be optionally utilized by developers.