### PR TITLE
Add `Tag` attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Tag.php
+++ b/src/Illuminate/Container/Attributes/Tag.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class Tag implements ContextualAttribute
+{
+    public function __construct(
+        public string $tag,
+    ) {
+    }
+
+    /**
+     * Resolve the tag.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->tagged($attribute->tag);
+    }
+}

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -15,7 +15,9 @@ use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Container\Attributes\Database;
 use Illuminate\Container\Attributes\Log;
 use Illuminate\Container\Attributes\Storage;
+use Illuminate\Container\Attributes\Tag;
 use Illuminate\Container\Container;
+use Illuminate\Container\RewindableGenerator;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Guard as GuardContract;
 use Illuminate\Contracts\Container\ContextualAttribute;
@@ -234,6 +236,20 @@ class ContextualAttributeBindingTest extends TestCase
         });
 
         $this->assertEquals('Europe/Paris', $value);
+    }
+
+    public function testTagAttribute()
+    {
+        $container = new Container;
+        $container->bind('one', fn (): int => 1);
+        $container->bind('two', fn (): int => 2);
+        $container->tag(['one', 'two'], 'numbers');
+
+        $value = $container->call(function (#[Tag('numbers')] RewindableGenerator $integers) {
+            return $integers;
+        });
+
+        $this->assertEquals([1, 2], iterator_to_array($value));
     }
 }
 


### PR DESCRIPTION
This PR makes it easier to inject tags into services.
Instead of manually having to bind the instance that uses the tag, you can now reference the tag in the target class.

Before:
```php
$this->app->bind(ReportAnalyzer::class, function (Application $app) {
    return new ReportAnalyzer($app->tagged('reports'));
});
```

After:
```php
class ReportAnalyzer
{
    public function __construct(
        #[Tag('reports')] iterable $reports
    )
}
```
