### PR TITLE
Add `cancel` abilities to Deferred Callbacks

### DIFF
--- a/src/Illuminate/Foundation/Defer/DeferredCallback.php
+++ b/src/Illuminate/Foundation/Defer/DeferredCallback.php
@@ -7,6 +7,35 @@ use Illuminate\Support\Str;
 class DeferredCallback
 {
     /**
+     * Define whether the defer callback has been cancelled.
+     *
+     * @var bool
+     */
+    protected bool $cancelled = false;
+
+    /**
+     * Cancels a deferred callback.
+     *
+     * @return $this
+     */
+    public function cancel(): self
+    {
+        $this->cancelled = true;
+
+        return $this;
+    }
+
+    /**
+     * Indicate whether the deferred callback has been cancelled or not.
+     *
+     * @return bool
+     */
+    public function isCancelled(): bool
+    {
+        return $this->cancelled;
+    }
+
+    /**
      * Create a new deferred callback instance.
      *
      * @param  callable  $callback
@@ -50,6 +79,8 @@ class DeferredCallback
      */
     public function __invoke(): void
     {
-        call_user_func($this->callback);
+        if (! $this->cancelled) {
+            call_user_func($this->callback);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
@@ -26,6 +26,16 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     }
 
     /**
+     * Get all the deferred callbacks registered.
+     *
+     * @return array
+     */
+    public function all(): array
+    {
+        return $this->callbacks;
+    }
+
+    /**
      * Cancels an existing deferred function by its name.
      *
      * @param  string  $name

--- a/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
@@ -26,6 +26,22 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     }
 
     /**
+     * Cancels an existing deferred function by its name
+     *
+     * @param string $name
+     * @return void
+     */
+    public function cancel(string $name): void
+    {
+        foreach ($this->callbacks as $callback) {
+            if ($callback->name === $name) {
+                $callback->cancel();
+                break;
+            }
+        }
+    }
+
+    /**
      * Invoke the deferred callbacks.
      *
      * @return void
@@ -48,7 +64,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
         $this->forgetDuplicates();
 
         foreach ($this->callbacks as $index => $callback) {
-            if ($when($callback)) {
+            if (! $callback->isCancelled() && $when($callback)) {
                 rescue($callback);
             }
 

--- a/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
@@ -28,8 +28,8 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     /**
      * Cancels an existing deferred function by its name.
      *
-     * @param   string  $name
-     * @return  void
+     * @param  string  $name
+     * @return void
      */
     public function cancel(string $name): void
     {

--- a/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Foundation/Defer/DeferredCallbackCollection.php
@@ -26,10 +26,10 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     }
 
     /**
-     * Cancels an existing deferred function by its name
+     * Cancels an existing deferred function by its name.
      *
-     * @param string $name
-     * @return void
+     * @param   string  $name
+     * @return  void
      */
     public function cancel(string $name): void
     {

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -198,12 +198,14 @@ class FoundationServiceProvider extends AggregateServiceProvider
         $this->app->scoped(DeferredCallbackCollection::class);
 
         $this->app['events']->listen(function (CommandFinished $event) {
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => app()->runningInConsole() && ($event->exitCode === 0 || $callback->always)
+            app(DeferredCallbackCollection::class)->invokeWhen(
+                fn ($callback) => app()->runningInConsole() && ($event->exitCode === 0 || $callback->always)
             );
         });
 
         $this->app['events']->listen(function (JobAttempted $event) {
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => $event->connectionName !== 'sync' && ($event->successful() || $callback->always)
+            app(DeferredCallbackCollection::class)->invokeWhen(
+                fn ($callback) => $event->connectionName !== 'sync' && ($event->successful() || $callback->always)
             );
         });
     }


### PR DESCRIPTION
> [!NOTE]
> A PR was created with the purpose to mention the `forget` method in the documentation: https://github.com/laravel/docs/pull/9902.

Hello Laravel team,

In this PR I'm adding capabilities to the new `defer()` helper to be cancelled.

### What is `defer()`?

Check this [announcement](https://x.com/taylorotwell/status/1834260396816933365) out.

## Proposed change

Add the ability to cancel deferred callbacks before they are executed. This can be achieved in two ways:

#### Option 1: Cancelling by name

```php
defer(fn() => performTask(), 'task-name');
// Later...
defer()->cancel('task-name');
```

#### Option 2: Cancelling directly

```php
$task = defer(fn() => performTask());
// Later...
$task->cancel();
```


> [!IMPORTANT]  
> I've opened a discussion thread about this topic [here](https://github.com/laravel/framework/discussions/52817).

### Recreation instructions

The best way to recreate this feature is by using routes.

```php
Route::get('/500', function () {
    $a = defer(function () {
        usleep(microseconds: 250000);
        info(message: 'executing defer: a');
    }, name: 'a');

    $b = defer(function () {
        usleep(microseconds: 500000);
        info(message: 'executing defer: b');
    }, name: 'b');

    $c = defer(function () {
        usleep(microseconds: 750000);
        info(message: 'executing defer: c');
    }, name: 'c');

    $d = defer(function () {
        usleep(microseconds: 1000000);
        info(message: 'executing defer: d');
    }, name: 'd');

    $a->always()->cancel('a'); // this cancels $a
    $b->always();
    $c->always();
    $d->always(); // this never got cancelled

    // this cancels $b
    if ( true ) {
        $b->cancel();
    }

    // this cancels $c
    defer()->cancel('c');

    return response([ 'status' => '500'], 500);
});
```

The expected result of the code above is:
<img width="526" alt="image" src="https://github.com/user-attachments/assets/bee0c2ee-18c8-47a7-bbca-8781865a5e51">

### Pending

Depending on the feedback received and whether the community takes this approach positively, I need to complete this feature by adding:

- [x] Code and details about the feature
- [ ] Test cases (?)
- [ ] Documentation

Thanks,
Ronny