### PR TITLE
Fix docblock for `Model::getEventDispatcher()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -399,7 +399,7 @@ trait HasEvents
     /**
      * Get the event dispatcher instance.
      *
-     * @return \Illuminate\Contracts\Events\Dispatcher
+     * @return ?\Illuminate\Contracts\Events\Dispatcher
      */
     public static function getEventDispatcher()
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -399,7 +399,7 @@ trait HasEvents
     /**
      * Get the event dispatcher instance.
      *
-     * @return ?\Illuminate\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
      */
     public static function getEventDispatcher()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -134,7 +134,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The event dispatcher instance.
      *
-     * @var \Illuminate\Contracts\Events\Dispatcher
+     * @var ?\Illuminate\Contracts\Events\Dispatcher
      */
     protected static $dispatcher;
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -134,7 +134,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The event dispatcher instance.
      *
-     * @var ?\Illuminate\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected static $dispatcher;
 


### PR DESCRIPTION
The `static::$dispatcher` property may be `null` after using `Model::unsetEventDispatcher()`. The docblock for `Model::getEventDispatcher` and the docblock for the property itself should reflect that.

This fix avoids warnings from static analysers such as PHPstan when using the `getEventDispatcher` method:
```
Using nullsafe method call on non-nullable type Illuminate\Contracts\Events\Dispatcher. Use -> instead.
```