### PR TITLE
[11.x] Adds `@throws` section to Concurrency manager doc block

### DIFF
--- a/src/Illuminate/Concurrency/ConcurrencyManager.php
+++ b/src/Illuminate/Concurrency/ConcurrencyManager.php
@@ -39,6 +39,8 @@ class ConcurrencyManager extends MultipleInstanceManager
      *
      * @param  array  $config
      * @return \Illuminate\Concurrency\ForkDriver
+     *
+     * @throws \RuntimeException
      */
     public function createForkDriver(array $config)
     {


### PR DESCRIPTION
This PR adds exception information to some doc blocks in the Concurrency manager.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
