### PR TITLE
[11.x] Add prependLocation method to View Factory

### DIFF
--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -18,6 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasRenderedOnce(string $id)
  * @method static void markAsRenderedOnce(string $id)
  * @method static void addLocation(string $location)
+ * @method static void prependLocation(string $location)
  * @method static \Illuminate\View\Factory addNamespace(string $namespace, string|array $hints)
  * @method static \Illuminate\View\Factory prependNamespace(string $namespace, string|array $hints)
  * @method static \Illuminate\View\Factory replaceNamespace(string $namespace, string|array $hints)

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -425,6 +425,17 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Prepend a location to the array of view locations.
+     *
+     * @param  string  $location
+     * @return void
+     */
+    public function prependLocation($location)
+    {
+        $this->finder->prependLocation($location);
+    }
+
+    /**
      * Add a new namespace to the loader.
      *
      * @param  string  $namespace


### PR DESCRIPTION
This PR adds the `prependLocation` method to the View Factory.
This is useful if you want to prepend paths using the View Facade.

## Before
use Illuminate\Support\Facades\View;
![2024-09-16_16h55_23](https://github.com/user-attachments/assets/db1037c9-f334-4747-a30c-6adb519a7777)

## After
![2024-09-16_16h56_39](https://github.com/user-attachments/assets/6c70be6c-2595-4379-ac33-6e675a8f5cb8)


`Illuminate\View\ViewFinderInterface` doesn't have `prependLocation`. However, I'll leave it as is since adding it could be a breaking change if someone implements it.
