### PR TITLE
[12.x] Add missing provides method to `ParallelTestingServiceProvider`

### DIFF
--- a/src/Illuminate/Testing/ParallelTestingServiceProvider.php
+++ b/src/Illuminate/Testing/ParallelTestingServiceProvider.php
@@ -35,4 +35,14 @@ class ParallelTestingServiceProvider extends ServiceProvider implements Deferrab
             });
         }
     }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [ParallelTesting::class];
+    }
 }


### PR DESCRIPTION
The `ParallelTestingServiceProvider` implements the `DeferrableProvider` interface but is missing the `provides` method. This method is necessary to specify which services the provider offers and to enable deferred loading.