### PR TITLE
[11.x] feat: add whereRawIn method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1334,6 +1334,79 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a raw "where in" clause to the query.
+     *
+     * @param  string  $sql
+     * @param  mixed  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereRawIn($sql, $values, $bindings = [], $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'RawNotIn' : 'RawIn';
+
+        if ($this->isQueryable($values)) {
+            [$query, $subBindings] = $this->createSub($values);
+
+            $values = [new Expression($query)];
+
+            $this->addBinding($subBindings, 'where');
+        }
+
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        if (count($values) !== count(Arr::flatten($values, 1))) {
+            throw new \InvalidArgumentException('Nested arrays may not be passed to whereRawIn method.');
+        }
+
+        $this->wheres[] = compact('type', 'sql', 'values', 'boolean');
+
+        $this->addBinding((array) $bindings, 'where');
+        $this->addBinding($this->cleanBindings($values), 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add a raw "where not in" clause to the query.
+     *
+     * @param  string  $sql
+     * @param  mixed  $values
+     * @return $this
+     */
+    public function whereRawNotIn($sql, $values, $bindings = [])
+    {
+        return $this->whereRawIn($sql, $values, $bindings, 'and', true);
+    }
+
+    /**
+     * Add a raw "or where in" clause to the query.
+     *
+     * @param  string  $sql
+     * @param  mixed  $values
+     * @return $this
+     */
+    public function orWhereRawIn($sql, $values, $bindings = [])
+    {
+        return $this->whereRawIn($sql, $values, $bindings, 'or');
+    }
+
+    /**
+     * Add a raw "or where not in" clause to the query.
+     *
+     * @param  string  $sql
+     * @param  mixed  $values
+     * @return $this
+     */
+    public function orWhereRawNotIn($sql, $values, $bindings = [])
+    {
+        return $this->whereRawIn($sql, $values, $bindings, 'or', true);
+    }
+
+    /**
      * Add a "where null" clause to the query.
      *
      * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $columns

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -281,6 +281,42 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a raw "where in" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereRawIn(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            $sql = $where['sql'] instanceof Expression ? $where['sql']->getValue($this) : $where['sql'];
+
+            return $sql.' in ('.$this->parameterize($where['values']).')';
+        }
+
+        return '0 = 1';
+    }
+
+    /**
+     * Compile a raw "where not in" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereRawNotIn(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            $sql = $where['sql'] instanceof Expression ? $where['sql']->getValue($this) : $where['sql'];
+
+            return $sql.' not in ('.$this->parameterize($where['values']).')';
+        }
+
+        return '1 = 1';
+    }
+
+    /**
      * Compile a basic where clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
This PR adds the following methods to `/Illuminate/Database/Query/Builder.php`

- `whereRawIn`
- `whereRawNotIn`
- `orWhereRawIn`
- `orWhereRawNotIn`

these methods are useful when you want to use raw queries with `IN` and `NOT IN` clauses.

Before 🛠
```php
User::query()->whereIn(DB::raw("concat_ws('-', first_name , NULLIF(last_name , '' ) )"), ['John-Doe']);

// or 
$values = ['John-Doe', 'Alice'] ;
User::query()->whereRaw("concat_ws('-', first_name , NULLIF(last_name , '' ) ) in ('" . implode("', '", $values) . "')");
```


After 🚀
```php
User::query()->whereRawIn("concat_ws('-', first_name , NULLIF(last_name , '' ) )", ['John-Doe']);

// with raw where bindings
$sperator = '-';
User::query()->whereRawIn("concat_ws(?, first_name , NULLIF(last_name , '' ) )", ['John-Doe'], [$sperator]);

// subQuery as values
User::query()->whereRawIn("concat_ws('-', first_name , NULLIF(last_name , '' ) )", Customer::query()->select('full_name'));
```
