### PR TITLE
[11.x] Remove unused namespaces from DatabaseInspectionCommand and LocalFileSystemAdapter

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Arr;
 

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Filesystem;
 
 use Closure;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Traits\Conditionable;
 use RuntimeException;
 


### PR DESCRIPTION
In this PR, unused namespaces have been removed from the `DatabaseInspectionCommand` and `LocalFilesystemAdapter` files. These changes improve code readability and optimize the project by eliminating unnecessary code.

Thanks!