### PR TITLE
[11.x] Added Number::isBetween() method

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -269,6 +269,23 @@ class Number
     }
 
     /**
+     * Check if the given number is between given min and max number.
+     *
+     * @param  int|float  $value
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @param  bool  $inclusive
+     * @return bool
+     */
+    public static function isBetween(int|float $value, int|float $min, int|float $max, bool $inclusive = true)
+    {
+        return match ($inclusive) {
+            true => $value >= $min && $value <= $max,
+            false => $value > $min && $value < $max,
+        };
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -304,4 +304,23 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    public function testBetween()
+    {
+        $this->assertTrue(Number::isBetween(5, 1, 10));
+        $this->assertTrue(Number::isBetween(1, 1, 10));
+        $this->assertTrue(Number::isBetween(10, 1, 10));
+        $this->assertFalse(Number::isBetween(0, 1, 10));
+        $this->assertFalse(Number::isBetween(11, 1, 10));
+        $this->assertTrue(Number::isBetween(7.5, 1.2, 7.5));
+        $this->assertTrue(Number::isBetween(7.5, 7.5, 10.5));
+        $this->assertTrue(Number::isBetween(5, 1, 10, false));
+        $this->assertFalse(Number::isBetween(1, 1, 10, false));
+        $this->assertFalse(Number::isBetween(10, 1, 10, false));
+        $this->assertFalse(Number::isBetween(0, 1, 10, false));
+        $this->assertFalse(Number::isBetween(11, 1, 10, false));
+        $this->assertFalse(Number::isBetween(7.5, 1.2, 7.5, false));
+        $this->assertFalse(Number::isBetween(7.5, 7.5, 10.5, false));
+        $this->assertTrue(Number::isBetween(7.4, 1.2, 7.5, false));
+    }
 }


### PR DESCRIPTION
This PR adds new `isBetween` method to `Number` class.

Method tests if given number is between given min and max. There is also 4th `$inclusive` parameter where we can decide wether min and max should be inclusive or not.

I've had this function for years in my `helpers.php` file and though that since we have `Number` class for a while now it may be worth to include it there so others can benefit from it.

I'm wondering why nobody came up with this simple method before. Maybe there was a reason, if this is the case could you point me to the PR so I can see explanation please ?

I know this is very basic functionality but believe this will improve code readability and see it being used a lot by Laravel community.

Thanks

