### PR TITLE
[11.x] Add `fromUrl()` to Attachment

### DIFF
--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Support\Traits\Macroable;
-use InvalidArgumentException;
 use RuntimeException;
 
 class Attachment
@@ -61,15 +60,9 @@ class Attachment
      *
      * @param  string  $url
      * @return static
-     *
-     * @throws InvalidArgumentException
      */
     public static function fromUrl($url)
     {
-        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
-            throw new InvalidArgumentException('Invalid URL provided.');
-        }
-
         return static::fromPath($url);
     }
 

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Attachment
@@ -53,6 +54,23 @@ class Attachment
     public static function fromPath($path)
     {
         return new static(fn ($attachment, $pathStrategy) => $pathStrategy($path, $attachment));
+    }
+
+    /**
+     * Create a mail attachment from a URL.
+     *
+     * @param  string  $url
+     * @return static
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function fromUrl($url)
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException('Invalid URL provided.');
+        }
+
+        return static::fromPath($url);
     }
 
     /**

--- a/tests/Mail/AttachableTest.php
+++ b/tests/Mail/AttachableTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Mail;
 use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailable;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class AttachableTest extends TestCase
@@ -138,13 +137,5 @@ class AttachableTest extends TestCase
                 'mime' => 'application/pdf',
             ],
         ], $mailable->attachments[0]);
-    }
-
-    public function testFromUrlMethodWithInvalidUrl()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid URL provided.');
-
-        Attachment::fromUrl('/path/to/file');
     }
 }

--- a/tests/Mail/AttachableTest.php
+++ b/tests/Mail/AttachableTest.php
@@ -113,10 +113,12 @@ class AttachableTest extends TestCase
 
     public function testFromUrlMethod()
     {
-        $mailable = new class extends Mailable {
+        $mailable = new class extends Mailable
+        {
             public function build()
             {
-                $this->attach(new class implements Attachable {
+                $this->attach(new class implements Attachable
+                {
                     public function toMailAttachment()
                     {
                         return Attachment::fromUrl('https://example.com/file.pdf')


### PR DESCRIPTION
The current `Attachment::fromPath()` method allows adding attachments from file paths, but it isn't immediately clear that URLs can be used with this method. This ambiguity could lead to confusion for users who want to attach files hosted on external URLs.

By adding the `Attachment::fromUrl()` method, the intent becomes explicit, improving the developer experience.

```php
public function attachments(): array
{
    return [
        Attachment::fromUrl('https://host.com/files/file.pdf'),
    ];
}
```

Wdyt?