### PR TITLE
[11.x] PHPStan Improvements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1400,7 +1400,7 @@ trait HasAttributes
             return Hash::make($value);
         }
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore staticMethod.notFound */
         if (! Hash::verifyConfiguration($value)) {
             throw new RuntimeException("Could not verify the hashed value's configuration.");
         }

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -27,7 +27,7 @@ class ContextServiceProvider extends ServiceProvider
     public function boot()
     {
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore staticMethod.notFound */
             $context = Context::dehydrate();
 
             return $context === null ? $payload : [
@@ -37,7 +37,7 @@ class ContextServiceProvider extends ServiceProvider
         });
 
         $this->app['events']->listen(function (JobProcessing $event) {
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore staticMethod.notFound */
             Context::hydrate($event->job->payload()['illuminate:log:context'] ?? null);
         });
     }


### PR DESCRIPTION
Static Analysis only ignore PHPStan error for `staticMethod.notFound` on Facade usage.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
