### PR TITLE
[11.x] Fix PHPDoc for TestResponse's `Response` Type to \Symfony\Component\HttpFoundation\Response

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -28,6 +28,8 @@ use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
+ * @template TResponse of \Symfony\Component\HttpFoundation\Response
+ *
  * @mixin \Illuminate\Http\Response
  */
 class TestResponse implements ArrayAccess
@@ -46,7 +48,7 @@ class TestResponse implements ArrayAccess
     /**
      * The response to delegate to.
      *
-     * @var \Illuminate\Http\Response
+     * @var TResponse
      */
     public $baseResponse;
 
@@ -67,7 +69,7 @@ class TestResponse implements ArrayAccess
     /**
      * Create a new test response instance.
      *
-     * @param  \Illuminate\Http\Response  $response
+     * @param  TResponse  $response
      * @param  \Illuminate\Http\Request|null  $request
      * @return void
      */
@@ -81,9 +83,11 @@ class TestResponse implements ArrayAccess
     /**
      * Create a new TestResponse from another response.
      *
-     * @param  \Illuminate\Http\Response  $response
+     * @template R of TResponse
+     *
+     * @param  R  $response
      * @param  \Illuminate\Http\Request|null  $request
-     * @return static
+     * @return static<R>
      */
     public static function fromBaseResponse($response, $request = null)
     {

--- a/types/Testing/TestResponse.php
+++ b/types/Testing/TestResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+use function PHPStan\Testing\assertType;
+
+$response = TestResponse::fromBaseResponse(response()->redirectTo(''));
+assertType(RedirectResponse::class, $response->baseResponse);
+
+$response = TestResponse::fromBaseResponse(response()->download(''));
+assertType(BinaryFileResponse::class, $response->baseResponse);
+
+$response = TestResponse::fromBaseResponse(response()->json());
+assertType(JsonResponse::class, $response->baseResponse);
+
+$response = TestResponse::fromBaseResponse(response()->streamDownload(fn () => 1));
+assertType(StreamedResponse::class, $response->baseResponse);

--- a/types/Testing/TestResponse.php
+++ b/types/Testing/TestResponse.php
@@ -2,11 +2,15 @@
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 use function PHPStan\Testing\assertType;
+
+$response = TestResponse::fromBaseResponse(response('Laravel', 200));
+assertType(Response::class, $response->baseResponse);
 
 $response = TestResponse::fromBaseResponse(response()->redirectTo(''));
 assertType(RedirectResponse::class, $response->baseResponse);


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where the PHPDoc for `TestResponse` incorrectly specifies the `Response` type as `\Illuminate\Http\Response`. Upon closer inspection, it was found that the actual response type can be more generalized to `\Symfony\Component\HttpFoundation\Response`. Specifically, when dealing with download responses or redirect responses, the type is not `\Illuminate\Http\Response`.
