### PR TITLE
[11.x] allow guessing of nested component

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -299,6 +299,10 @@ class ComponentTagCompiler
             return $class;
         }
 
+         if (class_exists($class = $class.'\\'.Str::afterLast($class, '\\'))) {
+             return $class;
+         }
+
         if (! is_null($guess = $this->guessAnonymousComponentUsingNamespaces($viewFactory, $component)) ||
             ! is_null($guess = $this->guessAnonymousComponentUsingPaths($viewFactory, $component))) {
             return $guess;

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -299,9 +299,9 @@ class ComponentTagCompiler
             return $class;
         }
 
-         if (class_exists($class = $class.'\\'.Str::afterLast($class, '\\'))) {
-             return $class;
-         }
+        if (class_exists($class = $class.'\\'.Str::afterLast($class, '\\'))) {
+            return $class;
+        }
 
         if (! is_null($guess = $this->guessAnonymousComponentUsingNamespaces($viewFactory, $component)) ||
             ! is_null($guess = $this->guessAnonymousComponentUsingPaths($viewFactory, $component))) {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -342,6 +342,7 @@ class ComponentTagCompiler
                 if (! is_null($guess = match (true) {
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent) => $guess,
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.index') => $guess,
+                    $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.'.Str::afterLast($formattedComponent, '.')) => $guess,
                     default => null,
                 })) {
                     return $guess;
@@ -378,6 +379,10 @@ class ComponentTagCompiler
                 }
 
                 if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory).'.index')) {
+                    return $view;
+                }
+
+                if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory).'.'.Str::afterLast($componentName, '.'))) {
                     return $view;
                 }
             });

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -130,7 +130,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php \$attributes = \$attributes->except(\App\View\Components\Card\Card::ignoredParameterNames()); ?>
 <?php endif; ?>
 <?php \$component->withAttributes([]); ?>\n".
-            "@endComponentClass##END-COMPONENT-CLASS##</div>", trim($result));
+            '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
     public function testBasicComponentWithEmptyAttributesParsing()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -115,6 +115,24 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
+    public function testNestedDefaultComponentParsing()
+    {
+        $container = new Container;
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
+        $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
+        Container::setInstance($container);
+
+        $result = $this->compiler()->compileTags('<div><x-card /></div>');
+
+        $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('App\View\Components\Card\Card', 'card', [])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\App\View\Components\Card\Card::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+            "@endComponentClass##END-COMPONENT-CLASS##</div>", trim($result));
+    }
+
     public function testBasicComponentWithEmptyAttributesParsing()
     {
         $this->mockViewFactory();
@@ -853,5 +871,17 @@ class TestContainerComponent extends Component
     public function render()
     {
         return 'container';
+    }
+}
+
+namespace App\View\Components\Card;
+
+use Illuminate\View\Component;
+
+class Card extends Component
+{
+    public function render()
+    {
+        return 'card';
     }
 }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -546,7 +546,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $container->instance(Factory::class, $factory = m::mock(Factory::class));
 
         $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
-        $factory->shouldReceive('exists')->times(3)->andReturnUsing(function ($arg) {
+        $factory->shouldReceive('exists')->times(4)->andReturnUsing(function ($arg) {
             // In our test, we'll do as if the 'public.frontend.anonymous-component'
             // view exists and not the others.
             return $arg === 'public.frontend.anonymous-component';
@@ -580,7 +580,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $container->instance(Factory::class, $factory = m::mock(Factory::class));
 
         $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
-        $factory->shouldReceive('exists')->times(4)->andReturnUsing(function (string $viewNameBeingCheckedForExistence) {
+        $factory->shouldReceive('exists')->times(5)->andReturnUsing(function (string $viewNameBeingCheckedForExistence) {
             // In our test, we'll do as if the 'public.frontend.anonymous-component'
             // view exists and not the others.
             return $viewNameBeingCheckedForExistence === 'admin.auth.components.anonymous-component.index';
@@ -707,7 +707,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $container->instance(Application::class, $app = m::mock(Application::class));
         $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
-        $factory->shouldReceive('exists')->twice()->andReturn(false);
+        $factory->shouldReceive('exists')->times(3)->andReturn(false);
         Container::setInstance($container);
 
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
sometimes components will be part of a larger component grouping, and you may wish to group those components in a folder.

as a simple example we'll use the classic "Card" component, which may be organized as such:

- `App\View\Components\Card\Card`
- `App\View\Components\Card\Header`
- `App\View\Components\Card\Body`

to utilize these in your Blade file you would:

```blade
<x-card.card>
    <x-card.header>Title</x-card.header>
    <x-card.body>lorem ipsum</x-card.body>
</x-card.card>
```

while this is fine, it doesn't read as nice as it could. with this commit, we can now omit the trailing duplicated word, as long as the class name matches the folder name.

```blade
<x-card>
    <x-card.header>Title</x-card.header>
    <x-card.body>lorem ipsum</x-card.body>
</x-card>
```

we do something similar with [Anonymous components](https://laravel.com/docs/11.x/blade#anonymous-index-components)

*If* a component at the root level exists with the same name as the folder, it **will** take precedence.

Tried to write a test for this, but was honestly a little lost.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
