### PR TITLE
Bypass accessor on increment/decrement

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -975,7 +975,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->{$column} = $this->isClassDeviable($column)
             ? $this->deviateClassCastableAttribute($method, $column, $amount)
-            : $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
+            : $this->getRawOriginal($column) + ($method === 'increment' ? $amount : $amount * -1);
 
         $this->forceFill($extra);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When incrementing/decrementing database values using `increment()`/`decrement()` it isn't desirable to execute an accessor that may exist on the column, as it's not really being "accessed".

The intention with this PR is to bypass any accessors to avoid unintended side effects.

https://github.com/laravel/framework/discussions/52694

(replaces previous PR #52697)
