### PR TITLE
[11.x] Fix issue where `$name` variable in non base config file becomes it's key

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -93,9 +93,7 @@ class LoadConfiguration
      */
     protected function loadConfigurationFile(RepositoryContract $repository, $name, $path, array $base)
     {
-        $config = (function () use ($path) {
-            return require $path;
-        })();
+        $config = (fn () => require $path)();
 
         if (isset($base[$name])) {
             $config = array_merge($base[$name], $config);

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -93,7 +93,9 @@ class LoadConfiguration
      */
     protected function loadConfigurationFile(RepositoryContract $repository, $name, $path, array $base)
     {
-        $config = require $path;
+        $config = (function () use ($path) {
+            return require $path;
+        })();
 
         if (isset($base[$name])) {
             $config = array_merge($base[$name], $config);

--- a/tests/Foundation/Bootstrap/LoadConfigurationTest.php
+++ b/tests/Foundation/Bootstrap/LoadConfigurationTest.php
@@ -26,4 +26,15 @@ class LoadConfigurationTest extends TestCase
 
         $this->assertNull($app['config']['app.name']);
     }
+
+    public function testLoadsConfigurationInIsolation()
+    {
+        $app = new Application(__DIR__.'/../fixtures');
+        $app->useConfigPath(__DIR__.'/../fixtures/config');
+
+        (new LoadConfiguration())->bootstrap($app);
+
+        $this->assertNull($app['config']['bar.foo']);
+        $this->assertSame('bar', $app['config']['custom.foo']);
+    }
 }

--- a/tests/Foundation/fixtures/config/custom.php
+++ b/tests/Foundation/fixtures/config/custom.php
@@ -1,0 +1,7 @@
+<?php
+
+$name = 'bar';
+
+return [
+    'foo' => $name,
+];


### PR DESCRIPTION
I noticed a bug in one of my apps where it seemed like my published config file was not loaded. After debugging I noticed that
the config file was actually loaded, but under a different key. It looks like this happens when you define a variable named `$name` in one of your non base config files.

This happens because after requiring the config file, the `$name` variable is used to call `$repository->set($name, $config);`.

I fixed this issue by wrapping the require statement in a closure which makes it run in isolation.