### PR TITLE
[11.x] add nullOnUpdate() method to ForeignKeyDefinition

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -45,6 +45,16 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
+     * Indicate that updates should set the foreign key value to null.
+     *
+     * @return $this
+     */
+    public function nullOnUpdate()
+    {
+        return $this->onUpdate('set null');
+    }
+
+    /**
      * Indicate that deletes should cascade.
      *
      * @return $this

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -35,16 +35,6 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
-     * Indicate that updates should have "no action".
-     *
-     * @return $this
-     */
-    public function noActionOnUpdate()
-    {
-        return $this->onUpdate('no action');
-    }
-
-    /**
      * Indicate that updates should set the foreign key value to null.
      *
      * @return $this
@@ -52,6 +42,16 @@ class ForeignKeyDefinition extends Fluent
     public function nullOnUpdate()
     {
         return $this->onUpdate('set null');
+    }
+
+    /**
+     * Indicate that updates should have "no action".
+     *
+     * @return $this
+     */
+    public function noActionOnUpdate()
+    {
+        return $this->onUpdate('no action');
     }
 
     /**


### PR DESCRIPTION
### Summary:
This PR introduces the `nullOnUpdate()` method to the `ForeignKeyDefinition` class. This method allows for setting the foreign key value to `null` when the referenced record is updated.

### Usage:
```php
$table->foreign('user_id')
      ->references('id')
      ->on('users')
      ->nullOnUpdate();