### PR TITLE
[11.x] add lazy default to when helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -242,15 +242,16 @@ if (! function_exists('when')) {
      * Output a value if the given condition is true.
      *
      * @param  mixed  $condition
-     * @param  \Closure|mixed  $output
+     * @param  \Closure|mixed  $value
+     * @param  \Closure|mixed  $default
      * @return mixed
      */
-    function when($condition, $output)
+    function when($condition, $value, $default = null)
     {
         if ($condition) {
-            return value($output);
+            return value($value, $condition);
         }
 
-        return null;
+        return value($default, $condition);
     }
 }

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -239,7 +239,7 @@ if (! function_exists('value')) {
 
 if (! function_exists('when')) {
     /**
-     * Output a value if the given condition is true.
+     * Return a value if the given condition is true.
      *
      * @param  mixed  $condition
      * @param  \Closure|mixed  $value

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -103,15 +103,23 @@ class SupportHelpersTest extends TestCase
     public function testWhen()
     {
         $this->assertEquals('Hello', when(true, 'Hello'));
-        $this->assertEquals(null, when(false, 'Hello'));
+        $this->assertNull(when(false, 'Hello'));
         $this->assertEquals('There', when(1 === 1, 'There')); // strict types
         $this->assertEquals('There', when(1 == '1', 'There')); // loose types
-        $this->assertEquals(null, when(1 == 2, 'There'));
-        $this->assertEquals(null, when('1', fn () => null));
-        $this->assertEquals(null, when(0, fn () => null));
+        $this->assertNull(when(1 == 2, 'There'));
+        $this->assertNull(when('1', fn () => null));
+        $this->assertNull(when(0, fn () => null));
         $this->assertEquals('True', when([1, 2, 3, 4], 'True')); // Array
-        $this->assertEquals(null, when([], 'True')); // Empty Array = Falsy
+        $this->assertNull(when([], 'True')); // Empty Array = Falsy
         $this->assertEquals('True', when(new StdClass, fn () => 'True')); // Object
+        $this->assertEquals('World', when(false, 'Hello', 'World'));
+        $this->assertEquals('World', when(1 === 0, 'Hello', 'World')); // strict types
+        $this->assertEquals('World', when(1 == '0', 'Hello', 'World')); // loose types
+        $this->assertNull(when('', fn () => 'There', fn () => null));
+        $this->assertNull(when(0, fn () => 'There', fn () => null));
+        $this->assertEquals('False', when([], 'True', 'False'));  // Empty Array = Falsy
+        $this->assertTrue(when(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
+        $this->assertTrue(when(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
     }
 
     public function testFilled()


### PR DESCRIPTION
PR #52665 added a new helper to Laravel: `when()`

It simplifies the evaluation of a condition to output a value similar to PHP's ternary operator, with the `false` branch always returning `null`.

### This PR:

- Augments the helper feature set by allowing a developer to define a default value in case the conditions evaluates to `false`.
- Aligns the implementation with the `Illuminate\Support\Traits\Conditionable@when()` method, by passing the `$condition` value to the `value()` helper, so it is passed down as an argument to any `\Closure` used as the `true` or `default` values.
- Adds new test assertions to account for the newly added parameter

### Notes

Why not use the null-coalesce (`??`) operator?

One could argue that the `$default` parameter is not needed, as a developer could use the null-coalesce operator instead, like this:

```blade
{{ when($user, fn() => $user->preference('theme')) ?? 'light' }}
```

But that doesn't allow for the lazy evaluation of the `$default` value, in case we want to use a dynamic default value, for example, when using `Pennant` to test a new design:

```blade
{{ when(Auth::user(), fn($user) => $user->preference('theme'), fn() => Feature::active('site-redesign') ? 'new-theme' : 'old-theme') }}
```

In the example above, the `$default` value would be lazily evaluated when a guest is visiting the application.

Also, as we are passing the `$condition` value down to the truthy `\Closure`, we don't need to `Auth::user` again.

### Breaking change

As a new parameter is added, it could be considered a breaking change. 

But the `when()` helper was just added in today's release, also the `$default` parameter is optional with a `null` default value, preserving the original behavior.

### Disclaimer

I suggested this implementation in the original PR in this comment: https://github.com/laravel/framework/pull/52665#issuecomment-2338362014

But, although the author of that PR was very welcoming of all suggestions, the addition of the `$default` value didn't make the cut.

### Post Script

I changed some of the original test assertions to use `assertNull(...)` instead of `assertEquals(null, ...)`.