### PR TITLE
Update `everyThirtyMinutes` cron expression

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -234,7 +234,7 @@ trait ManagesFrequencies
      */
     public function everyThirtyMinutes()
     {
-        return $this->spliceIntoPosition(1, '0,30');
+        return $this->spliceIntoPosition(1, '*/30');
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -37,7 +37,7 @@ class FrequencyTest extends TestCase
         $this->assertSame('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
         $this->assertSame('*/10 * * * *', $this->event->everyTenMinutes()->getExpression());
         $this->assertSame('*/15 * * * *', $this->event->everyFifteenMinutes()->getExpression());
-        $this->assertSame('0,30 * * * *', $this->event->everyThirtyMinutes()->getExpression());
+        $this->assertSame('*/30 * * * *', $this->event->everyThirtyMinutes()->getExpression());
     }
 
     public function testDaily()


### PR DESCRIPTION
When using Sentry for cronjob monitoring, I noticed a difference in the way the cron frequency for `everyFiveMinutes` and `everyThirtyMinutes` was transformed in a human readable format.

![CleanShot 2024-09-05 at 18 08 21@2x](https://github.com/user-attachments/assets/86e81a83-9882-423d-8d1e-759284203a0f)

I decided to target the 11.x branch since I don't think this is a breaking change. However I am not sure how monitoring tools like for example Sentry would react to this change.