### PR TITLE
[11.x] Ability to not run defer on validation errors

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\Request;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,10 +32,10 @@ class InvokeDeferredCallbacks
      */
     public function terminate(Request $request, Response $response)
     {
-        $hasErrors = session()?->has('errors') ?? false;
+        $hasErrors = $request->hasSession() && $request->session()->has('errors');
         Container::getInstance()
             ->make(DeferredCallbackCollection::class)
-            ->invokeWhen(fn($callback) => ($response->getStatusCode() < 400 || $callback->always)
-                && (!$hasErrors) || $callback->evenWithErrors);
+            ->invokeWhen(fn ($callback) => ($response->getStatusCode() < 400 || $callback->always)
+                && (! $hasErrors || $callback->evenWithErrors));
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\Request;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
-use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
 class InvokeDeferredCallbacks

--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
+use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
 class InvokeDeferredCallbacks
@@ -31,8 +32,10 @@ class InvokeDeferredCallbacks
      */
     public function terminate(Request $request, Response $response)
     {
+        $hasErrors = session()?->has('errors') ?? false;
         Container::getInstance()
             ->make(DeferredCallbackCollection::class)
-            ->invokeWhen(fn ($callback) => $response->getStatusCode() < 400 || $callback->always);
+            ->invokeWhen(fn($callback) => ($response->getStatusCode() < 400 || $callback->always)
+                && (!$hasErrors) || $callback->evenWithErrors);
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -408,9 +408,9 @@ if (! function_exists('defer')) {
      * @param  bool  $always
      * @return \Illuminate\Foundation\Defer\DeferredCallback
      */
-    function defer(?callable $callback = null, ?string $name = null, bool $always = false)
+    function defer(?callable $callback = null, ?string $name = null, bool $always = false, $evenWithErrors = true)
     {
-        return \Illuminate\Support\defer($callback, $name, $always);
+        return \Illuminate\Support\defer($callback, $name, $always, $evenWithErrors);
     }
 }
 

--- a/src/Illuminate/Support/Defer/DeferredCallback.php
+++ b/src/Illuminate/Support/Defer/DeferredCallback.php
@@ -12,8 +12,12 @@ class DeferredCallback
      * @param  callable  $callback
      * @return void
      */
-    public function __construct(public $callback, public ?string $name = null, public bool $always = false)
-    {
+    public function __construct(
+        public $callback,
+        public ?string $name = null,
+        public bool $always = false,
+        public bool $evenWithErrors = true,
+    ) {
         $this->name = $name ?? (string) Str::uuid();
     }
 
@@ -39,6 +43,19 @@ class DeferredCallback
     public function always(bool $always = true): self
     {
         $this->always = $always;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the deferred callback should run even on unsuccessful requests validations.
+     *
+     * @param  bool  $evenWithErrors
+     * @return $this
+     */
+    public function evenWithErrors(bool $evenWithErrors = true): self
+    {
+        $this->evenWithErrors = $evenWithErrors;
 
         return $this;
     }

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -14,14 +14,14 @@ use Illuminate\Support\Process\PhpExecutableFinder;
  * @param  bool  $always
  * @return \Illuminate\Support\Defer\DeferredCallback
  */
-function defer(?callable $callback = null, ?string $name = null, bool $always = false)
+function defer(?callable $callback = null, ?string $name = null, bool $always = false, $evenWithErrors = true)
 {
     if ($callback === null) {
         return app(DeferredCallbackCollection::class);
     }
 
     return tap(
-        new DeferredCallback($callback, $name, $always),
+        new DeferredCallback($callback, $name, $always, $evenWithErrors),
         fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
     );
 }


### PR DESCRIPTION
Refer feature is very flexible and robust, but when using it I found a point where it does not have the desired behavior and at the same time does not implement anything that makes this possible.

I'm referring to preventing defer from being called when validation errors exist.

Where might this be useful? In my case, for example, I send an upload using FilePond in a request before sending the form, so in the form I only send the ID of the file sent previously. If validation passes, I process the file and then use the `refer()` to delete the original file without harming the response.

It is important to emphasize that I call defer within a request class, that is, when validation fails, defer has already been configured.


```php
// Use it is easy
  defer(fn() => Filepond::delete($id))->evenWithErrors(false);
```

