### PR TITLE
[12.x] Suggestion to rename $ignoreCase to $caseSensitive

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -283,12 +283,12 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
-     * @param  bool  $ignoreCase
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function contains($haystack, $needles, $ignoreCase = false)
+    public static function contains($haystack, $needles, $caseSensitive = true)
     {
-        if ($ignoreCase) {
+        if (!$caseSensitive) {
             $haystack = mb_strtolower($haystack);
         }
 
@@ -297,7 +297,7 @@ class Str
         }
 
         foreach ($needles as $needle) {
-            if ($ignoreCase) {
+            if (!$caseSensitive) {
                 $needle = mb_strtolower($needle);
             }
 
@@ -314,13 +314,13 @@ class Str
      *
      * @param  string  $haystack
      * @param  iterable<string>  $needles
-     * @param  bool  $ignoreCase
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function containsAll($haystack, $needles, $ignoreCase = false)
+    public static function containsAll($haystack, $needles, $caseSensitive = true)
     {
         foreach ($needles as $needle) {
-            if (! static::contains($haystack, $needle, $ignoreCase)) {
+            if (! static::contains($haystack, $needle, $caseSensitive)) {
                 return false;
             }
         }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -203,24 +203,24 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Determine if a given string contains a given substring.
      *
      * @param  string|iterable<string>  $needles
-     * @param  bool  $ignoreCase
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public function contains($needles, $ignoreCase = false)
+    public function contains($needles, $caseSensitive = true)
     {
-        return Str::contains($this->value, $needles, $ignoreCase);
+        return Str::contains($this->value, $needles, $caseSensitive);
     }
 
     /**
      * Determine if a given string contains all array values.
      *
      * @param  iterable<string>  $needles
-     * @param  bool  $ignoreCase
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public function containsAll($needles, $ignoreCase = false)
+    public function containsAll($needles, $caseSensitive = true)
     {
-        return Str::containsAll($this->value, $needles, $ignoreCase);
+        return Str::containsAll($this->value, $needles, $caseSensitive);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2659,7 +2659,7 @@ trait ValidatesAttributes
     {
         $stringValue = (string) $value;
 
-        if (! is_numeric($value) || ! Str::contains($stringValue, 'e', ignoreCase: true)) {
+        if (! is_numeric($value) || ! Str::contains($stringValue, 'e', caseSensitive: false)) {
             return $value;
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1259,8 +1259,8 @@ class SupportStrTest extends TestCase
         return [
             ['Taylor', 'ylo', true, true],
             ['Taylor', 'ylo', true, false],
-            ['Taylor', 'taylor', true, true],
-            ['Taylor', 'taylor', false, false],
+            ['Taylor', 'taylor', false, true],
+            ['Taylor', 'taylor', true, false],
             ['Taylor', ['ylo'], true, true],
             ['Taylor', ['ylo'], true, false],
             ['Taylor', ['xxx', 'ylo'], true, true],
@@ -1276,10 +1276,10 @@ class SupportStrTest extends TestCase
     public static function strContainsAllProvider()
     {
         return [
-            ['Taylor Otwell', ['taylor', 'otwell'], false, false],
-            ['Taylor Otwell', ['taylor', 'otwell'], true, true],
-            ['Taylor Otwell', ['taylor'], false, false],
-            ['Taylor Otwell', ['taylor'], true, true],
+            ['Taylor Otwell', ['taylor', 'otwell'], true, false],
+            ['Taylor Otwell', ['taylor', 'otwell'], false, true],
+            ['Taylor Otwell', ['taylor'], true, false],
+            ['Taylor Otwell', ['taylor'], false, true],
             ['Taylor Otwell', ['taylor', 'xxx'], false, false],
             ['Taylor Otwell', ['taylor', 'xxx'], false, true],
         ];

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -698,7 +698,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('taylor')->contains(['ylo']));
         $this->assertTrue($this->stringable('taylor')->contains(['xxx', 'ylo']));
         $this->assertTrue($this->stringable('taylor')->contains(collect(['xxx', 'ylo'])));
-        $this->assertTrue($this->stringable('taylor')->contains(['LOR'], true));
+        $this->assertTrue($this->stringable('taylor')->contains(['LOR'], false));
         $this->assertFalse($this->stringable('taylor')->contains('xxx'));
         $this->assertFalse($this->stringable('taylor')->contains(['xxx']));
         $this->assertFalse($this->stringable('taylor')->contains(''));
@@ -707,7 +707,7 @@ class SupportStringableTest extends TestCase
     public function testContainsAll()
     {
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor', 'otwell']));
-        $this->assertTrue($this->stringable('taylor otwell')->containsAll(['TAYLOR', 'OTWELL'], true));
+        $this->assertTrue($this->stringable('taylor otwell')->containsAll(['TAYLOR', 'OTWELL'], false));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(collect(['taylor', 'otwell'])));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor']));
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));


### PR DESCRIPTION
### Description
This is a suggestion to rename the `$ignoreCase` parameter in `Str::contains` and `Str::containsAll` methods to `$caseSensitive`. The latter looks more readable and intuitive in my opinion and other methods in the `Str` support class, such as `Str::replace` and `Str::remove` use the same name. I feel this inconsistency needs to be resolved.

### Backwards Compatibility 
This change would break BC when the method is called using named arguments. Since Laravel doesn't guarantee BC for named arguments I think this should not be a problem.