### PR TITLE
[11.x] Add `Skip` middleware for Queue Jobs

### DIFF
--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -13,7 +13,7 @@ class Skip
     /**
      * Apply the middleware if the given condition is truthy.
      *
-     * @param bool|Closure(): bool $condition
+     * @param  bool|Closure(): bool  $condition
      */
     public static function if(bool|Closure $condition): self
     {
@@ -25,7 +25,7 @@ class Skip
     /**
      * Apply the middleware unless the given condition is truthy.
      *
-     * @param bool|Closure(): bool $condition
+     * @param  bool|Closure(): bool  $condition
      */
     public static function unless(bool|Closure $condition): self
     {

--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Closure;
+
+class Skip
+{
+    public function __construct(protected bool $skip = false)
+    {
+    }
+
+    /**
+     * Apply the middleware if the given condition is truthy.
+     *
+     * @param bool|Closure(): bool $condition
+     */
+    public static function if(bool|Closure $condition): self
+    {
+        $condition = $condition instanceof Closure ? $condition() : $condition;
+
+        return new self($condition);
+    }
+
+    /**
+     * Apply the middleware unless the given condition is truthy.
+     *
+     * @param bool|Closure(): bool $condition
+     */
+    public static function unless(bool|Closure $condition): self
+    {
+        $condition = $condition instanceof Closure ? $condition() : $condition;
+
+        return new self(! $condition);
+    }
+
+    public function handle(mixed $job, callable $next): mixed
+    {
+        if ($this->skip) {
+            return false;
+        }
+
+        return $next($job);
+    }
+}

--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -15,11 +15,9 @@ class Skip
      *
      * @param  bool|Closure(): bool  $condition
      */
-    public static function if(bool|Closure $condition): self
+    public static function when(Closure|bool $condition): self
     {
-        $condition = $condition instanceof Closure ? $condition() : $condition;
-
-        return new self($condition);
+        return new self(value($condition));
     }
 
     /**
@@ -27,13 +25,14 @@ class Skip
      *
      * @param  bool|Closure(): bool  $condition
      */
-    public static function unless(bool|Closure $condition): self
+    public static function unless(Closure|bool $condition): self
     {
-        $condition = $condition instanceof Closure ? $condition() : $condition;
-
-        return new self(! $condition);
+        return new self(! value($condition));
     }
 
+    /**
+     * Handle the job.
+     */
     public function handle(mixed $job, callable $next): mixed
     {
         if ($this->skip) {

--- a/tests/Integration/Queue/SkipMiddlewareTest.php
+++ b/tests/Integration/Queue/SkipMiddlewareTest.php
@@ -127,6 +127,6 @@ class SkipTestJob
             return [Skip::unless($skip)];
         }
 
-        return [Skip::if($skip)];
+        return [Skip::when($skip)];
     }
 }

--- a/tests/Integration/Queue/SkipMiddlewareTest.php
+++ b/tests/Integration/Queue/SkipMiddlewareTest.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\Middleware\Skip;
 use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\Skip;
+use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
-use Laravel\SerializableClosure\SerializableClosure;
 
 class SkipMiddlewareTest extends TestCase
 {

--- a/tests/Integration/Queue/SkipMiddlewareTest.php
+++ b/tests/Integration/Queue/SkipMiddlewareTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\Middleware\Skip;
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\InteractsWithQueue;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+use Laravel\SerializableClosure\SerializableClosure;
+
+class SkipMiddlewareTest extends TestCase
+{
+    public function testJobIsSkippedWhenConditionIsTrue()
+    {
+        $job = new SkipTestJob(skip: true);
+
+        $this->assertJobWasSkipped($job);
+    }
+
+    public function testJobIsSkippedWhenConditionIsTrueUsingClosure()
+    {
+        $job = new SkipTestJob(skip: new SerializableClosure(fn () => true));
+
+        $this->assertJobWasSkipped($job);
+    }
+
+    public function testJobIsNotSkippedWhenConditionIsFalse()
+    {
+        $job = new SkipTestJob(skip: false);
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobIsNotSkippedWhenConditionIsFalseUsingClosure()
+    {
+        $job = new SkipTestJob(skip: new SerializableClosure(fn () => false));
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobIsNotSkippedWhenConditionIsTrueWithUnless()
+    {
+        $job = new SkipTestJob(skip: true, useUnless: true);
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobIsNotSkippedWhenConditionIsTrueWithUnlessUsingClosure()
+    {
+        $job = new SkipTestJob(skip: new SerializableClosure(fn () => true), useUnless: true);
+
+        $this->assertJobRanSuccessfully($job);
+    }
+
+    public function testJobIsSkippedWhenConditionIsFalseWithUnless()
+    {
+        $job = new SkipTestJob(skip: false, useUnless: true);
+
+        $this->assertJobWasSkipped($job);
+    }
+
+    public function testJobIsSkippedWhenConditionIsFalseWithUnlessUsingClosure()
+    {
+        $job = new SkipTestJob(skip: new SerializableClosure(fn () => false), useUnless: true);
+
+        $this->assertJobWasSkipped($job);
+    }
+
+    protected function assertJobRanSuccessfully(SkipTestJob $class)
+    {
+        $this->assertJobHandled(class: $class, expectedHandledValue: true);
+    }
+
+    protected function assertJobWasSkipped(SkipTestJob $class)
+    {
+        $this->assertJobHandled(class: $class, expectedHandledValue: false);
+    }
+
+    protected function assertJobHandled(SkipTestJob $class, bool $expectedHandledValue)
+    {
+        $class::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize($class),
+        ]);
+
+        $this->assertEquals($expectedHandledValue, $class::$handled);
+    }
+}
+
+class SkipTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function __construct(
+        protected bool|SerializableClosure $skip,
+        protected bool $useUnless = false,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        static::$handled = true;
+    }
+
+    public function middleware(): array
+    {
+        $skip = $this->skip instanceof SerializableClosure
+            ? $this->skip->getClosure()
+            : $this->skip;
+
+        if ($this->useUnless) {
+            return [Skip::unless($skip)];
+        }
+
+        return [Skip::if($skip)];
+    }
+}


### PR DESCRIPTION
I noticed a pattern where I was frequently using closure middleware to skip some jobs after they were queued (some of my jobs are delayed):

```php
class MyJob implements ShouldQueue
{
    use Queueable;

    public function handle(): void
    {
        // TODO
    }

    public function middleware(): array
    {
        return [
            function ($job, $next) {
                if ($someCondition) {
                    $next($job);
                }
            },
        ];
    }
}
```

So, I created a Skip middleware for Queue Jobs to replace those use cases:

```php
class MyJob implements ShouldQueue
{
    use Queueable;

    public function handle(): void
    {
        // TODO
    }

    public function middleware(): array
    {
        return [
            Skip::when($someCondition),
        ];
    }
}
```

I thought it might be useful to include this in the core. This middleware can be used by passing a bool or a closure:

```php
class MyJob implements ShouldQueue
{
    use Queueable;

    public function handle(): void
    {
        // TODO
    }

    public function middleware(): array
    {
        return [
            Skip::when($someCondition),

            Skip::unless($someCondition),

            Skip::when(function(): bool {
                if ($someCondition) {
                    return true;
                }
                return false;
            }),
        ];
    }
}
```