### PR TITLE
Proposal to add new methods: Str::isExactly and Str::isExactlyAny

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -488,6 +488,41 @@ class Str
     }
 
     /**
+     * Determine if a given string exactly matches a string.
+     *
+     * @param  string  $subject
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $caseSensitive
+     * @return bool
+     */
+    public static function isExactly($subject, $needles, $caseSensitive = true)
+    {
+        return static::isExactlyAny($subject, $needles, $caseSensitive);
+    }
+
+    /**
+     * Determine if a given string exactly matches a string from a list.
+     *
+     * @param  string  $subject
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $caseSensitive
+     * @return bool
+     */
+    public static function isExactlyAny($subject, $needles, $caseSensitive = true)
+    {
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
+        }
+
+        if (! $caseSensitive) {
+            $subject = mb_strtolower($subject);
+            $needles = array_map('mb_strtolower', $needles);
+        }
+
+        return in_array($subject, $needles);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -338,6 +338,30 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string exactly matches a string.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $caseSensitive
+     * @return bool
+     */
+    public function isExactly($needles, $caseSensitive = true)
+    {
+        return Str::isExactly($this->value, $needles, $caseSensitive);
+    }
+
+    /**
+     * Determine if a given string exactly matches a string from a list.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $caseSensitive
+     * @return bool
+     */
+    public function isExactlyAny($needles, $caseSensitive = true)
+    {
+        return Str::isExactlyAny($this->value, $needles, $caseSensitive);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -564,6 +564,21 @@ class SupportStrTest extends TestCase
         PATTERN, $multilineValue));
     }
 
+    public function testIsExactly()
+    {
+        $this->assertTrue(Str::isExactly('taylor', 'taylor'));
+        $this->assertTrue(Str::isExactly('taylor', 'TAYLOR', false));
+        $this->assertFalse(Str::isExactly('taylor', 'tayl'));
+        $this->assertFalse(Str::isExactly('taylor', 'otwell'));
+    }
+
+    public function testIsExactlyAny()
+    {
+        $this->assertTrue(Str::isExactlyAny('taylor', ['taylor', 'otwell']));
+        $this->assertTrue(Str::isExactlyAny('taylor', ['TAYLOR', 'otwell'], false));
+        $this->assertFalse(Str::isExactlyAny('taylor', ['tayl', 'otwell']));
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue(Str::isUrl('https://laravel.com'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -802,6 +802,21 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('test')->is([]));
     }
 
+    public function testIsExactly()
+    {
+        $this->assertTrue($this->stringable('taylor')->isExactly('taylor'));
+        $this->assertTrue($this->stringable('taylor')->isExactly('TAYLOR', false));
+        $this->assertFalse($this->stringable('taylor')->isExactly('tayl'));
+        $this->assertFalse($this->stringable('taylor')->isExactly('otwell'));
+    }
+
+    public function testIsExactlyAny()
+    {
+        $this->assertTrue($this->stringable('taylor')->isExactlyAny(['taylor', 'otwell']));
+        $this->assertTrue($this->stringable('taylor')->isExactlyAny(['TAYLOR', 'otwell'], false));
+        $this->assertFalse($this->stringable('taylor')->isExactlyAny(['tayl', 'otwell']));
+    }
+
     public function testIsWithMultilineStrings()
     {
         $this->assertFalse($this->stringable("/\n")->is('/'));


### PR DESCRIPTION
I am proposing to add two new methods: `Str::isExactly` and `Str::isExactlyAny`. These methods will check if a given string **exactly** matches another string or matches a string from a given list. The functionality of `Str::isExactly` method is identical to `$str1 == $str2`, and `Str::isExactlyAny` to PHP's `in_array` function. However, the benefit of these methods is that it allows case-insensitivity by passing `caseSensitive: false`

``` php
Str::isExactly('taylor', 'taylor'); // true
Str::isExactly('taylor', 'TAYLOR', caseSensitive: false); // true
Str::isExactly('taylor', 'tayl'); // false

Str::isExactlyAny('taylor', ['taylor', 'otwell']); // true
Str::isExactly('taylor', ['TAYLOR', 'otwell'], caseSensitive: false); // true
```
I personally found a case-insensitive `in_array` function to be really helpful (which is what `Str::isExactlyAny` is), but I am not sure how useful all of this is. I would like to hear what others think about this proposal.

Cheers :)
