### PR TITLE
Fixing Str::trim to remove the default trim/ltrim/rtim characters " \n\r\t\v\0" 

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1497,7 +1497,9 @@ class Str
     public static function trim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}]+|[\s\x{FEFF}\x{200B}\x{200E}]+$~u', '', $value) ?? trim($value);
+            $trimDefaultCharacters = " \n\r\t\v\0";
+
+            return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}'.$trimDefaultCharacters.']+|[\s\x{FEFF}\x{200B}\x{200E}'.$trimDefaultCharacters.']+$~u', '', $value) ?? trim($value);
         }
 
         return trim($value, $charlist);
@@ -1513,7 +1515,9 @@ class Str
     public static function ltrim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}]+~u', '', $value) ?? ltrim($value);
+            $ltrimDefaultCharacters = " \n\r\t\v\0";
+
+            return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}'.$ltrimDefaultCharacters.']+~u', '', $value) ?? ltrim($value);
         }
 
         return ltrim($value, $charlist);
@@ -1529,7 +1533,9 @@ class Str
     public static function rtrim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~[\s\x{FEFF}\x{200B}\x{200E}]+$~u', '', $value) ?? rtrim($value);
+            $rtrimDefaultCharacters = " \n\r\t\v\0";
+
+            return preg_replace('~[\s\x{FEFF}\x{200B}\x{200E}'.$rtrimDefaultCharacters.']+$~u', '', $value) ?? rtrim($value);
         }
 
         return rtrim($value, $charlist);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -862,9 +862,9 @@ class SupportStrTest extends TestCase
 
         $this->assertSame("\xE9", Str::trim(" \xE9 "));
 
-        $phpDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
+        $trimDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
 
-        foreach ($phpDefaultChars as $char) {
+        foreach ($trimDefaultChars as $char) {
             $this->assertSame('', Str::trim(" {$char} "));
             $this->assertSame(trim(" {$char} "), Str::trim(" {$char} "));
 
@@ -892,9 +892,9 @@ class SupportStrTest extends TestCase
         );
         $this->assertSame("\xE9 ", Str::ltrim(" \xE9 "));
 
-        $phpDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
+        $ltrimDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
 
-        foreach ($phpDefaultChars as $char) {
+        foreach ($ltrimDefaultChars as $char) {
             $this->assertSame('', Str::ltrim(" {$char} "));
             $this->assertSame(ltrim(" {$char} "), Str::ltrim(" {$char} "));
 
@@ -923,9 +923,9 @@ class SupportStrTest extends TestCase
 
         $this->assertSame(" \xE9", Str::rtrim(" \xE9 "));
 
-        $phpDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
+        $rtrimDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
 
-        foreach ($phpDefaultChars as $char) {
+        foreach ($rtrimDefaultChars as $char) {
             $this->assertSame('', Str::rtrim(" {$char} "));
             $this->assertSame(rtrim(" {$char} "), Str::rtrim(" {$char} "));
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -861,6 +861,16 @@ class SupportStrTest extends TestCase
         );
 
         $this->assertSame("\xE9", Str::trim(" \xE9 "));
+
+        $phpDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
+
+        foreach ($phpDefaultChars as $char) {
+            $this->assertSame('', Str::trim(" {$char} "));
+            $this->assertSame(trim(" {$char} "), Str::trim(" {$char} "));
+
+            $this->assertSame('foo bar', Str::trim("{$char} foo bar {$char}"));
+            $this->assertSame(trim("{$char} foo bar {$char}"), Str::trim("{$char} foo bar {$char}"));
+        }
     }
 
     public function testLtrim()
@@ -881,6 +891,16 @@ class SupportStrTest extends TestCase
             ')
         );
         $this->assertSame("\xE9 ", Str::ltrim(" \xE9 "));
+
+        $phpDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
+
+        foreach ($phpDefaultChars as $char) {
+            $this->assertSame('', Str::ltrim(" {$char} "));
+            $this->assertSame(ltrim(" {$char} "), Str::ltrim(" {$char} "));
+
+            $this->assertSame("foo bar {$char}", Str::ltrim("{$char} foo bar {$char}"));
+            $this->assertSame(ltrim("{$char} foo bar {$char}"), Str::ltrim("{$char} foo bar {$char}"));
+        }
     }
 
     public function testRtrim()
@@ -902,6 +922,16 @@ class SupportStrTest extends TestCase
         );
 
         $this->assertSame(" \xE9", Str::rtrim(" \xE9 "));
+
+        $phpDefaultChars = [' ', "\n", "\r", "\t", "\v", "\0"];
+
+        foreach ($phpDefaultChars as $char) {
+            $this->assertSame('', Str::rtrim(" {$char} "));
+            $this->assertSame(rtrim(" {$char} "), Str::rtrim(" {$char} "));
+
+            $this->assertSame("{$char} foo bar", Str::rtrim("{$char} foo bar {$char}"));
+            $this->assertSame(rtrim("{$char} foo bar {$char}"), Str::rtrim("{$char} foo bar {$char}"));
+        }
     }
 
     public function testSquish()


### PR DESCRIPTION
Fixes #52681 (https://github.com/laravel/framework/issues/52681)

