### PR TITLE
[11.x] Add format artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/FormatCommand.php
+++ b/src/Illuminate/Foundation/Console/FormatCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\Process;
+
+#[AsCommand(name: 'format')]
+class FormatCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'format
+                    {path? : The path to the file or directory to format}
+                    {--test : Run Pint in test mode}
+                    {--dirty : Only modify uncommitted files}';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'format';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Format the application code using Laravel Pint';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        try {
+            $command = ['./vendor/bin/pint'];
+
+            if ($this->option('test')) {
+                $command[] = '--test';
+            }
+
+            if ($this->option('dirty')) {
+                $command[] = '--dirty';
+            }
+
+            $path = $this->argument('path');
+            if ($path) {
+                $command[] = $path;
+            }
+
+            $process = new Process($command);
+            $process->setTimeout(null);
+
+            if (Process::isTtySupported()) {
+                $process->setTty(true);
+            }
+
+            $process->run();
+
+            return 0;
+        } catch (Exception $e) {
+            $this->components->error(sprintf(
+                'Failed to format the application: %s.',
+                $e->getMessage(),
+            ));
+
+            return 1;
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -53,6 +53,7 @@ use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
+use Illuminate\Foundation\Console\FormatCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
@@ -222,6 +223,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'TraitMake' => TraitMakeCommand::class,
         'VendorPublish' => VendorPublishCommand::class,
         'ViewMake' => ViewMakeCommand::class,
+        'Format' => FormatCommand::class,
     ];
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Because Laravel Pint has been built into the Laravel framework in the recent release, this PR provides a new artisan command: `php artisan format`, offering developers a more convenient and intuitive way to format code.

https://github.com/user-attachments/assets/49d8d1c2-ec4b-461f-bc47-f847470e0547

## Usage

> The command's options all refer to the https://laravel.com/docs/11.x/pint#running-pint file, and the usage method is the same.

### Format all files
```bash
php artisan format
```

### Format specific files or directories
```bash
php artisan format app/Models
php artisan format app/Models/User.php
```

### Format and display the updated list and detailed changes
```bash
php artisan format -v
```

### Inspection without changes
```bash
php artisan format --test
```

### Format only uncommitted files
```bash
php artisan format --dirty
```