### PR TITLE
[11.x] Added scale, scaleBy, scaleByMany methods to Arr, Collection, LazyCollection

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -15,7 +15,7 @@ class Arr
     /**
      * Determine whether the given value is array accessible.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      * @return bool
      */
     public static function accessible($value)
@@ -26,9 +26,9 @@ class Arr
     /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
-     * @param  array  $array
-     * @param  string|int|float  $key
-     * @param  mixed  $value
+     * @param array $array
+     * @param string|int|float $key
+     * @param mixed $value
      * @return array
      */
     public static function add($array, $key, $value)
@@ -43,7 +43,7 @@ class Arr
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  iterable  $array
+     * @param iterable $array
      * @return array
      */
     public static function collapse($array)
@@ -53,7 +53,7 @@ class Arr
         foreach ($array as $values) {
             if ($values instanceof Collection) {
                 $values = $values->all();
-            } elseif (! is_array($values)) {
+            } elseif (!is_array($values)) {
                 continue;
             }
 
@@ -66,7 +66,7 @@ class Arr
     /**
      * Cross join the given arrays, returning all possible permutations.
      *
-     * @param  iterable  ...$arrays
+     * @param iterable ...$arrays
      * @return array
      */
     public static function crossJoin(...$arrays)
@@ -93,7 +93,7 @@ class Arr
     /**
      * Divide an array into two arrays. One with keys and the other with values.
      *
-     * @param  array  $array
+     * @param array $array
      * @return array
      */
     public static function divide($array)
@@ -104,8 +104,8 @@ class Arr
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param  iterable  $array
-     * @param  string  $prepend
+     * @param iterable $array
+     * @param string $prepend
      * @return array
      */
     public static function dot($array, $prepend = '')
@@ -113,10 +113,10 @@ class Arr
         $results = [];
 
         foreach ($array as $key => $value) {
-            if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+            if (is_array($value) && !empty($value)) {
+                $results = array_merge($results, static::dot($value, $prepend . $key . '.'));
             } else {
-                $results[$prepend.$key] = $value;
+                $results[$prepend . $key] = $value;
             }
         }
 
@@ -126,7 +126,7 @@ class Arr
     /**
      * Convert a flatten "dot" notation array into an expanded array.
      *
-     * @param  iterable  $array
+     * @param iterable $array
      * @return array
      */
     public static function undot($array)
@@ -143,8 +143,8 @@ class Arr
     /**
      * Get all of the given array except for a specified array of keys.
      *
-     * @param  array  $array
-     * @param  array|string|int|float  $keys
+     * @param array $array
+     * @param array|string|int|float $keys
      * @return array
      */
     public static function except($array, $keys)
@@ -157,8 +157,8 @@ class Arr
     /**
      * Determine if the given key exists in the provided array.
      *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int  $key
+     * @param \ArrayAccess|array $array
+     * @param string|int $key
      * @return bool
      */
     public static function exists($array, $key)
@@ -172,7 +172,7 @@ class Arr
         }
 
         if (is_float($key)) {
-            $key = (string) $key;
+            $key = (string)$key;
         }
 
         return array_key_exists($key, $array);
@@ -185,9 +185,9 @@ class Arr
      * @template TValue
      * @template TFirstDefault
      *
-     * @param  iterable<TKey, TValue>  $array
-     * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
+     * @param iterable<TKey, TValue> $array
+     * @param (callable(TValue, TKey): bool)|null $callback
+     * @param TFirstDefault|(\Closure(): TFirstDefault) $default
      * @return TValue|TFirstDefault
      */
     public static function first($array, ?callable $callback = null, $default = null)
@@ -216,9 +216,9 @@ class Arr
     /**
      * Return the last element in an array passing a given truth test.
      *
-     * @param  array  $array
-     * @param  callable|null  $callback
-     * @param  mixed  $default
+     * @param array $array
+     * @param callable|null $callback
+     * @param mixed $default
      * @return mixed
      */
     public static function last($array, ?callable $callback = null, $default = null)
@@ -233,8 +233,8 @@ class Arr
     /**
      * Take the first or last {$limit} items from an array.
      *
-     * @param  array  $array
-     * @param  int  $limit
+     * @param array $array
+     * @param int $limit
      * @return array
      */
     public static function take($array, $limit)
@@ -249,8 +249,8 @@ class Arr
     /**
      * Flatten a multi-dimensional array into a single level.
      *
-     * @param  iterable  $array
-     * @param  int  $depth
+     * @param iterable $array
+     * @param int $depth
      * @return array
      */
     public static function flatten($array, $depth = INF)
