### PR TITLE
decimal validation rule failed when set strict_types = 1

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -636,7 +636,7 @@ trait ValidatesAttributes
 
         $matches = [];
 
-        if (preg_match('/^[+-]?\d*\.?(\d*)$/', $value, $matches) !== 1) {
+        if (preg_match('/^[+-]?\d*\.?(\d*)$/', strval($value), $matches) !== 1) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -640,7 +640,11 @@ trait ValidatesAttributes
             return false;
         }
 
-        $decimals = strlen(end($matches));
+        if (!isset($matches[1])) {
+            return false;
+        }
+
+        $decimals = strlen($matches[1]);
 
         if (! isset($parameters[1])) {
             return $decimals == $parameters[0];

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -640,7 +640,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        if (!isset($matches[1])) {
+        if (! isset($matches[1])) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3111,6 +3111,7 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateDecimal()
     {
+        declare(strict_types=1);
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Decimal:2,3']);
         $this->assertFalse($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 namespace Illuminate\Tests\Validation;
 
@@ -3149,7 +3148,13 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Decimal:0,1']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => 1], ['foo' => 'Decimal:0,1']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:0,1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 1.2], ['foo' => 'Decimal:0,1']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '-1.2'], ['foo' => 'Decimal:0,1']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Illuminate\Tests\Validation;
 
@@ -3111,7 +3112,6 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateDecimal()
     {
-        declare(strict_types=1);
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Decimal:2,3']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
setting `declare(strict_types=1)` will result to a exception throwing at the `preg_match`  pos
