### PR TITLE
Add result shorthands for `Process` fakes

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -364,6 +364,10 @@ class PendingProcess
     {
         $result = $fake($this);
 
+        if (is_int($result)) {
+            return (new FakeProcessResult(exitCode: $result))->withCommand($command);
+        }
+
         if (is_string($result) || is_array($result)) {
             return (new FakeProcessResult(output: $result))->withCommand($command);
         }
@@ -373,6 +377,7 @@ class PendingProcess
             $result instanceof FakeProcessResult => $result->withCommand($command),
             $result instanceof FakeProcessDescription => $result->toProcessResult($command),
             $result instanceof FakeProcessSequence => $this->resolveSynchronousFake($command, fn () => $result()),
+            $result instanceof \Throwable => throw $result,
             default => throw new LogicException('Unsupported synchronous process fake result provided.'),
         };
     }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -178,6 +178,16 @@ class ProcessTest extends TestCase
         $this->assertFalse($result->successful());
     }
 
+    public function testProcessFakeExitCodeShorthand()
+    {
+        $factory = new Factory;
+        $factory->fake(['ls -la' => 1]);
+
+        $result = $factory->run('ls -la');
+        $this->assertSame(1, $result->exitCode());
+        $this->assertFalse($result->successful());
+    }
+
     public function testBasicProcessFakeWithCustomOutput()
     {
         $factory = new Factory;
@@ -387,6 +397,18 @@ class ProcessTest extends TestCase
 
         $result = $factory->path(__DIR__)->run($this->ls());
         $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
+    }
+
+    public function testProcessFakeThrowShorthand()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('fake exception message');
+
+        $factory = new Factory;
+
+        $factory->fake(['cat me' => new \RuntimeException('fake exception message')]);
+
+        $factory->run('cat me');
     }
 
     public function testFakeProcessesCanThrow()


### PR DESCRIPTION
This adds two new shorthands for faking process results in tests. The first is a shorthand to simply set the exit code. The second is a shorthand to throw an exception.

```php
Process::fake([
    'php -l script.php' => 255, 
    'cat README.txt' => new \RuntimeException('fake exception message'),
]);
```

Note: while the latter is not common as it is only possible for the underlying Symfony `Process` to throw a `RuntimeException`. This path was hard to test unless a fake process can throw an exception - basically you had to single out the command in a callback, then `throw`. This is cleaner and can be used to test other paths, such as process timeout, etc.