### PR TITLE
Feat:add new method for checkNotExists in Db query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1890,6 +1890,23 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Check a table doesn't have relation with another table.
+     *
+     * @param  string  $relation
+     * @param  string  $foreignKeyColumn
+     * @return $this
+     */
+    public function relationNotExists($relation, $foreignKeyColumn)
+    {
+        $relationKey = $relation.'.id';
+        $foreignKey = new Expression(sprintf('"%s"."%s"', $this->from, $foreignKeyColumn));
+
+        return $this->from($this->from)->whereNotExists(function ($q) use ($foreignKey, $relationKey, $relation) {
+            $q->select('*')->from($relation)->where($relationKey, '=', $foreignKey);
+        });
+    }
+
+    /**
      * Adds a where condition using row values.
      *
      * @param  array  $columns

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2478,6 +2478,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
     }
 
+    public function testRelationNotExists()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->relationNotExists('products', 'product_id');
+        $this->assertSame('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."product_id")', $builder->toSql());
+    }
+
     public function testBasicJoins()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Unlike Eloquent, DB builder doesn't have any specific method for checking whether a table has a relation or not. We should use a syntax like this to find data that doesn't have a relation:

`
$builder->select('*')->from('orders')->whereNotExists(function ($q) {
            $q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
        });
`

Having a method for these aims would be efficient like Eloquent. So I made a method called `relationNotExists` for this purpose.