### PR TITLE
Add function addCharAtInterval() to Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -111,6 +111,19 @@ class Str
     }
 
     /**
+     * Return the given string with a custom character every X character.
+     *
+     * @param  string  $subject
+     * @param  string  $char
+     * @param  int  $length
+     * @return string
+     */
+    public static function addCharAtInterval($subject, $char, $length = 1)
+    {
+        return implode($char, str_split($subject, $length));
+    }
+
+    /**
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -46,6 +46,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Return the given string with a custom character every X character.
+     *
+     * @param  $char
+     * @param  $length
+     * @return static
+     */
+    public function addCharAtInterval($char, $length = 1)
+    {
+        return new static(Str::addCharAtInterval($this->value, $char, $length));
+    }
+
+    /**
      * Return the remainder of a string after the last occurrence of a given value.
      *
      * @param  string  $search

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -12,6 +12,12 @@ use ValueError;
 
 class SupportStrTest extends TestCase
 {
+    public function testItAddsACustomCharacterEveryXTimes(): void
+    {
+        $this->assertSame('12 34 56 78 90', Str::addCharAtInterval('1234567890', ' ', 2));
+        $this->assertSame('123-456-789', Str::addCharAtInterval('123456789', '-', 3));
+    }
+
     public function testStringCanBeLimitedByWords(): void
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -29,6 +29,12 @@ class SupportStringableTest extends TestCase
         );
     }
 
+    public function testItAddsACustomCharacterEveryXTimes()
+    {
+        $this->assertSame('12 34 56 78 90', (string) $this->stringable('1234567890')->addCharAtInterval(' ', 2));
+        $this->assertSame('123-456-789', (string) $this->stringable('123456789')->addCharAtInterval('-', 3));
+    }
+
     public function testIsAscii()
     {
         $this->assertTrue($this->stringable('A')->isAscii());


### PR DESCRIPTION
This pull request adds a new function, `addCharAtInterval`, to the `Str` class.
This function adds a character to the subject every X occurrences.

Example:
Str::addCharAtInterval('123456789', '-', 3) will return `123-456-789`

