### PR TITLE
Add psr/simple-cache v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "opis/closure": "^3.6",
         "psr/container": "^1.0",
         "psr/log": "^1.0|^2.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1.0|^2.0",
         "ramsey/uuid": "^4.2.2",
         "swiftmailer/swiftmailer": "^6.3",
         "symfony/console": "^5.4",


### PR DESCRIPTION
Why is this a security issue?
The lack of support for simple-cache v2 blocks applying security updates to other packages that require `simple-cache ^2.0|^3.0`.

Since simple cache v1 and v2 are backward compatible, I'm confident it won't be difficult for you to merge this change.