### PR TITLE
[11.x] Do not trigger missing translation key handling when checking existence of translation key

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -117,7 +117,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locale = $locale ?: $this->locale;
 
+        $handleMissingTranslationKeys = $this->handleMissingTranslationKeys;
+
+        $this->handleMissingTranslationKeys = false;
+
         $line = $this->get($key, [], $locale, $fallback);
+
+        $this->handleMissingTranslationKeys = $handleMissingTranslationKeys;
 
         // For JSON translations, the loaded files will contain the correct line.
         // Otherwise, we must assume we are handling typical translation file

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -41,6 +41,19 @@ class TranslatorTest extends TestCase
         $this->assertTrue($this->app['translator']->hasForLocale('30 Days'));
     }
 
+    public function testItCanCheckKeyExistsWithoutTriggeringHandleMissingKeys()
+    {
+        $this->app['translator']->handleMissingKeysUsing(function ($key) {
+            $_SERVER['__missing_translation_key'] = $key;
+        });
+
+        $this->assertFalse($this->app['translator']->has('Foo Bar'));
+        $this->assertFalse(isset($_SERVER['__missing_translation_key']));
+
+        $this->assertFalse($this->app['translator']->hasForLocale('Foo Bar', 'nl'));
+        $this->assertFalse(isset($_SERVER['__missing_translation_key']));
+    }
+
     public function testItCanHandleMissingKeysUsingCallback()
     {
         $this->app['translator']->handleMissingKeysUsing(function ($key) {


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/52343, the missing translation key handling is triggered when using the `trans_choice` method with a translation key that has no translation in the app's current locale but does have a translation in the fallback locale. 

```php
// Translation key: "foo.bar"
// Translation in English (en): ":count Foo|:count Bar"
// Translation in Dutch (nl): Not set!
// Fallback Locale is English

app()->setLocale('en');
trans_choice('foo.bar', 1);
// --> Does not trigger "Lang::handleMissingKeysUsing" closure which is correct

app()->setLocale('nl');
trans_choice('foo.bar', 1);
// --> Triggers "Lang::handleMissingKeysUsing" closure which is not correct
//     because a translation in the fallback locale (= 'en') does exist!
```

This is caused by the fact that it checks the existence of a translation key without a fallback to the fallback locale. To fix this, I changed the `has` method of the `Translator` class so that checking the existence of a key does not trigger the `Lang::handleMissingKeysUsing` closure.
