### PR TITLE
add decimal rule test case

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,7 +5,6 @@ namespace Illuminate\Validation\Concerns;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
-use Brick\Math\Exception\NumberFormatException;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
@@ -636,7 +635,7 @@ trait ValidatesAttributes
         }
 
         try {
-            $big_decimal =BigDecimal::of($value)->stripTrailingZeros();
+            $big_decimal = BigDecimal::of($value)->stripTrailingZeros();
         } catch (Exception) {
             return false;
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -636,25 +636,18 @@ trait ValidatesAttributes
         }
 
         try {
-            $value_str = sprintf('%s', BigDecimal::of($value)->stripTrailingZeros());
-        } catch (NumberFormatException) {
+            $big_decimal =BigDecimal::of($value)->stripTrailingZeros();
+        } catch (Exception) {
             return false;
         }
 
-        $matches = [];
-
-        if (preg_match('/^[+-]?\d*\.?(\d*)$/', $value_str, $matches) !== 1) {
-            return false;
-        }
-
-        $decimals = strlen(end($matches));
-
+        $decimals = $big_decimal->getScale();
         if (! isset($parameters[1])) {
             return $decimals == $parameters[0];
         }
 
         return $decimals >= $parameters[0] &&
-               $decimals <= $parameters[1];
+            $decimals <= $parameters[1];
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation\Concerns;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
+use Brick\Math\Exception\NumberFormatException;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
@@ -634,9 +635,15 @@ trait ValidatesAttributes
             return false;
         }
 
+        try {
+            $value_str = sprintf('%s', BigDecimal::of($value)->stripTrailingZeros());
+        } catch (NumberFormatException) {
+            return false;
+        }
+
         $matches = [];
 
-        if (preg_match('/^[+-]?\d*\.?(\d*)$/', $value, $matches) !== 1) {
+        if (preg_match('/^[+-]?\d*\.?(\d*)$/', $value_str, $matches) !== 1) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3112,6 +3112,10 @@ class ValidationValidatorTest extends TestCase
     public function testValidateDecimal()
     {
         $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => 0.000004], ['foo' => 'Decimal:6']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Decimal:2,3']);
         $this->assertFalse($v->passes());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3248,6 +3248,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Max:1.88888888888888888888']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => '10.9e-10000000000'], ['foo' => 'Decimal:6']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, [
             // these are the same number
             'decimal' => '0.555',

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3266,7 +3266,7 @@ class ValidationValidatorTest extends TestCase
             'decimal' => 'Decimal:0,3',
             'scientific' => 'Decimal:0,3',
         ]);
-        $this->assertSame(['scientific'], $v->errors()->keys());
+        $this->assertSame([], $v->errors()->keys());
 
         $v = new Validator($trans, ['foo' => '+'], ['foo' => 'Decimal:0,2']);
         $this->assertTrue($v->fails());


### PR DESCRIPTION
this case will result in test failure, because the implicit type-cast will cast the double `0.000004` to string `4.0E-6`,but I don't know how to resolve it
