### PR TITLE
[11.x] Refactor `Container::getInstance()` to use null coalescing assignment

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1519,11 +1519,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
-        if (is_null(static::$instance)) {
-            static::$instance = new static;
-        }
-
-        return static::$instance;
+        return static::$instance ??= new static;
     }
 
     /**


### PR DESCRIPTION
This PR refactors the `getInstance()` method to use the null coalescing assignment operator `(??=)` for conciseness and better readability. The new implementation provides the same functionality but in a more modern way.