### PR TITLE
[11.x] Fixing Concurrency Facade Docblocks

### DIFF
--- a/src/Illuminate/Support/Facades/Concurrency.php
+++ b/src/Illuminate/Support/Facades/Concurrency.php
@@ -18,7 +18,7 @@ use Illuminate\Concurrency\ConcurrencyManager;
  * @method static \Illuminate\Concurrency\ConcurrencyManager extend(string $name, \Closure $callback)
  * @method static \Illuminate\Concurrency\ConcurrencyManager setApplication(\Illuminate\Contracts\Foundation\Application $app)
  * @method static array run(\Closure|array $tasks)
- * @method static void background(\Closure|array $tasks)
+ * @method static \Illuminate\Foundation\Defer\DeferredCallback defer(\Closure|array $tasks)
  *
  * @see \Illuminate\Concurrency\ConcurrencyManager
  */


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR is a complement of: https://github.com/laravel/framework/pull/52750. Removes the inexistent `background` method and adds the `defer` method.