### PR TITLE
[11.x] Add `Eloquent\Collection::findOrFail`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -51,6 +51,37 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Find a model in the collection by key or throw an exception.
+     *
+     * @param  mixed  $key
+     * @return TModel
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findOrFail($key)
+    {
+        $result = $this->find($key);
+
+        if (is_array($key) && count($result) === count(array_unique($key))) {
+            return $result;
+        } elseif (! is_array($key) && ! is_null($result)) {
+            return $result;
+        }
+
+        $exception = new ModelNotFoundException;
+
+        if (! $model = head($this->items)) {
+            throw $exception;
+        }
+
+        $ids = is_array($key) ? array_diff($key, $result->modelKeys()) : $key;
+
+        $exception->setModel(get_class($model), $ids);
+
+        throw $exception;
+    }
+
+    /**
      * Load a set of relationships onto the collection.
      *
      * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder<TModel>): mixed)|string>|string  $relations


### PR DESCRIPTION
## Description

This PR adds a way to find a model in a collection (or throw an exception) with an already populated Eloquent collection.

Having this method available is handy in edge-case circumstances, and is also a nice to have for feature parity with the core `Support\Collection` instance (as it sports its own `findOrFail` method).

## Usage

```php
$users = User::get(); // [User(id: 1), User(id: 2)]

$users->findOrFail(1); // User

$user->findOrFail([]); // []

$user->findOrFail([1, 2]); // [User, User]

$user->findOrFail(3); // ModelNotFoundException: 'No query results for model [User] 3'

$user->findOrFail([1, 2, 3]); // ModelNotFoundException: 'No query results for model [User] 3'
```

**Empty Collection Behaviour**:
> Since no models exist in the collection, there will be no message set, since a model cannot be determined.
```php
$users = User::get(); // []

$users->findOrFail(); // ModelNotFoundException: ''
```