### PR TITLE
[11.x] Apply Laracon 2024 private files feature

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -32,7 +32,8 @@ return [
 
         'local' => [
             'driver' => 'local',
-            'root' => storage_path('app'),
+            'root' => storage_path('app/private'),
+            'serve' => true,
             'throw' => false,
         ],
 


### PR DESCRIPTION
This PR adds [newly added features](https://github.com/laravel/laravel/pull/6450) to the Laravel skeleton configuration files.

Otherwise, the [Configuration Publishing](https://laravel.com/docs/11.x/configuration#configuration-publishing) commands use outdated configuration files that do not contain the changes.

It might be worth coming up with some mechanism to synchronize configuration files in the future.