### PR TITLE
[11.x] Add EnumeratesValues::getOrFail

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -307,7 +307,7 @@ trait EnumeratesValues
     /**
      * Get an item from the collection by key or throw an exception if it does not exist.
      *
-     * @param  TKey $key
+     * @param  TKey  $key
      * @return TValue
      *
      * @throws \Illuminate\Support\ItemNotFoundException

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -12,8 +12,10 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
+use Illuminate\Support\ItemNotFoundException;
 use InvalidArgumentException;
 use JsonSerializable;
+use stdClass;
 use Traversable;
 use UnexpectedValueException;
 use UnitEnum;
@@ -300,6 +302,27 @@ trait EnumeratesValues
         }
 
         return $this->every($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
+     * Get an item from the collection by key or throw an exception if it does not exist.
+     *
+     * @param TKey $key
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function getOrFail($key)
+    {
+        $placeholder = new stdClass();
+
+        $item = $this->get($key, $placeholder);
+
+        if ($item === $placeholder) {
+            throw new ItemNotFoundException;
+        }
+
+        return $item;
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -307,7 +307,7 @@ trait EnumeratesValues
     /**
      * Get an item from the collection by key or throw an exception if it does not exist.
      *
-     * @param TKey $key
+     * @param  TKey $key
      * @return TValue
      *
      * @throws \Illuminate\Support\ItemNotFoundException

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5318,6 +5318,16 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testGetOrFail($collection)
+    {
+        $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $this->assertEquals('taylor', $data->getOrFail('name'));
+
+        $this->expectException(ItemNotFoundException::class);
+        $data->getOrFail('age');
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testWhereNull($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
I often write stuff like
```php
$collection->get($key, fn() => throw new ItemNotFoundException);
```

I thought that it would be convenient to have a `getOrFail` method, consistent with `firstOrFail`.
```php
$collection->getOrFail($key);
```

Even if it would be possible to make a macro for that, parameter and return types cannot be determined by PHPStan.