### PR TITLE
[11.x] Add Number::makePositive() and Number::makeNegative()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -269,6 +269,28 @@ class Number
     }
 
     /**
+     * Ensure the given number is negative.
+     *
+     * @param  int|float  $number
+     * @return int|float
+     */
+    public static function makeNegative(int|float $number)
+    {
+        return $number < 0 ? $number : -$number;
+    }
+
+    /**
+     * Ensure the given number is positive.
+     *
+     * @param  int|float  $number
+     * @return int|float
+     */
+    public static function makePositive(int|float $number)
+    {
+        return $number > 0 ? $number : abs($number);
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -304,4 +304,24 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    public function testMakeNegative()
+    {
+        $this->assertSame(-12, Number::makeNegative(12));
+        $this->assertSame(-12, Number::makeNegative(-12));
+        $this->assertSame(0, Number::makeNegative(0));
+        $this->assertSame(-0, Number::makeNegative(-0));
+        $this->assertSame(-12.34, Number::makeNegative(-12.34));
+        $this->assertSame(-12.34, Number::makeNegative(-12.34));
+    }
+
+    public function testMakePositive()
+    {
+        $this->assertSame(12, Number::makePositive(-12));
+        $this->assertSame(12, Number::makePositive(12));
+        $this->assertSame(0, Number::makePositive(0));
+        $this->assertSame(0, Number::makePositive(-0));
+        $this->assertSame(12.34, Number::makePositive(-12.34));
+        $this->assertSame(12.34, Number::makePositive(12.34));
+    }
 }


### PR DESCRIPTION
This pull request adds two new functions, `makeNegative` and `makePositive`, to the `Number` class. These functions ensure that a given number is always negative or positive.

### Summary
These functions provide a convenient way to manipulate numbers to always be in a desired sign. They are intended to simplify scenarios where the sign of a number needs to be controlled programmatically.  This feature will be beneficial in any application performing number calculations since it helps with readability. I made a global helper in the company I work for since there are many places where number calculations are performed and it was necessary to ensure the number's sign.

### Use Case
When a random function can accept negative and positive numbers but the outcome can be different then it's crucial to ensure the number has the correct sign. Using `-$number` or `-abs($number)` can be easily overlooked when reading through. And it has been much more effective to use clear explanatory methods.

### Details
- Added `makeNegative($number)` method: Returns the negative version of the input number. If the number is already negative, it is returned unchanged.
- Added `makePositive($number)` method: Returns the positive version of the input number. If the number is already positive, it is returned unchanged.

These methods have been added to the `Number` class. They handle both integer and float types.
Tests have been added to `SupportNumberTest.php` with assertions covering integers and floats for positive and negative signed numbers.
