### PR TITLE
[11.x] Fix for not automatically registering commands in App\Console\Commands

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -282,12 +282,14 @@ class ApplicationBuilder
      */
     public function withCommands(array $commands = [])
     {
-        if (empty($commands) && is_file($this->app->basePath('routes/console.php'))) {
-            $commands = [$this->app->basePath('routes/console.php')];
-        }
+        if (empty($commands)) {
+            if (is_file($this->app->basePath('routes/console.php'))) {
+                $commands = [$this->app->basePath('routes/console.php')];
+            }
 
-        if (empty($commands) && is_dir($this->app->path('Console/Commands'))) {
-            $commands = [$this->app->path('Console/Commands')];
+            if (is_dir($this->app->path('Console/Commands'))) {
+                $commands = [...$commands, $this->app->path('Console/Commands')];
+            }
         }
 
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($commands) {


### PR DESCRIPTION
PR #52867 introduced a Bug #52902 when registering commands using both the `routes/console.php` and `app/Commands` namespace. 

This PR fixes the bug by simply merging the commands found.
Again, unfortunately no tests.