### PR TITLE
[11.x] Only hydrate envelop addresses if they are instance of `Mailable\Address`

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1682,7 +1682,9 @@ class Mailable implements MailableContract, Renderable
 
         foreach (['to', 'cc', 'bcc', 'replyTo'] as $type) {
             foreach ($envelope->{$type} as $address) {
-                $this->{$type}($address->address, $address->name);
+                if ($address instanceof Mailables\Address) {
+                    $this->{$type}($address->address, $address->name);
+                }
             }
         }
 


### PR DESCRIPTION
When trying to send a mail from the queue an error is thrown because is trying to hydrated the envelop from an non-address-object;

`Attempt to read property "address" on array {"exception":"[object] (ErrorException(code: 0): Attempt to read property \"address\"`

This PR fixes that.

