### PR TITLE
[11.x] Pass iterable keys to `withProgressBar` in InteractsWithIO

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -263,8 +263,8 @@ trait InteractsWithIO
         $bar->start();
 
         if (is_iterable($totalSteps)) {
-            foreach ($totalSteps as $value) {
-                $callback($value, $bar);
+            foreach ($totalSteps as $key => $value) {
+                $callback($value, $bar, $key);
 
                 $bar->advance();
             }

--- a/tests/Console/Concerns/InteractsWithIOTest.php
+++ b/tests/Console/Concerns/InteractsWithIOTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Console\Concerns;
+
+use Generator;
+use Illuminate\Console\Command;
+use Illuminate\Console\Concerns\InteractsWithIO;
+use Illuminate\Console\OutputStyle;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class InteractsWithIOTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    #[DataProvider('iterableDataProvider')]
+    public function testWithProgressBarIterable($iterable)
+    {
+        $command = new CommandInteractsWithIO;
+        $bufferedOutput = new BufferedOutput();
+        $output = m::mock(OutputStyle::class, [new ArgvInput(), $bufferedOutput])->makePartial();
+        $command->setOutput($output);
+
+        $output->shouldReceive('createProgressBar')
+            ->once()
+            ->with(count($iterable))
+            ->andReturnUsing(function ($steps) use ($bufferedOutput) {
+                // we can't mock ProgressBar because it's final, so return a real one
+                return new ProgressBar($bufferedOutput, $steps);
+            });
+
+        $calledTimes = 0;
+        $result = $command->withProgressBar($iterable, function ($value, $bar, $key) use (&$calledTimes, $iterable) {
+            $this->assertInstanceOf(ProgressBar::class, $bar);
+            $this->assertSame(array_values($iterable)[$calledTimes], $value);
+            $this->assertSame(array_keys($iterable)[$calledTimes], $key);
+            $calledTimes++;
+        });
+
+        $this->assertSame(count($iterable), $calledTimes);
+        $this->assertSame($iterable, $result);
+    }
+
+    public static function iterableDataProvider(): Generator
+    {
+        yield [['a', 'b', 'c']];
+
+        yield [['foo' => 'a', 'bar' => 'b', 'baz' => 'c']];
+    }
+
+    public function testWithProgressBarInteger()
+    {
+        $command = new CommandInteractsWithIO;
+        $bufferedOutput = new BufferedOutput();
+        $output = m::mock(OutputStyle::class, [new ArgvInput(), $bufferedOutput])->makePartial();
+        $command->setOutput($output);
+
+        $totalSteps = 5;
+
+        $output->shouldReceive('createProgressBar')
+            ->once()
+            ->with($totalSteps)
+            ->andReturnUsing(function ($steps) use ($bufferedOutput) {
+                // we can't mock ProgressBar because it's final, so return a real one
+                return new ProgressBar($bufferedOutput, $steps);
+            });
+
+        $called = false;
+        $command->withProgressBar($totalSteps, function ($bar) use (&$called) {
+            $this->assertInstanceOf(ProgressBar::class, $bar);
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+}
+
+class CommandInteractsWithIO extends Command
+{
+    use InteractsWithIO;
+}


### PR DESCRIPTION
The `withProgressBar` method in the `InteractsWithIO` console trait can be used to iterate over an iterable while displaying a progress bar in the console, in essence adding a progress bar to a `foreach` loop.

Currently the callback only takes the `$value` of each step, which means it can't be used as easily if we want to unpack both `$key` and `$value` in each step.

This PR adds `$key` to the callback called in the `foreach`, transforming it from `$callback($value, $bar)` to `$callback($value, $bar, $key)`, with arguments in that order to keep backward compatibility (`$bar` is the ProgressBar instance).

---
I'm not sure if it's really necessary to update [the progress bar docs](https://laravel.com/docs/11.x/artisan#progress-bars) to show that extra parameter, but if you think it'd be better I'd be happy to.