### PR TITLE
[11.x] delegate `ProcessDriver@defer()` to `ProcessDriver@run()` method

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -59,20 +59,7 @@ class ProcessDriver implements Driver
      */
     public function defer(Closure|array $tasks): DeferredCallback
     {
-        $php = $this->phpBinary();
-        $artisan = $this->artisanBinary();
-
-        return defer(function () use ($tasks, $php, $artisan) {
-            foreach (Arr::wrap($tasks) as $task) {
-                $this->processFactory->path(base_path())->env([
-                    'LARAVEL_INVOKABLE_CLOSURE' => serialize(new SerializableClosure($task)),
-                ])->run([
-                    $php,
-                    $artisan,
-                    'invoke-serialized-closure 2>&1 &',
-                ]);
-            }
-        });
+        return defer(fn () => $this->run($tasks));
     }
 
     /**


### PR DESCRIPTION
Closes #52790

Current implementation of `ProcessDriver::defer()` includes output redirection and background on the command array:

https://github.com/laravel/framework/blob/05d920410e58f04b13dcaa83937b9d4574fc9b3f/src/Illuminate/Concurrency/ProcessDriver.php#L60-L76

This ends building up this command line:

```bash
"/usr/bin/php" "artisan" "invoke-serialized-closure 2>&1 &"
```

As the third-part is quoted, when building the command, Artisan ends up looking for a command called literally `invoke-serialized-closure 2>&1 &`, including the `2>&1 &` as the command name, which it fails to find.

This PR

- Delegates the `ProcessDriver@defer()` to use the `ProcessDriver@run()` method
- Same approach is used by the `ForkDriver`:
  
  https://github.com/laravel/framework/blob/05d920410e58f04b13dcaa83937b9d4574fc9b3f/src/Illuminate/Concurrency/ForkDriver.php#L25-L28
  
- I chose this approach as, from the method's docblock description, and from previous implementation (the `&` at the end), the deferred tasks should be run in the background and thus the implementation would be almost the same as the `ProcessDriver::run()` method (minus the output processing).


No tests were added, as this is not dependent on user's parameters, and I have no idea how to write a test to prevent it from happening in the future.