### PR TITLE
[11.x] Fix some helpers return annotation

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -810,7 +810,7 @@ if (! function_exists('response')) {
      * @param  \Illuminate\Contracts\View\View|string|array|null  $content
      * @param  int  $status
      * @param  array  $headers
-     * @return ($content is null ? \Illuminate\Contracts\Routing\ResponseFactory : \Illuminate\Http\Response)
+     * @return (when called without any args ? \Illuminate\Contracts\Routing\ResponseFactory : \Illuminate\Http\Response)
      */
     function response($content = null, $status = 200, array $headers = [])
     {
@@ -1013,7 +1013,7 @@ if (! function_exists('validator')) {
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $attributes
-     * @return ($data is null ? \Illuminate\Contracts\Validation\Factory : \Illuminate\Contracts\Validation\Validator)
+     * @return (when called without any args ? \Illuminate\Contracts\Validation\Factory : \Illuminate\Contracts\Validation\Validator)
      */
     function validator(?array $data = null, array $rules = [], array $messages = [], array $attributes = [])
     {
@@ -1034,7 +1034,7 @@ if (! function_exists('view')) {
      * @param  string|null  $view
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  array  $mergeData
-     * @return ($view is null ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View)
+     * @return (when called without any args ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View)
      */
     function view($view = null, $data = [], $mergeData = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -810,7 +810,7 @@ if (! function_exists('response')) {
      * @param  \Illuminate\Contracts\View\View|string|array|null  $content
      * @param  int  $status
      * @param  array  $headers
-     * @return (when called without any args ? \Illuminate\Contracts\Routing\ResponseFactory : \Illuminate\Http\Response)
+     * @return ($content is null ? ($status is int<200, 200> ? ($headers is array{} ? \Illuminate\Contracts\Routing\ResponseFactory : \Illuminate\Http\Response) : \Illuminate\Http\Response) : \Illuminate\Http\Response)
      */
     function response($content = null, $status = 200, array $headers = [])
     {
@@ -1013,7 +1013,7 @@ if (! function_exists('validator')) {
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $attributes
-     * @return (when called without any args ? \Illuminate\Contracts\Validation\Factory : \Illuminate\Contracts\Validation\Validator)
+     * @return ($data is null ? ($rules is array{} ? ($messages is array{} ? ($attributes is array{} ? \Illuminate\Contracts\Validation\Factory : \Illuminate\Contracts\Validation\Validator) : \Illuminate\Contracts\Validation\Validator) : \Illuminate\Contracts\Validation\Validator) : \Illuminate\Contracts\Validation\Validator)
      */
     function validator(?array $data = null, array $rules = [], array $messages = [], array $attributes = [])
     {
@@ -1034,7 +1034,7 @@ if (! function_exists('view')) {
      * @param  string|null  $view
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  array  $mergeData
-     * @return (when called without any args ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View)
+     * @return ($view is null ? ($data is array{} ? ($mergeData is array{} ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View) : \Illuminate\Contracts\View\View) : \Illuminate\Contracts\View\View)
      */
     function view($view = null, $data = [], $mergeData = [])
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -338,7 +338,7 @@ if (! function_exists('str')) {
      * Get a new stringable object from the given string.
      *
      * @param  string|null  $string
-     * @return ($string not given ? object : \Illuminate\Support\Stringable)
+     * @return ($string is null ? object : \Illuminate\Support\Stringable)
      */
     function str($string = null)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -338,7 +338,7 @@ if (! function_exists('str')) {
      * Get a new stringable object from the given string.
      *
      * @param  string|null  $string
-     * @return ($string is null ? object : \Illuminate\Support\Stringable)
+     * @return ($string not given ? object : \Illuminate\Support\Stringable)
      */
     function str($string = null)
     {

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -51,6 +51,8 @@ assertType('array<string, mixed>', request(['foo', 'bar']));
 
 assertType('Illuminate\Contracts\Routing\ResponseFactory', response());
 assertType('Illuminate\Http\Response', response('foo'));
+assertType('Illuminate\Http\Response', response(status: 111));
+assertType('Illuminate\Http\Response', response(headers: ['foo' => 'bar']));
 
 assertType('Illuminate\Session\SessionManager', session());
 assertType('mixed', session('foo'));
@@ -60,10 +62,14 @@ assertType('Illuminate\Contracts\Translation\Translator', trans());
 assertType('array|string', trans('foo'));
 
 assertType('Illuminate\Contracts\Validation\Factory', validator());
-assertType('Illuminate\Contracts\Validation\Validator', validator([]));
+assertType('Illuminate\Contracts\Validation\Validator', validator(rules: ['foo']));
+assertType('Illuminate\Contracts\Validation\Validator', validator(messages: ['bar']));
+assertType('Illuminate\Contracts\Validation\Validator', validator(attributes: ['foo', 'bar']));
 
 assertType('Illuminate\Contracts\View\Factory', view());
 assertType('Illuminate\Contracts\View\View', view('foo'));
+assertType('Illuminate\Contracts\View\View', view(data: ['foo']));
+assertType('Illuminate\Contracts\View\View', view(mergeData: ['bar']));
 
 assertType('Illuminate\Contracts\Routing\UrlGenerator', url());
 assertType('string', url('foo'));


### PR DESCRIPTION
When dealing with some `helpers`, I've realized that some `return annotation` are incorrect since the following commit : https://github.com/laravel/framework/commit/5d006a562c6a2bb6f73c77491ee59117a103217d

Each time, the annotation indicate that **if the first function argument is null**, so the `Factory` (or an `object` for `str`) will be returned. This is incorrect as we are not checking if the first argument is `null` but **if there is zero argument** passed to the function.

Moreover, from PHP 8.0 we are not aware that the developer is using **named parameters**, so even checking the first argument value is incorrect.

Last thing, if we are manually passing `null` to the first argument, we'll don't enter the condition so this again incorrect.

---

I propose this PR with the according changes. Note that as there is no [PHPStan Conditional return types](https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types) support for `func_num_args` I had to handle it the hard way.