### PR TITLE
[11.x]  Add  method to concatenate arrays with customizable conjunction

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1991,4 +1991,23 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Implode an array of strings with commas and a custom conjunction before the last item.
+     *
+     * @param  array<string>  $items
+     * @param  string  $conjunction
+     * @return string
+     */
+    public static function implodeWithConjunction(array $items, string $conjunction = 'and'): string
+    {
+        $items = array_filter($items);
+
+        if (count($items) > 1) {
+            $last = array_pop($items);
+            return implode(', ', $items) . ' ' . $conjunction . ' ' . $last;
+        }
+
+        return $items[0] ?? '';
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1612,6 +1612,50 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    public function testImplodeWithConjunction()
+    {
+        $testCases = [
+            [
+                'items' => ['apple', 'banana', 'cherry'],
+                'conjunction' => 'and',
+                'expected' => 'apple, banana and cherry',
+            ],
+            [
+                'items' => ['apple', 'banana', 'cherry'],
+                'conjunction' => 'or',
+                'expected' => 'apple, banana or cherry',
+            ],
+            [
+                'items' => ['apple', 'banana'],
+                'conjunction' => 'and',
+                'expected' => 'apple and banana',
+            ],
+            [
+                'items' => ['apple', 'banana'],
+                'conjunction' => 'or',
+                'expected' => 'apple or banana',
+            ],
+            [
+                'items' => ['apple'],
+                'conjunction' => 'and',
+                'expected' => 'apple',
+            ],
+            [
+                'items' => [],
+                'conjunction' => 'and',
+                'expected' => '',
+            ],
+            [
+                'items' => ['apple', '', 'banana', ''],
+                'conjunction' => 'and',
+                'expected' => 'apple and banana',
+            ],
+        ];
+        foreach($testCases as $testCase) {
+            $this->assertSame($testCase['expected'], Str::implodeWithConjunction($testCase['items'], $testCase['conjunction']));
+        }
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
This PR adds a new `Str::implodeWithConjunction` method, allowing arrays to be imploded with commas and a customizable conjunction (e.g., 'and', 'or') before the last item defaulting to 'and'. The method filters out empty items and improves readability for human-friendly lists.

### **Examples**
```php
Str::implodeWithConjunction(['apple', 'banana', 'cherry']); // "apple, banana and cherry"
Str::implodeWithConjunction(['apple', 'banana'], 'or'); // "apple or banana"
Str::implodeWithConjunction([]); // ""
```

### **Tests**
Includes comprehensive test cases covering:
- Multiple items with default and custom conjunctions.
- Handling single items and empty arrays.
- Filtering out empty strings.

### **Benefit**
This method simplifies creating readable lists with flexible conjunctions, reducing the need for repetitive custom code.