### PR TITLE
[11.x] Allow prefetch to start on custom event

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -112,6 +112,13 @@ class Vite implements Htmlable
     protected $prefetchConcurrently = 3;
 
     /**
+     * The name of the event that should trigger prefetching. The event must be dispatched on the `window`.
+     *
+     * @var string
+     */
+    protected $prefetchEvent = 'load';
+
+    /**
      * Get the preloaded assets.
      *
      * @return array
@@ -285,10 +292,13 @@ class Vite implements Htmlable
      * Eagerly prefetch assets.
      *
      * @param  int|null  $concurrency
+     * @param  string  $event
      * @return $this
      */
-    public function prefetch($concurrency = null)
+    public function prefetch($concurrency = null, $event = 'load')
     {
+        $this->prefetchEvent = $event;
+
         return $concurrency === null
             ? $this->usePrefetchStrategy('aggressive')
             : $this->usePrefetchStrategy('waterfall', ['concurrency' => $concurrency]);
@@ -486,7 +496,7 @@ class Vite implements Htmlable
                 'waterfall' => new HtmlString($base.<<<HTML
 
                     <script{$this->nonceAttribute()}>
-                         window.addEventListener('load', () => window.setTimeout(() => {
+                         window.addEventListener('{$this->prefetchEvent}', () => window.setTimeout(() => {
                             const makeLink = (asset) => {
                                 const link = document.createElement('link')
 
@@ -529,7 +539,7 @@ class Vite implements Htmlable
                 'aggressive' => new HtmlString($base.<<<HTML
 
                     <script{$this->nonceAttribute()}>
-                         window.addEventListener('load', () => window.setTimeout(() => {
+                         window.addEventListener('{$this->prefetchEvent}', () => window.setTimeout(() => {
                             const makeLink = (asset) => {
                                 const link = document.createElement('link')
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1676,6 +1676,23 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest($buildDir);
     }
 
+    public function testItCanConfigureThePrefetchTriggerEvent()
+    {
+        $manifest = json_decode(file_get_contents(__DIR__.'/fixtures/prefetching-manifest.json'));
+        $buildDir = Str::random();
+        $this->makeViteManifest($manifest, $buildDir);
+        app()->usePublicPath(__DIR__);
+
+        $html = (string) tap(ViteFacade::withEntryPoints(['resources/js/app.js']))
+            ->useBuildDirectory($buildDir)
+            ->prefetch(event: 'vite:prefetch')
+            ->toHtml();
+        $this->assertStringNotContainsString("window.addEventListener('load', ", $html);
+        $this->assertStringContainsString("window.addEventListener('vite:prefetch', ", $html);
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     protected function cleanViteManifest($path = 'build')
     {
         if (file_exists(public_path("{$path}/manifest.json"))) {


### PR DESCRIPTION
In my initial design of the asset prefetching feature, I included a delay before prefetching started. I removed the delay to simplify the design in the final version.

Having not yet documented the feature, an initial delay has [already being requested](https://github.com/laravel/framework/pull/52462#issuecomment-2306995221). I can see the advantage of having control of this.

Instead of introducing an arbitrary delay or configurable delay, I've instead opted for a configurable event name that triggers prefetching.

This allows for a custom delay or more dynamic prefetching control, e.g., start after an initial request.

```php
// Service provider...

use Illuminate\Support\Facades\Vite;

Vite::prefetch(
    concurrency: 3,
    event: 'vite:prefetch',
]);
```

then...

```html
<script>
    // prefetch Vite assets 1 second after the load event...

    addEventListener('load', () => {
        setTimeout(() => dispatchEvent(new Event('vite:prefetch')), 1000)
    })
</script>
```

or ...

```html
<script>
    // prefetch Vite assets after downloading the user's profile information...

    const profile = await axios.get('/me').then(() => dispatchEvent(new Event('vite:prefetch'))
    
    // ...
</script>
```