### PR TITLE
[11.x] Use the same parameter type for 'throwUnless' as used for 'throwIf'

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -716,7 +716,7 @@ class PendingRequest
     /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to false.
      *
-     * @param  bool  $condition
+     * @param  callable|bool  $condition
      * @return $this
      */
     public function throwUnless($condition)


### PR DESCRIPTION
`throwUnless` is basically an inverted `throwIf` and should use the same parameter type.