### PR TITLE
[11.x] Add getMorphAlias method to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -931,6 +932,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function loadMorphAvg($relation, $relations, $column)
     {
         return $this->loadMorphAggregate($relation, $relations, $column, 'avg');
+    }
+
+    /**
+     * Get the actual class name for a given morph class.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    public static function getMorphAlias()
+    {
+        return Relation::getMorphAlias(static::class);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -479,6 +479,23 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertFalse($relation->is($model));
     }
 
+    public function testGetMorphAlias()
+    {
+        // Clear any existing morph maps
+        Relation::morphMap([], false);
+
+        // Define a morph map
+        Relation::morphMap([
+            'test_get_morph_alias' => EloquentMorphResetModelStub::class,
+        ]);
+
+        // Assert that getMorphAlias returns the correct alias
+        $this->assertSame('test_get_morph_alias', EloquentMorphResetModelStub::getMorphAlias());
+
+        // Clean up after test
+        Relation::morphMap([], false);
+    }
+
     protected function getOneRelation()
     {
         $queryBuilder = m::mock(QueryBuilder::class);


### PR DESCRIPTION
This PR introduces a new static method `getMorphAlias()` to the `Illuminate\Database\Eloquent\Model` class. This method provides a convenient way to retrieve the morph alias for a model, as registered in the morph map.

**Background:**

In polymorphic relationships, morph maps allow developers to map aliases to model classes, simplifying references and improving code readability. However, retrieving the alias for a given model class wasn't straightforward. This addition aims to fill that gap.

**Usage Example:**

```php
use Illuminate\Database\Eloquent\Relations\Relation;

// Define morph map
Relation::morphMap([
    'user' => User::class,
]);

// Retrieve morph alias
$alias = User::getMorphAlias(); // Returns 'user'