### PR TITLE
[11.x] apply excludeUnvalidatedArrayKeys to list validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -593,7 +593,7 @@ class Validator implements ValidatorContract
             $value = data_get($this->getData(), $key, $missingValue);
 
             if ($this->excludeUnvalidatedArrayKeys &&
-                in_array('array', $rules) &&
+                (in_array('array', $rules) || in_array('list', $rules)) &&
                 $value !== null &&
                 ! empty(preg_grep('/^'.preg_quote($key, '/').'\.+/', array_keys($this->getRules())))) {
                 continue;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8933,6 +8933,15 @@ class ValidationValidatorTest extends TestCase
         $validator->excludeUnvalidatedArrayKeys = true;
         $this->assertTrue($validator->passes());
         $this->assertSame(['users' => [1, 2, 3]], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
+            ['users' => 'list', 'users.*.name' => 'string']
+        );
+        $validator->excludeUnvalidatedArrayKeys = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => [['name' => 'Mohamed']]], $validator->validated());
     }
 
     public function testExcludeUnless()


### PR DESCRIPTION
Laravel 11 introduced a `list` validation rule (with https://github.com/laravel/framework/pull/50454). However, the `Validator::excludeUnvalidatedArrayKeys()` feature was not extended to work with `list`; this PR fixes that.

Intuitively, I would expect `list` to work exactly as `array` + ensuring that the array is a list. However, in the case of a list of arrays, extra fields in subarrays are always included when validating the top-level field with the `list` rule and without the `array` rule. Even adding the `array` rule to the subarrays doesn't solve the issue.

With this PR, extra fields are excluded from arrays, regardless of whether the top-level field is `array` or `list`. A test is included.

## Issues with the current behaviour ##

Assume that we have the following data to validate:

```php
$data = [
    'field' => [
        [
            'sub' => 'aaa',
            'extra' => 'bbb',
        ],
    ],
];
```

If we validate it with:
```php
$rules = [
    'field' => 'array',
    'field.*.sub' => 'string',
];
```

then the `extra` field is not included in `Validator::make($data, $rules)->validated()`; but is included with the following rules:

```php
$rules = [
    'field' => 'list',
    'field.*.sub' => 'string',
];
```

and not even with:
```php
$rules = [
    'field' => 'list',
    'field.*' => 'array',
    'field.*.sub' => 'string',
];
```

I would argue that the `list` rule should be coherent with the `array` rule; but even if we allow it not to be, I believe that failing to exclude unvalidated array keys when the `array` rule is explicitly included in the last example is an issue.
