### PR TITLE
[Feature] Introduce EpochSoftDeletes for Unique Constraints in Soft-Deleted Records

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/EpochCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/EpochCast.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+class EpochCast implements Castable
+{
+
+    /**
+     * @param array $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Carbon\Carbon, int>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class() implements CastsAttributes
+        {
+
+            public function get(Model $model, string $key, mixed $value, array $attributes)
+            {
+                if (is_null($value) || $value === 0) {
+                    return null;
+                }
+
+                return Carbon::parse($value);
+            }
+
+            public function set(Model $model, string $key, mixed $value, array $attributes)
+            {
+                if ($value === null || $value === 0) {
+                    return 0;
+                }
+
+                return Carbon::parse($value)->timestamp;
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/EpochCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/EpochCast.php
@@ -9,16 +9,14 @@ use Illuminate\Support\Carbon;
 
 class EpochCast implements Castable
 {
-
     /**
-     * @param array $arguments
+     * @param  array  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Carbon\Carbon, int>
      */
     public static function castUsing(array $arguments)
     {
         return new class() implements CastsAttributes
         {
-
             public function get(Model $model, string $key, mixed $value, array $attributes)
             {
                 if (is_null($value) || $value === 0) {

--- a/src/Illuminate/Database/Eloquent/EpochSoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/EpochSoftDeletes.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Database\Eloquent\Casts\EpochCast;
+
+trait EpochSoftDeletes
+{
+    use SoftDeletes;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function bootSoftDeletes()
+    {
+        // it is important to override bootSoftDeletes method and leave it empty
+        // to prevent the default scope of SoftDeletes trait from being applied
+        // we use SoftDeletes trait, because we do not want to implement the whole logic from scratch
+    }
+
+    public static function bootEpochSoftDeletes(): void
+    {
+        static::addGlobalScope(new EpochSoftDeletingScope());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initializeSoftDeletes(): void
+    {
+        if (! isset($this->casts[$this->getDeletedAtColumn()])) {
+            $this->casts[$this->getDeletedAtColumn()] = EpochCast::class;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function runSoftDelete(): void
+    {
+        $query = $this->setKeysForSaveQuery($this->newModelQuery());
+
+        $time = $this->freshTimestamp()->timestamp;
+
+        $columns = [$this->getDeletedAtColumn() => $time];
+
+        $this->{$this->getDeletedAtColumn()} = $time;
+
+        if ($this->usesTimestamps() && ! is_null($this->getUpdatedAtColumn())) {
+            $this->{$this->getUpdatedAtColumn()} = $time;
+
+            $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
+        }
+
+        $query->update($columns);
+
+        $this->syncOriginalAttributes(array_keys($columns));
+
+        $this->fireModelEvent('trashed', false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function performDeleteOnModel()
+    {
+        if ($this->forceDeleting) {
+            return tap($this->setKeysForSaveQuery($this->newModelQuery())->forceDelete(), function () {
+                $this->exists = false;
+            });
+        }
+
+        $this->runSoftDelete();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function restore()
+    {
+        if ($this->fireModelEvent('restoring') === false) {
+            return false;
+        }
+
+        $this->{$this->getDeletedAtColumn()} = 0;
+
+        $this->exists = true;
+
+        $result = $this->save();
+
+        $this->fireModelEvent('restored', false);
+
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function trashed()
+    {
+        return $this->{$this->getDeletedAtColumn()} !== 0;
+    }
+
+    public function scopeWhereDeleted()
+    {
+        return $this->where($this->getDeletedAtColumn(), '!=', 0);
+    }
+
+    public function scopeWhereNotDeleted()
+    {
+        return $this->where($this->getDeletedAtColumn(), 0);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/EpochSoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/EpochSoftDeletingScope.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+class EpochSoftDeletingScope extends SoftDeletingScope
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        $builder->where($model->getQualifiedDeletedAtColumn(), 0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extend(Builder $builder): void
+    {
+        foreach ($this->extensions as $extension) {
+            $this->{"add{$extension}"}($builder);
+        }
+
+        $builder->onDelete(function (Builder $builder) {
+            $column = $this->getDeletedAtColumn($builder);
+
+            return $builder->update([
+                $column => time(),
+            ]);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function addRestore(Builder $builder)
+    {
+        $builder->macro('restore', function (Builder $builder) {
+            $builder->withTrashed();
+
+            return $builder->update([$builder->getModel()->getDeletedAtColumn() => 0]);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function addWithoutTrashed(Builder $builder)
+    {
+        $builder->macro('withoutTrashed', function (Builder $builder) {
+            $model = $builder->getModel();
+
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedDeletedAtColumn(),
+                0
+            );
+
+            return $builder;
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function addOnlyTrashed(Builder $builder)
+    {
+        $builder->macro('onlyTrashed', function (Builder $builder) {
+            $model = $builder->getModel();
+
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedDeletedAtColumn(),
+                '!=',
+                0
+            );
+
+            return $builder;
+        });
+    }
+}

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1297,7 +1297,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function epochSoftDeletes($column = 'deleted_at',)
+    public function epochSoftDeletes($column = 'deleted_at')
     {
         return $this->integer(column: $column, unsigned: true)->default(0);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1292,6 +1292,17 @@ class Blueprint
     }
 
     /**
+     * Add a "deleted at" epoch timestamp for the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function epochSoftDeletes($column = 'deleted_at',)
+    {
+        return $this->integer(column: $column, unsigned: true)->default(0);
+    }
+
+    /**
      * Add a "deleted at" timestampTz for the table.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseEloquentEpochSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentEpochSoftDeletesIntegrationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\EpochSoftDeletes;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentEpochSoftDeletesIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->timestamps();
+            $table->epochSoftDeletes();
+
+            $table->unique(['email', 'deleted_at']);
+        });
+    }
+
+    public function testSoftDeletesStoreEpochTimestamp()
+    {
+        Carbon::setTestNow($now = Carbon::now());
+        $this->createUsers();
+
+        $user = EpochSoftDeletesTestUser::find(1);
+        $user->delete();
+
+        $this->assertEquals($now->timestamp, $user->getAttributes()['deleted_at']);
+        $this->assertInstanceOf(Carbon::class, $user->getOriginal('deleted_at'));
+    }
+
+    public function testSoftDeletesAreNotRetrieved()
+    {
+        $this->createUsers();
+
+        $user = EpochSoftDeletesTestUser::find(1);
+        $user->delete();
+
+        $users = EpochSoftDeletesTestUser::all();
+        $this->assertCount(2, $users);
+
+        $trashedUsers = EpochSoftDeletesTestUser::withTrashed()->get();
+        $this->assertCount(3, $trashedUsers);
+    }
+
+    public function testRestoringSoftDeletedItem()
+    {
+        $this->createUsers();
+
+        $user = EpochSoftDeletesTestUser::find(1);
+        $user->delete();
+        $user->restore();
+
+        $this->assertEquals(0, $user->getAttributes()['deleted_at']);
+
+        $restoredUser = EpochSoftDeletesTestUser::find(1);
+        $this->assertNotNull($restoredUser);
+    }
+
+    public function testUniqueConstraintsAfterSoftDelete()
+    {
+        $this->createUsers();
+
+        $user = EpochSoftDeletesTestUser::find(1);
+        $user->delete();
+
+        $duplicateUser = new EpochSoftDeletesTestUser();
+        $duplicateUser->email = $user->email;
+
+        $this->expectNotToPerformAssertions();
+        $duplicateUser->save();
+    }
+
+    /**
+     * Helpers...
+     *
+     * @return EpochSoftDeletesTestUser[]
+     */
+    protected function createUsers()
+    {
+        $taylor = EpochSoftDeletesTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $abigail = EpochSoftDeletesTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        $ismayil = EpochSoftDeletesTestUser::create(['id' => 3, 'email' => 'me@ismayil.dev']);
+
+        return [$taylor, $abigail, $ismayil];
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class EpochSoftDeletesTestUser extends Eloquent
+{
+    use EpochSoftDeletes;
+
+    protected $table = 'users';
+    protected $guarded = [];
+}

--- a/tests/Database/DatabaseEpochSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseEpochSoftDeletingScopeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\EpochSoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class DatabaseEpochSoftDeletingScopeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testApplyingScopeToABuilder()
+    {
+        $scope = m::mock(EpochSoftDeletingScope::class.'[extend]');
+        $builder = m::mock(EloquentBuilder::class);
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getQualifiedDeletedAtColumn')->once()->andReturn('table.deleted_at');
+        $builder->shouldReceive('where')->once()->with('table.deleted_at', 0);
+
+        $scope->apply($builder, $model);
+    }
+
+    public function testRestoreExtension()
+    {
+        $builder = new EloquentBuilder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            m::mock(Grammar::class),
+            m::mock(Processor::class)
+        ));
+        $scope = new EpochSoftDeletingScope;
+        $scope->extend($builder);
+        $callback = $builder->getMacro('restore');
+        $givenBuilder = m::mock(EloquentBuilder::class);
+        $givenBuilder->shouldReceive('withTrashed')->once();
+        $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(stdClass::class));
+        $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
+        $givenBuilder->shouldReceive('update')->once()->with(['deleted_at' => 0]);
+
+        $callback($givenBuilder);
+    }
+
+    public function testOnlyTrashedExtension()
+    {
+        $builder = new EloquentBuilder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            m::mock(Grammar::class),
+            m::mock(Processor::class)
+        ));
+        $model = m::mock(Model::class);
+        $model->makePartial();
+        $scope = m::mock(EpochSoftDeletingScope::class.'[remove]');
+        $scope->extend($builder);
+        $callback = $builder->getMacro('onlyTrashed');
+        $givenBuilder = m::mock(EloquentBuilder::class);
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(stdClass::class));
+        $givenBuilder->shouldReceive('getModel')->andReturn($model);
+        $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
+        $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $givenBuilder->shouldReceive('where')->once()->with('table.deleted_at', '!=', 0);
+        $result = $callback($givenBuilder);
+
+        $this->assertEquals($givenBuilder, $result);
+    }
+
+    public function testWithoutTrashedExtension()
+    {
+        $builder = new EloquentBuilder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            m::mock(Grammar::class),
+            m::mock(Processor::class)
+        ));
+        $model = m::mock(Model::class);
+        $model->makePartial();
+        $scope = m::mock(EpochSoftDeletingScope::class.'[remove]');
+        $scope->extend($builder);
+        $callback = $builder->getMacro('withoutTrashed');
+        $givenBuilder = m::mock(EloquentBuilder::class);
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(stdClass::class));
+        $givenBuilder->shouldReceive('getModel')->andReturn($model);
+        $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
+        $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $givenBuilder->shouldReceive('where')->once()->with('table.deleted_at', 0);
+        $result = $callback($givenBuilder);
+
+        $this->assertEquals($givenBuilder, $result);
+    }
+}

--- a/tests/Database/DatabaseEpochSoftDeletingTest.php
+++ b/tests/Database/DatabaseEpochSoftDeletingTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Casts\EpochCast;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\EpochSoftDeletes;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEpochSoftDeletingTest extends TestCase
+{
+    public function testDeletedAtIsAddedToCastsAsDefaultType()
+    {
+        $model = new EpochSoftDeletingModel;
+
+        $this->assertArrayHasKey('deleted_at', $model->getCasts());
+        $this->assertSame(EpochCast::class, $model->getCasts()['deleted_at']);
+    }
+
+    public function testDeletedAtIsCastToCarbonInstance()
+    {
+        $expected = Carbon::createFromFormat('Y-m-d H:i:s', '2018-12-29 13:59:39');
+        $model = new EpochSoftDeletingModel(['deleted_at' => $expected->timestamp]);
+
+        $this->assertInstanceOf(Carbon::class, $model->deleted_at);
+        $this->assertTrue($expected->eq($model->deleted_at));
+    }
+
+    public function testExistingCastOverridesAddedDateCast()
+    {
+        $model = new class(['deleted_at' => Carbon::now()->timestamp]) extends EpochSoftDeletingModel
+        {
+            protected $casts = ['deleted_at' => 'bool'];
+        };
+
+        $this->assertTrue($model->deleted_at);
+    }
+
+    public function testExistingMutatorOverridesAddedDateCast()
+    {
+        $model = new class(['deleted_at' => Carbon::now()->timestamp]) extends EpochSoftDeletingModel
+        {
+            protected function getDeletedAtAttribute()
+            {
+                return 'expected';
+            }
+        };
+
+        $this->assertSame('expected', $model->deleted_at);
+    }
+
+    public function testCastingToStringOverridesAutomaticDateCastingToRetainPreviousBehaviour()
+    {
+        $model = new class(['deleted_at' => Carbon::now()->timestamp]) extends EpochSoftDeletingModel
+        {
+            protected $casts = ['deleted_at' => 'string'];
+        };
+
+        $this->assertSame((string) Carbon::now()->timestamp, $model->deleted_at);
+    }
+}
+
+class EpochSoftDeletingModel extends Model
+{
+    use EpochSoftDeletes;
+
+    protected $guarded = [];
+
+    protected $dateFormat = 'Y-m-d H:i:s';
+}

--- a/tests/Database/DatabaseEpochSoftDeletingTest.php
+++ b/tests/Database/DatabaseEpochSoftDeletingTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Casts\EpochCast;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\EpochSoftDeletes;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Database/DatabaseEpochSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseEpochSoftDeletingTraitTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\EpochSoftDeletes;
+use Illuminate\Support\Carbon;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class DatabaseEpochSoftDeletingTraitTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testDeleteSetsEpochDeletedAtColumn()
+    {
+        $model = m::mock(DatabaseEpochSoftDeletingTraitStub::class);
+        $model->makePartial();
+        $model->shouldReceive('newModelQuery')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('update')->once()->with([
+            'deleted_at' => Carbon::now()->timestamp,
+            'updated_at' => 'date-time',
+        ]);
+        $model->shouldReceive('syncOriginalAttributes')->once()->with([
+            'deleted_at',
+            'updated_at',
+        ]);
+        $model->shouldReceive('usesTimestamps')->once()->andReturn(true);
+        $model->delete();
+
+        $this->assertIsInt($model->deleted_at);
+    }
+
+    public function testRestore()
+    {
+        $model = m::mock(DatabaseEpochSoftDeletingTraitStub::class);
+        $model->makePartial();
+        $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
+        $model->shouldReceive('save')->once();
+        $model->shouldReceive('fireModelEvent')->with('restored', false)->andReturn(true);
+
+        $model->restore();
+
+        $this->assertEquals(0, $model->deleted_at);
+    }
+
+    public function testRestoreCancel()
+    {
+        $model = m::mock(DatabaseEpochSoftDeletingTraitStub::class);
+        $model->makePartial();
+        $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(false);
+        $model->shouldReceive('save')->never();
+
+        $this->assertFalse($model->restore());
+    }
+}
+
+class DatabaseEpochSoftDeletingTraitStub
+{
+    use EpochSoftDeletes;
+
+    public $deleted_at;
+    public $updated_at;
+    public $timestamps = true;
+    public $exists = false;
+
+    public function newQuery()
+    {
+        //
+    }
+
+    public function getKey()
+    {
+        return 1;
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function save()
+    {
+        //
+    }
+
+    public function delete()
+    {
+        return $this->performDeleteOnModel();
+    }
+
+    public function fireModelEvent()
+    {
+        //
+    }
+
+    public function freshTimestamp()
+    {
+        return Carbon::now();
+    }
+
+    public function fromDateTime()
+    {
+        return 'date-time';
+    }
+
+    public function getUpdatedAtColumn()
+    {
+        return defined('static::UPDATED_AT') ? static::UPDATED_AT : 'updated_at';
+    }
+
+    public function setKeysForSaveQuery($query)
+    {
+        $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
+
+        return $query;
+    }
+
+    protected function getKeyForSaveQuery()
+    {
+        return 1;
+    }
+}


### PR DESCRIPTION
**PR Description:** This pull request introduces a new `EpochSoftDeletes` trait that extends Laravel's soft delete functionality by storing the `deleted_at` column as an epoch timestamp. This solves a common issue in some software applications where soft-deleted records can cause duplicate entry problems due to unique constraints.

**Benefits to End Users:**

- **Better Handling of Unique Constraints:** The epoch-based approach allows unique constraints to be enforced on soft-deleted records without causing conflicts. Users can delete records without facing errors when recreating similar records later.
- **Consistent Developer Experience:** `EpochSoftDeletes` works just like Laravel's default `SoftDeletes` trait. Developers only need to adjust the `deleted_at` column type to an integer. Everything else — soft deleting, restoring, querying — remains the same.
- **Default Value Handling:** Non-deleted records have a default `deleted_at` value of `0`, ensuring clarity and consistency in the database.


**Why It Doesn’t Break Existing Features:** This addition does not modify any existing features or behaviors. It simply offers an alternative trait for developers who need more control over unique constraints when using soft deletes. The default soft delete functionality remains fully backward-compatible.

**How It Makes Building Web Applications Easier:** The `EpochSoftDeletes` trait simplifies the management of soft-deleted records in scenarios where unique constraints need strict enforcement. By preventing soft-deleted records from causing conflicts with new entries, it streamlines data management and reduces errors in software and high-integrity systems.

Tests are included to ensure compatibility and correctness of the new trait.