### PR TITLE
[11.x] Ensure headers are only attached to illuminate responses

### DIFF
--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Middleware;
 
+use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Vite;
 
@@ -17,7 +18,7 @@ class AddLinkHeadersForPreloadedAssets
     public function handle($request, $next)
     {
         return tap($next($request), function ($response) {
-            if (Vite::preloadedAssets() !== []) {
+            if ($response instanceof Response && Vite::preloadedAssets() !== []) {
                 $response->header('Link', Collection::make(Vite::preloadedAssets())
                     ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
                     ->join(', '));

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class VitePreloadingTest extends TestCase
 {
@@ -20,7 +21,7 @@ class VitePreloadingTest extends TestCase
 
     public function testItDoesNotSetLinkTagWhenNoTagsHaveBeenPreloaded()
     {
-        $app = new Container();
+        $app = new Container;
         $app->instance(Vite::class, new class extends Vite
         {
             protected $preloadedAssets = [];
@@ -36,7 +37,7 @@ class VitePreloadingTest extends TestCase
 
     public function testItAddsPreloadLinkHeader()
     {
-        $app = new Container();
+        $app = new Container;
         $app->instance(Vite::class, new class extends Vite
         {
             protected $preloadedAssets = [
@@ -56,5 +57,26 @@ class VitePreloadingTest extends TestCase
             $response->headers->get('Link'),
             '<https://laravel.com/app.js>; rel="modulepreload"; foo="bar"'
         );
+    }
+
+    public function testItDoesNotAttachHeadersToNonIlluminateResponses()
+    {
+        $app = new Container;
+        $app->instance(Vite::class, new class extends Vite
+        {
+            protected $preloadedAssets = [
+                'https://laravel.com/app.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+            ];
+        });
+        Facade::setFacadeApplication($app);
+
+        $response = (new AddLinkHeadersForPreloadedAssets)->handle(new Request, function () {
+            return new SymfonyResponse('Hello Laravel');
+        });
+
+        $this->assertNull($response->headers->get('Link'));
     }
 }


### PR DESCRIPTION
The base symfony response does not have the `header` method. This can cause issues when you are returning a download, which uses the `Symfony\Component\HttpFoundation\BinaryFileResponse` class.

I think we can safely only attach the Vite headers to Illuminate responses considering this is the first report of the issue.

fixes https://github.com/laravel/framework/issues/52784