### PR TITLE
Add @method annotations to Concurrency facade for IDE support

### DIFF
--- a/src/Illuminate/Support/Facades/Concurrency.php
+++ b/src/Illuminate/Support/Facades/Concurrency.php
@@ -3,8 +3,13 @@
 namespace Illuminate\Support\Facades;
 
 use Illuminate\Concurrency\ConcurrencyManager;
+use Illuminate\Foundation\Defer\DeferredCallback;
 
 /**
+ *
+ * @method static array run(\Closure|array $tasks)
+ * @method static DeferredCallback defer(\Closure|array $tasks)
+ *
  * @see \Illuminate\Concurrency\ConcurrencyManager
  */
 class Concurrency extends Facade


### PR DESCRIPTION
Added @method annotations to the Concurrency facade to enhance IDE auto-completion and documentation generation. These annotations reflect the static methods available in the ConcurrencyManager.

- Added @method static array run(\Closure|array $tasks)
- Added @method static DeferredCallback defer(\Closure|array $tasks)

No changes to the functionality or logic of the code. Existing tests have been run and all pass successfully.