### PR TITLE
[11.x] Fix etag headers for binary file responses

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -62,7 +62,7 @@ class SetCacheHeaders
         }
 
         if (isset($options['etag']) && $options['etag'] === true) {
-            $options['etag'] = $response->getEtag() ?? md5($response->getContent());
+            $options['etag'] = $response->getEtag() ?? ($response->getContent() ? md5($response->getContent()) : null);
         }
 
         if (isset($options['last_modified'])) {

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -173,4 +173,13 @@ class CacheTest extends TestCase
 
         $this->assertSame($time, $response->getLastModified()->getTimestamp());
     }
+
+    public function testItDoesNotSetEtagHeadersForBinaryContent()
+    {
+        $response = (new Cache)->handle(new Request, function () {
+            return new BinaryFileResponse(__DIR__.'/../fixtures/test.txt');
+        }, 'etag');
+
+        $this->assertNull($response->getEtag());
+    }
 }


### PR DESCRIPTION
The `getContent` method always returns `false` for instances of `BinaryFileResponse` or `StreamedResponse`. Consequently, for any file served via `return response()->download(...)`, the ETag header wil be set to the MD5 hash of `false`, which is `d41d8cd98f00b204e9800998ecf8427e`.

This leads to an identical ETag for all downloads, regardless of the actual file content. I propose that the ETag header be removed in cases where the content cannot be determined, as this would provide a more accurate response.
