### PR TITLE
[11.x] Update remaining workflows to run on latest possible ubuntu version

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -193,7 +193,7 @@ jobs:
           DB_PASSWORD: password
 
   mssql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     services:
       sqlsrv:
@@ -240,7 +240,7 @@ jobs:
           DB_PASSWORD: Forge123
 
   sqlite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: true

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -193,7 +193,7 @@ jobs:
           DB_PASSWORD: password
 
   mssql:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     services:
       sqlsrv:


### PR DESCRIPTION
Seems like I missed some workflows in https://github.com/laravel/framework/pull/51946 because I did not search for `ubuntu-20.04`.

MsSql does not support Ubuntu 24.04 yet, therefor this was only updated to Ubuntu 22.04.
See https://learn.microsoft.com/en-us/sql/connect/php/microsoft-php-drivers-for-sql-server-support-matrix?view=sql-server-ver15#supported-operating-systems