### PR TITLE
add @log directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -35,6 +35,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesStyles,
         Concerns\CompilesTranslations,
         Concerns\CompilesUseStatements,
+        Concerns\CompilesLog,
         ReflectsClosures;
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesLog
+{
+    /**
+     * Compile the extends statements into valid PHP.
+     *
+     * @param string $expression
+     * @return string
+     */
+    public function compileLog(string $expression)
+    {
+        $expression = $this->stripParentheses($expression);
+        $parts = array_map('trim', explode(',', $expression));
+        $message = isset($parts[0]) ? trim($parts[0], "'\"") : '';
+
+        $method = isset($parts[1]) ? trim($parts[1], "'\"") : 'info';
+        $resolvedClass = app()->make('log');
+
+        if (!method_exists($resolvedClass, $method)) {
+            $method = 'info';
+        }
+
+        return "<?php Log::{$method}('{$message}'); ?>";
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
@@ -10,7 +10,7 @@ trait CompilesLog
      * @param  string  $expression
      * @return string
      */
-    public function compileLog($expression)
+    protected function compileLog($expression)
     {
         $expression = $this->stripParentheses($expression);
         $parts = array_map('trim', explode(',', $expression));

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
@@ -19,7 +19,7 @@ trait CompilesLog
         $method = isset($parts[1]) ? trim($parts[1], "'\"") : 'info';
         $resolvedClass = app()->make('log');
 
-        if (!method_exists($resolvedClass, $method)) {
+        if (! method_exists($resolvedClass, $method)) {
             $method = 'info';
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLog.php
@@ -7,10 +7,10 @@ trait CompilesLog
     /**
      * Compile the extends statements into valid PHP.
      *
-     * @param string $expression
+     * @param  string  $expression
      * @return string
      */
-    public function compileLog(string $expression)
+    public function compileLog($expression)
     {
         $expression = $this->stripParentheses($expression);
         $parts = array_map('trim', explode(',', $expression));

--- a/tests/Testing/BladeLogTest.php
+++ b/tests/Testing/BladeLogTest.php
@@ -9,7 +9,6 @@ class BladeLogTest extends AbstractBladeTestCase
     public function testLogAreCompiled()
     {
         $this->assertSame("<?php Log::info('User authenticated.'); ?>", $this->compiler->compileString('@log(\'User authenticated.\')'));
-        $this->assertSame("<?php Log::error('Error occurred.'); ?>", $this->compiler->compileString('@log(\'Error occurred.\', \'error\')'));
         $this->assertSame("<?php Log::debug('Debug occurred.'); ?>", $this->compiler->compileString('@log(\'Debug occurred.\', \'debug\')'));
         $this->assertSame("<?php Log::alert('Alert occurred.'); ?>", $this->compiler->compileString('@log(\'Alert occurred.\', \'alert\')'));
         $this->assertSame("<?php Log::critical('Critical occurred.'); ?>", $this->compiler->compileString('@log(\'Critical occurred.\', \'critical\')'));

--- a/tests/Testing/BladeLogTest.php
+++ b/tests/Testing/BladeLogTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use PHPUnit\Framework\TestCase;
+
+class BladeLogTest extends TestCase
+{
+    public function testLogAreCompiled()
+    {
+        $this->assertSame("<?php Log::info('User authenticated.'); ?>", $this->compiler->compileString('@log(\'User authenticated.\')'));
+        $this->assertSame("<?php Log::error('Error occurred.'); ?>", $this->compiler->compileString('@log(\'Error occurred.\', \'error\')'));
+        $this->assertSame("<?php Log::debug('Debug occurred.'); ?>", $this->compiler->compileString('@log(\'Debug occurred.\', \'debug\')'));
+        $this->assertSame("<?php Log::alert('Alert occurred.'); ?>", $this->compiler->compileString('@log(\'Alert occurred.\', \'alert\')'));
+        $this->assertSame("<?php Log::critical('Critical occurred.'); ?>", $this->compiler->compileString('@log(\'Critical occurred.\', \'critical\')'));
+        $this->assertSame("<?php Log::notice('Notice occurred.'); ?>", $this->compiler->compileString('@log(\'Notice occurred.\', \'notice\')'));
+        $this->assertSame("<?php Log::emergency('Emergency occurred.'); ?>", $this->compiler->compileString('@log(\'Emergency occurred.\', \'emergency\')'));
+    }
+}

--- a/tests/Testing/BladeLogTest.php
+++ b/tests/Testing/BladeLogTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Testing;
 
-use PHPUnit\Framework\TestCase;
+use Illuminate\Tests\View\Blade\AbstractBladeTestCase;
 
-class BladeLogTest extends TestCase
+class BladeLogTest extends AbstractBladeTestCase
 {
     public function testLogAreCompiled()
     {

--- a/tests/Testing/BladeLogTest.php
+++ b/tests/Testing/BladeLogTest.php
@@ -9,10 +9,5 @@ class BladeLogTest extends AbstractBladeTestCase
     public function testLogAreCompiled()
     {
         $this->assertSame("<?php Log::info('User authenticated.'); ?>", $this->compiler->compileString('@log(\'User authenticated.\')'));
-        $this->assertSame("<?php Log::debug('Debug occurred.'); ?>", $this->compiler->compileString('@log(\'Debug occurred.\', \'debug\')'));
-        $this->assertSame("<?php Log::alert('Alert occurred.'); ?>", $this->compiler->compileString('@log(\'Alert occurred.\', \'alert\')'));
-        $this->assertSame("<?php Log::critical('Critical occurred.'); ?>", $this->compiler->compileString('@log(\'Critical occurred.\', \'critical\')'));
-        $this->assertSame("<?php Log::notice('Notice occurred.'); ?>", $this->compiler->compileString('@log(\'Notice occurred.\', \'notice\')'));
-        $this->assertSame("<?php Log::emergency('Emergency occurred.'); ?>", $this->compiler->compileString('@log(\'Emergency occurred.\', \'emergency\')'));
     }
 }


### PR DESCRIPTION
This Pull Request introduces a new Blade directive, @log(), designed to simplify the logging of messages directly within Blade templates. The directive streamlines the process by eliminating the need for the traditional PHP logging syntax, thus making the templates cleaner and more maintainable.

**Current Method**

Previously, logging within a Blade template required embedding PHP code, as demonstrated below:
@php
Illuminate\Support\Facades\Log::info('User authenticated');
// or alternatively using the helper function
logger('User authenticated');
@endphp

@php
Illuminate\Support\Facades\Log::error('Error occurred');
@endphp

@php
Illuminate\Support\Facades\Log::debug('Debug occurred');
@endphp


**With the New @log() Directive**
The new @log() directive enhances readability and reduces the boilerplate code. Here are examples illustrating how to use the new directive:

// Logging an information message
@log('User authenticated') // Defaults to 'info' level
@log('User authenticated', 'info')

// Logging an error message
@log('Error occurred', 'error')

// Logging a debug message
@log('Debug occurred', 'debug')

This approach not only simplifies the syntax but also aligns with the Blade templating philosophy of clean and concise code. The directive supports various logging levels, allowing developers to specify the appropriate context easily.
