### PR TITLE
[11.x] Make `Cache::forget` compatible with `Cache::flexible`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -534,9 +534,10 @@ class Repository implements ArrayAccess, CacheContract
     {
         $this->event(new ForgettingKey($this->getName(), $key));
 
-        if ($this->store->get("{$this->itemKey($key)}:created") !== null) {
-            return $this->forget("{$this->itemKey($key)}:created");
-        }
+        $itemKey = "{$this->itemKey($key)}:created";
+        defer(function () use ($itemKey) {
+            $this->store->forget($itemKey);
+        }, name: "illuminate:cache:forget:flexible:{$key}");
 
         return tap($this->store->forget($this->itemKey($key)), function ($result) use ($key) {
             if ($result) {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -534,6 +534,10 @@ class Repository implements ArrayAccess, CacheContract
     {
         $this->event(new ForgettingKey($this->getName(), $key));
 
+        if ($this->store->get("{$this->itemKey($key)}:created") !== null) {
+            return $this->forget("{$this->itemKey($key)}:created");
+        }
+
         return tap($this->store->forget($this->itemKey($key)), function ($result) use ($key) {
             if ($result) {
                 $this->event(new KeyForgotten($this->getName(), $key));


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/52847

### Current Behavior
The `Cache::flexible` method, which implements the ["stale-while-revalidate"](https://laravel.com/docs/11.x/cache#swr) pattern, currently creates two cache items:

- The main item with the given key
- A metadata item with the key + ":created" suffix

When `Cache::forget` is called, it only removes the main item, leaving the metadata item in place. This leads to unexpected behavior in the cache lifecycle.

### The issue

When `Cache::forget` is called, it only removes the main item, leaving the ":created" timestamp intact.
On the next request, `Cache::flexible` finds a `null` value for the main item but an existing ":created" timestamp.

This causes the method to incorrectly assume the item is in the stale or expired state, rather than treating it as a fresh cache miss.

As a result, the cache remains null until the stale period is over, effectively breaking the expected cache regeneration behavior.

### Current behavior

https://github.com/user-attachments/assets/7a1bdd3c-ec61-47e3-9f12-0d25f9ca2b9b

### Expected behavior

https://github.com/user-attachments/assets/9d7b4e6d-9ba5-4729-85f2-51c27e4d3ae0

### Proposed Fix

Update the `Cache::forget` method to remove both the main item and the associated metadata item when called on a key created by `Cache::flexible`.

### PoC

My PoC if you want to interactively test the issue.

```php
<?php

use Illuminate\Support\Facades\Cache;
use Illuminate\Support\Facades\Route;

Route::get('/debug', function () {

    $cachedAt = Cache::flexible('current-time', [5, 10], function () {
        $start = microtime(true);
        $when = now()->toTimeString();
        sleep(2);

        $end = microtime(true);
        $executionTime = ($end - $start) * 1000;
        return [
            "when" => $when,
            'execution_time_ms' => round($executionTime, 2),
        ];
    });

    $mainItem = Cache::get('current-time');
    $createdItem = Cache::get('current-time:created');


    return response()->json([
        'status' => 'ok',
        'cached_at' => $cachedAt,
        'current_time' => now()->toTimeString(),
        'cache_state' => [
            'main_item' => $mainItem,
            'created_item' => $createdItem,
        ],
    ]);
});

Route::get('/refresh', function () {
    $beforeForget = [
        'main_item' => Cache::get('current-time'),
        'created_item' => Cache::get('current-time:created'),
    ];

    Cache::forget('current-time');

    $afterForget = [
        'main_item' => Cache::get('current-time'),
        'created_item' => Cache::get('current-time:created'),
    ];

    return response()->json([
        'status' => 'ok',
        'message' => 'Cache forcefully refreshed',
        'time' => now()->toTimeString(),
        'cache_state_before_forget' => $beforeForget,
        'cache_state_after_forget' => $afterForget,
    ]);
});

Route::get('/force-refresh', function () {
    $beforeForget = [
        'main_item' => Cache::get('current-time'),
        'created_item' => Cache::get('current-time:created'),
    ];

    Cache::forget('current-time');
    Cache::forget('current-time:created');

    $afterForget = [
        'main_item' => Cache::get('current-time'),
        'created_item' => Cache::get('current-time:created'),
    ];

    return response()->json([
        'status' => 'ok',
        'message' => 'Cache forcefully refreshed',
        'time' => now()->toTimeString(),
        'cache_state_before' => $beforeForget,
        'cache_state_after' => $afterForget,
    ]);
});
```