### PR TITLE
[11.x] Refactor `Container::getInstance()` to use null coalescing assignment

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1519,11 +1519,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
-        if (is_null(static::$instance)) {
-            static::$instance = new static;
-        }
-
-        return static::$instance;
+        return static::$instance ??= new static;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -124,14 +124,11 @@ class BladeMapper
 
         if (! $compilerEngineReflection->hasProperty('lastCompiled') && $compilerEngineReflection->hasProperty('engine')) {
             $compilerEngine = $compilerEngineReflection->getProperty('engine');
-            $compilerEngine->setAccessible(true);
             $compilerEngine = $compilerEngine->getValue($bladeCompilerEngine);
             $lastCompiled = new ReflectionProperty($compilerEngine, 'lastCompiled');
-            $lastCompiled->setAccessible(true);
             $lastCompiled = $lastCompiled->getValue($compilerEngine);
         } else {
             $lastCompiled = $compilerEngineReflection->getProperty('lastCompiled');
-            $lastCompiled->setAccessible(true);
             $lastCompiled = $lastCompiled->getValue($bladeCompilerEngine);
         }
 

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -132,10 +132,7 @@ class MiddlewareTest extends TestCase
 
         $reflection = new ReflectionClass($middleware);
         $method = $reflection->getMethod('proxies');
-        $method->setAccessible(true);
-
         $property = $reflection->getProperty('proxies');
-        $property->setAccessible(true);
 
         $this->assertNull($method->invoke($middleware));
 
@@ -169,10 +166,7 @@ class MiddlewareTest extends TestCase
 
         $reflection = new ReflectionClass($middleware);
         $method = $reflection->getMethod('headers');
-        $method->setAccessible(true);
-
         $property = $reflection->getProperty('headers');
-        $property->setAccessible(true);
 
         $this->assertEquals(Request::HEADER_X_FORWARDED_FOR |
             Request::HEADER_X_FORWARDED_HOST |

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -49,8 +49,6 @@ class ViewComponentTest extends TestCase
 
         $reflectionMethod = new ReflectionMethod($component, 'ignoredMethods');
 
-        $reflectionMethod->setAccessible(true);
-
         $ignoredMethods = $reflectionMethod->invoke($component);
 
         foreach ($ignoredMethods as $method) {


### PR DESCRIPTION
This PR refactors the `getInstance()` method to use the null coalescing assignment operator (`??=`) for conciseness and better readability. The new implementation provides the same functionality but in a more modern way.
