### PR TITLE
[11.x] Add vector column support to migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1453,6 +1453,18 @@ class Blueprint
     }
 
     /**
+     * Create a new vector column on the table.
+     * @param  string  $column
+     * @param  int|null  $dimension
+     * @return ColumnDefinition
+     */
+    public function vector($column, $dimension = null)
+    {
+        $dimension = $dimension ?: Builder::$defaultVectorDimension;
+        return $this->addColumn('vector', $column, compact('dimension'));
+    }
+
+    /**
      * Add the proper columns for a polymorphic table.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -42,6 +42,13 @@ class Builder
     public static $defaultStringLength = 255;
 
     /**
+     * The default vector dimensions for migrations.
+     *
+     * @var int|null
+     */
+    public static $defaultVectorDimension = 384;
+
+    /**
      * The default relationship morph key type.
      *
      * @var string

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Support\Fluent;
 use RuntimeException;
@@ -1101,6 +1102,18 @@ class MySqlGrammar extends Grammar
     protected function typeComputed(Fluent $column)
     {
         throw new RuntimeException('This database driver requires a type, see the virtualAs / storedAs modifiers.');
+    }
+
+    /**
+     * Create the column definition for a vector type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVector(Fluent $column)
+    {
+        $dimension = $column->dimension ? $column->dimension : Builder::$defaultVectorDimension;
+        return "vector($dimension)";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Fluent;
 use LogicException;
 
@@ -1051,6 +1052,18 @@ class PostgresGrammar extends Grammar
         }
 
         return 'geography';
+    }
+
+    /**
+     * Create the column definition for a vector type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVector(Fluent $column)
+    {
+        $dimension = $column->dimension ? $column->dimension : Builder::$defaultVectorDimension;
+        return "vector($dimension)";
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1322,6 +1322,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 
+    public function testAddingVector()
+    {
+        $blueprint = new Blueprint('embeddings');
+        $blueprint->vector('embedding');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `embeddings` add `embedding` vector(384) not null', $statements[0]);
+    }
+
     public function testCreateDatabase()
     {
         $connection = $this->getConnection();

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -42,6 +42,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingVector()
+    {
+        $blueprint = new Blueprint('embeddings');
+        $blueprint->vector('embedding');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "embeddings" add column "embedding" vector(384) not null', $statements[0]);
+    }
+
     public function testCreateTableWithAutoIncrementStartingValue()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -896,6 +896,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create table "products" ("price" integer not null, "discounted_virtual" integer as ("price" - 5), "discounted_stored" integer as ("price" - 5) stored)', $statements[0]);
     }
 
+    public function testAddingVector()
+    {
+        $blueprint = new Blueprint('embeddings');
+        $blueprint->vector('embedding');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "embeddings" add column "embedding" blob not null check(length(embedding) = 1536)', $statements[0]);
+    }
+
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.


### PR DESCRIPTION
This PR adds support for creating vector columns in SQLite, MySQL, and PostgreSQL. The changes include adding new tests to verify the creation of vector columns across these databases.

With the growing popularity of semantic searching and RAG, I thought it would be good to start the process for Laravel to support semantic searching using vectorised data natively.  