### PR TITLE
[11.x] Allow View Components to be returned from Controllers

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -5,12 +5,13 @@ namespace Illuminate\View;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\View\View as ViewContract;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
-abstract class Component
+abstract class Component implements Responsable
 {
     /**
      * The properties / methods that should not be exposed to the component.
@@ -161,6 +162,16 @@ abstract class Component
             return $resolver($view($data));
         }
         : $resolver($view);
+    }
+
+    /**
+     * Get the view and data that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     */
+    public function toResponse($request)
+    {
+        return $this->resolveView()->with($this->data());
     }
 
     /**

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -368,6 +368,15 @@ class ComponentTest extends TestCase
         $this->assertTrue((bool) $anotherSlot->hasActualContent());
         $this->assertTrue((bool) $moreComplexSlot->hasActualContent());
     }
+
+    public function testComponentIsRenderedFromResponse()
+    {
+        $component = new TestHtmlableReturningViewComponent('title');
+
+        $response = $component->toResponse(new Request());
+
+        $this->assertSame('<p>Hello title</p>', $response->getContent());
+    }
 }
 
 class TestInlineViewComponent extends Component


### PR DESCRIPTION
This functionality allows a component to be returned from a controller and enhances the type safety of the data flow to views

```php
// Component

class Layout extends Component
{
    public function __construct(public string $title)
    {}

    public function render()
    {
        return view('components.layout');
    }
}

// Controller

use App\View\Components\Layout;

class PageController extends Controller
{
    public function show($id)
    {
        return new Layout(title: 'I love Laravel');
    }
}
```