### PR TITLE
[11.x] Remove a unused import and fix docblock for DeferredCallbackCollection

### DIFF
--- a/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Defer;
 use ArrayAccess;
 use Closure;
 use Countable;
-use Illuminate\Support\Collection;
 
 class DeferredCallbackCollection implements ArrayAccess, Countable
 {
@@ -39,7 +38,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     /**
      * Invoke the deferred callbacks if the given truth test evaluates to true.
      *
-     * @param  \Closure  $when
+     * @param  \Closure|null  $when
      * @return void
      */
     public function invokeWhen(?Closure $when = null): void


### PR DESCRIPTION
As what I mention in the title.
- `Illuminate\Support\Collection` is imported but not to be used, so I remove it.
- The `$when` parameter of the `invokeWhen` method can also be a null value, so it should be `\Closure|null`.