### PR TITLE
[11.x] Improve performance of Redis queue block_for when a worker has multiple queues to service

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -221,11 +221,11 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
-    public function pop($queue = null)
+    public function pop($queue = null, $block = true)
     {
         $this->migrate($prefixed = $this->getQueue($queue));
 
-        [$job, $reserved] = $this->retrieveNextJob($prefixed);
+        [$job, $reserved] = $this->retrieveNextJob($prefixed, $block);
 
         if ($reserved) {
             return new RedisJob(

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -55,6 +55,15 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $migrationBatchSize = -1;
 
     /**
+     * Indicates if a secondary queue had a job available between checks of the primary queue
+     * 
+     * Only applicable when monitoring multiple named queues with a single instance
+     * 
+     * @var bool
+     */
+    protected $secondaryQueueHadJob = false;
+
+    /**
      * Create a new Redis queue instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
@@ -221,13 +230,23 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
-    public function pop($queue = null, $block = true)
+    public function pop($queue = null, $index = 0)
     {
         $this->migrate($prefixed = $this->getQueue($queue));
 
+        $block = ! $this->secondaryQueueHadJob && $index == 0;
+
         [$job, $reserved] = $this->retrieveNextJob($prefixed, $block);
 
+        if($index == 0) {
+            $this->secondaryQueueHadJob = false;
+        }
+
         if ($reserved) {
+            if($index > 0) {
+                $this->secondaryQueueHadJob = true;
+            }
+
             return new RedisJob(
                 $this->container, $this, $job,
                 $reserved, $this->connectionName, $queue ?: $this->default

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -55,10 +55,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $migrationBatchSize = -1;
 
     /**
-     * Indicates if a secondary queue had a job available between checks of the primary queue
-     * 
-     * Only applicable when monitoring multiple named queues with a single instance
-     * 
+     * Indicates if a secondary queue had a job available between checks of the primary queue.
+     *
+     * Only applicable when monitoring multiple named queues with a single instance.
+     *
      * @var bool
      */
     protected $secondaryQueueHadJob = false;
@@ -238,12 +238,12 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
 
         [$job, $reserved] = $this->retrieveNextJob($prefixed, $block);
 
-        if($index == 0) {
+        if ($index == 0) {
             $this->secondaryQueueHadJob = false;
         }
 
         if ($reserved) {
-            if($index > 0) {
+            if ($index > 0) {
                 $this->secondaryQueueHadJob = true;
             }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -353,7 +353,7 @@ class Worker
      */
     protected function getNextJob($connection, $queue)
     {
-        $popJobCallback = function ($queue, $block) use ($connection) {
+        $popJobCallback = function ($queue, $block = true) use ($connection) {
             return $connection->pop($queue, $block);
         };
 
@@ -380,7 +380,7 @@ class Worker
             }
 
             $this->lastJobCycleHadJob = false;
-            
+
         } catch (Throwable $e) {
             $this->exceptions->report($e);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -92,7 +92,7 @@ class Worker
     public $paused = false;
 
     /**
-     * Indicates whether we pulled a job from any queue in the last read cycle
+     * Indicates whether we pulled a job from any queue in the last read cycle.
      * 
      * @var bool
      */
@@ -367,7 +367,7 @@ class Worker
                 );
             }
 
-            foreach (explode(',', $queue) as $index=>$queue) {
+            foreach (explode(',', $queue) as $index => $queue) {
                 $block = ! $this->lastJobCycleHadJob && $index == 0;
 
                 if (! is_null($job = $popJobCallback($queue, $block))) {
@@ -380,7 +380,6 @@ class Worker
             }
 
             $this->lastJobCycleHadJob = false;
-
         } catch (Throwable $e) {
             $this->exceptions->report($e);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -93,7 +93,7 @@ class Worker
 
     /**
      * Indicates whether we pulled a job from any queue in the last read cycle.
-     * 
+     *
      * @var bool
      */
     protected bool $lastJobCycleHadJob = false;


### PR DESCRIPTION
This is a change to attempt to fix/improve https://github.com/laravel/framework/issues/51612

I'm aware this was closed as not a bug, but it is still impacting some people and I believe there is still room for performance improvement here.

The crux of the issue is if you use the redis queue driver with block_for with a worker servicing multiple queues, it will always block for the block_for time before it can get to a job on a secondary (and further) queue. For example - if you configure block_for as 5 and run queue:work with --queue=default,low and are in a situation where you have 0 jobs in default a 100 jobs in low, the current implementation will block on default for 5 seconds each time before it runs a job in low, so we're getting 5 * 100 = 500 seconds of delay while getting through those 100 jobs.

What this change does is track if we had a job to process in our last round of checking the queues and not block in our next check if so. With this, if we got a job from the low queue in our last job round, we will not block on the default queue our next check to remove the delay before getting back to the low queue. If we eventually have no jobs on any queues we will go back to blocking each check. This maintains the efficiency of blocking in most cases without adding a delay if we have jobs to process. This also maintains priority of the default queue - it will still check default first, it just won't block under this condition.

I had to expose the $block out to the Queue\Worker, which I understand is specific to the RedisQueue implementation and not applicable for other connections, however, blocking as a concept is not specific to Redis, it could be applicable for other implementations, so I feel it doesn't muddy the waters.
