### PR TITLE
[11.x] Fix validation rule type hints

### DIFF
--- a/src/Illuminate/Contracts/Validation/InvokableRule.php
+++ b/src/Illuminate/Contracts/Validation/InvokableRule.php
@@ -14,7 +14,7 @@ interface InvokableRule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      * @return void
      */
     public function __invoke(string $attribute, mixed $value, Closure $fail);

--- a/src/Illuminate/Contracts/Validation/ValidationRule.php
+++ b/src/Illuminate/Contracts/Validation/ValidationRule.php
@@ -11,7 +11,7 @@ interface ValidationRule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void;

--- a/src/Illuminate/Foundation/Console/stubs/rule.implicit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.implicit.stub
@@ -17,7 +17,7 @@ class {{ class }} implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -10,7 +10,7 @@ class {{ class }} implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string, ?string = null): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/types/Contracts/Validation/ValidationRule.php
+++ b/types/Contracts/Validation/ValidationRule.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Contracts\Validation\ValidationRule;
+
+use function PHPStan\Testing\assertType;
+
+new class implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        assertType('Closure(string, string|null=): Illuminate\Translation\PotentiallyTranslatedString', $fail);
+    }
+};


### PR DESCRIPTION
PR #52644 changed the type hints for validation rules, but it seems this was done incorrectly, this PR aims to fix that. After this change both PHPStan and PHPStorm correctly infer the type of `$fail`

