### PR TITLE
[11.x] remove empty constructor body from stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/channel.stub
+++ b/src/Illuminate/Foundation/Console/stubs/channel.stub
@@ -9,10 +9,7 @@ class {{ class }}
     /**
      * Create a new channel instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Authenticate the user's access to the channel.

--- a/src/Illuminate/Foundation/Console/stubs/class.invokable.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.invokable.stub
@@ -7,10 +7,7 @@ class {{ class }}
     /**
      * Create a new class instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Invoke the class instance.

--- a/src/Illuminate/Foundation/Console/stubs/class.stub
+++ b/src/Illuminate/Foundation/Console/stubs/class.stub
@@ -7,8 +7,5 @@ class {{ class }}
     /**
      * Create a new class instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -17,10 +17,7 @@ class {{ class }}
     /**
      * Create a new event instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/src/Illuminate/Foundation/Console/stubs/job.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.queued.stub
@@ -15,10 +15,7 @@ class {{ class }} implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.

--- a/src/Illuminate/Foundation/Console/stubs/job.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.stub
@@ -11,10 +11,7 @@ class {{ class }}
     /**
      * Create a new job instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Execute the job.

--- a/src/Illuminate/Foundation/Console/stubs/listener.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.queued.stub
@@ -12,10 +12,7 @@ class {{ class }} implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -10,10 +10,7 @@ class {{ class }}
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/src/Illuminate/Foundation/Console/stubs/listener.typed.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.typed.queued.stub
@@ -13,10 +13,7 @@ class {{ class }} implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/src/Illuminate/Foundation/Console/stubs/listener.typed.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.typed.stub
@@ -11,10 +11,7 @@ class {{ class }}
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -16,10 +16,7 @@ class {{ class }} extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the message envelope.

--- a/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
@@ -16,10 +16,7 @@ class {{ class }} extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the message envelope.

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
@@ -14,10 +14,7 @@ class {{ class }} extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the notification's delivery channels.

--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -14,10 +14,7 @@ class {{ class }} extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the notification's delivery channels.

--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -9,8 +9,5 @@ class {{ class }}
     /**
      * Create a new policy instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 }

--- a/src/Illuminate/Foundation/Console/stubs/view-component.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-component.stub
@@ -11,10 +11,7 @@ class {{ class }} extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the view / contents that represent the component.

--- a/src/Illuminate/Foundation/Console/stubs/view-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-mail.stub
@@ -16,10 +16,7 @@ class {{ class }} extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     /**
      * Get the message envelope.


### PR DESCRIPTION
constructors more often than not are now just promoted properties with a couple of assignments. behavior in the constructor body is less and less common.

if you look at the Laravel docs, we show 35 examples of a constructor, and only 10 of those examples have anything in the constructor body. of those 10, all of them are a single line in the body. they are also examples of less common things you could do, such as `onQueue()`, `onConnection`, or `BroadcastVia()`.

this commit removes those empty constructor bodies from the stubs. obviously this PR is pretty subjective, but IMO opinion this simplifies the stub for the more common use case.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
