### PR TITLE
[11.x]: Fixed method parameter formatting

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -283,10 +283,7 @@ class ThrottleRequests
      * @param  \Symfony\Component\HttpFoundation\Response|null  $response
      * @return array
      */
-    protected function getHeaders($maxAttempts,
-        $remainingAttempts,
-        $retryAfter = null,
-        ?Response $response = null)
+    protected function getHeaders($maxAttempts, $remainingAttempts, $retryAfter = null, ?Response $response = null)
     {
         if ($response &&
             ! is_null($response->headers->get('X-RateLimit-Remaining')) &&


### PR DESCRIPTION
I was just looking around in the code and suddenly I saw a totally different structure with define parameters. I thought we should make that consistent with the rest of the code base.