### PR TITLE
[11.x] Ensure `withoutPretending` method properly resets state after callback execution

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -672,11 +672,11 @@ class Connection implements ConnectionInterface
 
         $this->pretending = false;
 
-        $result = $callback();
-
-        $this->pretending = true;
-
-        return $result;
+        try {
+            return $callback();
+        } finally {
+            $this->pretending = true;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adjusts the `withoutPretending` method to ensure that the `$pretending` state is always reset to true after the provided callback executes, even if an exception is thrown.

The change uses a `try/finally` block to guarantee the state is correctly restored after execution. This prevents unintended behavior in scenarios where exceptions occur.