### PR TITLE
[11.x] Add new `match` method inside `Conditionable` trait

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -73,10 +73,10 @@ trait Conditionable
 
     /**
      * Apply the callback which key matches the given "value".
-     * 
+     *
      * @template TMatchParameter
      * @template TMatchReturnType
-     * 
+     *
      * @param  (\Closure($this): TMatchParameter)|TMatchParameter  $value
      * @param  array<TMatchParameter, callable($this): TMatchReturnType>  $conditions
      * @return $this|TMatchReturnType

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -70,4 +70,27 @@ trait Conditionable
 
         return $this;
     }
+
+    /**
+     * Apply the callback which key matches the given "value".
+     * 
+     * @template TMatchParameter
+     * @template TMatchReturnType
+     * 
+     * @param  (\Closure($this): TMatchParameter)|TMatchParameter  $value
+     * @param  array<TMatchParameter, callable($this): TMatchReturnType>  $conditions
+     * @return $this|TMatchReturnType
+     */
+    public function match($value, array $conditions)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
+        foreach ($conditions as $key => $callback) {
+            if ($key === $value) {
+                return $callback($this) ?? $this;
+            }
+        }
+
+        return $this;
+    }
 }

--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HigherOrderWhenProxy;
+use Illuminate\Support\Traits\Conditionable;
 use PHPUnit\Framework\TestCase;
 
 class ConditionableTest extends TestCase
@@ -42,8 +43,65 @@ class ConditionableTest extends TestCase
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(false, function () {
         }));
     }
+
+    public function testMatch(): void
+    {
+        $model = new TestConditionableModel([
+            'name' => 'foo',
+        ]);
+
+        $result = $model->match(
+            fn ($model) => $model->name,
+            [
+                'foo' => function ($model) {
+                    return 'matched foo';
+                },
+                'bar' => function ($model) {
+                    return 'matched bar';
+                },
+            ]
+        );
+
+        $this->assertEquals('matched foo', $result);
+
+        $result = $model->match('foo', [
+            'foo' => function ($model) {
+                return 'matched foo';
+            },
+            'bar' => function ($model) {
+                return 'matched bar';
+            },
+        ]);
+
+        $this->assertEquals('matched foo', $result);
+
+        $result = $model->match('bar', [
+            'foo' => function ($model) {
+                return 'matched foo';
+            },
+            'bar' => function ($model) {
+                return 'matched bar';
+            },
+        ]);
+
+        $this->assertEquals('matched bar', $result);
+
+        $result = $model->match('baz', [
+            'foo' => function ($model) {
+                return 'matched foo';
+            },
+            'bar' => function ($model) {
+                return 'matched bar';
+            },
+        ]);
+
+        $this->assertInstanceOf(TestConditionableModel::class, $result);
+    }
 }
 
 class TestConditionableModel extends Model
 {
+    use Conditionable;
+
+    protected $fillable = ['name'];
 }


### PR DESCRIPTION
This pull request aims to add a new `match` method inside the `Conditionable` trait.
This new feature was heavily inspired by the [match](https://www.php.net/manual/en/control-structures.match.php) php expression.

Recently in a project I was working on at work I needed to implement an api to serve analytics data for an e-commerce like application.
While trying to organize the code as best as i could i ended up with an action class with smaller private helper methods to customize the main query and return the correct data.

Initially I was using the available `when` method to call the correct private method for that specific case.
![using `when` function](https://github.com/user-attachments/assets/d32112f8-06fc-4afd-b529-5de3c114b365)

Then I thought that it would be nice if there was the possibility to use the php `match` expression to be more concise.
![using `match` function](https://github.com/user-attachments/assets/ad395878-22f1-4150-abc4-92e9ea56ed3d)
As you can see this is much more readable and concise.

So initially I wrote a basic implementation as an Eloquent Builder macro with the intent to later open a pull request to the framework to see if this idea was considered valuable to add.

`Conditionable` trait seemed the best place to put this kind of function.
I wrote a test but I'm very new to testing so I hope that it's adeguate and covers all necessary cases.