### PR TITLE
[11.x] Support `Model::class` Table Discovery in Migrations Schema

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
@@ -577,6 +578,10 @@ class Builder
         $prefix = $this->connection->getConfig('prefix_indexes')
                     ? $this->connection->getConfig('prefix')
                     : '';
+
+        if (class_exists($table) && $table instanceof Model) {
+            $table = (new $table)->getTable();
+        }
 
         if (isset($this->resolver)) {
             return call_user_func($this->resolver, $table, $callback, $prefix);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR consists of adding the same support we have for test stuff like:

```php
$this->assertDatabaseHas(User::class, [...]);

$this->assertDatabaseMissing(User::class, [...]);

$this->assertDatabaseEmpty(User::class);

$this->assertDatabaseCount(User::class, 1);
```

... but thinking about migrations, making possible things like:

```php
Schema::table(User::class, function (Blueprint $table) {
    /* ... */
});
```

**The main benefit** of this is that it allows us to fix the name of the table defined through the model, which can be reused mainly in the `table` method, making errors related to the table name impossible.