### PR TITLE
[11.x] Add withQuery, withoutQuery methods to redirect response

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -200,7 +200,7 @@ class RedirectResponse extends BaseRedirectResponse
 
         $url = match (true) {
             empty($query) => $url,
-            empty($qs) => $url.'?'.$query,
+            is_null($qs) => $url.'?'.$query,
             default => str_replace('?'.$qs, '?'.$query, $url)
         };
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -216,12 +216,14 @@ class RedirectResponse extends BaseRedirectResponse
     {
         $url = $this->getTargetUrl();
 
-        $qs = parse_url($url, PHP_URL_QUERY);
+        $qs = (string) parse_url($url, PHP_URL_QUERY);
 
         $current = [];
 
         if (! is_null($keys)) {
             parse_str($qs, $current);
+
+            $current = (array) $current;
 
             Arr::forget($current, $keys);
         }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -194,9 +194,9 @@ class RedirectResponse extends BaseRedirectResponse
 
         $qs = parse_url($url, PHP_URL_QUERY);
 
-        parse_str($qs, $current);
+        parse_str((string) $qs, $current);
 
-        $query = Arr::query(array_replace_recursive($current, $query));
+        $query = Arr::query(array_replace_recursive((array) $current, $query));
 
         $url = match (true) {
             empty($query) => $url,

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -54,6 +54,20 @@ class HttpRedirectResponseTest extends TestCase
 
     public function testFragmentIdentifierOnRedirect()
     {
+        $response = new RedirectResponse('foo.bar');
+
+        $response->withFragment('foo');
+        $this->assertSame('foo', parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
+
+        $response->withFragment('#bar');
+        $this->assertSame('bar', parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
+
+        $response->withoutFragment();
+        $this->assertNull(parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
+    }
+
+    public function testQueryOnRedirect()
+    {
         $response = new RedirectResponse('foo.bar?category=laravel');
 
         $response->withQuery(['v' => '11', 'meta' => ['package' => 'routing']]);
@@ -67,20 +81,6 @@ class HttpRedirectResponseTest extends TestCase
 
         $response->withoutQuery();
         $this->assertNull(parse_url($response->getTargetUrl(), PHP_URL_QUERY));
-    }
-
-    public function testQueryOnRedirect()
-    {
-        $response = new RedirectResponse('foo.bar');
-
-        $response->withFragment('foo');
-        $this->assertSame('foo', parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
-
-        $response->withFragment('#bar');
-        $this->assertSame('bar', parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
-
-        $response->withoutFragment();
-        $this->assertNull(parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
     }
 
     public function testInputOnRedirect()

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -54,6 +54,23 @@ class HttpRedirectResponseTest extends TestCase
 
     public function testFragmentIdentifierOnRedirect()
     {
+        $response = new RedirectResponse('foo.bar?category=laravel');
+
+        $response->withQuery(['v' => '11', 'meta' => ['package' => 'routing']]);
+        $this->assertSame(
+            'category=laravel&v=11&meta[package]=routing',
+            urldecode(parse_url($response->getTargetUrl(), PHP_URL_QUERY))
+        );
+
+        $response->withoutQuery('meta.package');
+        $this->assertSame('category=laravel&v=11', parse_url($response->getTargetUrl(), PHP_URL_QUERY));
+
+        $response->withoutQuery();
+        $this->assertNull(parse_url($response->getTargetUrl(), PHP_URL_QUERY));
+    }
+
+    public function testQueryOnRedirect()
+    {
         $response = new RedirectResponse('foo.bar');
 
         $response->withFragment('foo');


### PR DESCRIPTION
Sometimes it would be great to have the ability to manage query strings on the redirect response, like the fragment.

This PR allows to add, remove, replace query string parameters (even nested) on the target URL.

```php
$url = '/login?loggedout=true';

$response = Redirect::to($url)
    ->withQuery(['status' => 'success'])
    ->withFragment('oauth-box')
    ->withoutQuery('loggedout');

$response->getTargetUrl(); // /login?status=success#oauth-box
```

If this PR accepted, I'll gladly update the docs as well.