### PR TITLE
[11.x] Auto-register commands in `routes/console.php`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -282,7 +282,11 @@ class ApplicationBuilder
      */
     public function withCommands(array $commands = [])
     {
-        if (empty($commands)) {
+        if (empty($commands) && is_file($this->app->basePath('routes/console.php'))) {
+            $commands = [$this->app->basePath('routes/console.php')];
+        }
+
+        if (empty($commands) && is_dir($this->app->path('Console/Commands'))) {
             $commands = [$this->app->path('Console/Commands')];
         }
 


### PR DESCRIPTION
While working on route registration in a Laravel app, I noticed some inconvenience when using the `using` callback of the `withRouting` method.
In particular, the main issue was that commands defined in `routes/console.php` were not registered anymore. When checking the docs, I saw that there is a way to register commands using the `withCommands` method. 

However, to achieve the same behaviour of the `withRouting` method you must pass the `routes/console.php` file as a parameter.
I think the DX could be improved by checking if the `routes/console.php` file exists and if so, registering all commands (including their schedule) automatically. This should be a good sensible default since the `routes/console.php` file is the default way to register commands in Laravel 11.

So before:

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withCommands([
        __DIR__ . 'routes/console.php',
    ]);
```

and after:

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withCommands();
```

I couldn't find any existing tests for the `ApplicationBuilder` so I decided to also not add any in this PR.