### PR TITLE
[11.x] fix: Builder::with closure types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1537,8 +1537,8 @@ class Builder implements BuilderContract
     /**
      * Set the relationships that should be eager loaded.
      *
-     * @param  string|array  $relations
-     * @param  string|\Closure|null  $callback
+     * @param  array<array-key, (\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>|string  $relations
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string|null  $callback
      * @return $this
      */
     public function with($relations, $callback = null)
@@ -1572,7 +1572,7 @@ class Builder implements BuilderContract
     /**
      * Set the relationships that should be eager loaded while removing any previously added eager loading specifications.
      *
-     * @param  mixed  $relations
+     * @param  array<array-key, (\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>|string  $relations
      * @return $this
      */
     public function withOnly($relations)

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -24,8 +24,14 @@ function test(
     assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhere('name', 'John'));
     assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereNot('status', 'active'));
     assertType('Illuminate\Database\Eloquent\Builder<User>', $query->with('relation'));
+    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->with(['relation' => function ($query) {
+        // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
+    }]));
     assertType('Illuminate\Database\Eloquent\Builder<User>', $query->without('relation'));
     assertType('Illuminate\Database\Eloquent\Builder<User>', $query->withOnly(['relation']));
+    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->withOnly(['relation' => function ($query) {
+        // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
+    }]));
     assertType('array<int, User>', $query->getModels());
     assertType('array<int, User>', $query->eagerLoadRelations([]));
     assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->get());

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -11,66 +11,66 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $co
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string']));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }], 'string', 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount(['string']));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax(['string'], 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin(['string'], 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum(['string'], 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg(['string'], 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists(['string']));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing(['string']));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing(['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorph('string', ['string']));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorph('string', ['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorphCount('string', ['string']));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorphCount('string', ['string' => function ($query) {
-    // assertType('Illuminate\Database\Eloquent\Builder<User>', $query);
+    // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
 }]));
 
 assertType('bool', $collection->contains(function ($user) {


### PR DESCRIPTION
Hello!

#52724 fixed the Collection types, but this fixes the `Builder::{with,withOnly}` types as well to specify closures with the Relation passed to them.

Thanks!

CC: @staudenmeir 