### PR TITLE
[11.x] add `withoutDelay()` to PendingDispatch

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -101,6 +101,18 @@ class PendingDispatch
     }
 
     /**
+     * Set the delay for the job to zero seconds.
+     *
+     * @return $this
+     */
+    public function withoutDelay()
+    {
+        $this->job->withoutDelay();
+
+        return $this;
+    }
+
+    /**
      * Indicate that the job should be dispatched after all database transactions have committed.
      *
      * @return $this

--- a/tests/Queue/QueueDelayTest.php
+++ b/tests/Queue/QueueDelayTest.php
@@ -30,6 +30,17 @@ class QueueDelayTest extends TestCase
 
         $this->assertEquals(0, $job->delay);
     }
+
+    public function test_pending_dispatch_without_delay()
+    {
+        Queue::fake();
+
+        $job = new TestJob;
+
+        dispatch($job)->withoutDelay();
+
+        $this->assertEquals(0, $job->delay);
+    }
 }
 
 class TestJob implements ShouldQueue


### PR DESCRIPTION
Following: https://github.com/laravel/framework/pull/51555

With this, users can now write:

```php
TestJob::dispatch()->withoutDelay();
```

This change ensures a more consistent API for job dispatching.