### PR TITLE
[11.x] - Prevent stray queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -175,7 +175,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $modelsShouldPreventLazyLoading = false;
 
     /**
-     * Indicates whether models should allow forwarding to a new query.
+     * Indicates if calls to be forwarded to new queries on an existing model should be prevented.
      *
      * @var bool
      */
@@ -462,7 +462,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Prevent model relationships from being lazy loaded.
+     * Prevent calls to be forwarded to new queries on an existing model.
      *
      * @param  bool  $value
      * @return void

--- a/src/Illuminate/Database/StrayQueryException.php
+++ b/src/Illuminate/Database/StrayQueryException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class StrayQueryException extends RuntimeException
+{
+    /**
+     * The name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  object  $model
+     * @return void
+     */
+    public function __construct($model)
+    {
+        $class = get_class($model);
+
+        parent::__construct("Stray query detected on model [{$class}] but stray queries are being prevented.");
+
+        $this->model = $class;
+    }
+}

--- a/tests/Integration/Database/EloquentPreventStrayQueriesTest.php
+++ b/tests/Integration/Database/EloquentPreventStrayQueriesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\StrayQueryException;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+class EloquentPreventStrayQueriesTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::preventStrayQueries();
+    }
+
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('stray_queries_test_model', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('number')->default(1);
+        });
+    }
+
+    public function testAnExceptionIsThrownIfTheModelExists()
+    {
+        $model = EloquentPreventStrayQueriesTestModel::create();
+
+        $this->expectException(StrayQueryException::class);
+        $this->expectExceptionMessage('Stray query detected');
+
+        $model->each(function ($model) {
+            //
+        });
+    }
+
+    public function testAnExceptionIsNotThrownIfTheModelDoesNotExist()
+    {
+        $model = EloquentPreventStrayQueriesTestModel::make(['number' => 5]);
+
+        $model->each(function ($model) {
+            $this->assertInstanceOf(EloquentPreventStrayQueriesTestModel::class, $model);
+        });
+    }
+
+    public function testBadMethodCallExceptionIsStillThrownIfMethodDoesNotExist()
+    {
+        $model = EloquentPreventStrayQueriesTestModel::create();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method');
+
+        $model->foo(function ($model) {
+            //
+        });
+    }
+}
+
+class EloquentPreventStrayQueriesTestModel extends Model
+{
+    public $table = 'stray_queries_test_model';
+    public $timestamps = false;
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentPreventStrayQueriesTest.php
+++ b/tests/Integration/Database/EloquentPreventStrayQueriesTest.php
@@ -20,6 +20,13 @@ class EloquentPreventStrayQueriesTest extends DatabaseTestCase
         Model::preventStrayQueries();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Model::preventStrayQueries(false);
+    }
+
     protected function afterRefreshingDatabase()
     {
         Schema::create('stray_queries_test_model', function (Blueprint $table) {

--- a/tests/Integration/Database/EloquentPreventStrayQueriesTest.php
+++ b/tests/Integration/Database/EloquentPreventStrayQueriesTest.php
@@ -56,7 +56,7 @@ class EloquentPreventStrayQueriesTest extends DatabaseTestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Call to undefined method');
 
-        $model->foo(function ($model) {
+        $model->nonExistingMethod(function ($model) {
             //
         });
     }


### PR DESCRIPTION
## Problem

If you call an eloquent method on a model that already exists, it spins up a new query and executes that query due to the `ForwardsCalls` trait on the `Model` class.

Consider you have some service `UserService` which has two methods;
- `createUser`
- `createUsers`


```php
class UserService
{
    public function createUser(array $data): User;

    public function createUsers(array $data): Collection;
}
```

Then somewhere else in your code base you do something like
```php
class CreateUserAction
{
  public function __construct(private readonly UserService $service)
  {
  }

  public function execute(array $data)
  {
    $this->service->createUser()->each(function ($user) {
      $user->sendInviteEmail();
    });
  }
}

```

Note there was a typo (on purpose) in the snippet above whereby we called `createUser` instead of `createUsers`. When we get our single `User` back from the service, `each` will then be forward to a new query and essentially we will now send an invite email to every single user in our database because the forwarded call calls `each` on a new query which would include every single user in the database.

Testing may catch this but it's also common to only create a single record during tests or to assert an email was sent to the target user - not that every other user didn't get an email as well.

## Solution

By calling `Model::preventStrayQueries()` we can prevent this behaviour be ensuring no queries can be instantiated from an existing model.

```php
// In AppServiceProvider

Model::preventStrayQueries();

class CreateUserAction
{
  public function __construct(private readonly UserService $service)
  {
  }

  public function execute(array $data)
  {
    $this->service->createUser()->each(function ($user) { // StrayQueryException will be thrown
      $user->sendInviteEmail();
    });
  }
}

```

## Calling undefined methods

This PR also ensured that methods that don't exist still behave as expected however there may be a better way to achieve this as this would still allow the query to be instantiated, as the exception is thrown afterwards. This ensures only methods that would normally result in a stray query will throw the exception.
```php
$user = $this->service->createUsers($user);
$user->doSomethingImaginary(); // BadMethodCallException
```

## Naming

I'm not too sure on the naming but would be happy to make any adjustments and PR this to the docs if necessary.


## Breaking Changes
There are no breaking changes as this is completely opt-in.