### PR TITLE
[11.x] Assert Not Listening

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void flushMacros()
  * @method static \Illuminate\Support\Testing\Fakes\EventFake except(array|string $eventsToDispatch)
  * @method static void assertListening(string $expectedEvent, string|array $expectedListener)
+ * @method static void assertNotListening(string $expectedEvent, string|array $expectedListener)
  * @method static void assertDispatched(string|\Closure $event, callable|int|null $callback = null)
  * @method static void assertDispatchedTimes(string $event, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $event, callable|null $callback = null)

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Events;
 
 use Closure;
 use Exception;
+use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
@@ -177,6 +178,17 @@ class EventFakeTest extends TestCase
         Event::assertListening('eloquent.saving: '.Post::class, PostObserver::class.'@saving');
         Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
         Event::assertListening('event', InvokableEventSubscriber::class);
+    }
+
+    public function testAssertNotListening()
+    {
+        Event::fake();
+
+        if(app()->isProduction()) {
+            Event::listen(CommandFinished::class, 'logCommandListener');
+        }
+
+        Event::assertNotListening(CommandFinished::class, 'logCommandListener');
     }
 
     public function testMissingMethodsAreForwarded()

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -184,7 +184,7 @@ class EventFakeTest extends TestCase
     {
         Event::fake();
 
-        if(app()->isProduction()) {
+        if (app()->isProduction()) {
             Event::listen(CommandFinished::class, 'logCommandListener');
         }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -88,7 +88,7 @@ class SupportTestingEventFakeTest extends TestCase
     public function testAssertNotListeningWithStringCallback()
     {
         // Case 3: Listener attached as a string with method, should fail
-        $listener = ListenerStub::class . '@handle';
+        $listener = ListenerStub::class.'@handle';
 
         $dispatcher = m::mock(Dispatcher::class);
         $dispatcher->shouldReceive('getListeners')->andReturn([function ($event, $payload) use ($listener) {
@@ -149,7 +149,7 @@ class SupportTestingEventFakeTest extends TestCase
     public function testAssertNotListeningWithMatchingParsedCallback()
     {
         // Case 7: Listener with parsed callback, should fail
-        $listener = ListenerStub::class . '@handle';
+        $listener = ListenerStub::class.'@handle';
 
         $dispatcher = m::mock(Dispatcher::class);
         $dispatcher->shouldReceive('getListeners')->andReturn([function ($event, $payload) use ($listener) {
@@ -159,7 +159,7 @@ class SupportTestingEventFakeTest extends TestCase
         $fake = new EventFake($dispatcher);
 
         $this->expectException(ExpectationFailedException::class);
-        $fake->assertNotListening(EventStub::class, ListenerStub::class . '@handle');
+        $fake->assertNotListening(EventStub::class, ListenerStub::class.'@handle');
     }
 
     public function testAssertDispatchedWithCallbackInt()


### PR DESCRIPTION
This PR introduces a new assertNotListening method to the Event class, allowing developers to assert that an event does not have a listener attached. This is useful when testing scenarios where certain listeners (such as logging or notifications) should be disabled, particularly in testing environments.

Use Case:

In my current app, I need to deactivate listeners for events like CommandFinished during tests to avoid unnecessary log generation. However, without this method, it was difficult to assert that these listeners were not attached in my tests. The existing assertListening method returns void, so it couldn’t be used for such assertions.

Benefits:
- Testing Absence of Listeners: Ensures that certain listeners are not attached during tests, avoiding side effects like unnecessary logging or notifications.
- Improved Test Accuracy: Verifies that event handling is correctly scoped (e.g., listeners active in production but disabled in tests).
- Cleaner Test Output: Prevents unwanted logs or event-driven actions in test environments, leading to clearer and faster tests.

Notes: 
I will write the documentation if it gets merged, and I hope it does, as this would be my first open-source contribution