### PR TITLE
[11.x] Implements route description

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -49,6 +49,13 @@ class Route
     public $action;
 
     /**
+     * The route description.
+     *
+     * @var mixed
+     */
+    public $description;
+
+    /**
      * Indicates whether the route is a fallback route.
      *
      * @var bool
@@ -1029,6 +1036,28 @@ class Route
     public function missing($missing)
     {
         $this->action['missing'] = $missing;
+
+        return $this;
+    }
+
+    /**
+     * Get the description of the route instance.
+     *
+     * @return mixed
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Add or change the route description.
+     *
+     * @param  mixed  $description
+     * @return $this
+     */
+    public function description($description) {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1056,7 +1056,8 @@ class Route
      * @param  mixed  $description
      * @return $this
      */
-    public function description($description) {
+    public function description($description)
+    {
         $this->description = $description;
 
         return $this;

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -96,6 +96,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar name(\BackedEnum|string $value)
  * @method static \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string $prefix)
+ * @method static \Illuminate\Routing\RouteRegistrar description(mixed $description)
  * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1338,6 +1338,14 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
     }
 
+    public function testCanRegisterWithDescription()
+    {
+        $desc = 'User route';
+        $this->router->get('user')->description($desc);
+
+        $this->assertSame($desc, $this->getRoute()->getDescription());
+    }
+
     /**
      * Get the last route registered with the router.
      *


### PR DESCRIPTION
Routes currently supports name actions, that are very handy for call routes using some kind of canonical name, however the names are not very descriptive, so I decided to implement optional description for routes.

Some examples of route description usage are:

```PHP
    Route::get('account/view/{id}', 'BankAccountController@viewAccount')
        ->name('account:view:account')
        ->description('View the bank account for customer %s');

    Route::post('user/secret', 'UserController@storePin')
        ->name('user:set:secret')
        ->description('Set user secret PIN'); 

    Route::post('user/secret', 'TranslationEsController@store')
        ->name('store:spanish:translation')
        ->description([
              'language' => 'spanish',
              'operation' => 'store translation'
              'only' => 'admin'
         ]);
```

The benefits for this feature are:
- Descriptions can be used for log semantic description of an action into a log, user activity, journal, etc.
- Descriptions can be show to end-user in order to help with interaction (Ex: "You cannot set user secret PIN" instead "Unable to perform operation user:set:secret").
- Descriptions accept mixed values like arrays so it can be used in order to pass data directly to the controller.

The implementation of the description is totally innocuous and it doesn't modify the default "Routing" behavior. It's just a getter and setter implementation.

This feature can be easily implemented using macros, so it may have not sense to overload more the framework with extra features. If your feel that this feature is very trivial please close this PR without answer.

Example of this feature implementation using macros:

```PHP
        Route::macro('description', function (string $desc) {
            $this->desc = $desc;
            return $this;
        });

        Route::macro('getDescription', function () {
           return $this->desc ?? null;
        });
```
