### PR TITLE
[11.x] Fix build failures due to enum collide After adding BackedEnum support to Gate

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+include_once 'Enums.php';
+
 class AuthAccessGateTest extends TestCase
 {
     public function testBasicClosuresCanBeDefined()
@@ -1540,10 +1542,4 @@ class AccessGateTestPolicyThrowingAuthorizationException
     {
         throw new AuthorizationException('Not allowed.', 'some_code');
     }
-}
-
-enum AbilitiesEnum: string
-{
-    case VIEW_DASHBOARD = 'view-dashboard';
-    case UPDATE = 'update';
 }

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -19,6 +19,8 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+include_once 'Enums.php';
+
 class AuthorizeMiddlewareTest extends TestCase
 {
     protected $container;
@@ -350,9 +352,4 @@ class AuthorizeMiddlewareTest extends TestCase
     {
         return $this->container->make(GateContract::class);
     }
-}
-
-enum AbilitiesEnum: string
-{
-    case VIEW_DASHBOARD = 'view-dashboard';
 }

--- a/tests/Auth/Enums.php
+++ b/tests/Auth/Enums.php
@@ -2,7 +2,8 @@
 
 namespace Illuminate\Tests\Auth;
 
-enum AbilitiesEnum: string {
+enum AbilitiesEnum: string
+{
     case VIEW_DASHBOARD = 'view-dashboard';
     case UPDATE = 'update';
 }

--- a/tests/Auth/Enums.php
+++ b/tests/Auth/Enums.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+enum AbilitiesEnum: string {
+    case VIEW_DASHBOARD = 'view-dashboard';
+    case UPDATE = 'update';
+}


### PR DESCRIPTION
This PR fixes the build failures due to enum collide After adding BackedEnum support to Gate