### PR TITLE
[11.x] Bugfix for calling pluck() on chaperoned relations.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -97,7 +97,7 @@ trait SupportsInverseRelations
         $parent ??= $this->getParent();
 
         foreach ($models as $model) {
-            $this->applyInverseRelationToModel($model, $parent);
+            $model instanceof Model && $this->applyInverseRelationToModel($model, $parent);
         }
 
         return $models;

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -272,6 +272,27 @@ class DatabaseEloquentInverseRelationTest extends TestCase
         $this->assertSame('test', $relation->getInverseRelationship());
     }
 
+    public function testOnlyHydratesInverseRelationOnModels()
+    {
+        $relation = m::mock(HasInverseRelationStub::class)->shouldAllowMockingProtectedMethods()->makePartial();
+        $relation->shouldReceive('getParent')->andReturn(new HasInverseRelationParentStub);
+        $relation->shouldReceive('applyInverseRelationToModel')->times(6);
+        $relation->exposeApplyInverseRelationToCollection([
+            new HasInverseRelationRelatedStub(),
+            12345,
+            new HasInverseRelationRelatedStub(),
+            new HasInverseRelationRelatedStub(),
+            Model::class,
+            new HasInverseRelationRelatedStub(),
+            true,
+            [],
+            new HasInverseRelationRelatedStub(),
+            'foo',
+            new class() {},
+            new HasInverseRelationRelatedStub(),
+        ]);
+    }
+
     public static function guessedParentRelationsDataProvider()
     {
         yield ['hasInverseRelationParentStub'];
@@ -360,5 +381,10 @@ class HasInverseRelationStub extends Relation
     public function exposeGuessInverseRelation(): string|null
     {
         return $this->guessInverseRelation();
+    }
+
+    public function exposeApplyInverseRelationToCollection($models, ?Model $parent = null)
+    {
+        return $this->applyInverseRelationToCollection($models, $parent);
     }
 }


### PR DESCRIPTION
Issue #52660 discovered an issue where calling `$model->relationship()->pluck('foo')` would fail on chaperoned relations, as the `pluck()` method sends only the selected field to the `afterQuery()` callback instead of the model.

This PR includes a failing test case, and a commit which resolves the issue by only attempting to hydrate the relationship on models in the callback, and skipping anything that's not a model.