### PR TITLE
[11.x] Allow `BackedEnum` to be passed to `Route::can()` 

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1081,12 +1081,14 @@ class Route
     /**
      * Specify that the "Authorize" / "can" middleware should be applied to the route with the given options.
      *
-     * @param  string  $ability
+     * @param  \BackedEnum|string  $ability
      * @param  array|string  $models
      * @return $this
      */
     public function can($ability, $models = [])
     {
+        $ability = $ability instanceof BackedEnum ? $ability->value : $ability;
+
         return empty($models)
                     ? $this->middleware(['can:'.$ability])
                     : $this->middleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);

--- a/tests/Integration/Routing/AbilityBackedEnum.php
+++ b/tests/Integration/Routing/AbilityBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+enum AbilityBackedEnum: string
+{
+    case AccessRoute = 'access-route';
+    case NotAccessRoute = 'not-access-route';
+}

--- a/tests/Integration/Routing/RouteCanBackedEnumTest.php
+++ b/tests/Integration/Routing/RouteCanBackedEnumTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use User;
+
+class RouteCanBackedEnumTest extends TestCase
+{
+    public function testSimpleRouteWithStringBackedEnumCanAbilityGuestForbiddenThroughTheFramework()
+    {
+        $gate = Gate::define(AbilityBackedEnum::NotAccessRoute, fn (?User $user) => false);
+        $this->assertArrayHasKey('not-access-route', $gate->abilities());
+
+        $route = Route::get('/', function () {
+            return 'Hello World';
+        })->can(AbilityBackedEnum::NotAccessRoute);
+        $this->assertEquals(['can:not-access-route'], $route->middleware());
+
+        $response = $this->get('/');
+        $response->assertForbidden();
+    }
+
+    public function testSimpleRouteWithStringBackedEnumCanAbilityGuestAllowedThroughTheFramework()
+    {
+        $gate = Gate::define(AbilityBackedEnum::AccessRoute, fn (?User $user) => true);
+        $this->assertArrayHasKey('access-route', $gate->abilities());
+
+        $route = Route::get('/', function () {
+            return 'Hello World';
+        })->can(AbilityBackedEnum::AccessRoute);
+        $this->assertEquals(['can:access-route'], $route->middleware());
+
+        $response = $this->get('/');
+        $response->assertOk();
+        $response->assertContent('Hello World');
+    }
+}


### PR DESCRIPTION
Hi,

Like the recently merged #52677 and #52679 using enums improves code readability, maintainability and reduces the hassle of using string values within the code itself.

This PR proposes to add BackedEnum support to the `can` method on `\Illuminate\Routing\Route`, allowing to use it inline for simple routing.

```php
Route::post('/request', function () {...})->can(Permissions::CAN_REQUEST);
```

This PR is backward compatible and shouldn't bring any breaking changes.