### PR TITLE
[php84] Fix some deprecations and lower requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.4 sebastian/exporter:^6.0.1 --no-interaction --no-update
+          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.4.0 sebastian/exporter:^6.0.1 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
           - 8888:8000
 
     strategy:
-      fail-fast: true
+      # fail-fast: true
       matrix:
         php: [8.4]
         phpunit: ['10.5.12', '11.3.2']
-        stability: [prefer-lowest]
+        stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.4]
-        phpunit: ['11.3.2']
+        phpunit: ['10.5.12', '11.3.2']
         stability: [prefer-lowest]
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/promises:^2.0.3 mocker/mocker:^1.6.10 symfony/http-foundation:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.0 --no-interaction --no-update
+          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.0 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.4]
-        phpunit: ['10.5', '11.0.1']
-        stability: [prefer-lowest, prefer-stable]
+        phpunit: ['11.0.1']
+        stability: [prefer-lowest]
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.4]
-        phpunit: ['11.0.1']
+        phpunit: ['11.3.2']
         stability: [prefer-lowest]
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.4 --no-interaction --no-update
+          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.4 sebastian/exporter:^6.0.1 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.4.0 sebastian/exporter:^6.0.1 --no-interaction --no-update
+          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^2.0.1|^3.0.1 nesbot/carbon:^3.4.0 sebastian/exporter:^6.0.1 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.0 --no-interaction --no-update
+          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.4 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^2.0.1|^3.0.1 nesbot/carbon:^3.4.0 sebastian/exporter:^6.0.1 --no-interaction --no-update
+          command: composer require guzzlehttp/promises:^2.0.3 mockery/mockery:^1.6.10 symfony/http-foundation:^7.1.3 symfony/translation:^7.1.3 symfony/console:^7.1.3 sebastian/cli-parser:^2.0.1\|^3.0.1 nesbot/carbon:^3.4.0 sebastian/exporter:^6.0.1 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,13 @@ jobs:
           max_attempts: 5
           command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
 
+      - name: Set minimum PHP 8.4 versions
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require guzzlehttp/promises:^2.0.3 mocker/mocker:^1.6.10 symfony/http-foundation:^7.1.3 sebastian/cli-parser:^3.0.1 nesbot/carbon:^3.2.0 --no-interaction --no-update
+
       - name: Set PHPUnit
         uses: nick-fields/retry@v3
         with:

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -93,7 +93,7 @@ class ValidatedInput implements ValidatedData
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenMissing($key, callable $callback, callable $default = null)
+    public function whenMissing($key, callable $callback, ?callable $default = null)
     {
         if ($this->missing($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;
@@ -212,7 +212,7 @@ class ValidatedInput implements ValidatedData
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenHas($key, callable $callback, callable $default = null)
+    public function whenHas($key, callable $callback, ?callable $default = null)
     {
         if ($this->has($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;
@@ -290,7 +290,7 @@ class ValidatedInput implements ValidatedData
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenFilled($key, callable $callback, callable $default = null)
+    public function whenFilled($key, callable $callback, ?callable $default = null)
     {
         if ($this->filled($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;

--- a/tests/Bus/QueueableTest.php
+++ b/tests/Bus/QueueableTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Bus;
 
 use Illuminate\Bus\Queueable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class QueueableTest extends TestCase
@@ -17,9 +18,7 @@ class QueueableTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider connectionDataProvider
-     */
+    #[DataProvider('connectionDataProvider')]
     public function testOnConnection(mixed $connection, ?string $expected): void
     {
         $job = new FakeJob();
@@ -28,9 +27,7 @@ class QueueableTest extends TestCase
         $this->assertSame($job->connection, $expected);
     }
 
-    /**
-     * @dataProvider connectionDataProvider
-     */
+    #[DataProvider('connectionDataProvider')]
     public function testAllOnConnection(mixed $connection, ?string $expected): void
     {
         $job = new FakeJob();
@@ -50,9 +47,7 @@ class QueueableTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider queuesDataProvider
-     */
+    #[DataProvider('queuesDataProvider')]
     public function testOnQueue(mixed $queue, ?string $expected): void
     {
         $job = new FakeJob();
@@ -61,9 +56,7 @@ class QueueableTest extends TestCase
         $this->assertSame($job->queue, $expected);
     }
 
-    /**
-     * @dataProvider queuesDataProvider
-     */
+    #[DataProvider('queuesDataProvider')]
     public function testAllOnQueue(mixed $queue, ?string $expected): void
     {
         $job = new FakeJob();


### PR DESCRIPTION
~I send the PR to the php84 branch, or should it go directly to 11.x branch?~

Is there a StyleCI Rule to enforce explicit nullable types?
A Quick Look / search on https://docs.styleci.io/fixers resulted in nothing.

PHP-CS-Fixer has a rule for this (which is also enforced in Laravel Pint)
https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html

Lower Requirements for PHP 8.4:
- guzzle/promises should be [`^2.0.3`](https://github.com/guzzle/promises/releases/tag/2.0.3)
- mockery/mockery should be [`^1.6.10`](https://github.com/mockery/mockery/releases/tag/1.6.10)
- symfony/* should be [`^7.1.3`](https://github.com/symfony/symfony/releases/tag/v7.1.3) or [`^7.0.10`](https://github.com/symfony/symfony/releases/tag/v7.0.10)
- sebastian/cli-parser should be [`^2.0.1`](https://github.com/sebastianbergmann/cli-parser/blob/2.0/ChangeLog.md) for PHPUnit 10 and [`^3.0.1`](https://github.com/sebastianbergmann/cli-parser/blob/main/ChangeLog.md) for PHPunit 11
- nesbot/carbon should be [`^3.4.0`](https://github.com/briannesbitt/Carbon/releases/tag/3.4.0)
- sebastian/exporter should be [`^6.0.1`](https://github.com/sebastianbergmann/exporter/blob/main/ChangeLog.md)

I also adjusted the PHPunit requirements in Github Workflows accordingly for nullable types.