### PR TITLE
[11.x] Add `@match` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -283,6 +283,21 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the match statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileMatch($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression), 2);
+        $parts[1] = substr($parts[1], 2);
+        $parts[1] = substr_replace($parts[1], "", -1);
+
+        return "<?php echo match({$parts[0]}) { {$parts[1]} }; ?>";
+    }
+
+    /**
      * Compile a once block into valid PHP.
      *
      * @param  string|null  $id

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -292,7 +292,7 @@ trait CompilesConditionals
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
         $parts[1] = substr($parts[1], 2);
-        $parts[1] = substr_replace($parts[1], "", -1);
+        $parts[1] = substr_replace($parts[1], '', -1);
 
         return "<?php echo match({$parts[0]}) { {$parts[1]} }; ?>";
     }

--- a/tests/View/Blade/BladeIfStatementsTest.php
+++ b/tests/View/Blade/BladeIfStatementsTest.php
@@ -61,4 +61,12 @@ bar
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testMatchStatementsAreCompiledWithDefaultValue()
+    {
+        $string = '@match(2, [0 => "false", 1 => "true", default => "not bool"])';
+        $expected = '<?php echo match(2) { 0 => "false", 1 => "true", default => "not bool" }; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeIfStatementsTest.php
+++ b/tests/View/Blade/BladeIfStatementsTest.php
@@ -53,4 +53,12 @@ bar
 <?php endswitch; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testMatchStatementsAreCompiled()
+    {
+        $string = '@match(true, [0 => "false", 1 => "true"])';
+        $expected = '<?php echo match(true) { 0 => "false", 1 => "true" }; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This directive is highly useful. While Blade views typically require the use of a switch-case structure or method calls, the new @match directive simplifies this process significantly.

```blade
// Before
@switch($name)
    @case('milwad')
        Fun Developer
        @break
 
    @case('...')
        ...
        @break
@endswitch

// After
@match($name, ['milwad' => 'Fun Developer', '...' => '...'])

OR 

@match($name, [
     'milwad' => 'Fun Developer',
     '...' => '...'
])
```

With `@match`, you no longer need to use `@break`, streamlining your Blade view code and making it more concise. 😁

- [x] Tests