### PR TITLE
[11.x] Restore Request::HEADER_X_FORWARDED_PREFIX in TrustProxies

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -23,6 +23,7 @@ class TrustProxies
                          Request::HEADER_X_FORWARDED_HOST |
                          Request::HEADER_X_FORWARDED_PORT |
                          Request::HEADER_X_FORWARDED_PROTO |
+                         Request::HEADER_X_FORWARDED_PREFIX |
                          Request::HEADER_X_FORWARDED_AWS_ELB;
 
     /**

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -178,6 +178,7 @@ class MiddlewareTest extends TestCase
             Request::HEADER_X_FORWARDED_HOST |
             Request::HEADER_X_FORWARDED_PORT |
             Request::HEADER_X_FORWARDED_PROTO |
+            Request::HEADER_X_FORWARDED_PREFIX |
             Request::HEADER_X_FORWARDED_AWS_ELB, $method->invoke($middleware));
 
         $property->setValue($middleware, Request::HEADER_X_FORWARDED_AWS_ELB);


### PR DESCRIPTION
It seems like `Request::HEADER_X_FORWARDED_PREFIX` was removed in https://github.com/laravel/framework/pull/47309 but we need this header to make this work in our environment. 

Looking at the [actual diff](https://github.com/laravel/framework/pull/47309/files#diff-c93fa6d8308b983c4ad429cbef9a44e14876ff4e7aff000dec47e0e0c6b20f5f), it seems like it was removed by accident?
There was not explanation for it being removed at least. 

This fix will also make it aligned with the [default fallback](https://github.com/laravel/framework/blob/b9cf7d3217732e9a0fa4f00e996b3f9cc5bf7abd/src/Illuminate/Http/Middleware/TrustProxies.php#L127) when `$header` is not defined.

