### PR TITLE
[11.x] Fix docblock for Filesystem::hash()

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -184,7 +184,7 @@ class Filesystem
      *
      * @param  string  $path
      * @param  string  $algorithm
-     * @return string
+     * @return string|false
      */
     public function hash($path, $algorithm = 'md5')
     {


### PR DESCRIPTION
Since the [hash_file()](https://php.net/hash_file) function also returns false, Filesystem::hash() should also return false.