### PR TITLE
[11.x] Unless helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -255,3 +255,22 @@ if (! function_exists('when')) {
         return value($default, $condition);
     }
 }
+
+if (! function_exists('unless')) {
+    /**
+     * Return a value if the given condition is false.
+     *
+     * @param  mixed  $condition
+     * @param  \Closure|mixed  $value
+     * @param  \Closure|mixed  $default
+     * @return mixed
+     */
+    function unless($condition, $value, $default = null)
+    {
+        if (! $condition) {
+            return value($value, $condition);
+        }
+
+        return value($default, $condition);
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -122,6 +122,28 @@ class SupportHelpersTest extends TestCase
         $this->assertTrue(when(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
     }
 
+    public function testUnless()
+    {
+        $this->assertEquals('Hello', unless(false, 'Hello'));
+        $this->assertNull(unless(true, 'Hello'));
+        $this->assertEquals('There', unless(1 !== 1, 'There')); // strict types
+        $this->assertEquals('There', unless(1 != '1', 'There')); // loose types
+        $this->assertNull(unless(1 != 2, 'There'));
+        $this->assertNull(unless('1', fn() => null));
+        $this->assertNull(unless(0, fn() => null));
+        $this->assertEquals('True', unless(![1, 2, 3, 4], 'True')); // Array
+        $this->assertNull(unless(![], 'True')); // Empty Array = Falsy
+        $this->assertEquals('True', unless(!new StdClass, fn() => 'True')); // Object
+        $this->assertEquals('World', unless(true, 'Hello', 'World'));
+        $this->assertEquals('World', unless(1 !== 0, 'Hello', 'World')); // strict types
+        $this->assertEquals('World', unless(1 != '0', 'Hello', 'World')); // loose types
+        $this->assertNull(unless('1', fn() => 'There', fn() => null));
+        $this->assertNull(unless(1, fn() => 'There', fn() => null));
+        $this->assertEquals('False', unless(![], 'True', 'False'));  // Empty Array = Falsy
+        $this->assertFalse(unless(false, fn($value) => $value, fn($value) => ! $value)); // lazy evaluation
+        $this->assertFalse(unless(true, fn($value) => $value, fn($value) => ! $value)); // lazy evaluation
+    }
+
     public function testFilled()
     {
         $this->assertFalse(filled(null));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -129,19 +129,19 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('There', unless(1 !== 1, 'There')); // strict types
         $this->assertEquals('There', unless(1 != '1', 'There')); // loose types
         $this->assertNull(unless(1 != 2, 'There'));
-        $this->assertNull(unless('1', fn() => null));
-        $this->assertNull(unless(0, fn() => null));
-        $this->assertEquals('True', unless(![1, 2, 3, 4], 'True')); // Array
-        $this->assertNull(unless(![], 'True')); // Empty Array = Falsy
-        $this->assertEquals('True', unless(!new StdClass, fn() => 'True')); // Object
+        $this->assertNull(unless('1', fn () => null));
+        $this->assertNull(unless(0, fn () => null));
+        $this->assertEquals('True', unless(! [1, 2, 3, 4], 'True')); // Array
+        $this->assertNull(unless(! [], 'True')); // Empty Array = Falsy
+        $this->assertEquals('True', unless(! new StdClass, fn () => 'True')); // Object
         $this->assertEquals('World', unless(true, 'Hello', 'World'));
         $this->assertEquals('World', unless(1 !== 0, 'Hello', 'World')); // strict types
         $this->assertEquals('World', unless(1 != '0', 'Hello', 'World')); // loose types
-        $this->assertNull(unless('1', fn() => 'There', fn() => null));
-        $this->assertNull(unless(1, fn() => 'There', fn() => null));
-        $this->assertEquals('False', unless(![], 'True', 'False'));  // Empty Array = Falsy
-        $this->assertFalse(unless(false, fn($value) => $value, fn($value) => ! $value)); // lazy evaluation
-        $this->assertFalse(unless(true, fn($value) => $value, fn($value) => ! $value)); // lazy evaluation
+        $this->assertNull(unless('1', fn () => 'There', fn () => null));
+        $this->assertNull(unless(1, fn () => 'There', fn () => null));
+        $this->assertEquals('False', unless(! [], 'True', 'False'));  // Empty Array = Falsy
+        $this->assertFalse(unless(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
+        $this->assertFalse(unless(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
     }
 
     public function testFilled()


### PR DESCRIPTION
### Add `unless()` Helper Function

This PR introduces a new `unless()` helper function to provide a more expressive alternative to conditional logic in Laravel. The `unless()` function complements the existing `when()` function by handling the inverse logic, allowing developers to execute a given callback or return a value **if** the condition evaluates to `false`.

#### Example Usage:
```php
$result = unless(false, 'Hello'); // returns 'Hello'
$result = unless(true, 'Hello', 'World'); // returns 'World'
```
