### PR TITLE
[11.x] Add BackedEnum support to Gate methods

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -323,7 +323,7 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $ability
+     * @param  iterable|\BackedEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -335,7 +335,7 @@ class Gate implements GateContract
     /**
      * Determine if any of the given abilities should be denied for the current user.
      *
-     * @param  iterable|string  $ability
+     * @param  iterable|\BackedEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -347,7 +347,7 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -361,7 +361,7 @@ class Gate implements GateContract
     /**
      * Determine if any one of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -373,7 +373,7 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be denied for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -385,7 +385,7 @@ class Gate implements GateContract
     /**
      * Determine if the given ability should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  \BackedEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      *
@@ -399,12 +399,14 @@ class Gate implements GateContract
     /**
      * Inspect the user for the given ability.
      *
-     * @param  string  $ability
+     * @param  \BackedEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      */
     public function inspect($ability, $arguments = [])
     {
+        $ability = $ability instanceof BackedEnum ? $ability->value : $ability;
+
         try {
             $result = $this->raw($ability, $arguments);
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Access;
 
+use BackedEnum;
 use Closure;
 use Exception;
 use Illuminate\Auth\Access\Events\GateEvaluated;
@@ -191,7 +192,7 @@ class Gate implements GateContract
     /**
      * Define a new ability.
      *
-     * @param  string  $ability
+     * @param  \BackedEnum|string  $ability
      * @param  callable|array|string  $callback
      * @return $this
      *
@@ -199,6 +200,8 @@ class Gate implements GateContract
      */
     public function define($ability, $callback)
     {
+        $ability = $ability instanceof BackedEnum ? $ability->value : $ability;
+
         if (is_array($callback) && isset($callback[0]) && is_string($callback[0])) {
             $callback = $callback[0].'@'.$callback[1];
         }


### PR DESCRIPTION
Hi,
Using Enums enhances code readability and reduces typos; it also improves IDE support by providing better autocomplete

This change is backward compatible and shouldn't bring any breaking changes.

```php
enum Abilities: string {
    case VIEW_DASHBOARD = 'view-dashboard';
    case EDIT = 'edit';
    case UPDATE = 'update';
}


// Before
Gate::define('view-dashboard', function (User $user) {
    return $user->isAdmin;
});

Gate::authorize('view-dashboard');
Gate::inspect('view-dashboard');
Gate::check('view-dashboard');
Gate::any(['edit', 'update], $post);
Gate::none(['edit', 'update]], $post);
Gate::allows('update', $post)
Gate::denies('update', $post)

// After
Gate::define(Abilities::VIEW_DASHBOARD, function (User $user) {
    return $user->isAdmin;
});

Gate::authorize(Abilities::VIEW_DASHBOARD);
Gate::inspect(Abilities::VIEW_DASHBOARD);
Gate::check(Abilities::VIEW_DASHBOARD);
Gate::any([Abilities::EDIT, Abilities::UPDATE], $post);
Gate::none([Abilities::EDIT, Abilities::UPDATE], $post);
Gate::allows(Abilities::UPDATE, $post)
Gate::denies(Abilities::UPDATE, $post)
```