### PR TITLE
[11.x] Fix incorrect variable-length argument `$guards` from array to string

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -52,7 +52,7 @@ class Authenticate implements AuthenticatesRequests
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  string[]  ...$guards
+     * @param  string  ...$guards
      * @return mixed
      *
      * @throws \Illuminate\Auth\AuthenticationException

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1344,7 +1344,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Alias for the "currentRouteUses" method.
      *
-     * @param  array  ...$patterns
+     * @param  array|string  ...$patterns
      * @return bool
      */
     public function uses(...$patterns)


### PR DESCRIPTION
### Description

This pull request fixes an issue in the PHPDoc where the variable-length parameter `$guards` was incorrectly declare as an array of strings. The correct type should be string as the variable-length parameter represents multiple string arguments before they are converted into an array.
