### PR TITLE
[11.x] `Cache::flexible` improvements

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -380,7 +380,7 @@ class DatabaseStore implements LockProvider, Store
     {
         $this->table()->whereIn('key', collect($keys)->flatMap(fn ($key) => [
             $this->prefix.$key,
-            $this->prefix.$key.':created',
+            "{$this->prefix}illuminate:cache:flexible:created:{$key}",
         ]))->delete();
 
         return true;
@@ -398,10 +398,10 @@ class DatabaseStore implements LockProvider, Store
         $this->table()
             ->whereIn('key', collect($keys)->flatMap(fn ($key) => $prefixed ? [
                 $key,
-                "{$key}:created",
+                "illuminate:cache:flexible:created:{$key}",
             ] : [
                 "{$this->prefix}{$key}",
-                "{$this->prefix}{$key}:created",
+                "{$this->prefix}illuminate:cache:flexible:created:{$key}",
             ]))
             ->where('expiration', '<=', $this->getTime())
             ->delete();

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -381,7 +381,7 @@ class DatabaseStore implements LockProvider, Store
         $this->table()->whereIn('key', collect($keys)->flatMap(fn ($key) => [
             $this->prefix.$key,
             "{$this->prefix}illuminate:cache:flexible:created:{$key}",
-        ]))->delete();
+        ])->all())->delete();
 
         return true;
     }
