### PR TITLE
[11.x] Implement CacheCleared and CacheClearing events for cache repository

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Cache\Console;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Events\CacheCleared;
+use Illuminate\Cache\Events\CacheClearing;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -62,8 +64,17 @@ class ClearCommand extends Command
      */
     public function handle()
     {
+        /*
+         * Keep both events for backwards compatibility?
+         * Remove old event only with Laravel 12?
+         * Don't add new event = inconsistent?
+         * */
         $this->laravel['events']->dispatch(
             'cache:clearing', [$this->argument('store'), $this->tags()]
+        );
+
+        $this->laravel['events']->dispatch(
+            CacheClearing::class, [$this->argument('store'), $this->tags()]
         );
 
         $successful = $this->cache()->flush();
@@ -76,6 +87,10 @@ class ClearCommand extends Command
 
         $this->laravel['events']->dispatch(
             'cache:cleared', [$this->argument('store'), $this->tags()]
+        );
+
+        $this->laravel['events']->dispatch(
+            CacheCleared::class, [$this->argument('store'), $this->tags()]
         );
 
         $this->components->info('Application cache cleared successfully.');

--- a/src/Illuminate/Cache/Events/CacheCleared.php
+++ b/src/Illuminate/Cache/Events/CacheCleared.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheCleared extends CacheEvent
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @param  string  $key
+     */
+    public function __construct($storeName,$key = '*')
+    {
+        parent::__construct($storeName,$key);
+    }
+}

--- a/src/Illuminate/Cache/Events/CacheCleared.php
+++ b/src/Illuminate/Cache/Events/CacheCleared.php
@@ -10,8 +10,8 @@ class CacheCleared extends CacheEvent
      * @param  string|null  $storeName
      * @param  string  $key
      */
-    public function __construct($storeName,$key = '*')
+    public function __construct($storeName, $key = '*')
     {
-        parent::__construct($storeName,$key);
+        parent::__construct($storeName, $key);
     }
 }

--- a/src/Illuminate/Cache/Events/CacheClearing.php
+++ b/src/Illuminate/Cache/Events/CacheClearing.php
@@ -10,8 +10,8 @@ class CacheClearing extends CacheEvent
      * @param  string|null  $storeName
      * @param  string  $key
      */
-    public function __construct($storeName,$key = '*')
+    public function __construct($storeName, $key = '*')
     {
-        parent::__construct($storeName,$key);
+        parent::__construct($storeName, $key);
     }
 }

--- a/src/Illuminate/Cache/Events/CacheClearing.php
+++ b/src/Illuminate/Cache/Events/CacheClearing.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheClearing extends CacheEvent
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @param  string  $key
+     */
+    public function __construct($storeName,$key = '*')
+    {
+        parent::__construct($storeName,$key);
+    }
+}

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -583,7 +583,7 @@ class Repository implements ArrayAccess, CacheContract
     public function clear(): bool
     {
         $this->event(new CacheClearing($this->getName()));
-        $flush =  $this->store->flush();
+        $flush = $this->store->flush();
         $this->event(new CacheCleared($this->getName()));
         return $flush;
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -6,6 +6,8 @@ use ArrayAccess;
 use BadMethodCallException;
 use Closure;
 use DateTimeInterface;
+use Illuminate\Cache\Events\CacheCleared;
+use Illuminate\Cache\Events\CacheClearing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -580,7 +582,10 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function clear(): bool
     {
-        return $this->store->flush();
+        $this->event(new CacheClearing($this->getName()));
+        $flush =  $this->store->flush();
+        $this->event(new CacheCleared($this->getName()));
+        return $flush;
     }
 
     /**


### PR DESCRIPTION
During the development of a package I noticed that there is no possibility to keep certain keys despite cache()->clear();.
With these events you could keep certain variables in the cache even if it is completely deleted.

I have extended the class as with the other CacheEvents and thus I had to set $key = ‘*’

There is a problem with backwards compatibility if I also use the event with the cache:clear command. I have written 3 lines of comments about this.

```PHP
public function handle(CacheClearing $event): void
{
    $foo = cache()->get(‘foo’);
    Event::listen(CacheCleared::class, function (CacheCleared $event)use($foo) {
        cache()->put(‘foo’,$foo);
    });
}
```

With this function you can create the following functionality

```PHP
cache()->put("foo", "value");
cache()->put("bar", "value");
cache()->clear();
cache()->get("foo"); // "value"
cache()->get("bar"); // null
```

I am looking forward to your feedback and your help to integrate this function because unfortunately I don't know how to write tests for these functions in Laravel style