### PR TITLE
[11.x] Add Exceptions\Handler::mapLogLevel(...) so the logic can be easily overridden

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1058,7 +1058,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Map the exception to a log level.
      *
-     * @param Throwable $e
+     * @param  Throwable  $e
      * @return \Psr\Log\LogLevel::*
      */
     protected function mapLogLevel(Throwable $e)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -368,9 +368,7 @@ class Handler implements ExceptionHandlerContract
             throw $e;
         }
 
-        $level = Arr::first(
-            $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
-        );
+        $level = $this->mapLogLevel($e);
 
         $context = $this->buildExceptionContext($e);
 
@@ -1055,5 +1053,18 @@ class Handler implements ExceptionHandlerContract
     protected function newLogger()
     {
         return $this->container->make(LoggerInterface::class);
+    }
+
+    /**
+     * Map the exception to a log level.
+     *
+     * @param Throwable $e
+     * @return \Psr\Log\LogLevel::*
+     */
+    protected function mapLogLevel(Throwable $e)
+    {
+        return Arr::first(
+            $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
+        );
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1046,19 +1046,9 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Create a new logger instance.
-     *
-     * @return \Psr\Log\LoggerInterface
-     */
-    protected function newLogger()
-    {
-        return $this->container->make(LoggerInterface::class);
-    }
-
-    /**
      * Map the exception to a log level.
      *
-     * @param  Throwable  $e
+     * @param  \Throwable  $e
      * @return \Psr\Log\LogLevel::*
      */
     protected function mapLogLevel(Throwable $e)
@@ -1066,5 +1056,15 @@ class Handler implements ExceptionHandlerContract
         return Arr::first(
             $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
+    }
+
+    /**
+     * Create a new logger instance.
+     *
+     * @return \Psr\Log\LoggerInterface
+     */
+    protected function newLogger()
+    {
+        return $this->container->make(LoggerInterface::class);
     }
 }


### PR DESCRIPTION
I would like to customize the level mapping logic in the exception handler but currently I have to override the entire `reportThrowable` to do so. Extracting the log level mapping logic as a new method `mapLogLevel` would allow me to override the method to add the custom logic I need.

Specifically, I would like use this change to add a logic that will lower the log level of `QueryException` when the underlying exception inherits a certain class.
