### PR TITLE
[11.x] Introducing Artisan `find` Command

### DIFF
--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -24,7 +24,6 @@ class FindCommand extends Command
      */
     protected $description = 'Find an Artisan command.';
 
-
     /**
      * Execute the console command.
      *

--- a/src/Illuminate/Foundation/Console/FindCommand.php
+++ b/src/Illuminate/Foundation/Console/FindCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\suggest;
+
+#[AsCommand(name: 'find')]
+class FindCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'find';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Find an Artisan command.';
+
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $commands = collect(array_keys($this->getApplication()->all()))
+            ->filter(fn (string $command) => $command !== $this->signature)
+            ->values();
+
+        $command = suggest(
+            'Search for a command',
+            options: $commands->toArray(),
+            required: true,
+            hint: 'Type parts of a command name to search for'
+        );
+
+        $this->call($command);
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -54,6 +54,7 @@ use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
+use Illuminate\Foundation\Console\FindCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
@@ -136,6 +137,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,
+        'Find' => FindCommand::class,
         'InvokeSerializedClosure' => InvokeSerializedClosureCommand::class,
         'KeyGenerate' => KeyGenerateCommand::class,
         'Optimize' => OptimizeCommand::class,


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Reason

As the framework grows, it is common for new commands to be added frequently. In Laravel 11, for example, we had the addition of some `make` commands, which ends up **making the output of `php artisan` large.**

As many of you may know, the default terminal scroll has a limit, and without a feature like this, the number of commands can exceed the scroll limit in some time, limiting the visualization.

Therefore, this PR proposes the addition of the `php artisan find` command, which aims to help locate commands for sequential execution.

### Demonstration

![CleanShot 2024-09-17 at 00 02 29](https://github.com/user-attachments/assets/82adc7d3-b097-409a-b049-ae8822b14daf)

### Notes

Another logical benefit, but one that may go unnoticed, is the fact that with the `find` command we will have the possibility to search in all existing commands, not just the native Artisan commands:

1. Horizon commands
![CleanShot 2024-09-17 at 01 22 41](https://github.com/user-attachments/assets/7d64ca4c-c00d-4114-992d-1e3345a55ead)

2. Spatie, Laravel Permission Commands:
![CleanShot 2024-09-17 at 01 24 19](https://github.com/user-attachments/assets/3a0cdd3c-23d9-4f74-ac81-6f6ee0626933)
