### PR TITLE
[11.x] Add `--json` flag to `queue:work` command for structured logging

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -115,18 +115,16 @@ class WorkCommand extends Command
         // connection being run for the queue operation currently being executed.
         $queue = $this->getQueue($connection);
 
-        if (Terminal::hasSttyAvailable()) {
-            if ($this->option('json')) {
-                $this->output->writeln(json_encode([
-                    'connection' => $connection,
-                    'queues' => explode(',', $queue),
-                    'status' => 'starting',
-                ]));
-            } else {
-                $this->components->info(
-                    sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
-                );
-            }
+        if ($this->option('json')) {
+            $this->output->writeln(json_encode([
+                'connection' => $connection,
+                'queues' => explode(',', $queue),
+                'status' => 'starting',
+            ]));
+        } elseif (Terminal::hasSttyAvailable()) {
+            $this->components->info(
+                sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
+            );
         }
 
         return $this->runWorker(

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -291,7 +291,7 @@ class WorkCommand extends Command
         if ($status === 'starting') {
             $this->latestStartedAt = microtime(true);
         } else {
-            $log['duration'] = round((microtime(true) - $this->latestStartedAt), 6);
+            $log['duration'] = round(microtime(true) - $this->latestStartedAt, 6);
         }
 
         $this->output->writeln(json_encode($log));

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -272,6 +272,7 @@ class WorkCommand extends Command
     {
         $log = array_filter([
             'timestamp' => $this->now()->format('Y-m-d\TH:i:s.uP'),
+            'level' => $status === 'starting' ||  $status === 'success'? 'info' : 'warning',
             'job' => $job->resolveName(),
             'id' => $job->getJobId(),
             'uuid' => $job->uuid(),

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -270,14 +270,14 @@ class WorkCommand extends Command
     {
         $log = array_filter([
             'timestamp' => $this->now()->format('Y-m-d\TH:i:s.uP'),
-            'level' => $status === 'starting' ||  $status === 'success'? 'info' : 'warning',
+            'level' => $status === 'starting' || $status === 'success' ? 'info' : 'warning',
             'job' => $job->resolveName(),
             'id' => $job->getJobId(),
             'uuid' => $job->uuid(),
             'connection' => $job->getConnectionName(),
             'queue' => $job->getQueue(),
             'status' => $status,
-            'result' => match(true) {
+            'result' => match (true) {
                 $job->isDeleted() => 'deleted',
                 $job->isReleased() => 'released',
                 $job->hasFailed() => 'failed',

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Terminal;
-
 use Throwable;
 
 use function Termwind\terminal;
@@ -293,7 +292,7 @@ class WorkCommand extends Command
         if ($status === 'starting') {
             $this->latestStartedAt = microtime(true);
         } else {
-            $log['ms'] = round((microtime(true) - $this->latestStartedAt) * 1000, 3);
+            $log['duration'] = round((microtime(true) - $this->latestStartedAt), 6);
         }
 
         $this->output->writeln(json_encode($log));


### PR DESCRIPTION
This PR introduces a new `--json` flag for the `queue:work` command, enabling structured JSON output for enhanced observability.

## Motivation

- Improves monitoring capabilities in cloud and Kubernetes environments without disrupting existing functionality.
- Provides contextual information about job execution, facilitating processing by log analysis tools.
- Standardizes log format, enabling community sharing of tooling (e.g., Grafana Loki dashboards).
- Aligns with recent JSON support additions to other Artisan commands.
- I’m ready to create a test if this PR is approved.

## Why not?

- Introduces changes to a core command. My sense of smell tells me that I am proposing changes in a place where unnecessary changes are not welcome.
- Similar functionality could be achieved using custom queue event listeners and logging with `Monolog\Formatter\JsonFormatter`.

## JSON output format

The JSON output continues to include two log entries per job: one at the start and another at completion.

Key fields include:

- `timestamp`: Datetime in ISO 8601 format.
- `level`: PSR-3 log level `info` or `warning`. It helps monitoring tools.
- `status`: Current execution status of `queue:work` command: `starting`, `success`, `released_after_exception` or `failed`.
- `result`: Outcome of completed jobs: `deleted`, `released` or `failed`.
- `duration`: In seconds.
- `exception`: FQCN of the Exception.
- `message`: Exception message.


### Sucessful Job

```json
{
  "timestamp": "2024-09-23T13:47:37.347077+00:00",
  "level": "info",
  "job": "App\\Jobs\\NotificarJob",
  "id": "9af01732-609a-4418-86f3-904f928fd8cc",
  "uuid": "88098a41-4a1e-4ea6-a4f0-58511f91e915",
  "connection": "rabbitmq",
  "queue": "default",
  "status": "success",
  "result": "deleted",
  "attempts": 1,
  "duration": 0.014354
}
```

### Failed Job

```json
{
  "timestamp": "2024-09-23T13:44:57.393616+00:00",
  "level": "warning",
  "job": "App\\Jobs\\TestJob",
  "id": "12c2916c-6a04-40d7-b0d8-c48897c425a0",
  "uuid": "7e719912-f6c2-4018-a1c2-c7254992f182",
  "connection": "rabbitmq",
  "queue": "default",
  "status": "failed",
  "result": "deleted",
  "attempts": 3,
  "exception": "App\\Exceptions\\TestException",
  "message": "I have failed you.",
  "duration": 0.001601
}
```

### Job Starting

```json
{
  "timestamp": "2024-09-23T13:48:37.593466+00:00",
  "level": "info",
  "job": "App\\Jobs\\ConsultarEnvioDocumentoAReguladorJob",
  "id": "e600e9dd-474b-4e18-ad5e-a3cadd3b04c9",
  "uuid": "e76cd7c8-1754-48e7-9b45-5a7ea8664d53",
  "connection": "rabbitmq",
  "queue": "regulador",
  "status": "starting",
  "attempts": 2
}
```


### Open Questions

- Is the "Job Starting" log entry necessary, or should we only log job completion?
- Should we use the `-v` argument to control the verbosity of the JSON output?
- Are there any additional fields that would be valuable to include in the JSON output?