@@ -402,7 +402,7 @@ class DatabaseStore implements LockProvider, Store
             ] : [
                 "{$this->prefix}{$key}",
                 "{$this->prefix}illuminate:cache:flexible:created:{$key}",
-            ]))
+            ])->all())
             ->where('expiration', '<=', $this->getTime())
             ->delete();
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -398,7 +398,7 @@ class DatabaseStore implements LockProvider, Store
         $this->table()
             ->whereIn('key', collect($keys)->flatMap(fn ($key) => $prefixed ? [
                 $key,
-                "illuminate:cache:flexible:created:{$key}",
+                $this->prefix.'illuminate:cache:flexible:created:'.Str::chopStart($key, $this->prefix),
             ] : [
                 "{$this->prefix}{$key}",
                 "{$this->prefix}illuminate:cache:flexible:created:{$key}",

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -248,6 +248,8 @@ class FileStore implements Store, LockProvider
     public function forget($key)
     {
         if ($this->files->exists($file = $this->path($key))) {
+            $this->files->delete($this->path("{$key}:created"));
+
             return $this->files->delete($file);
         }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -248,7 +248,7 @@ class FileStore implements Store, LockProvider
     public function forget($key)
     {
         if ($this->files->exists($file = $this->path($key))) {
-            $this->files->delete($this->path("{$key}:created"));
+            $this->files->delete($this->path("illuminate:cache:flexible:created:{$key}"));
 
             return $this->files->delete($file);
         }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -491,7 +491,10 @@ class Repository implements ArrayAccess, CacheContract
             "{$key}:created" => $created,
         ] = $this->many([$key, "{$key}:created"]);
 
-        if ($created === null) {
+        if (
+            $created === null ||
+            ($value === null && $this->missing($key))
+        ) {
             return tap(value($callback), fn ($value) => $this->putMany([
                 $key => $value,
                 "{$key}:created" => Carbon::now()->getTimestamp(),

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -519,7 +519,7 @@ class Repository implements ArrayAccess, CacheContract
             });
         };
 
-        defer($refresh, "illuminate:cache:refresh:{$key}");
+        defer($refresh, "illuminate:cache:flexible:{$key}");
 
         return $value;
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -504,7 +504,7 @@ class Repository implements ArrayAccess, CacheContract
 
         $refresh = function () use ($key, $ttl, $callback, $lock, $created) {
             $this->store->lock(
-                "illuminate:cache:refresh:lock:{$key}",
+                "illuminate:cache:flexible:lock:{$key}",
                 $lock['seconds'] ?? 0,
                 $lock['owner'] ?? null,
             )->get(function () use ($key, $callback, $created, $ttl) {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -488,13 +488,13 @@ class Repository implements ArrayAccess, CacheContract
     {
         [
             $key => $value,
-            "{$key}:created" => $created,
-        ] = $this->many([$key, "{$key}:created"]);
+            "illuminate:cache:flexible:created:{$key}" => $created,
+        ] = $this->many([$key, "illuminate:cache:flexible:created:{$key}"]);
 
         if (in_array(null, [$value, $created], true)) {
             return tap(value($callback), fn ($value) => $this->putMany([
                 $key => $value,
-                "{$key}:created" => Carbon::now()->getTimestamp(),
+                "illuminate:cache:flexible:created:{$key}" => Carbon::now()->getTimestamp(),
             ], $ttl[1]));
         }
 
@@ -508,13 +508,13 @@ class Repository implements ArrayAccess, CacheContract
                 $lock['seconds'] ?? 0,
                 $lock['owner'] ?? null,
             )->get(function () use ($key, $callback, $created, $ttl) {
-                if ($created !== $this->get("{$key}:created")) {
+                if ($created !== $this->get("illuminate:cache:flexible:created:{$key}")) {
                     return;
                 }
 
                 $this->putMany([
                     $key => value($callback),
-                    "{$key}:created" => Carbon::now()->getTimestamp(),
+                    "illuminate:cache:flexible:created:{$key}" => Carbon::now()->getTimestamp(),
                 ], $ttl[1]);
             });
         };

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -491,10 +491,7 @@ class Repository implements ArrayAccess, CacheContract
             "{$key}:created" => $created,
         ] = $this->many([$key, "{$key}:created"]);
 
-        if (
-            $created === null ||
-            ($value === null && $this->missing($key))
-        ) {
+        if (in_array(null, [$value, $created], true)) {
             return tap(value($callback), fn ($value) => $this->putMany([
                 $key => $value,
                 "{$key}:created" => Carbon::now()->getTimestamp(),

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -37,7 +37,7 @@ class CacheDatabaseStoreTest extends TestCase
         $getQuery->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'expiration' => 1]]));
 
         $deleteQuery = m::mock(stdClass::class);
-        $deleteQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($deleteQuery);
+        $deleteQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($deleteQuery);
         $deleteQuery->shouldReceive('where')->once()->with('expiration', '<=', m::any())->andReturn($deleteQuery);
         $deleteQuery->shouldReceive('delete')->once()->andReturnNull();
 
@@ -105,7 +105,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
+        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($table);
         $table->shouldReceive('delete')->once();
 
         $store->forget('foo');

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -285,14 +285,15 @@ class CacheFileStoreTest extends TestCase
 
     public function testRemoveDeletesFile()
     {
-        $files = $this->mockFilesystem();
-        $hash = sha1('foobar');
-        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $files = new Filesystem;
         $store = new FileStore($files, __DIR__);
         $store->put('foobar', 'Hello Baby', 10);
-        $files->expects($this->once())->method('exists')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash))->willReturn(true);
-        $files->expects($this->once())->method('delete')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash));
+
+        $this->assertFileExists($store->path('foobar'));
+
         $store->forget('foobar');
+
+        $this->assertFileDoesNotExist($store->path('foobar'));
     }
 
     public function testFlushCleansDirectory()

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -105,7 +105,7 @@ class RepositoryTest extends TestCase
         // our own lock. This means that the value should not be refreshed by
         // deferred callback.
         /** @var Lock */
-        $lock = $cache->lock('illuminate:cache:refresh:lock:foo');
+        $lock = $cache->lock('illuminate:cache:flexible:lock:foo');
 
         $this->assertTrue($lock->acquire());
         defer()->first()();

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -146,4 +146,29 @@ class RepositoryTest extends TestCase
         $this->assertSame(99, $cache->get('foo'));
         $this->assertSame(946684863, $cache->get('foo:created'));
     }
+
+    public function testItHandlesStrayTtlKeyAfterMainKeyIsForgotten()
+    {
+        $cache = Cache::driver('array');
+        $count = 0;
+
+        $value = $cache->flexible('count', [5, 10], function () use (&$count) {
+            $count = 1;
+
+            return $count;
+        });
+
+        $this->assertSame(1, $value);
+        $this->assertSame(1, $count);
+
+        $cache->forget('count');
+
+        $value = $cache->flexible('count', [5, 10], function () use (&$count) {
+            $count = 2;
+
+            return $count;
+        });
+        $this->assertSame(2, $value);
+        $this->assertSame(2, $count);
+    }
 }

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -27,7 +27,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(1, $value);
         $this->assertCount(0, defer());
         $this->assertSame(1, $cache->get('foo'));
-        $this->assertSame(946684800, $cache->get('foo:created'));
+        $this->assertSame(946684800, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // Cache is fresh. The value should be retrieved from the cache and used...
         $value = $cache->flexible('foo', [10, 20], function () use (&$count) {
@@ -36,7 +36,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(1, $value);
         $this->assertCount(0, defer());
         $this->assertSame(1, $cache->get('foo'));
-        $this->assertSame(946684800, $cache->get('foo:created'));
+        $this->assertSame(946684800, $cache->get('illuminate:cache:flexible:created:foo'));
 
         Carbon::setTestNow(now()->addSeconds(11));
 
@@ -48,7 +48,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(1, $value);
         $this->assertCount(1, defer());
         $this->assertSame(1, $cache->get('foo'));
-        $this->assertSame(946684800, $cache->get('foo:created'));
+        $this->assertSame(946684800, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // We will hit it again within the same request. This should not queue
         // up an additional deferred callback as only one can be registered at
@@ -59,14 +59,14 @@ class RepositoryTest extends TestCase
         $this->assertSame(1, $value);
         $this->assertCount(1, defer());
         $this->assertSame(1, $cache->get('foo'));
-        $this->assertSame(946684800, $cache->get('foo:created'));
+        $this->assertSame(946684800, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // We will now simulate the end of the request lifecycle by executing the
         // deferred callback. This should refresh the cache.
         defer()->invoke();
         $this->assertCount(0, defer());
         $this->assertSame(2, $cache->get('foo')); // this has been updated!
-        $this->assertSame(946684811, $cache->get('foo:created')); // this has been updated!
+        $this->assertSame(946684811, $cache->get('illuminate:cache:flexible:created:foo')); // this has been updated!
 
         // Now the cache is fresh again...
         $value = $cache->flexible('foo', [10, 20], function () use (&$count) {
@@ -75,7 +75,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(2, $value);
         $this->assertCount(0, defer());
         $this->assertSame(2, $cache->get('foo'));
-        $this->assertSame(946684811, $cache->get('foo:created'));
+        $this->assertSame(946684811, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // Let's now progress time beyond the stale TTL...
         Carbon::setTestNow(now()->addSeconds(21));
@@ -87,7 +87,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(3, $value);
         $this->assertCount(0, defer());
         $this->assertSame(3, $cache->get('foo'));
-        $this->assertSame(946684832, $cache->get('foo:created'));
+        $this->assertSame(946684832, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // Now lets see what happens when another request, job, or command is
         // also trying to refresh the same key at the same time. Will push past
@@ -99,7 +99,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(3, $value);
         $this->assertCount(1, defer());
         $this->assertSame(3, $cache->get('foo'));
-        $this->assertSame(946684832, $cache->get('foo:created'));
+        $this->assertSame(946684832, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // Now we will execute the deferred callback but we will first aquire
         // our own lock. This means that the value should not be refreshed by
@@ -112,7 +112,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(3, $value);
         $this->assertCount(1, defer());
         $this->assertSame(3, $cache->get('foo'));
-        $this->assertSame(946684832, $cache->get('foo:created'));
+        $this->assertSame(946684832, $cache->get('illuminate:cache:flexible:created:foo'));
         $this->assertTrue($lock->release());
 
         // Now we have cleared the lock we will, one last time, confirm that
@@ -120,7 +120,7 @@ class RepositoryTest extends TestCase
         defer()->invoke();
         $this->assertCount(0, defer());
         $this->assertSame(4, $cache->get('foo'));
-        $this->assertSame(946684843, $cache->get('foo:created'));
+        $this->assertSame(946684843, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // The last thing is to check that we don't refresh the cache in the
         // deferred callback if another thread has already done the work for us.
@@ -132,13 +132,13 @@ class RepositoryTest extends TestCase
         $this->assertSame(4, $value);
         $this->assertCount(1, defer());
         $this->assertSame(4, $cache->get('foo'));
-        $this->assertSame(946684843, $cache->get('foo:created'));
+        $this->assertSame(946684843, $cache->get('illuminate:cache:flexible:created:foo'));
 
         // There is now a deferred callback ready to refresh the cache. We will
         // simulate another thread updating the value.
         $cache->putMany([
             'foo' => 99,
-            'foo:created' => 946684863,
+            'illuminate:cache:flexible:created:foo' => 946684863,
         ]);
 
         // then we will run the refresh callback
@@ -149,7 +149,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(99, $value);
         $this->assertCount(0, defer());
         $this->assertSame(99, $cache->get('foo'));
-        $this->assertSame(946684863, $cache->get('foo:created'));
+        $this->assertSame(946684863, $cache->get('illuminate:cache:flexible:created:foo'));
     }
 
     public function testItHandlesStrayTtlKeyAfterMainKeyIsForgotten()
@@ -185,25 +185,25 @@ class RepositoryTest extends TestCase
         $cache->flexible('count', [5, 10], fn () => 1);
 
         $this->assertTrue($cache->has('count'));
-        $this->assertTrue($cache->has('count:created'));
+        $this->assertTrue($cache->has('illuminate:cache:flexible:created:count'));
 
         $cache->forget('count');
 
         $this->assertEmpty($cache->getConnection()->table('cache')->get());
         $this->assertTrue($cache->missing('count'));
-        $this->assertTrue($cache->missing('count:created'));
+        $this->assertTrue($cache->missing('illuminate:cache:flexible:created:count'));
 
         $cache->flexible('count', [5, 10], fn () => 1);
 
         $this->assertTrue($cache->has('count'));
-        $this->assertTrue($cache->has('count:created'));
+        $this->assertTrue($cache->has('illuminate:cache:flexible:created:count'));
 
         $this->travel(20)->seconds();
         $cache->forgetIfExpired('count');
 
         $this->assertEmpty($cache->getConnection()->table('cache')->get());
         $this->assertTrue($cache->missing('count'));
-        $this->assertTrue($cache->missing('count:created'));
+        $this->assertTrue($cache->missing('illuminate:cache:flexible:created:count'));
     }
 
     public function testItImplicitlyClearsTtlKeysFromFileDriver()
@@ -214,25 +214,25 @@ class RepositoryTest extends TestCase
         $cache->flexible('count', [5, 10], fn () => 1);
 
         $this->assertTrue($cache->has('count'));
-        $this->assertTrue($cache->has('count:created'));
+        $this->assertTrue($cache->has('illuminate:cache:flexible:created:count'));
 
         $cache->forget('count');
 
         $this->assertFalse($cache->getFilesystem()->exists($cache->path('count')));
-        $this->assertFalse($cache->getFilesystem()->exists($cache->path('count:created')));
+        $this->assertFalse($cache->getFilesystem()->exists($cache->path('illuminate:cache:flexible:created:count')));
         $this->assertTrue($cache->missing('count'));
-        $this->assertTrue($cache->missing('count:created'));
+        $this->assertTrue($cache->missing('illuminate:cache:flexible:created:count'));
 
         $cache->flexible('count', [5, 10], fn () => 1);
 
         $this->assertTrue($cache->has('count'));
-        $this->assertTrue($cache->has('count:created'));
+        $this->assertTrue($cache->has('illuminate:cache:flexible:created:count'));
 
         $this->travel(20)->seconds();
 
         $this->assertTrue($cache->missing('count'));
         $this->assertFalse($cache->getFilesystem()->exists($cache->path('count')));
-        $this->assertFalse($cache->getFilesystem()->exists($cache->path('count:created')));
-        $this->assertTrue($cache->missing('count:created'));
+        $this->assertFalse($cache->getFilesystem()->exists($cache->path('illuminate:cache:flexible:created:count')));
+        $this->assertTrue($cache->missing('illuminate:cache:flexible:created:count'));
     }
 }


### PR DESCRIPTION
## Bugfix

Addresses a potential bug in `Cache::flexible` where the main key has been forgotten, via `Cache::forget('foo')`, but the TTL key, i.e., `foo:created`, remains in the cache.

When `Cache::flexible` is called again, `null` is returned rather than calling the `Closure $callback` and refreshing the value in the cache.

There is a race condition in this solution where the `$value` is intentionally `null` and the value expires after we retrieve it from the cache but before we check `$this->missing($key)`. I don't really see any real-world problem with refreshing the cache in that situation though. The value just expired after all. Heck, I'd even call it a feature.

## Cleanup flexible TTL keys

The database and file driver may leave behind TTL keys when the main key has been forgotten. Both the database and file driver will now attempt to cleanup the flexible TTL keys as well.

## TTL key rename

Because we now implicitly clean up flexible TTL keys in the database and file driver, I felt it best we rename the TTL key, as `...:created` could easily be a user land key that we accidentally delete.

We now namespace the key `illuminate:cache:flexible:created:{key}`.

I suppose this is a breaking change, but I think removing the possibility of accidentally deleting user-land keys is more breaking than having the cache value refreshed early for this one off change.

## Standardise key names

While I was in here making this change I also updated the defer key and the cache lock name to match the `illuminate:cache:flexible:*` pattern.

fixes #52847