### PR TITLE
Update SerializesCastableAttributes to include array generics

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/SerializesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/SerializesCastableAttributes.php
@@ -12,7 +12,7 @@ interface SerializesCastableAttributes
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
      * @param  mixed  $value
-     * @param  array  $attributes
+     * @param  array<string, mixed>  $attributes
      * @return mixed
      */
     public function serialize(Model $model, string $key, mixed $value, array $attributes);


### PR DESCRIPTION
I tried spinning up a new Laravel project with PHPStan on level 7 and came across this issue. [CastAttributes](https://github.com/laravel/framework/blob/f243db71351433dd5050c1a3b445be7fcf156c52/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php#L19) already has the array generics for instance.