### PR TITLE
[11.x] Add stringable output to ProcessResult

### DIFF
--- a/src/Illuminate/Contracts/Process/ProcessResult.php
+++ b/src/Illuminate/Contracts/Process/ProcessResult.php
@@ -40,6 +40,13 @@ interface ProcessResult
     public function output();
 
     /**
+     * Get the standard output of the process as Stringable.
+     *
+     * @return \Illuminate\Support\Stringable
+     */
+    public function stringable();
+
+    /**
      * Determine if the output contains the given string.
      *
      * @param  string  $output

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -137,7 +137,9 @@ class FakeProcessResult implements ProcessResultContract
     }
 
     /**
-     * {@inheritdoc}
+     * Get the standard output of the process as Stringable.
+     *
+     * @return \Illuminate\Support\Stringable
      */
     public function stringable()
     {

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -4,6 +4,7 @@ namespace Illuminate\Process;
 
 use Illuminate\Contracts\Process\ProcessResult as ProcessResultContract;
 use Illuminate\Process\Exceptions\ProcessFailedException;
+use Illuminate\Support\Str;
 
 class FakeProcessResult implements ProcessResultContract
 {
@@ -133,6 +134,14 @@ class FakeProcessResult implements ProcessResultContract
     public function output()
     {
         return $this->output;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stringable()
+    {
+        return Str::of($this->output());
     }
 
     /**

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -4,6 +4,7 @@ namespace Illuminate\Process;
 
 use Illuminate\Contracts\Process\ProcessResult as ProcessResultContract;
 use Illuminate\Process\Exceptions\ProcessFailedException;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
 class ProcessResult implements ProcessResultContract
@@ -74,6 +75,14 @@ class ProcessResult implements ProcessResultContract
     public function output()
     {
         return $this->process->getOutput();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stringable()
+    {
+        return Str::of($this->output());
     }
 
     /**

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -78,7 +78,9 @@ class ProcessResult implements ProcessResultContract
     }
 
     /**
-     * {@inheritdoc}
+     * Get the standard output of the process as Stringable.
+     *
+     * @return \Illuminate\Support\Stringable
      */
     public function stringable()
     {

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
+use Illuminate\Support\Stringable;
 use OutOfBoundsException;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
@@ -104,6 +105,15 @@ class ProcessTest extends TestCase
 
         $this->assertTrue(str_contains($pool['first']->output(), 'ProcessTest.php'));
         $this->assertTrue(str_contains($pool['second']->output(), 'ProcessTest.php'));
+    }
+
+    public function testOutputStringable()
+    {
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run($this->ls());
+
+        $this->assertInstanceOf(Stringable::class, $result->stringable());
+        $this->assertEquals($result->output(), $result->stringable()->value());
     }
 
     public function testOutputCanBeRetrievedViaStartCallback()


### PR DESCRIPTION
Hey

im pretty sure @aarondfrancis can tell you why this is cool.

----

Unfortunately `PendingResult` isn't macroable but i think its a common thing to work with the output as a stringable.

Currently you need to write this
```php
Str::of(Process::run('ls -l')->output())->match('/some regex/');
```

With this PR it would be
```php
Process::run('ls -l')->stringable()->match('/some regex/');
```

alternative API
```php
Process::run('ls -l')->output(stringable: true)->match('/some regex/');
```

Cheers
Adrian