### PR TITLE
[11.x] Add Native Timestamps method to Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1241,6 +1241,19 @@ class Blueprint
     }
 
     /**
+     * Add native creation and update timestamps to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function nativeTimestamps($precision = 0)
+    {
+        $this->timestamp('created_at', $precision)->useCurrent();
+
+        $this->timestamp('updated_at', $precision)->useCurrent()->useCurrentOnUpdate();
+    }
+
+    /**
      * Add nullable creation and update timestamps to the table.
      *
      * Alias for self::timestamps().


### PR DESCRIPTION
Introduced nativeTimestamps Method 

This pull request introduces a new nativeTimestamps method that automatically adds timestamps to records using the database's native default settings for the current time. 

Motivation

In the real world, the database is used in a wide variety of uses by a large number of applications Therefore, it is important to let the database update the respective time fields

Also, by allowing the database to handle default timestamps, we can avoid such errors sql errors and ensure smoother record insertion processes.

**both of the 2 scenario** will be with records of `created_at` and `updated_at`:
1.
```php
$user = new \App\Models\User();
$user->name ='name';
$user->email='email@email.email';
$user->password='hashed_secret';
$user->save();
```
2.
```php
DB::table('users')
->insert([
'name'=>'name',
'email'=>'email@email.email',
'password'=>'hashed_secret'
]);

```

Database Migration Adjustments:

Updated database migration scripts to include `created_at` and `updated_at` columns using the timestamp method, which now optionally supports database-native defaults for timestamp fields,
adhering to Laravel's philosophy of convention over configuration.

Benefits of the Change:
  Reduces Boilerplate Code: Developers no longer need to manually set `created_at` and `updated_at` fields for each record insertion, simplifying the development process.

 Ensures Data Integrity: By using the database to manage timestamps, we guarantee accurate and consistent creation and modification times across all records, enhancing data reliability and consistency.

Improves Developer Experience:  reduces the likelihood of errors and provides a more streamlined, efficient development workflow.

> This function is not intended to change original `timestamps` function behavior.