### PR TITLE
[11.x] Add BackedEnum support to Authorize middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Middleware;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
@@ -29,12 +30,14 @@ class Authorize
     /**
      * Specify the ability and models for the middleware.
      *
-     * @param  string  $ability
+     * @param  \BackedEnum|string  $ability
      * @param  string  ...$models
      * @return string
      */
     public static function using($ability, ...$models)
     {
+        $ability = $ability instanceof BackedEnum ? $ability->value : $ability;
+
         return static::class.':'.implode(',', [$ability, ...$models]);
     }
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -122,6 +122,23 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
+    public function testSimpleAbilityWithBackedEnumParameter()
+    {
+        $this->gate()->define('view-dashboard', function ($user) {
+            return true;
+        });
+
+        $this->router->middleware(Authorize::using(AbilitiesEnum::VIEW_DASHBOARD))->get('dashboard', [
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+
+        $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
+
+        $this->assertSame('success', $response->content());
+    }
+
     public function testSimpleAbilityWithNullParameter()
     {
         $this->gate()->define('view-dashboard', function ($user, $param = null) {
@@ -333,4 +350,8 @@ class AuthorizeMiddlewareTest extends TestCase
     {
         return $this->container->make(GateContract::class);
     }
+}
+
+enum AbilitiesEnum: string {
+    case VIEW_DASHBOARD = 'view-dashboard';
 }


### PR DESCRIPTION
Hi,
Using Enums enhances code readability and reduces typos; it also improves IDE support by providing better autocomplete

After merging this PR https://github.com/laravel/framework/pull/52561
I tried to use BackedEnums with `Authorize::using()` but it didn't worked:
```php
 Route::get('/dashboard', [AdminDashboardController::class, 'index'])->middleware(Authorize::using(Abilities::VIEW_DASHBOARD))->name(AdminRoutes::DASHBOARD);
```
This PR adds support for using BackedEnums with `Authorize::using()`

This PR is backward compatible and shouldn't bring any breaking changes.
