### PR TITLE
[11.x] Fixes trust proxy `REMOTE_ADDR` not working in Swoole

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -90,6 +90,16 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddressesToSpecificIps(Request $request, array $trustedIps)
     {
+        $trustedIps = array_reduce($trustedIps, function ($ips, $trustedIp) use ($request) {
+            if ('REMOTE_ADDR' !== $trustedIp) {
+                $ips[] = $trustedIp;
+            } elseif ($request->server->get($trustedIp)) {
+                $ips[] = $request->server->get($trustedIp);
+            }
+
+            return $ips;
+        }, []);
+
         $request->setTrustedProxies($trustedIps, $this->getTrustedHeaderNames());
     }
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -90,17 +90,13 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddressesToSpecificIps(Request $request, array $trustedIps)
     {
-        $trustedIps = array_reduce($trustedIps, function ($ips, $trustedIp) use ($request) {
-            if ('REMOTE_ADDR' !== $trustedIp) {
-                $ips[] = $trustedIp;
-            } elseif ($request->server->get($trustedIp)) {
-                $ips[] = $request->server->get($trustedIp);
-            }
+        $request->setTrustedProxies(array_reduce($trustedIps, function ($ips, $trustedIp) use ($request) {
+            $ips[] = $trustedIp === 'REMOTE_ADDR'
+                ? $request->server->get('REMOTE_ADDR')
+                : $trustedIp;
 
             return $ips;
-        }, []);
-
-        $request->setTrustedProxies($trustedIps, $this->getTrustedHeaderNames());
+        }, []), $this->getTrustedHeaderNames());
     }
 
     /**

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -80,6 +80,20 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
+     * Test the next most typical usage of TrustedProxies:
+     * Trusted X-Forwarded-For header, REMOTE_ADDR for TrustedProxies.
+     */
+    public function test_trusted_proxy_sets_trusted_proxies_with_REMOTE_ADDR()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, 'REMOTE_ADDR');
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with REMOTE_ADDR proxy setting');
+        });
+    }
+
+    /**
      * Test the most typical usage of TrustProxies:
      * Trusted X-Forwarded-For header.
      */


### PR DESCRIPTION
When using `REMOTE_ADDR` set the trust proxy in Swoole, like this:

```php
      $middleware->trustProxies(
            at: [
                'REMOTE_ADDR',
            ],
            headers: Request::HEADER_X_FORWARDED_FOR
        );
```

Is nothing set to `request->trustedProxies`  because `$_SERVER['REMOTE_ADDR']` does not exist in Swoole. But Laravel internally converts the server information in Swoole into the `request->server` attribute, which includes `REMOTE_ADDR`, and then `request()->server->get('REMOTE_ADDR')` can get the corresponding value normally.

This leads to some logical ambiguity and increases the cognitive burden and learning cost.


So we need to unify the logic to avoid inconsistency. I can't change this in the `Request` class because of the method attribute restrictions, so the solution I've come up with so far is this, it works for me, and I hope there's another better way to solve it.
