### PR TITLE
Fix: Unreachable action buttons in notification template when using "align" prop with "left" or "right".

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -219,6 +219,7 @@ img {
     padding: 0;
     text-align: center;
     width: 100%;
+    float: unset;
 }
 
 .button {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes an issue with the alignment of action buttons in the notification template when the align prop is used.

The option to pass align as a prop was introduced in [PR #45362](https://github.com/laravel/framework/pull/45362). When set to `left` or `right`, the action button becomes unreachable as it gets overlaid by a following text element:

<img width="634" alt="screenshot 170" src="https://github.com/user-attachments/assets/c166e0fb-6013-46c2-8cac-9d0f97fd821d">

(Screenshot of the PasswordReset notification rendered in Google Chrome; the issue was also reproducible in multiple mail clients.)


This occurs because applying `align="left"` to a table element basically adds a `float: left`.


**Steps to reproduce:**
- Set up a fresh Laravel project.
- Publish the `email.blade.php` file (`php artisan vendor:publish --tag=laravel-notifications`).
- Add `align="left"` to the `<x-mail::button>`.
- Send or render a notification (e.g., PasswordReset).


**Proposed fix:**
We could address this by either removing the inheritance of the align prop for the table in [this line](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Mail/resources/views/html/button.blade.php#L6) and always setting the alignment to center.

However, I propose unsetting the float for the `.action` class in the default theme, which feels like a less intrusive solution.
