### PR TITLE
[11.x] Adds the ability to call defer conditionally

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -33,7 +33,6 @@ class InvokeDeferredCallbacks
     {
         Container::getInstance()
             ->make(DeferredCallbackCollection::class)
-            ->invokeWhen(fn ($callback) => $callback->shouldCall($request, $response) &&
-                $response->getStatusCode() < 400 || $callback->always);
+            ->invokeWhen(fn ($callback) => $callback->shouldCall($request, $response) && ($response->getStatusCode() < 400 || $callback->always));
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php
@@ -33,6 +33,7 @@ class InvokeDeferredCallbacks
     {
         Container::getInstance()
             ->make(DeferredCallbackCollection::class)
-            ->invokeWhen(fn ($callback) => $response->getStatusCode() < 400 || $callback->always);
+            ->invokeWhen(fn ($callback) => $callback->shouldCall($request, $response) &&
+                $response->getStatusCode() < 400 || $callback->always);
     }
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -198,12 +198,12 @@ class FoundationServiceProvider extends AggregateServiceProvider
         $this->app->scoped(DeferredCallbackCollection::class);
 
         $this->app['events']->listen(function (CommandFinished $event) {
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => app()->runningInConsole() && ($event->exitCode === 0 || $callback->always)
+            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => app()->runningInConsole() && $callback->shouldCall() && ($event->exitCode === 0 || $callback->always)
             );
         });
 
         $this->app['events']->listen(function (JobAttempted $event) {
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => $event->connectionName !== 'sync' && ($event->successful() || $callback->always)
+            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => $event->connectionName !== 'sync' && $callback->shouldCall() && ($event->successful() || $callback->always)
             );
         });
     }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -414,6 +414,21 @@ if (! function_exists('defer')) {
     }
 }
 
+if (! function_exists('defer_if')) {
+    /**
+     * Defer execution of the given callback if conditional is valid.
+     *
+     * @param  callable|null  $callback
+     * @param  string|null  $name
+     * @param  bool  $always
+     * @return \Illuminate\Foundation\Defer\DeferredCallback
+     */
+    function defer_if(bool|callable $conditional = true, ?callable $callback = null, ?string $name = null, bool $always = false)
+    {
+        return \Illuminate\Support\defer($callback, $name, $always, $conditional);
+    }
+}
+
 if (! function_exists('dispatch')) {
     /**
      * Dispatch a job to its appropriate handler.

--- a/src/Illuminate/Support/Defer/DeferredCallback.php
+++ b/src/Illuminate/Support/Defer/DeferredCallback.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Defer;
 
-use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,10 +26,10 @@ class DeferredCallback
     /**
      * Specify an if condition to run or not the callback.
      *
-     * @param  bool|Closure  $conditional
+     * @param  bool|callable  $conditional
      * @return $this
      */
-    public function if(bool|Closure $conditional): self
+    public function if(bool|callable $conditional): self
     {
         $this->conditional = $conditional;
 

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Closure;
 use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Process\PhpExecutableFinder;
@@ -14,14 +15,14 @@ use Illuminate\Support\Process\PhpExecutableFinder;
  * @param  bool  $always
  * @return \Illuminate\Support\Defer\DeferredCallback
  */
-function defer(?callable $callback = null, ?string $name = null, bool $always = false)
+function defer(?callable $callback = null, ?string $name = null, bool $always = false, bool|callable $conditional = true)
 {
     if ($callback === null) {
         return app(DeferredCallbackCollection::class);
     }
 
     return tap(
-        new DeferredCallback($callback, $name, $always),
+        new DeferredCallback($callback, $name, $always, $conditional),
         fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
     );
 }

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support;
 
-use Closure;
 use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Process\PhpExecutableFinder;


### PR DESCRIPTION
With this proposal it is now possible to pass a boolean or a callback (evaluated at the end of the cycle) to defer. This way it is possible to validate later whether the defer should be executed or not.

This is especially useful for Laravel packages, as they do not have the same control over the application as the developer. They cannot call `defer` only when all possibilities where it should not be called have been evaluated, so the conditional gives the package developer the possibility to evaluate this after the developer flow.

Of course, it can be very useful for application developer flows as well. In some more complex logics, it can be used within a request class, or placed generically within a provider or middleware.

Some examples:
```php
// Defer if none errors was emitted by validation
defer_if(fn($request) => $request->session()->missing('errors'), fn() => /*--*/);

// Defer if at the end of request an user is logger. It even works when logging in.
defer_if(fn($request) => $request->user(), fn() => /*--*/);
// the bellow works equal
defer(fn() => /*--*/)->if(fn($request) => $request->user());
```