### PR TITLE
[11.x] Add `\DateTimeInterface` and `\DateInterval` to type for `Cache::flexible()`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -479,7 +479,7 @@ class Repository implements ArrayAccess, CacheContract
      * @template TCacheValue
      *
      * @param  string  $key
-     * @param  array{ 0: int, 1: int }  $ttl
+     * @param  array{ 0: \DateTimeInterface|\DateInterval|int, 1: \DateTimeInterface|\DateInterval|int }  $ttl
      * @param  (callable(): TCacheValue)  $callback
      * @param  array{ seconds?: int, owner?: string }|null  $lock
      * @return TCacheValue


### PR DESCRIPTION
The `\Illuminate\Cache\Repository::flexible` also supports being passed the following I believe:


```php
cache()->flexible(
  'key',
  [now()->addHour(), now()->addHours(2)],
  fn () => 'value',
);
```

This is now reflected in the phpdoc. The purpose of this PR is to add these types to be allowed in the docblock, improving PHPStan understanding of the code.

I have used the same ordering of types as on `\Illuminate\Cache\Repository::putMany`.

This PR will also eliminate the following PHPStan error:

```
Parameter $ttl of method Illuminate\Cache\Repository::flexible() expects array{int, int}, array{Illuminate\Support\Carbon, Illuminate\Support\Carbon} given.
```