### PR TITLE
Feat:using @mixin phpstrom comment insted of list all methods in Hash…

### DIFF
--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -3,24 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Hashing\BcryptHasher createBcryptDriver()
- * @method static \Illuminate\Hashing\ArgonHasher createArgonDriver()
- * @method static \Illuminate\Hashing\Argon2IdHasher createArgon2idDriver()
- * @method static array info(string $hashedValue)
- * @method static string make(string $value, array $options = [])
- * @method static bool check(string $value, string $hashedValue, array $options = [])
- * @method static bool needsRehash(string $hashedValue, array $options = [])
- * @method static bool isHashed(string $value)
- * @method static string getDefaultDriver()
- * @method static mixed driver(string|null $driver = null)
- * @method static \Illuminate\Hashing\HashManager extend(string $driver, \Closure $callback)
- * @method static array getDrivers()
- * @method static \Illuminate\Contracts\Container\Container getContainer()
- * @method static \Illuminate\Hashing\HashManager setContainer(\Illuminate\Contracts\Container\Container $container)
- * @method static \Illuminate\Hashing\HashManager forgetDrivers()
- *
- * @see \Illuminate\Hashing\HashManager
- * @see \Illuminate\Hashing\AbstractHasher
+ * @mixin \Illuminate\Hashing\HashManager
  */
 class Hash extends Facade
 {


### PR DESCRIPTION

Sometimes we need to find out what the method exactly does in the under hood not only merely having an autocomplete feature for Phpstorm, List methods in facade classes are better off navigating to the exact method directly. With this comment, we have an autocomplete feature and navigate to the precise class in the calling facade.
