### PR TITLE
Fix Apostrophe Handling in SeeInOrder.php and Enhance Test Coverage

### DIFF
--- a/src/Illuminate/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Testing/Constraints/SeeInOrder.php
@@ -41,6 +41,7 @@ class SeeInOrder extends Constraint
     public function matches($values): bool
     {
         $decodedContent = html_entity_decode($this->content, ENT_QUOTES, 'UTF-8');
+
         $position = 0;
 
         foreach ($values as $value) {
@@ -49,6 +50,7 @@ class SeeInOrder extends Constraint
             }
 
             $decodedValue = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+
             $valuePosition = mb_strpos($decodedContent, $decodedValue, $position);
 
             if ($valuePosition === false || $valuePosition < $position) {

--- a/src/Illuminate/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Testing/Constraints/SeeInOrder.php
@@ -40,6 +40,7 @@ class SeeInOrder extends Constraint
      */
     public function matches($values): bool
     {
+        $decodedContent = html_entity_decode($this->content, ENT_QUOTES, 'UTF-8');
         $position = 0;
 
         foreach ($values as $value) {
@@ -47,7 +48,8 @@ class SeeInOrder extends Constraint
                 continue;
             }
 
-            $valuePosition = mb_strpos($this->content, $value, $position);
+            $decodedValue = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+            $valuePosition = mb_strpos($decodedContent, $decodedValue, $position);
 
             if ($valuePosition === false || $valuePosition < $position) {
                 $this->failedValue = $value;
@@ -55,7 +57,7 @@ class SeeInOrder extends Constraint
                 return false;
             }
 
-            $position = $valuePosition + mb_strlen($value);
+            $position = $valuePosition + mb_strlen($decodedValue);
         }
 
         return true;

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -136,6 +136,92 @@ class MailMailableAssertionsTest extends TestCase
             '<li>Third Item</li>',
         ]);
     }
+
+    public function testMailableAssertSeeInTextWithApostrophePassesWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertSeeInText("It's a wonderful day");
+    }
+
+    public function testMailableAssertSeeInTextWithApostropheFailsWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInText("It's not a wonderful day");
+    }
+
+    public function testMailableAssertDontSeeInTextWithApostrophePassesWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertDontSeeInText("It's not a wonderful day");
+    }
+
+    public function testMailableAssertDontSeeInTextWithApostropheFailsWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertDontSeeInText("It's a wonderful day");
+    }
+
+    public function testMailableAssertSeeInHtmlWithApostropheFailsWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInHtml("<li>It's not a wonderful day</li>");
+    }
+
+    public function testMailableAssertDontSeeInHtmlWithApostrophePassesWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertDontSeeInHtml("<li>It's not a wonderful day</li>");
+    }
+
+    public function testMailableAssertDontSeeInHtmlWithApostropheFailsWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertDontSeeInHtml("<li>It's a wonderful day</li>", false);
+    }
+
+    public function testMailableAssertSeeInOrderInHtmlWithApostrophePassesWhenPresentInOrder()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertSeeInOrderInHtml([
+            'First Item',
+            'Sixth Item',
+            'It\'s a wonderful day',
+        ]);
+
+        $mailable->assertSeeInOrderInHtml([
+            '<li>First Item</li>',
+            '<li>It\'s a wonderful day</li>',
+        ], false);
+    }
+
+    public function testMailableAssertSeeInOrderInHtmlWithApostropheFailsWhenAbsentInOrder()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInOrderInHtml([
+            'It\'s a wonderful day',
+            'First Item',
+            'Sixth Item',
+        ]);
+    }
 }
 
 class MailableAssertionsStub extends Mailable
@@ -149,6 +235,7 @@ class MailableAssertionsStub extends Mailable
         - Third Item
         - Fourth & Fifth Item
         - Sixth Item
+        - It's a wonderful day
         EOD;
 
         $html = <<<'EOD'
@@ -167,6 +254,7 @@ class MailableAssertionsStub extends Mailable
         <li>Third Item</li>
         <li>Fourth &amp; Fifth Item</li>
         <li>Sixth Item</li>
+        <li>It's a wonderful day</li>
         </ul>
         </body>
         </html>


### PR DESCRIPTION
This PR addresses an issue where assertions for checking the order of text in a mailable fail when one of the strings in the order array contains an apostrophe. The issue was occurring due to improper handling of apostrophes in the comparison logic, leading to false negatives in the test results.