### PR TITLE
Add $loop->pageIteration to track iteration across paginated items in…

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Concerns;
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\LazyCollection;
 
@@ -28,6 +29,12 @@ trait ManagesLoops
 
         $parent = Arr::last($this->loopsStack);
 
+        $pageIteration = 1;
+
+        if ($data instanceof LengthAwarePaginator) {
+            $pageIteration = ($data->currentPage() - 1) * $data->perPage();
+        }
+
         $this->loopsStack[] = [
             'iteration' => 0,
             'index' => 0,
@@ -39,6 +46,7 @@ trait ManagesLoops
             'even' => true,
             'depth' => count($this->loopsStack) + 1,
             'parent' => $parent ? (object) $parent : null,
+            'pageIteration' => $pageIteration,
         ];
     }
 
@@ -59,6 +67,7 @@ trait ManagesLoops
             'even' => ! $loop['even'],
             'remaining' => isset($loop['count']) ? $loop['remaining'] - 1 : null,
             'last' => isset($loop['count']) ? $loop['iteration'] == $loop['count'] - 1 : null,
+            'pageIteration' => $loop['pageIteration'] + 1,
         ]);
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -927,6 +927,7 @@ class ViewFactoryTest extends TestCase
             'even' => true,
             'depth' => 1,
             'parent' => null,
+            'pageIteration' => 1,
         ];
 
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
@@ -944,6 +945,7 @@ class ViewFactoryTest extends TestCase
             'even' => true,
             'depth' => 2,
             'parent' => (object) $expectedLoop,
+            'pageIteration' => 1,
         ];
         $this->assertEquals([$expectedLoop, $secondExpectedLoop], $factory->getLoopStack());
 
@@ -990,6 +992,7 @@ class ViewFactoryTest extends TestCase
             'even' => true,
             'depth' => 1,
             'parent' => null,
+            'pageIteration' => 1,
         ];
 
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
@@ -1014,6 +1017,7 @@ class ViewFactoryTest extends TestCase
             'even' => true,
             'depth' => 1,
             'parent' => null,
+            'pageIteration' => 1,
         ];
 
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());


### PR DESCRIPTION
… Blade

- Introduced the $loop->pageIteration feature in Blade views to track the iteration index across paginated items.
- This feature ensures that when looping through paginated data using Blade, the iteration index starts correctly according to the current page.
- For example, if the current page is 1, $loop->pageIteration starts at 1. If the current page is 2 and each page contains 10 items, $loop->pageIteration starts at 11.
- This enhancement improves the usability of Blade loops in paginated contexts, providing more accurate iteration tracking for developers.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
