### PR TITLE
[11.x] Fixes `defer()` function return type

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -406,7 +406,7 @@ if (! function_exists('defer')) {
      * @param  callable|null  $callback
      * @param  string|null  $name
      * @param  bool  $always
-     * @return \Illuminate\Foundation\Defer\DeferredCallback
+     * @return \Illuminate\Support\Defer\DeferredCallback
      */
     function defer(?callable $callback = null, ?string $name = null, bool $always = false)
     {


### PR DESCRIPTION
The class had been moved in https://github.com/laravel/framework/pull/52801.
