### PR TITLE
[12.x] Improved algorithm for Number::pairs()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -235,9 +235,10 @@ class Number
     /**
      * Split the given number into pairs of min/max values.
      *
-     * @param  int|float  $to
-     * @param  int|float  $by
-     * @param  int|float  $offset
+     * @param int|float $to
+     * @param int|float $by
+     * @param int|float $start
+     * @param int|float $offset
      * @return array
      */
     public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -240,18 +240,18 @@ class Number
      * @param  int|float  $offset
      * @return array
      */
-    public static function pairs(int|float $to, int|float $by, int|float $offset = 1)
+    public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {
         $output = [];
 
-        for ($lower = 0; $lower < $to; $lower += $by) {
-            $upper = $lower + $by;
+        for ($lower = $start; $lower < $to; $lower += $by) {
+            $upper = $lower + $by - $offset;
 
             if ($upper > $to) {
                 $upper = $to;
             }
 
-            $output[] = [$lower + $offset, $upper];
+            $output[] = [$lower, $upper];
         }
 
         return $output;

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -289,8 +289,13 @@ class SupportNumberTest extends TestCase
 
     public function testPairs()
     {
-        $this->assertSame([[1, 10], [11, 20], [21, 25]], Number::pairs(25, 10));
-        $this->assertSame([[0, 10], [10, 20], [20, 25]], Number::pairs(25, 10, 0));
-        $this->assertSame([[0, 2.5], [2.5, 5.0], [5.0, 7.5], [7.5, 10.0]], Number::pairs(10, 2.5, 0));
+        $this->assertSame([[0, 10], [10, 20], [20, 25]], Number::pairs(25, 10, 0, 0));
+        $this->assertSame([[0, 9], [10, 19], [20, 25]], Number::pairs(25, 10, 0, 1));
+        $this->assertSame([[1, 11], [11, 21], [21, 25]], Number::pairs(25, 10, 1, 0));
+        $this->assertSame([[1, 10], [11, 20], [21, 25]], Number::pairs(25, 10, 1, 1));
+        $this->assertSame([[0, 2.5], [2.5, 5.0], [5.0, 7.5], [7.5, 10.0]], Number::pairs(10, 2.5, 0, 0));
+        $this->assertSame([[0, 2.0], [2.5, 4.5], [5.0, 7.0], [7.5, 9.5]], Number::pairs(10, 2.5, 0, 0.5));
+        $this->assertSame([[0.5, 3.0], [3.0, 5.5], [5.5, 8.0], [8.0, 10]], Number::pairs(10, 2.5, 0.5, 0));
+        $this->assertSame([[0.5, 2.5], [3.0, 5.0], [5.5, 7.5], [8.0, 10.0]], Number::pairs(10, 2.5, 0.5, 0.5));
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -293,6 +293,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0, 9], [10, 19], [20, 25]], Number::pairs(25, 10, 0, 1));
         $this->assertSame([[1, 11], [11, 21], [21, 25]], Number::pairs(25, 10, 1, 0));
         $this->assertSame([[1, 10], [11, 20], [21, 25]], Number::pairs(25, 10, 1, 1));
+        $this->assertSame([[0, 1000], [1000, 2000], [2000, 2500]], Number::pairs(2500, 1000, 0, 0));
+        $this->assertSame([[0, 999], [1000, 1999], [2000, 2500]], Number::pairs(2500, 1000, 0, 1));
+        $this->assertSame([[1, 1001], [1001, 2001], [2001, 2500]], Number::pairs(2500, 1000, 1, 0));
+        $this->assertSame([[1, 1000], [1001, 2000], [2001, 2500]], Number::pairs(2500, 1000, 1, 1));
         $this->assertSame([[0, 2.5], [2.5, 5.0], [5.0, 7.5], [7.5, 10.0]], Number::pairs(10, 2.5, 0, 0));
         $this->assertSame([[0, 2.0], [2.5, 4.5], [5.0, 7.0], [7.5, 9.5]], Number::pairs(10, 2.5, 0, 0.5));
         $this->assertSame([[0.5, 3.0], [3.0, 5.5], [5.5, 8.0], [8.0, 10]], Number::pairs(10, 2.5, 0.5, 0));


### PR DESCRIPTION
### Description

A short while ago I submitted a PR for a new [`Number` macro called `pairs()`](https://github.com/laravel/framework/pull/51904). However, while using it in a production app I realized that it didn't perform _exactly_ how I intended because it was missing an important argument: the starting value.

This PR introduces a new `$start` argument, which improves the behavior of the method to match expectations. Before, the `$offset` argument was being reused for both but this was conflating things and resulted in weird offsets. With a distinct `$start` argument both the initial value and the increment between pairs can be individually controlled.

**Note:** This is a breaking change due to a new 3rd argument!

#### Before
```php
$output = Number::pairs(2500, 1000, 1); // Start at 1, offset also 1

// [[1, 1000], [1001, 2000], [2001, 2500]]

$output = Number::pairs(2500, 1000, 0); // Start at 0 offset also 0

// [[0, 1000], [1000, 2000], [2000, 2500]]
```

While this looks fine, you'll notice that you can't get the values to end in 999, ie. `[1, 999]` or `[0, 999]`. This means that your offset/pagination value must always start with `1`, which may be incorrect.

#### After
```php
$output = Number::pairs(2500, 1000, 1, 0); // Start at 1, offset 0

// [[1, 1001], [1001, 2001], [2001, 2500]]

$output = Number::pairs(2500, 1000, 1, 1); // Start at 1, offset 1

// [[1, 1000], [1001, 2000], [2001, 2500]]

$output = Number::pairs(2500, 1000, 0, 0); // Start at 0, offset 0

// [[0, 1000], [1000, 2000], [2000, 2500]]

$output = Number::pairs(2500, 1000, 0, 1); // Start at 0, offset 1

// [[0, 999], [1000, 1999], [2000, 2500]]
```

Now, starting value and offsets are distinct allowing for the proper pairing.