### PR TITLE
[10.x] BC Fix: Invalid platform: PostgreSQL120Platform after upgrade to doctrine/dbal to 3.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
     },
     "conflict": {
         "carbonphp/carbon-doctrine-types": ">=3.0",
-        "doctrine/dbal": ">=4.0",
+        "doctrine/dbal": ">=3.9",
         "mockery/mockery": "1.6.8",
         "tightenco/collect": "<5.5.33",
         "phpunit/phpunit": ">=11.0.0"

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -36,7 +36,7 @@
     },
     "conflict": {
         "carbonphp/carbon-doctrine-types": ">=3.0",
-        "doctrine/dbal": ">=4.0"
+        "doctrine/dbal": ">=3.9"
     },
     "suggest": {
         "ext-filter": "Required to use the Postgres database driver.",


### PR DESCRIPTION
## Summary

This PR adds a conflict in Laravel 10.x using the `doctrine/dbal >= 3.9` library instead of `doctrine/dbal >= 4.0` due to an `Invalid Platform: PostgreSQL120Platform` error when trying to modify a column in table in PostgreSQL (>= 12) during migration.

---

I know that bug fix support for Laravel 10.x ended on 06.08.2024, but for those who have not yet migrated their projects to Laravel 11.x (like me), this may become a big problem. :)

## Details

* `Laravel 10.48`
* `PostgresSQL >= 12`
* `doctrine/dbal 3.9.0`

Added new `Doctrine\DBAL\Platforms\PostgreSQL120Platform` (https://github.com/doctrine/dbal/pull/6199) to `doctrine/dbal 3.9.0` to detect PostgreSQL versions >= 12.

There is no new platform in `getSQLDeclaration()` in `src/Illuminate/Database/DBAL/TimestampType.php`,
Therefore, now when I try to execute the command, the exception `"Invalid platform: PostgreSQL120Platform"` is thrown.

```php
    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
    {
        return match (get_class($platform)) {
            MySQLPlatform::class,
            MySQL57Platform::class,
            MySQL80Platform::class,
            MariaDBPlatform::class,
            MariaDb1027Platform::class,
            MariaDb1052Platform::class,
            MariaDb1060Platform::class => $this->getMySqlPlatformSQLDeclaration($column),
            PostgreSQLPlatform::class,
            PostgreSQL94Platform::class,
            PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
            SQLServerPlatform::class,
            SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
            SqlitePlatform::class => 'DATETIME',
            default => throw new DBALException('Invalid platform: '.substr(strrchr(get_class($platform), '\\'), 1)),
        };
    }
```

```
 INFO  Running migrations.

  2020_02_20_103053_update_dir_plan_item_types_name_column ............................................................................... 25ms FAIL

   Doctrine\DBAL\Exception

  Invalid platform: PostgreSQL120Platform

  at vendor/laravel/framework/src/Illuminate/Database/DBAL/TimestampType.php:46
     42▕             PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
     43▕             SQLServerPlatform::class,
     44▕             SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
     45▕             SqlitePlatform::class => 'DATETIME',
  ➜  46▕             default => throw new DBALException('Invalid platform: '.substr(strrchr(get_class($platform), '\\'), 1)),
     47▕         };
     48▕     }
     49▕
     50▕     /**

      +13 vendor frames
```

The bug report was also previously mentioned in `doctrine/dbal` https://github.com/doctrine/dbal/issues/6506

### Another Solution

Maybe another fix would be to add `Doctrine\DBAL\Platforms\PostgreSQL120Platform` to `getSQLDeclaration()`

```php
    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
    {
        return match (get_class($platform)) {
            .........
            PostgreSQLPlatform::class,
            PostgreSQL94Platform::class,
            PostgreSQL100Platform::class,
            PostgreSQL120Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
            ........
        };
    }
```

But additional testing is needed.

---

Thanks. :)
