### PR TITLE
[11.x] Fixes `config:cache` command detects incorrect custom environment file

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -12,6 +12,11 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 class LoadEnvironmentVariables
 {
     /**
+     * The externally provided APP_ENV environment variable.
+     */
+    protected static ?string $externallyProvidedAppEnv = null;
+
+    /**
      * Bootstrap the given application.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -46,7 +51,7 @@ class LoadEnvironmentVariables
             return;
         }
 
-        $environment = Env::get('APP_ENV');
+        $environment = self::getExternallyProvidedAppEnv();
 
         if (! $environment) {
             return;
@@ -106,5 +111,21 @@ class LoadEnvironmentVariables
         http_response_code(500);
 
         exit(1);
+    }
+
+    /**
+     * Get the APP_ENV environment variable that is provided externally.
+     *
+     * Purely externally provided variables can only be retrieved
+     * before Dotenv is loaded, so the second and subsequent bootstrap processes
+     * reuse the values retrieved the first time.
+     */
+    protected static function getExternallyProvidedAppEnv(): string
+    {
+        if (self::$externallyProvidedAppEnv === null) {
+            self::$externallyProvidedAppEnv = Env::get('APP_ENV', '');
+        }
+
+        return self::$externallyProvidedAppEnv;
     }
 }

--- a/tests/Foundation/fixtures/.env.idempotence
+++ b/tests/Foundation/fixtures/.env.idempotence
@@ -1,0 +1,2 @@
+APP_ENV=baz
+FOO=BAR

--- a/tests/Foundation/fixtures/.env.idempotence.baz
+++ b/tests/Foundation/fixtures/.env.idempotence.baz
@@ -1,0 +1,2 @@
+APP_ENV=baz
+FOO=BAZ


### PR DESCRIPTION
The artisan config:cache command genarate incorrect configuration values under certain conditions.

Under the following conditions, the values set in the .env file are expected to be used, but the artisan config:cache command outputs the settings derived from the .env.[APP_ENV] file to the cache file.

1. there is an .env.[APP_ENV] file with the same extension as the APP_ENV value set in the .env file
2. no APP_ENV environment variable is provided externally.

The reason for this is that the getFreshConfiguration() method in the artisan config:cache command, the second application bootstrap process is executed, but the LoadEnvironmentVariables bootstrap process does not take into account multiple executions and takes the value of APP_ENV from the dotenv generated in the first run.

Purely externally provided variables can only be retrieved before loading dotenv.
In this fix, on the second and subsequent bootstrap processes reuse the values retrieved the first time.