### PR TITLE
[11.x] Accepts BackedEnum for onQueue, onConnection, allOnQueue, and allOnConnection methods in the Queueable trait

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -77,7 +77,7 @@ trait Queueable
     /**
      * Set the desired connection for the job.
      *
-     * @param  string|BackedEnum|null  $connection
+     * @param  \BackedEnum|string|null  $connection
      * @return $this
      */
     public function onConnection($connection)
@@ -92,7 +92,7 @@ trait Queueable
     /**
      * Set the desired queue for the job.
      *
-     * @param  string|BackedEnum|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)
@@ -107,7 +107,7 @@ trait Queueable
     /**
      * Set the desired connection for the chain.
      *
-     * @param  string|BackedEnum|null  $connection
+     * @param  \BackedEnum|string|null  $connection
      * @return $this
      */
     public function allOnConnection($connection)
@@ -125,7 +125,7 @@ trait Queueable
     /**
      * Set the desired queue for the chain.
      *
-     * @param  string|BackedEnum|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
     public function allOnQueue($queue)

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -7,6 +7,7 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
+use StringBackedEnum;
 
 trait Queueable
 {
@@ -76,12 +77,14 @@ trait Queueable
     /**
      * Set the desired connection for the job.
      *
-     * @param  string|null  $connection
+     * @param  string|StringBackedEnum|null  $connection
      * @return $this
      */
     public function onConnection($connection)
     {
-        $this->connection = $connection;
+        $this->connection = $connection instanceof StringBackedEnum
+            ? $connection->value
+            : $connection;
 
         return $this;
     }
@@ -89,12 +92,14 @@ trait Queueable
     /**
      * Set the desired queue for the job.
      *
-     * @param  string|null  $queue
+     * @param  string|StringBackedEnum|null  $queue
      * @return $this
      */
     public function onQueue($queue)
     {
-        $this->queue = $queue;
+        $this->queue = $queue instanceof StringBackedEnum
+            ? $queue->value
+            : $queue;
 
         return $this;
     }
@@ -102,13 +107,17 @@ trait Queueable
     /**
      * Set the desired connection for the chain.
      *
-     * @param  string|null  $connection
+     * @param  string|StringBackedEnum|null  $connection
      * @return $this
      */
     public function allOnConnection($connection)
     {
-        $this->chainConnection = $connection;
-        $this->connection = $connection;
+        $resolvedConnection = $connection instanceof StringBackedEnum
+            ? $connection->value
+            : $connection;
+
+        $this->chainConnection = $resolvedConnection;
+        $this->connection = $resolvedConnection;
 
         return $this;
     }
