### PR TITLE
[11.x] Supports `laravel/prompts` v0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "fruitcake/php-cors": "^1.3",
         "guzzlehttp/guzzle": "^7.8",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.1.18",
+        "laravel/prompts": "^0.1.18|^0.2.0",
         "laravel/serializable-closure": "^1.3",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -21,7 +21,7 @@
         "illuminate/macroable": "^11.0",
         "illuminate/support": "^11.0",
         "illuminate/view": "^11.0",
-        "laravel/prompts": "^0.1.12",
+        "laravel/prompts": "^0.1.18|^0.2.0",
         "nunomaduro/termwind": "^2.0",
         "symfony/console": "^7.0",
         "symfony/polyfill-php83": "^1.28",


### PR DESCRIPTION
Laravel Prompts 0.2.0 was released last week: https://github.com/laravel/prompts/releases/tag/v0.2.0