### PR TITLE
[11.x] SORT_NATURAL on Collection no longer throws warning for nulls

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1561,7 +1561,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                         $result = match ($options) {
                             SORT_NUMERIC => intval($values[0]) <=> intval($values[1]),
                             SORT_STRING => strcmp($values[0], $values[1]),
-                            SORT_NATURAL => strnatcmp($values[0], $values[1]),
+                            SORT_NATURAL => strnatcmp((string) $values[0], (string) $values[1]),
                             SORT_LOCALE_STRING => strcoll($values[0], $values[1]),
                             default => $values[0] <=> $values[1],
                         };

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2003,6 +2003,32 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testNaturalSortByManyWithNull($collection)
+    {
+        $itemFoo = new \stdClass();
+        $itemFoo->first = 'f';
+        $itemFoo->second = 's';
+        $itemBar = new \stdClass();
+        $itemBar->first = 'f';
+        $itemBar->second = null;
+
+        $data = new $collection([$itemFoo, $itemBar]);
+        $data->sortBy([
+            ['first', 'asc'],
+            ['second', 'asc'],
+        ], SORT_NATURAL);
+
+        $this->assertEquals($itemFoo, $data->first());
+        $this->assertEquals($itemBar, $data->get(2));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortKeys($collection)
     {
         $data = new $collection(['b' => 'dayle', 'a' => 'taylor']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2010,19 +2010,19 @@ class SupportCollectionTest extends TestCase
     {
         $itemFoo = new \stdClass();
         $itemFoo->first = 'f';
-        $itemFoo->second = 's';
+        $itemFoo->second = null;
         $itemBar = new \stdClass();
         $itemBar->first = 'f';
-        $itemBar->second = null;
+        $itemBar->second = 's';
 
         $data = new $collection([$itemFoo, $itemBar]);
-        $data->sortBy([
-            ['first', 'asc'],
-            ['second', 'asc'],
+        $data = $data->sortBy([
+            ['first', 'desc'],
+            ['second', 'desc'],
         ], SORT_NATURAL);
 
-        $this->assertEquals($itemFoo, $data->first());
-        $this->assertEquals($itemBar, $data->get(2));
+        $this->assertEquals($itemBar, $data->first());
+        $this->assertEquals($itemFoo, $data->skip(1)->first());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
Currently, when using SORT_NATURAL on a Collection, any null values passed in throw a warning:

`strnatcmp(): Passing null to parameter #1 ($string1) of type string is deprecated in /vendor/laravel/framework/src/Illuminate/Collections/Collection.php on line 1480`

OR

`strnatcmp(): Passing null to parameter #2 ($string2) of type string is deprecated in /vendor/laravel/framework/src/Illuminate/Collections/Collection.php on line 1480`

It's entirely valid and common for null values to get compared when using `sortBy()` and passing in an array of properties to sort by. Passing in multiple properties in an array is what triggers the `sortByMany()` function.

Example:
```
$book
->authors()
->sortBy([
        ['LastName', 'desc'],
        ['FirstName', 'desc'],
        ['MiddleName', 'desc'],
    ], SORT_NATURAL);
```

Not all authors will have a value for middle name. Receiving a warning for every missing middle name  every time you sort authors is too much noise.