### PR TITLE
Fix arguments passed to artisan commands that start with 'env'

### DIFF
--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -65,7 +65,7 @@ class EnvironmentDetector
                 return $args[$i + 1] ?? null;
             }
 
-            if (str_starts_with($value, '--env')) {
+            if (str_starts_with($value, '--env=')) {
                 return head(array_slice(explode('=', $value), 1));
             }
         }

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -46,4 +46,34 @@ class FoundationEnvironmentDetectorTest extends TestCase
         }, ['--env']);
         $this->assertSame('foobar', $result);
     }
+
+    public function testConsoleEnvironmentDetectionDoesNotUseArgumentThatStartsWithEnv()
+    {
+        $env = new EnvironmentDetector;
+
+        $result = $env->detect(function () {
+            return 'foobar';
+        }, ['--envelope=mail']);
+        $this->assertSame('foobar', $result);
+    }
+
+    public function testConsoleEnvironmentDetectionDoesNotUseArgumentThatStartsWithEnvSeparatedWithSpace()
+    {
+        $env = new EnvironmentDetector;
+
+        $result = $env->detect(function () {
+            return 'foobar';
+        }, ['--envelope', 'mail']);
+        $this->assertSame('foobar', $result);
+    }
+
+    public function testConsoleEnvironmentDetectionDoesNotUseArgumentThatStartsWithEnvWithNoValue()
+    {
+        $env = new EnvironmentDetector;
+
+        $result = $env->detect(function () {
+            return 'foobar';
+        }, ['--envelope']);
+        $this->assertSame('foobar', $result);
+    }
 }


### PR DESCRIPTION
This fixes artisan commands that have arguments that start with 'env'. Since it was previously only checking if the argument started with 'env' and not confirming that the entire argument name was 'env', the value of the argument would be used as the environment name.