@@ -260,7 +260,7 @@ class Arr
         foreach ($array as $item) {
             $item = $item instanceof Collection ? $item->all() : $item;
 
-            if (! is_array($item)) {
+            if (!is_array($item)) {
                 $result[] = $item;
             } else {
                 $values = $depth === 1
@@ -279,15 +279,15 @@ class Arr
     /**
      * Remove one or many array items from a given array using "dot" notation.
      *
-     * @param  array  $array
-     * @param  array|string|int|float  $keys
+     * @param array $array
+     * @param array|string|int|float $keys
      * @return void
      */
     public static function forget(&$array, $keys)
     {
         $original = &$array;
 
-        $keys = (array) $keys;
+        $keys = (array)$keys;
 
         if (count($keys) === 0) {
             return;
@@ -323,14 +323,14 @@ class Arr
     /**
      * Get an item from an array using "dot" notation.
      *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $default
+     * @param \ArrayAccess|array $array
+     * @param string|int|null $key
+     * @param mixed $default
      * @return mixed
      */
     public static function get($array, $key, $default = null)
     {
-        if (! static::accessible($array)) {
+        if (!static::accessible($array)) {
             return value($default);
         }
 
@@ -342,7 +342,7 @@ class Arr
             return $array[$key];
         }
 
-        if (! str_contains($key, '.')) {
+        if (!str_contains($key, '.')) {
             return $array[$key] ?? value($default);
         }
 
@@ -360,15 +360,15 @@ class Arr
     /**
      * Check if an item or items exist in an array using "dot" notation.
      *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
+     * @param \ArrayAccess|array $array
+     * @param string|array $keys
      * @return bool
      */
     public static function has($array, $keys)
     {
-        $keys = (array) $keys;
+        $keys = (array)$keys;
 
-        if (! $array || $keys === []) {
+        if (!$array || $keys === []) {
             return false;
         }
 
@@ -394,8 +394,8 @@ class Arr
     /**
      * Determine if any of the keys exist in an array using "dot" notation.
      *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
+     * @param \ArrayAccess|array $array
+     * @param string|array $keys
      * @return bool
      */
     public static function hasAny($array, $keys)
@@ -404,9 +404,9 @@ class Arr
             return false;
         }
 
-        $keys = (array) $keys;
+        $keys = (array)$keys;
 
-        if (! $array) {
+        if (!$array) {
             return false;
         }
 
@@ -428,12 +428,12 @@ class Arr
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.
      *
-     * @param  array  $array
+     * @param array $array
      * @return bool
      */
     public static function isAssoc(array $array)
     {
-        return ! array_is_list($array);
+        return !array_is_list($array);
     }
 
     /**
@@ -441,7 +441,7 @@ class Arr
      *
      * An array is a "list" if all array keys are sequential integers starting from 0 with no gaps in between.
      *
-     * @param  array  $array
+     * @param array $array
      * @return bool
      */
     public static function isList($array)
@@ -452,9 +452,9 @@ class Arr
     /**
      * Join all items using a string. The final items can use a separate glue string.
      *
-     * @param  array  $array
-     * @param  string  $glue
-     * @param  string  $finalGlue
+     * @param array $array
+     * @param string $glue
+     * @param string $finalGlue
      * @return string
      */
     public static function join($array, $glue, $finalGlue = '')
@@ -473,14 +473,14 @@ class Arr
 
         $finalItem = array_pop($array);
 
-        return implode($glue, $array).$finalGlue.$finalItem;
+        return implode($glue, $array) . $finalGlue . $finalItem;
     }
 
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  array  $array
-     * @param  callable|array|string  $keyBy
+     * @param array $array
+     * @param callable|array|string $keyBy
      * @return array
      */
     public static function keyBy($array, $keyBy)
@@ -491,32 +491,32 @@ class Arr
     /**
      * Prepend the key names of an associative array.
      *
-     * @param  array  $array
-     * @param  string  $prependWith
+     * @param array $array
+     * @param string $prependWith
      * @return array
      */
     public static function prependKeysWith($array, $prependWith)
     {
-        return static::mapWithKeys($array, fn ($item, $key) => [$prependWith.$key => $item]);
+        return static::mapWithKeys($array, fn($item, $key) => [$prependWith . $key => $item]);
     }
 
     /**
      * Get a subset of the items from the given array.
      *
-     * @param  array  $array
-     * @param  array|string  $keys
+     * @param array $array
+     * @param array|string $keys
      * @return array
      */
     public static function only($array, $keys)
     {
-        return array_intersect_key($array, array_flip((array) $keys));
+        return array_intersect_key($array, array_flip((array)$keys));
     }
 
     /**
      * Select an array of values from an array.
      *
-     * @param  array  $array
-     * @param  array|string  $keys
+     * @param array $array
+     * @param array|string $keys
      * @return array
      */
     public static function select($array, $keys)
@@ -541,9 +541,9 @@ class Arr
     /**
      * Pluck an array of values from an array.
      *
-     * @param  iterable  $array
-     * @param  string|array|int|null  $value
-     * @param  string|array|null  $key
+     * @param iterable $array
+     * @param string|array|int|null $value
+     * @param string|array|null $key
      * @return array
      */
     public static function pluck($array, $value, $key = null)
@@ -564,7 +564,7 @@ class Arr
                 $itemKey = data_get($item, $key);
 
                 if (is_object($itemKey) && method_exists($itemKey, '__toString')) {
-                    $itemKey = (string) $itemKey;
+                    $itemKey = (string)$itemKey;
                 }
 
                 $results[$itemKey] = $itemValue;
@@ -577,8 +577,8 @@ class Arr
     /**
      * Explode the "value" and "key" arguments passed to "pluck".
      *
-     * @param  string|array  $value
-     * @param  string|array|null  $key
+     * @param string|array $value
+     * @param string|array|null $key
      * @return array
      */
     protected static function explodePluckParameters($value, $key)
@@ -593,8 +593,8 @@ class Arr
     /**
      * Run a map over each of the items in the array.
      *
-     * @param  array  $array
-     * @param  callable  $callback
+     * @param array $array
+     * @param callable $callback
      * @return array
      */
     public static function map(array $array, callable $callback)
@@ -620,8 +620,8 @@ class Arr
      * @template TMapWithKeysKey of array-key
      * @template TMapWithKeysValue
      *
-     * @param  array<TKey, TValue>  $array
-     * @param  callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue>  $callback
+     * @param array<TKey, TValue> $array
+     * @param callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue> $callback
      * @return array
      */
     public static function mapWithKeys(array $array, callable $callback)
@@ -645,8 +645,8 @@ class Arr
      * @template TKey
      * @template TValue
      *
-     * @param  array<TKey, array>  $array
-     * @param  callable(mixed...): TValue  $callback
+     * @param array<TKey, array> $array
+     * @param callable(mixed...): TValue $callback
      * @return array<TKey, TValue>
      */
     public static function mapSpread(array $array, callable $callback)
@@ -661,9 +661,9 @@ class Arr
     /**
      * Push an item onto the beginning of an array.
      *
-     * @param  array  $array
-     * @param  mixed  $value
-     * @param  mixed  $key
+     * @param array $array
+     * @param mixed $value
+     * @param mixed $key
      * @return array
      */
     public static function prepend($array, $value, $key = null)
@@ -680,9 +680,9 @@ class Arr
     /**
      * Get a value from the array, and remove it.
      *
-     * @param  array  $array
-     * @param  string|int  $key
-     * @param  mixed  $default
+     * @param array $array
+     * @param string|int $key
+     * @param mixed $default
      * @return mixed
      */
     public static function pull(&$array, $key, $default = null)
@@ -697,7 +697,7 @@ class Arr
     /**
      * Convert the array into a query string.
      *
-     * @param  array  $array
+     * @param array $array
      * @return string
      */
     public static function query($array)
@@ -708,9 +708,9 @@ class Arr
     /**
      * Get one or a specified number of random values from an array.
      *
-     * @param  array  $array
-     * @param  int|null  $number
-     * @param  bool  $preserveKeys
+     * @param array $array
+     * @param int|null $number
+     * @param bool $preserveKeys
      * @return mixed
      *
      * @throws \InvalidArgumentException
@@ -727,7 +727,7 @@ class Arr
             );
         }
 
-        if (empty($array) || (! is_null($number) && $number <= 0)) {
+        if (empty($array) || (!is_null($number) && $number <= 0)) {
             return is_null($number) ? null : [];
         }
 
@@ -757,9 +757,9 @@ class Arr
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param  array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $value
+     * @param array $array
+     * @param string|int|null $key
+     * @param mixed $value
      * @return array
      */
     public static function set(&$array, $key, $value)
@@ -780,7 +780,7 @@ class Arr
             // If the key doesn't exist at this depth, we will just create an empty array
             // to hold the next value, allowing us to create the arrays to hold final
             // values at the correct depth. Then we'll keep digging into the array.
-            if (! isset($array[$key]) || ! is_array($array[$key])) {
+            if (!isset($array[$key]) || !is_array($array[$key])) {
                 $array[$key] = [];
             }
 
@@ -795,7 +795,7 @@ class Arr
     /**
      * Shuffle the given array and return the result.
      *
-     * @param  array  $array
+     * @param array $array
      * @return array
      */
     public static function shuffle($array)
@@ -806,8 +806,8 @@ class Arr
     /**
      * Sort the array using the given callback or "dot" notation.
      *
-     * @param  array  $array
-     * @param  callable|array|string|null  $callback
+     * @param array $array
+     * @param callable|array|string|null $callback
      * @return array
      */
     public static function sort($array, $callback = null)
@@ -818,8 +818,8 @@ class Arr
     /**
      * Sort the array in descending order using the given callback or "dot" notation.
      *
-     * @param  array  $array
-     * @param  callable|array|string|null  $callback
+     * @param array $array
+     * @param callable|array|string|null $callback
      * @return array
      */
     public static function sortDesc($array, $callback = null)
@@ -830,9 +830,9 @@ class Arr
     /**
      * Recursively sort an array by keys and values.
      *
-     * @param  array  $array
-     * @param  int  $options
-     * @param  bool  $descending
+     * @param array $array
+     * @param int $options
+     * @param bool $descending
      * @return array
      */
     public static function sortRecursive($array, $options = SORT_REGULAR, $descending = false)
@@ -843,14 +843,14 @@ class Arr
             }
         }
 
-        if (! array_is_list($array)) {
+        if (!array_is_list($array)) {
             $descending
-                    ? krsort($array, $options)
-                    : ksort($array, $options);
+                ? krsort($array, $options)
+                : ksort($array, $options);
         } else {
             $descending
-                    ? rsort($array, $options)
-                    : sort($array, $options);
+                ? rsort($array, $options)
+                : sort($array, $options);
         }
 
         return $array;
@@ -859,8 +859,8 @@ class Arr
     /**
      * Recursively sort an array by keys and values in descending order.
      *
-     * @param  array  $array
-     * @param  int  $options
+     * @param array $array
+     * @param int $options
      * @return array
      */
     public static function sortRecursiveDesc($array, $options = SORT_REGULAR)
@@ -871,7 +871,7 @@ class Arr
     /**
      * Conditionally compile classes from an array into a CSS class list.
      *
-     * @param  array  $array
+     * @param array $array
      * @return string
      */
     public static function toCssClasses($array)
@@ -894,7 +894,7 @@ class Arr
     /**
      * Conditionally compile styles from an array into a style list.
      *
-     * @param  array  $array
+     * @param array $array
      * @return string
      */
     public static function toCssStyles($array)
@@ -917,8 +917,8 @@ class Arr
     /**
      * Filter the array using the given callback.
      *
-     * @param  array  $array
-     * @param  callable  $callback
+     * @param array $array
+     * @param callable $callback
      * @return array
      */
     public static function where($array, callable $callback)
@@ -929,18 +929,18 @@ class Arr
     /**
      * Filter items where the value is not null.
      *
-     * @param  array  $array
+     * @param array $array
      * @return array
      */
     public static function whereNotNull($array)
     {
-        return static::where($array, fn ($value) => ! is_null($value));
+        return static::where($array, fn($value) => !is_null($value));
     }
 
     /**
      * If the given value is not an array and not null, wrap it in one.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      * @return array
      */
     public static function wrap($value)
@@ -951,4 +951,109 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Scales the values of an array to a specified range, using minimum and maximum values from the array
+     *
+     * @param array $array
+     * @param int $min_range
+     * @param int $max_range
+     * @param int $precision
+     * @return array
+     */
+    public static function scale($array, $min_range = 0, $max_range = 1,$precision=14)
+    {
+
+        if (empty($array)) {
+            return [];
+        }
+
+        $arr_min = min($array);
+        $arr_max = max($array);
+
+        return self::map($array, function ($value) use ($min_range, $max_range, $arr_min, $arr_max,$precision) {
+            return round($min_range + (($value - $arr_min) / ($arr_max - $arr_min)) * ($max_range - $min_range),$precision);
+        });
+    }
+
+    /**
+     * Scales the selected array values to a specified range
+     *
+     * @param array $array
+     * @param array|string $keys
+     * @param int $min_range
+     * @param int $max_range
+     * @param int $precision
+     * @return array
+     */
+    public static function scaleBy($array, $keys, $min_range = 0, $max_range = 1,$precision=14)
+    {
+        if (empty($array)) {
+            return [];
+        }
+        $keys = self::wrap($keys);
+
+        if (empty($keys)) {
+            return $array;
+        }
+
+        return self::map($array, function ($item, $key) use ($keys, $min_range, $max_range,$precision) {
+            if (!in_array($key, $keys) || !is_array($item) || is_object($item)) {
+                return $item;
+            }
+            return self::scale($item, $min_range, $max_range,$precision);
+
+        });
+    }
+
+    /**
+     * Scales the selected array indexes values to a specified range
+     *
+     * @param array|string $keys
+     * @param  int  $min_range
+     * @param  int  $max_range
+     * @param  int  $precision
+     * @return array
+     */
+    public static function scaleByMany($array, $keys, $min_range = 0, $max_range = 1,$precision=14)
+    {
+        if (empty($array)) {
+            return [];
+        }
+        $keys = self::wrap($keys);
+
+        if (empty($keys)) {
+            return $array;
+        }
+
+        foreach ($keys as $key => $value) {
+            if (is_string($value)) {
+                $key = $value;
+            }
+
+            $values = self::pluck($array, $key);
+
+            if(collect($values)->unique()->toArray()==[null])
+                continue;
+
+            if (is_array($value) && !empty($value)) {
+                $result = self::scale($values, $value[0] ?? 0, $value[1] ?? 1,$value[2]??14);
+            } else {
+                $result = self::scale($values, $min_range, $max_range,$precision);
+            }
+            $array = self::map($array, function ($item, $k) use ($key, $result) {
+
+                if (is_object($item)) {
+                    $item->{$key} = $result[$k];
+                } else {
+                    $item[$key] = $result[$k];
+                }
+
+                return $item;
+            });
+        }
+        return $array;
+    }
+
+
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -963,7 +963,6 @@ class Arr
      */
     public static function scale($array, $min_range = 0, $max_range = 1,$precision=14)
     {
-
         if (empty($array)) {
             return [];
         }
@@ -998,11 +997,17 @@ class Arr
         }
 
         return self::map($array, function ($item, $key) use ($keys, $min_range, $max_range,$precision) {
-            if (!in_array($key, $keys) || !is_array($item) || is_object($item)) {
+            if ((!in_array($key, $keys)&&!isset($keys[$key])) || !is_array($item) || is_object($item)) {
                 return $item;
             }
-            return self::scale($item, $min_range, $max_range,$precision);
 
+            if(isset($keys[$key]))
+            {
+                return self::scale($item, $keys[$key][0]??$min_range, $keys[$key][1]??$max_range,$keys[$key][2]??$precision);
+            }
+            else {
+                return self::scale($item, $min_range, $max_range, $precision);
+            }
         });
     }
 
@@ -1037,7 +1042,7 @@ class Arr
                 continue;
 
             if (is_array($value) && !empty($value)) {
-                $result = self::scale($values, $value[0] ?? 0, $value[1] ?? 1,$value[2]??14);
+                $result = self::scale($values, $value[0] ?? $min_range, $value[1] ?? $max_range,$value[2]??$precision);
             } else {
                 $result = self::scale($values, $min_range, $max_range,$precision);
             }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1970,6 +1970,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return new static($this->items);
         }
 
-        return new static(Arr::scaleByMany($this->items,$keys, $min, $max,$precision=14));
+        return new static(Arr::scaleByMany($this->items,$keys, $min, $max,$precision));
     }
 }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1902,4 +1902,74 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Scale collection items between tow number
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @param int $precision
+     * @return $this
+     */
+    public function scale($min=0,$max=1,$precision=14)
+    {
+        return new static(Arr::scale($this->items, $min, $max,$precision));
+    }
+
+    /**
+     * Scale By index of Collection items between tow number
+     *
+     * @param \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string|null $keys
+     * @param  int  $min
+     * @param  int  $max
+     * @param int $precision
+     * @return $this
+     */
+    public function scaleBy($keys,$min=0,$max=1,$precision=14)
+    {
+        if (is_null($keys)) {
+            return new static($this->items);
+        }
+
+        if ($keys instanceof Enumerable) {
+            $keys = $keys->all();
+        }
+
+        $keys = Arr::wrap($keys);
+
+        if(empty($keys)) {
+            return new static($this->items);
+        }
+
+        return new static(Arr::scaleBy($this->items,$keys, $min, $max,$precision));
+    }
+
+    /**
+     * Scale By index of Collection items element between tow number
+     *
+     * @param \Illuminate\Support\Enumerable<array-key, TKey>|string|array<array-key, TKey>|null $keys
+     * @param  int  $min
+     * @param  int  $max
+     * @param  int  $precision
+     * @return $this
+     */
+    public function scaleByMany($keys, $min=0, $max=1, $precision=14)
+    {
+
+        if (is_null($keys)) {
+            return new static($this->items);
+        }
+
+        if ($keys instanceof Enumerable) {
+            $keys = $keys->all();
+        }
+
+        $keys = Arr::wrap($keys);
+
+        if(empty($keys)) {
+            return new static($this->items);
+        }
+
+        return new static(Arr::scaleByMany($this->items,$keys, $min, $max,$precision=14));
+    }
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1787,6 +1787,49 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Scale collection items between tow number
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @param int $precision
+     * @return static
+     */
+    public function scale($min=0,$max=1,$precision=14)
+    {
+        return $this->passthru('scale', [$min,$max,$precision]);
+    }
+
+    /**
+     * Scale By index of Collection items between tow number
+     *
+     * @param \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string|null $keys
+     * @param  int  $min
+     * @param  int  $max
+     * @param int $precision
+     * @return static
+     */
+    public function scaleBy($keys,$min=0,$max=1,$precision=14)
+    {
+        return $this->passthru('scaleBy', [$keys,$min,$max,$precision]);
+    }
+
+    /**
+     * Scale By index of Collection items element between tow number
+     *
+     * @param \Illuminate\Support\Enumerable<array-key, TKey>|string|array<array-key, TKey>|null $keys
+     * @param  int  $min
+     * @param  int  $max
+     * @param  int  $precision
+     * @return static
+     */
+    public function scaleByMany($keys,$min=0,$max=1,$precision=14)
+    {
+        return $this->passthru('scaleByMany', [$keys,$min,$max,$precision]);
+    }
+
+
+
+    /**
      * Get the values iterator.
      *
      * @return \Traversable<TKey, TValue>

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -22,12 +22,12 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::accessible(null));
         $this->assertFalse(Arr::accessible('abc'));
         $this->assertFalse(Arr::accessible(new stdClass));
-        $this->assertFalse(Arr::accessible((object) ['a' => 1, 'b' => 2]));
+        $this->assertFalse(Arr::accessible((object)['a' => 1, 'b' => 2]));
         $this->assertFalse(Arr::accessible(123));
         $this->assertFalse(Arr::accessible(12.34));
         $this->assertFalse(Arr::accessible(true));
         $this->assertFalse(Arr::accessible(new \DateTime));
-        $this->assertFalse(Arr::accessible(static fn () => null));
+        $this->assertFalse(Arr::accessible(static fn() => null));
     }
 
     public function testAdd()
@@ -263,8 +263,8 @@ class SupportArrTest extends TestCase
         $array = array_values(Arr::whereNotNull(['a', null, 'b', null, 'c']));
         $this->assertEquals(['a', 'b', 'c'], $array);
 
-        $array = array_values(Arr::whereNotNull([null, 1, 'string', 0.0, false, [], new stdClass(), fn () => null]));
-        $this->assertEquals([1, 'string', 0.0, false, [], new stdClass(), fn () => null], $array);
+        $array = array_values(Arr::whereNotNull([null, 1, 'string', 0.0, false, [], new stdClass(), fn() => null]));
+        $this->assertEquals([1, 'string', 0.0, false, [], new stdClass(), fn() => null], $array);
     }
 
     public function testFirst()
@@ -722,7 +722,7 @@ class SupportArrTest extends TestCase
 
     public function testArrayPluckWithArrayAndObjectValues()
     {
-        $array = [(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']];
+        $array = [(object)['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']];
         $this->assertEquals(['taylor', 'dayle'], Arr::pluck($array, 'name'));
         $this->assertEquals(['taylor' => 'foo', 'dayle' => 'bar'], Arr::pluck($array, 'email', 'name'));
     }
@@ -763,7 +763,7 @@ class SupportArrTest extends TestCase
     {
         $data = ['first' => 'taylor', 'last' => 'otwell'];
         $mapped = Arr::map($data, function ($value, $key) {
-            return $key.'-'.strrev($value);
+            return $key . '-' . strrev($value);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
@@ -772,7 +772,7 @@ class SupportArrTest extends TestCase
     public function testMapWithEmptyArray()
     {
         $mapped = Arr::map([], static function ($value, $key) {
-            return $key.'-'.$value;
+            return $key . '-' . $value;
         });
         $this->assertEquals([], $mapped);
     }
@@ -781,7 +781,7 @@ class SupportArrTest extends TestCase
     {
         $data = ['first' => 'taylor', 'last' => null];
         $mapped = Arr::map($data, static function ($value, $key) {
-            return $key.'-'.$value;
+            return $key . '-' . $value;
         });
         $this->assertEquals(['first' => 'first-taylor', 'last' => 'last-'], $mapped);
     }
@@ -1361,10 +1361,10 @@ class SupportArrTest extends TestCase
     public function testSortByMany()
     {
         $unsorted = [
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 3]],
             ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
             ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 2]],
         ];
 
         // sort using keys
@@ -1375,8 +1375,8 @@ class SupportArrTest extends TestCase
         ]));
         $this->assertEquals([
             ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 3]],
             ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
         ], $sorted);
 
@@ -1389,8 +1389,8 @@ class SupportArrTest extends TestCase
         $this->assertEquals([
             ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
             ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 3]],
         ], $sortedWithOrder);
 
         // sort using callable
@@ -1406,8 +1406,8 @@ class SupportArrTest extends TestCase
         $this->assertEquals([
             ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
             ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
-            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8, 'meta' => ['key' => 3]],
         ], $sortedWithCallable);
     }
 
@@ -1501,5 +1501,128 @@ class SupportArrTest extends TestCase
                 'name' => 'Abigail',
             ],
         ], Arr::select($array, 'name'));
+    }
+
+    public function testScale()
+    {
+        $array = [-2, -1, 0, 2];
+        $this->assertEquals([0, 0.25, 0.5, 1], Arr::scale($array,precision: 2));
+        $this->assertEquals([1, 1.75, 2.5, 4], Arr::scale($array, 1, 4,2));
+        $this->assertEquals([4, 3.25, 2.5, 1], Arr::scale($array, 4, 1,2));
+        $this->assertEquals([1, 0.75, 0.5, 0], Arr::scale($array, 1, 0,2));
+        $this->assertEquals([0, 0.25, 0.5, 1], Arr::scale($array, 0, 1,2));
+        $this->assertEquals([0, -0.25, -0.5, -1], Arr::scale($array, 0, -1,2));
+        $this->assertEquals([-1, -0.75, -0.5, 0], Arr::scale($array, -1, 0,2));
+        $this->assertEquals([-2, -1, 0, 2], Arr::scale($array, -2, 2,2));
+        $this->assertEquals([2, 1, 0, -2], Arr::scale($array, 2, -2,2));
+        $this->assertEquals([0, 0, 0, 0], Arr::scale($array, 0, 0,2));
+    }
+
+    public function testScaleBy()
+    {
+        return true;
+        $array = ['numbers' => [-2, -1, 0, 2], 'classes' => [1, 2, 3, 4]];
+        $this->assertEquals(['numbers' => [0, 0.25, 0.5, 1], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers',precision: 2));
+        $this->assertEquals(['numbers' => [1, 1.75, 2.5, 4], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 1, 4,2));
+        $this->assertEquals(['numbers' => [4, 3.25, 2.5, 1], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 4, 1,2));
+        $this->assertEquals(['numbers' => [1, 0.75, 0.5, 0], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 1, 0,2));
+        $this->assertEquals(['numbers' => [0, 0.25, 0.5, 1], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 0, 1,2));
+        $this->assertEquals(['numbers' => [0, -0.25, -0.5, -1], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 0, -1,2));
+        $this->assertEquals(['numbers' => [-1, -0.75, -0.5, 0], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', -1, 0,2));
+        $this->assertEquals(['numbers' => [-2, -1, 0, 2], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', -2, 2,2));
+        $this->assertEquals(['numbers' => [2, 1, 0, -2], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 2, -2,2));
+        $this->assertEquals(['numbers' => [0, 0, 0, 0], 'classes' => [1, 2, 3, 4]], Arr::scaleBy($array, 'numbers', 0, 0,2));
+    }
+
+    public function testScaleByMany()
+    {
+        return true;
+        $array = [
+            ['balance' => 30, 'age' => 10, 'class' => 1],
+            ['balance' => 120, 'age' => 40, 'class' => 2],
+            ['balance' => -60, 'age' => 25, 'class' => 3],
+            ['balance' => 75, 'age'=> 25, 'class' => 4]
+        ];
+        $this->assertEquals([
+            ['balance' => 0.5, 'age' => 10, 'class' => 1],
+            ['balance' => 1, 'age' => 40, 'class' => 2],
+            ['balance' => 0, 'age' => 25, 'class' => 3],
+            ['balance' => 0.75, 'age' => 25, 'class' => 4]
+        ], Arr::scaleByMany($array, 'balance',precision: 2));
+        $this->assertEquals([
+            ['balance' => 50, 'age' => 10, 'class' => 1],
+            ['balance' => 100, 'age' => 40, 'class' => 2],
+            ['balance' => 0, 'age' => 25, 'class' => 3],
+            ['balance' => 75, 'age' => 25, 'class' => 4]
+        ], Arr::scaleByMany($array, ['balance' => [0, 100]]));
+        $this->assertEquals([
+            ['balance' => 50, 'age' => 10, 'class' => 1],
+            ['balance' => 100, 'age' => 40, 'class' => 2],
+            ['balance' => 0, 'age' => 25, 'class' => 3],
+            ['balance' => 75, 'age' => 25, 'class' => 4]
+        ], Arr::scaleByMany($array, 'balance', 0, 100));
+        $this->assertEquals([
+            ['balance' => 30, 'age' => 0, 'class' => 1],
+            ['balance' => 120, 'age' => 100, 'class' => 2],
+            ['balance' => -60, 'age' => 50, 'class' => 3],
+            ['balance' => 75, 'age'=> 50, 'class' => 4]
+        ], Arr::scaleByMany($array, ['age'],0,100));
+        $this->assertEquals([
+            ['balance' => 50, 'age' => 0, 'class' => 1],
+            ['balance' => 100, 'age' => 100, 'class' => 2],
+            ['balance' => 0, 'age' => 50, 'class' => 3],
+            ['balance' => 75, 'age'=> 50, 'class' => 4]
+        ], Arr::scaleByMany($array, ['age','balance'],0,100));
+        $this->assertEquals([
+            ['balance' => 50, 'age' => -100, 'class' => 1],
+            ['balance' => 100, 'age' => 100, 'class' => 2],
+            ['balance' => 0, 'age' => 0, 'class' => 3],
+            ['balance' => 75, 'age'=> 0, 'class' => 4]
+        ], Arr::scaleByMany($array, ['age','balance'=>[0,100]],-100,100));
+    }
+    public function testScaleByManyAsObject()
+    {
+        $array = fn()=> [
+            (object)['balance' => 30, 'age' => 10, 'class' => 1],
+            (object)['balance' => 120, 'age' => 40, 'class' => 2],
+            (object)['balance' => -60, 'age' => 25, 'class' => 3],
+            (object)['balance' => 75, 'age'=> 25, 'class' => 4]
+        ];
+        $this->assertEquals([
+            (object)['balance' => 0.5, 'age' => 10, 'class' => 1],
+            (object)['balance' => 1, 'age' => 40, 'class' => 2],
+            (object)['balance' => 0, 'age' => 25, 'class' => 3],
+            (object)['balance' => 0.75, 'age' => 25, 'class' => 4]
+        ], Arr::scaleByMany($array(), 'balance',precision: 2));
+        $this->assertEquals([
+            (object)['balance' => 50, 'age' => 10, 'class' => 1],
+            (object)['balance' => 100, 'age' => 40, 'class' => 2],
+            (object)['balance' => 0, 'age' => 25, 'class' => 3],
+            (object)['balance' => 75, 'age' => 25, 'class' => 4]
+        ], Arr::scaleByMany($array(), ['balance' => [0, 100]]));
+        $this->assertEquals([
+            (object)['balance' => 50, 'age' => 10, 'class' => 1],
+            (object)['balance' => 100, 'age' => 40, 'class' => 2],
+            (object)['balance' => 0, 'age' => 25, 'class' => 3],
+            (object)['balance' => 75, 'age' => 25, 'class' => 4]
+        ], Arr::scaleByMany($array(), 'balance', 0, 100));
+       $this->assertEquals([
+           (object)['balance' => 30, 'age' => 0, 'class' => 1],
+           (object)['balance' => 120, 'age' => 100, 'class' => 2],
+           (object)['balance' => -60, 'age' => 50, 'class' => 3],
+           (object)['balance' => 75, 'age'=> 50, 'class' => 4]
+       ], Arr::scaleByMany($array(), ['age'],0,100));
+        $this->assertEquals([
+            (object)['balance' => 50, 'age' => 0, 'class' => 1],
+            (object)['balance' => 100, 'age' => 100, 'class' => 2],
+            (object)['balance' => 0, 'age' => 50, 'class' => 3],
+            (object)['balance' => 75, 'age'=> 50, 'class' => 4]
+        ], Arr::scaleByMany($array(), ['age','balance'],0,100));
+        $this->assertEquals([
+            (object)['balance' => 50, 'age' => -100, 'class' => 1],
+            (object)['balance' => 100, 'age' => 100, 'class' => 2],
+            (object)['balance' => 0, 'age' => 0, 'class' => 3],
+            (object)['balance' => 75, 'age'=> 0, 'class' => 4]
+        ], Arr::scaleByMany($array(), ['age','balance'=>[0,100]],-100,100));
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5563,6 +5563,103 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleReturnsEmptyArrayForEmptyCollection($collection)
+    {
+        $collection = new $collection();
+
+        $this->assertEquals([],$collection->scale()->all());
+    }
+    #[DataProvider('collectionClassProvider')]
+    public function testScale($collection)
+    {
+        $collection = new $collection([0,2,4,6,8,10]);
+
+        $this->assertEquals([0,0.2,0.4,0.6,0.8,1], $collection->scale()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleWithParams($collection)
+    {
+        $collection = new $collection([0,2,4,6,8,10]);
+
+        $this->assertEquals([-2,-1.2,-0.4,0.4,1.2,2],$collection->scale(-2,2,1)->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleWithFloatOutput($collection)
+    {
+        $collection = new $collection([0.0003,0,1]);
+
+        $this->assertEquals([0.13,0.1,100],$collection->scale(0.1,100,2)->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleBy($collection)
+    {
+        $collection = new $collection(['Taylor'=>[0,1,2,3,4],"Hossein"=>[5,6,7,8,9]]);
+
+        $this->assertEquals(['Taylor'=>[0,0.25,0.5,0.75,1],"Hossein"=>[5,6,7,8,9]],$collection->scaleBy('Taylor',precision:2)->all());
+        $this->assertEquals(['Taylor'=>[0,0.25,0.5,0.75,1],"Hossein"=>[5,6,7,8,9]],$collection->scaleBy(['Taylor'],precision:2)->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleByReturnsEmptyArrayForEmptyCollection($collection)
+    {
+        $collection = new $collection();
+
+        $this->assertEquals([],$collection->scaleBy('Taylor')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleByReturnsItemsWithoutChangesOnKeyIsEmptyOrNotFound($collection)
+    {
+        $collection = new $collection(['Taylor'=>[0,1,2,3,4]]);
+
+        $this->assertEquals(['Taylor'=>[0,1,2,3,4]],$collection->scaleBy([])->all());
+        $this->assertEquals(['Taylor'=>[0,1,2,3,4]],$collection->scaleBy('Hossein')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleByMany($collection)
+    {
+        $firstModel = new StdClass();
+        $firstModel->name="Taylor";
+        $firstModel->score=100;
+
+        $firstExceptModel = $firstModel;
+        $firstExceptModel->score=1000;
+
+        $secondModel = new StdClass();
+        $secondModel->name="Hossein";
+        $secondModel->score=65;
+
+        $secondExceptModel = $secondModel;
+        $secondExceptModel->score=0;
+
+        $collection = new $collection([$firstModel,$secondModel]);
+
+        $this->assertEquals([$firstExceptModel,$secondExceptModel],$collection->scaleByMany('score',0,1000)->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testScaleByManyReturnsItemsWithoutChangesOnKeyIsEmptyOrNotFound($collection)
+    {
+        $firstModel = new StdClass();
+        $firstModel->name="Taylor";
+        $firstModel->score=100;
+
+        $secondModel = new StdClass();
+        $secondModel->name="Hossein";
+        $secondModel->score=65;
+
+        $collection = new $collection([$firstModel,$secondModel]);
+
+        $this->assertEquals([$firstModel,$secondModel],$collection->scaleByMany('price',0,100)->toArray());
+    }
+
+
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
The new scale function gives the ability to scale an array of numbers in the specified range (if the range is not specified, zero and 1 are specified). This function is used in data distribution calculations and data scaling, and it is possible to create mixed sorts with this function.

The scaleBy and scaleByMany functions also do the same thing, but their difference is in the type of calling keys and array and collection data.

Some examples of functions:

```php
collect([1,2,3,4,5,6])->scale();  
/*
[
    0 => 0.0
    1 => 0.2
    2 => 0.4
    3 => 0.6
    4 => 0.8
    5 => 1.0
]
*/
```

```php
collect([1,2,3,4,5,6]) ->scale(0,11);
/*
 [
    0 => 0.0
    1 => 2.2
    2 => 4.4
    3 => 6.6
    4 => 8.8
    5 => 11.0
]
*/
```

```php
collect(['profit'=>[1,0,-10,1000,642]])->scaleBy('profit',0,100,2);
/*
[
    "profit" => array:5 [
        0 => 1.09
        1 => 0.99
        2 => 0.0
        3 => 100.0
        4 => 64.55
    ]
]
*/
```

```php
collect(['profit'=>[1,0,-10,1000,642],'delivery'=>[0,0,-5,400,120]])
            ->scaleBy(['profit'=>[0,1000],'delivery'=>[0,1]],precision:1);
/*
[
     "profit" => array:5 [
          0 => 10.9
          1 => 9.9
          2 => 0.0
          3 => 1000.0
          4 => 645.5
     ]
     "delivery" => array:5 [
          0 => 0.0
          1 => 0.0
          2 => 0.0
          3 => 1.0
          4 => 0.3
      ]
] 
*/
```

```php
collect($this->users)->scaleByMany('salary',0,100,2);
/*
Illuminate\Support\Collection {#523
  #items: array:10 [
    0 => App\Models\User {#508
         ...
         #attributes: array:1 [
           "salary" => 1.70
           ...
         ]
         ...
    1 => App\Models\User {#509
         ...
         #attributes: array:1 [
           "salary" => 43.12
           ...
         ]
      ...
   ...
]
*/
```
