### PR TITLE
[11.x] Add optional parameter for `confirmed` validator rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -493,11 +493,12 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array{0: string} $parameters
      * @return bool
      */
-    public function validateConfirmed($attribute, $value)
+    public function validateConfirmed($attribute, $value, $parameters)
     {
-        return $this->validateSame($attribute, $value, [$attribute.'_confirmation']);
+        return $this->validateSame($attribute, $value, [$parameters[0] ?: $attribute.'_confirmation']);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -493,7 +493,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array{0: string} $parameters
+     * @param  array{0: string}  $parameters
      * @return bool
      */
     public function validateConfirmed($attribute, $value, $parameters)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2124,6 +2124,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['password' => '1e2', 'password_confirmation' => '100'], ['password' => 'Confirmed']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'passwordConfirmation' => 'foo'], ['password' => 'Confirmed:passwordConfirmation']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'passwordConfirmation' => 'bar'], ['password' => 'Confirmed:passwordConfirmation']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateSame()


### PR DESCRIPTION
This adds an optional parameter for the `confirmed` validator rule, allowing for more customization.

For example, you could do `"password" => "confirmed:passwordConfirmation"` if your front-end coding style required camelCase.

Providing no parameter results in the current behavior of checking the default naming convention, ie. `"password" => "confirmed"` checks `password_confirmation`.

The same behavior can be achieved with `"passwordConfirmation" => "same:password"` but I believe this better describes the intent of the validation by associating the confirmation with the original field, along with any other password rules that may be required.