### PR TITLE
[11.x] Prevent infinite recursion on `touchesParents()` for chaperoned models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -792,17 +792,19 @@ trait HasRelationships
      */
     public function touchOwners()
     {
-        foreach ($this->getTouchedRelations() as $relation) {
-            $this->$relation()->touch();
+        $this->withoutRecursion(function () {
+            foreach ($this->getTouchedRelations() as $relation) {
+                $this->$relation()->touch();
 
-            if ($this->$relation instanceof self) {
-                $this->$relation->fireModelEvent('saved', false);
+                if ($this->$relation instanceof self) {
+                    $this->$relation->fireModelEvent('saved', false);
 
-                $this->$relation->touchOwners();
-            } elseif ($this->$relation instanceof Collection) {
-                $this->$relation->each->touchOwners();
+                    $this->$relation->touchOwners();
+                } elseif ($this->$relation instanceof Collection) {
+                    $this->$relation->each->touchOwners();
+                }
             }
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
As #52865 got closed, I've pulled out just the fixes for `touchesParents()` to resolve #52660
