### PR TITLE
[11.x] Fix regression in database assertions with custom model connections

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -272,6 +272,10 @@ trait InteractsWithDatabase
      */
     protected function getTable($table)
     {
+        if ($table instanceof Model) {
+            return $table->getTable();
+        }
+
         return $this->newModelFor($table)?->getTable() ?: $table;
     }
 
@@ -283,6 +287,10 @@ trait InteractsWithDatabase
      */
     protected function getTableConnection($table)
     {
+        if ($table instanceof Model) {
+            return $table->getConnectionName();
+        }
+
         return $this->newModelFor($table)?->getConnectionName();
     }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -377,6 +377,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertEquals($this->table, $this->getTable(ProductStub::class));
         $this->assertEquals($this->table, $this->getTable(new ProductStub));
         $this->assertEquals($this->table, $this->getTable($this->table));
+        $this->assertEquals('all_products', $this->getTable((new ProductStub)->setTable('all_products')));
+    }
+
+    public function testGetTableConnectionNameFromModel()
+    {
+        $this->assertSame(null, $this->getTableConnection(ProductStub::class));
+        $this->assertSame(null, $this->getTableConnection(new ProductStub));
+        $this->assertSame('mysql', $this->getTableConnection((new ProductStub)->setConnection('mysql')));
     }
 
     public function testGetTableCustomizedDeletedAtColumnName()


### PR DESCRIPTION
This PR fixes a regression that was introduced by https://github.com/laravel/framework/pull/52464. Previously, `assertModelExists()` and `assertModelMissing()` would respect the model's table and connection (by passing the names to `assertDatabaseHas()` and `assertDatabaseMissing()` respectively). This is no longer the case, which caused test failures in my multi-connection project when upgrading to Laravel 11.21. This change ensures the table and connection that may have been changed at runtime are respected.