### PR TITLE
[11.x] Adds BackedEnum to PendingDispatch's phpDoc for onQueue, allOnQueue, onConnection, allOnConnection methods

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -38,7 +38,7 @@ class PendingDispatch
     /**
      * Set the desired connection for the job.
      *
-     * @param  string|null  $connection
+     * @param  \BackedEnum|string|null  $connection
      * @return $this
      */
     public function onConnection($connection)
@@ -51,7 +51,7 @@ class PendingDispatch
     /**
      * Set the desired queue for the job.
      *
-     * @param  string|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)
@@ -64,7 +64,7 @@ class PendingDispatch
     /**
      * Set the desired connection for the chain.
      *
-     * @param  string|null  $connection
+     * @param  \BackedEnum|string|null  $connection
      * @return $this
      */
     public function allOnConnection($connection)
@@ -77,7 +77,7 @@ class PendingDispatch
     /**
      * Set the desired queue for the chain.
      *
-     * @param  string|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
     public function allOnQueue($queue)


### PR DESCRIPTION
We already accept `BackendEnum` in `Queueable` trait (ref #52604), however, `PendingDispatch` is missing the phpDoc for BackedEnum

This PR adds that ✌️ 