### PR TITLE
[11.x] Feat: factory generic in make:model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -223,11 +223,9 @@ class ModelMakeCommand extends GeneratorCommand
             $replace["\n    {{ factoryDocBlock }}"] = '';
         }
 
-        $class = str_replace(
+        return str_replace(
             array_keys($replace), array_values($replace), parent::buildClass($name)
         );
-
-        return $class;
     }
 
     /**
@@ -237,11 +235,10 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function buildFactoryReplacements()
     {
-        $factory = Str::studly($this->argument('name')).'Factory';
-        $factoryNameSpace = '\\Database\\Factories\\'.$factory;
+        $factoryNamespace = '\\Database\\Factories\\'.Str::studly($this->argument('name')).'Factory';
 
         return <<<EOT
-        /** @use HasFactory<$factoryNameSpace> */
+        /** @use HasFactory<$factoryNamespace> */
         EOT;
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -206,6 +206,46 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $replace = [];
+
+        if ($this->option('factory')) {
+            $replace["{{ factoryDocBlock }}" ] = $this->buildFactoryReplacements();
+        }else{
+            $replace["\n    {{ factoryDocBlock }}"] = '';
+        }
+
+        $class = str_replace(
+            array_keys($replace), array_values($replace), parent::buildClass($name)
+        );
+
+        return $class;
+    }
+
+    /**
+     * Build the replacements for a factory doc block.
+     *
+     * @return string
+     */
+    protected function buildFactoryReplacements()
+    {
+        $factory = Str::studly($this->argument('name')).'Factory';
+        $factoryNameSpace = '\\Database\\Factories\\'.$factory;
+
+        return <<<EOT
+        /** @use HasFactory<$factoryNameSpace> */
+        EOT;
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -218,8 +218,8 @@ class ModelMakeCommand extends GeneratorCommand
         $replace = [];
 
         if ($this->option('factory')) {
-            $replace["{{ factoryDocBlock }}" ] = $this->buildFactoryReplacements();
-        }else{
+            $replace['{{ factoryDocBlock }}'] = $this->buildFactoryReplacements();
+        } else {
             $replace["\n    {{ factoryDocBlock }}"] = '';
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -229,7 +229,7 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Build the replacements for a factory doc block.
+     * Build the replacements for a factory DocBlock.
      *
      * @return string
      */

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -7,5 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class {{ class }} extends Model
 {
+    {{ factoryDocBlock }}
     use HasFactory;
 }

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -96,6 +96,8 @@ class ModelMakeCommandTest extends TestCase
             'namespace App\Models;',
             'use Illuminate\Database\Eloquent\Model;',
             'class Foo extends Model',
+            '/** @use HasFactory<\Database\Factories\FooFactory> */',
+            'use HasFactory;',
         ], 'app/Models/Foo.php');
 
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -25,6 +25,11 @@ class ModelMakeCommandTest extends TestCase
             'class Foo extends Model',
         ], 'app/Models/Foo.php');
 
+        $this->assertFileDoesNotContains([
+            '{{ factoryDocBlock }}',
+            '/** @use HasFactory<\Database\Factories\FooFactory> */',
+        ], 'app/Models/Foo.php');
+
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');
         $this->assertFilenameNotExists('database/factories/FooFactory.php');
         $this->assertFilenameNotExists('database/seeders/FooSeeder.php');


### PR DESCRIPTION
Based on this [comment](https://github.com/laravel/laravel/pull/6453#issuecomment-2360715808) by @taylorotwell, I have adjusted the `make:model` command to include a factory doc-block.

For example, if I run the following command:

`php artisan make:model Post`

I will get a file with the code below, as it was before:

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Database\Eloquent\Model;

class Post extends Model
{
    use HasFactory;
}
```

However, if I run the following command:

`php artisan make:model Comment -f`

or any other command that generates a factory along with it, the resulting file will contain the code below:

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Database\Eloquent\Model;

class Comment extends Model
{
    /** @use HasFactory<\Database\Factories\CommentFactory> */
    use HasFactory;
}
```