### PR TITLE
[11.x] Add dd_if helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -22,6 +22,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\VarDumper;
 
 if (! function_exists('abort')) {
     /**
@@ -411,6 +412,32 @@ if (! function_exists('defer')) {
     function defer(?callable $callback = null, ?string $name = null, bool $always = false)
     {
         return \Illuminate\Support\defer($callback, $name, $always);
+    }
+}
+
+if(! function_exists('dd_if')) {
+    /**
+     * Dump the passed variables if the condition is true and terminate the script.
+     *
+     * @param bool $condition
+     * @param mixed ...$vars
+     * @return mixed|null
+     */
+    function dd_if(bool $condition, ...$vars)
+    {
+        if (!$condition) {
+            return null;
+        }
+
+        if (array_key_exists(0, $vars) && 1 === count($vars)) {
+            VarDumper::dump($vars[0]);
+        } else {
+            foreach ($vars as $k => $v) {
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+            }
+        }
+
+        exit(1);
     }
 }
 


### PR DESCRIPTION
The `dd_if ` helper is a useful debugging tool that simplifies conditional variable dumping. Instead of wrapping dd() in an if statement, this function allows developers to easily inspect variables only when a given condition is true, enhancing code readability and reducing clutter.

**Before:**
```php

if ($user->isAdmin()) {
    dd($user);
}

```
**After:**
```php

dd_if($user->isAdmin(), $user);

```
**Example Usage:**
```php
// Dump variables only if the user is an admin
dd_if($user->isAdmin(), $user);

// Dump multiple variables if the application is in debug mode
dd_if(config('app.debug'), $user, $request, $response);

// Skip dumping if condition is false
dd_if(false, $data); // No output, execution continues

// Dump and terminate execution if condition is true
dd_if(true, $data); // Dumps $data and halts execution

```