### PR TITLE
The save method of the model returns true or false based on the numbe…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1235,14 +1235,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $dirty = $this->getDirtyForUpdate();
 
         if (count($dirty) > 0) {
-            $this->setKeysForSaveQuery($query)->update($dirty);
+            $affected = $this->setKeysForSaveQuery($query)->update($dirty);
 
             $this->syncChanges();
 
             $this->fireModelEvent('updated', false);
         }
 
-        return true;
+        return (bool) $affected;
     }
 
     /**


### PR DESCRIPTION
If the save method is called when the model lacks a primary key value, it will return true, which is unreasonable because the generated SQL condition is 'primary key = null', meaning no records will be updated.