### PR TITLE
 Resolve redirection errors by trimming parameter braces

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -31,7 +31,9 @@ class RedirectController extends Controller
 
         $parameters = $parameters->only(
             $route->getCompiled()->getPathVariables()
-        )->all();
+        )->map(function ($value) {
+            return trim($value, '{}');
+        })->all();
 
         $url = $url->toRoute($route, $parameters, false);
 


### PR DESCRIPTION
This PR fixes an issue where malformed parameters (e.g., {param}) caused route redirection failures due to untrimmed braces. The fix involves adding a trimming step in the redirection logic, ensuring parameters are parsed correctly, enhancing reliability and flexibility in handling dynamic routes.