### PR TITLE
[11.x] Let logger with replace_placeholders to be tap-able via env

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -63,6 +63,7 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
+            'tap' => array_filter(explode(',', env('LOG_TAPS', ''))),
         ],
 
         'daily' => [
@@ -71,6 +72,7 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+            'tap' => array_filter(explode(',', env('LOG_TAPS', ''))),
         ],
 
         'slack' => [
@@ -80,6 +82,7 @@ return [
             'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
             'level' => env('LOG_LEVEL', 'critical'),
             'replace_placeholders' => true,
+            'tap' => array_filter(explode(',', env('LOG_TAPS', ''))),
         ],
 
         'papertrail' => [
@@ -110,12 +113,14 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
             'replace_placeholders' => true,
+            'tap' => array_filter(explode(',', env('LOG_TAPS', ''))),
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
+            'tap' => array_filter(explode(',', env('LOG_TAPS', ''))),
         ],
 
         'null' => [


### PR DESCRIPTION
Added tap options to driver with `replace_placeholders=true` so the options can be configurable from env. The env should then provide list of `class-string`. 

This is added to make it easier to customize processor & line formatter without importing log config.
