### PR TITLE
[11.x] Fixed attempt to call `Application::routesAreCached()` when application doesn't implements `CachesRoutes` contract.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Filesystem;
 
+use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -78,7 +79,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function serveFiles()
     {
-        if ($this->app->routesAreCached()) {
+        if ($this->app instanceof CachesRoutes && $this->app->routesAreCached()) {
             return;
         }
 


### PR DESCRIPTION
fixes #52760

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
