### PR TITLE
[11.x] Fix $fail closure type in docblocks for validation rules

### DIFF
--- a/src/Illuminate/Contracts/Validation/InvokableRule.php
+++ b/src/Illuminate/Contracts/Validation/InvokableRule.php
@@ -14,7 +14,7 @@ interface InvokableRule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      * @return void
      */
     public function __invoke(string $attribute, mixed $value, Closure $fail);

--- a/src/Illuminate/Contracts/Validation/ValidationRule.php
+++ b/src/Illuminate/Contracts/Validation/ValidationRule.php
@@ -11,7 +11,7 @@ interface ValidationRule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void;

--- a/src/Illuminate/Foundation/Console/stubs/rule.implicit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.implicit.stub
@@ -17,7 +17,7 @@ class {{ class }} implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -10,7 +10,7 @@ class {{ class }} implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {


### PR DESCRIPTION
Fixes the closure type as defined in https://github.com/laravel/framework/blob/7a3166c8d6a2cb6e5c0890ad6a5b7067ba7d2a20/src/Illuminate/Validation/InvokableValidationRule.php#L102-L106


