### PR TITLE
[10.x] Backport #52557 - SORT_NATURAL on Collection no longer throws warning for nulls

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1477,7 +1477,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                         $result = match ($options) {
                             SORT_NUMERIC => intval($values[0]) <=> intval($values[1]),
                             SORT_STRING => strcmp($values[0], $values[1]),
-                            SORT_NATURAL => strnatcmp($values[0], $values[1]),
+                            SORT_NATURAL => strnatcmp((string) $values[0], (string) $values[1]),
                             SORT_LOCALE_STRING => strcoll($values[0], $values[1]),
                             default => $values[0] <=> $values[1],
                         };

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2213,19 +2213,19 @@ class SupportCollectionTest extends TestCase
     {
         $itemFoo = new \stdClass();
         $itemFoo->first = 'f';
-        $itemFoo->second = 's';
+        $itemFoo->second = null;
         $itemBar = new \stdClass();
         $itemBar->first = 'f';
-        $itemBar->second = null;
+        $itemBar->second = 's';
 
         $data = new $collection([$itemFoo, $itemBar]);
-        $data->sortBy([
-            ['first', 'asc'],
-            ['second', 'asc'],
+        $data = $data->sortBy([
+            ['first', 'desc'],
+            ['second', 'desc'],
         ], SORT_NATURAL);
 
-        $this->assertEquals($itemFoo, $data->first());
-        $this->assertEquals($itemBar, $data->get(2));
+        $this->assertEquals($itemBar, $data->first());
+        $this->assertEquals($itemFoo, $data->skip(1)->first());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2209,6 +2209,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testNaturalSortByManyWithNull($collection)
+    {
+        $itemFoo = new \stdClass();
+        $itemFoo->first = 'f';
+        $itemFoo->second = 's';
+        $itemBar = new \stdClass();
+        $itemBar->first = 'f';
+        $itemBar->second = null;
+
+        $data = new $collection([$itemFoo, $itemBar]);
+        $data->sortBy([
+            ['first', 'asc'],
+            ['second', 'asc'],
+        ], SORT_NATURAL);
+
+        $this->assertEquals($itemFoo, $data->first());
+        $this->assertEquals($itemBar, $data->get(2));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortKeys($collection)
     {
         $data = new $collection(['b' => 'dayle', 'a' => 'taylor']);


### PR DESCRIPTION
This PR backports https://github.com/laravel/framework/pull/52557 into 10.x. This will prevent constant warnings for a null value being passed to `strnatcmp()` for users of Laravel 10.