### PR TITLE
Update stub to remove unused trait imports

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/job.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.queued.stub
@@ -3,10 +3,7 @@
 namespace {{ namespace }};
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 
 class {{ class }} implements ShouldQueue
 {

--- a/tests/Integration/Generators/JobMakeCommandTest.php
+++ b/tests/Integration/Generators/JobMakeCommandTest.php
@@ -17,10 +17,7 @@ class JobMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Jobs;',
             'use Illuminate\Contracts\Queue\ShouldQueue;',
-            'use Illuminate\Foundation\Bus\Dispatchable;',
             'use Illuminate\Foundation\Queue\Queueable;',
-            'use Illuminate\Queue\InteractsWithQueue;',
-            'use Illuminate\Queue\SerializesModels;',
             'class FooCreated implements ShouldQueue',
             'use Queueable;',
         ], 'app/Jobs/FooCreated.php');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

They are already used in the `Illuminate\Foundation\Queue\Queueable` trait used in the class. So, there's no need to keep them here.