@@ -116,13 +125,17 @@ trait Queueable
     /**
      * Set the desired queue for the chain.
      *
-     * @param  string|null  $queue
+     * @param  string|StringBackedEnum|null  $queue
      * @return $this
      */
     public function allOnQueue($queue)
     {
-        $this->chainQueue = $queue;
-        $this->queue = $queue;
+        $resolvedQueue = $queue instanceof StringBackedEnum
+            ? $queue->value
+            : $queue;
+
+        $this->chainQueue = $resolvedQueue;
+        $this->queue = $resolvedQueue;
 
         return $this;
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Bus;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
-use StringBackedEnum;
 
 trait Queueable
 {
@@ -77,12 +77,12 @@ trait Queueable
     /**
      * Set the desired connection for the job.
      *
-     * @param  string|StringBackedEnum|null  $connection
+     * @param  string|BackedEnum|null  $connection
      * @return $this
      */
     public function onConnection($connection)
     {
-        $this->connection = $connection instanceof StringBackedEnum
+        $this->connection = $connection instanceof BackedEnum
             ? $connection->value
             : $connection;
 
@@ -92,12 +92,12 @@ trait Queueable
     /**
      * Set the desired queue for the job.
      *
-     * @param  string|StringBackedEnum|null  $queue
+     * @param  string|BackedEnum|null  $queue
      * @return $this
      */
     public function onQueue($queue)
     {
-        $this->queue = $queue instanceof StringBackedEnum
+        $this->queue = $queue instanceof BackedEnum
             ? $queue->value
             : $queue;
 
@@ -107,12 +107,12 @@ trait Queueable
     /**
      * Set the desired connection for the chain.
      *
-     * @param  string|StringBackedEnum|null  $connection
+     * @param  string|BackedEnum|null  $connection
      * @return $this
      */
     public function allOnConnection($connection)
     {
-        $resolvedConnection = $connection instanceof StringBackedEnum
+        $resolvedConnection = $connection instanceof BackedEnum
             ? $connection->value
             : $connection;
 
@@ -125,12 +125,12 @@ trait Queueable
     /**
      * Set the desired queue for the chain.
      *
-     * @param  string|StringBackedEnum|null  $queue
+     * @param  string|BackedEnum|null  $queue
      * @return $this
      */
     public function allOnQueue($queue)
     {
-        $resolvedQueue = $queue instanceof StringBackedEnum
+        $resolvedQueue = $queue instanceof BackedEnum
             ? $queue->value
             : $queue;
 

--- a/tests/Bus/QueueableTest.php
+++ b/tests/Bus/QueueableTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Bus;
+
+use Illuminate\Bus\Queueable;
+use PHPUnit\Framework\TestCase;
+
+class QueueableTest extends TestCase
+{
+    public static function connectionDataProvider(): array
+    {
+        return [
+            'uses string' => ['redis', 'redis'],
+            'uses BackedEnum #1' => [ConnectionEnum::SQS, 'sqs'],
+            'uses BackedEnum #2' => [ConnectionEnum::REDIS, 'redis'],
+            'uses null' => [null, null],
+        ];
+    }
+
+    /**
+     * @dataProvider connectionDataProvider
+     */
+    public function testOnConnection(mixed $connection, ?string $expected): void
+    {
+        $job = new FakeJob();
+        $job->onConnection($connection);
+
+        $this->assertSame($job->connection, $expected);
+    }
+
+    /**
+     * @dataProvider connectionDataProvider
+     */
+    public function testAllOnConnection(mixed $connection, ?string $expected): void
+    {
+        $job = new FakeJob();
+        $job->allOnConnection($connection);
+
+        $this->assertSame($job->connection, $expected);
+        $this->assertSame($job->chainConnection, $expected);
+    }
+
+    public static function queuesDataProvider(): array
+    {
+        return [
+            'uses string' => ['high', 'high',],
+            'uses BackedEnum #1' => [QueueEnum::DEFAULT, 'default'],
+            'uses BackedEnum #2' => [QueueEnum::HIGH, 'high'],
+            'uses null' => [null, null],
+        ];
+    }
+
+    /**
+     * @dataProvider queuesDataProvider
+     */
+    public function testOnQueue(mixed $queue, ?string $expected): void
+    {
+        $job = new FakeJob();
+        $job->onQueue($queue);
+
+        $this->assertSame($job->queue, $expected);
+    }
+
+    /**
+     * @dataProvider queuesDataProvider
+     */
+    public function testAllOnQueue(mixed $queue, ?string $expected): void
+    {
+        $job = new FakeJob();
+        $job->allOnQueue($queue);
+
+        $this->assertSame($job->queue, $expected);
+        $this->assertSame($job->chainQueue, $expected);
+    }
+}
+
+class FakeJob {
+    use Queueable;
+}
+
+enum ConnectionEnum: string {
+    case SQS = 'sqs';
+    case REDIS = 'redis';
+}
+
+enum QueueEnum: string {
+    case HIGH = 'high';
+    case DEFAULT = 'default';
+}


### PR DESCRIPTION
Hi guys,

I believe there are a lot of applications out there that are maintaining the Queue Names & Connections using Enums, which is awesome and less hardcoded string.

This PR enables us to pass an Enum instance to these methods:

- `onQueue`
- `onConnection`
- `allOnQueue`
- `allOnConnection`

This shouldn't bring any breaking changes. Tests are covered everything ✌️ 

Note: this only enhances those listed methods above, for jobs that use `$connection` & `$queue` properties, they still need to use a normal string (or `enum->value`)

## Before

![image](https://github.com/user-attachments/assets/4de047ba-5aaa-449c-9762-ce805aa4bcb4)

## After

![image](https://github.com/user-attachments/assets/1e04b7f5-4527-4b0e-b3da-2f6d228410dd)

