### PR TITLE
[11.x] Added `toInstance` method to Http client to convert response to class object

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use Closure;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
@@ -106,6 +107,22 @@ class Response implements ArrayAccess, Stringable
     public function collect($key = null)
     {
         return Collection::make($this->json($key));
+    }
+
+    /**
+     * Get the JSON decoded body of the response as a class instance.
+     *
+     * @param  \Closure|string  $instance
+     * @param  string|null  $key
+     * @return \Closure|mixed
+     */
+    public function toInstance(Closure|string $instance, $key = null)
+    {
+        if (is_callable($instance)) {
+            return $instance($this->json($key));
+        }
+
+        return new $instance($this->json($key));
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -354,6 +354,27 @@ class HttpClientTest extends TestCase
         $this->assertEquals(collect(), $response->collect('missing_key'));
     }
 
+    public function testResponseCanBeReturnedAsClassInstance()
+    {
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api');
+
+        $this->assertInstanceOf(Collection::class, $response->toInstance(Collection::class));
+        $this->assertEquals(collect(['result' => ['foo' => 'bar']]), $response->toInstance(Collection::class));
+        $this->assertEquals(collect(['foo' => 'bar']), $response->toInstance(Collection::class, 'result'));
+        $this->assertEquals(collect(['bar']), $response->toInstance(Collection::class, 'result.foo'));
+        $this->assertEquals(collect(), $response->toInstance(Collection::class, 'missing_key'));
+
+        $this->assertInstanceOf(Collection::class, $response->toInstance(fn ($data) => Collection::make($data)));
+        $this->assertEquals(collect(['result' => ['foo' => 'bar']]), $response->toInstance(fn ($data) => Collection::make($data)));
+        $this->assertEquals(collect(['foo' => 'bar']), $response->toInstance(fn ($data) => Collection::make($data), 'result'));
+        $this->assertEquals(collect(['bar']), $response->toInstance(fn ($data) => Collection::make($data), 'result.foo'));
+        $this->assertEquals(collect(), $response->toInstance(fn ($data) => Collection::make($data), 'missing_key'));
+    }
+
     public function testSendRequestBodyAsJsonByDefault()
     {
         $body = '{"test":"phpunit"}';


### PR DESCRIPTION
When using an Http client, you often need to generate an object from the response, so you have to do something like this:

```php
public function some(): Some
{
    $data = Http::post($url)->json();
    
    return new Some($data);
}
```

This PR adds a new method to the response object - “toInstance” (I couldn't think of a better name 😅). This way we can improve the data return:

```php
public function some(): Some
{
    return Http::post($url)->toInstance(Some::class);
}
```

In addition, it is possible to specify not only the name of the key, from where the data for translation will be taken, for example:

```php
public function some(): Some
{
    return Http::post($url)->toInstance(Some::class, 'foo.bar');
}
```

But also use callback function for manual control if object formation is a non-standard process. This will allow the developer to choose how the transformation should take place. For example:

```php
public function some($custom): Some
{
    return Http::post($url)->toInstance(
        fn (array $data) => new Some($data['foo'], $data['bar'], $custom)
    );
}
```

And, of course, you can specify the name of the key from which this data will be taken:

```php
public function some($custom): Some
{
    return Http::post($url)->toInstance(
        fn (array $data) => new Some($data['foo'], $data['bar'], $custom),
        'foo.bar'
    );
}
```