### PR TITLE
[11.x] allow skipping cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -412,16 +412,15 @@ class Repository implements ArrayAccess, CacheContract
      * @param  string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
+     * @param  bool  $fresh
      * @return TCacheValue
      */
-    public function remember($key, $ttl, Closure $callback)
+    public function remember($key, $ttl, Closure $callback, bool $fresh = false)
     {
-        $value = $this->get($key);
-
         // If the item exists in the cache we will just return this immediately and if
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
-        if (! is_null($value)) {
+        if (! $fresh && ! is_null($value = $this->get($key))) {
             return $value;
         }
 


### PR DESCRIPTION
this allows calling code to pass an optional parameter to skip the cache value, and force execution of the closure.

the problem this solves is sometimes we have code that should use the cache value *most* of the time, but there are some one-off scenarios when we know we **need** the fresh value.  currently we have have to write a conditional, which forces us to duplicate the code inside the closure, something I'd like to avoid.

I did not change the Contract for this yet. I'm assuming that would have to go to 12.x

If this is accepted, I believe it would also be relevant for the upcoming `flexible()` cache method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
