### PR TITLE
[11.x] Update Concurrency component's composer dependencies

### DIFF
--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -15,7 +15,10 @@
     ],
     "require": {
         "php": "^8.2",
+        "illuminate/console": "^11.0",
+        "illuminate/contracts": "^11.0",
         "illuminate/process": "^11.0",
+        "illuminate/support": "^11.0",
         "laravel/serializable-closure": "^1.2.2"
     },
     "autoload": {


### PR DESCRIPTION
This PR

- adds missing dependencies to the Concurrency component's `composer.json`

The dependencies are mostly inferred from `illuminate/process`, but as other components do, I added the ones used directly.