### PR TITLE
[11.x] Optimize commands registry

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -39,7 +39,12 @@ class OptimizeClearCommand extends Command
         $this->newLine();
     }
 
-    public function getOptimizeClearTasks(): array
+    /**
+     * Get the commands that should be run to clear the "optimization" files.
+     *
+     * @return array
+     */
+    public function getOptimizeClearTasks()
     {
         return [
             'cache' => 'cache:clear',
@@ -48,7 +53,7 @@ class OptimizeClearCommand extends Command
             'events' => 'event:clear',
             'routes' => 'route:clear',
             'views' => 'view:clear',
-            ...ServiceProvider::$optimizeClearingCommands,
+            ...ServiceProvider::$optimizeClearCommands,
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'optimize')]
@@ -31,13 +32,21 @@ class OptimizeCommand extends Command
     {
         $this->components->info('Caching framework bootstrap, configuration, and metadata.');
 
-        collect([
-            'config' => fn () => $this->callSilent('config:cache') == 0,
-            'events' => fn () => $this->callSilent('event:cache') == 0,
-            'routes' => fn () => $this->callSilent('route:cache') == 0,
-            'views' => fn () => $this->callSilent('view:cache') == 0,
-        ])->each(fn ($task, $description) => $this->components->task($description, $task));
+        foreach ($this->getOptimizeTasks() as $description => $command) {
+            $this->components->task($description, fn () => $this->callSilently($command) == 0);
+        }
 
         $this->newLine();
+    }
+
+    protected function getOptimizeTasks(): array
+    {
+        return [
+            'config' => 'config:cache',
+            'events' => 'event:cache',
+            'routes' => 'route:cache',
+            'views' => 'view:cache',
+            ...ServiceProvider::$optimizingCommands,
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -39,14 +39,19 @@ class OptimizeCommand extends Command
         $this->newLine();
     }
 
-    protected function getOptimizeTasks(): array
+    /**
+     * Get the commands that should be run to optimize the framework.
+     *
+     * @return array
+     */
+    protected function getOptimizeTasks()
     {
         return [
             'config' => 'config:cache',
             'events' => 'event:cache',
             'routes' => 'route:cache',
             'views' => 'view:cache',
-            ...ServiceProvider::$optimizingCommands,
+            ...ServiceProvider::$optimizeCommands,
         ];
     }
 }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -52,6 +52,20 @@ abstract class ServiceProvider
     public static $publishGroups = [];
 
     /**
+     * Commands that should be run during the optimize command.
+     *
+     * @var array<string, string>
+     */
+    public static array $optimizingCommands = [];
+
+    /**
+     * Commands that should be run during the optimize:clear command.
+     *
+     * @var array<string, string>
+     */
+    public static array $optimizeClearingCommands = [];
+
+    /**
      * The migration paths available for publishing.
      *
      * @var array
@@ -536,5 +550,16 @@ return [
         file_put_contents($path, $content.PHP_EOL);
 
         return true;
+    }
+
+    protected function registerOptimizeCommands(string $key, string $optimize = null, string $optimizeClear = null): void
+    {
+        if ($optimize) {
+            static::$optimizingCommands[$key] = $optimize;
+        }
+
+        if ($optimizeClear) {
+            static::$optimizeClearingCommands[$key] = $optimizeClear;
+        }
     }
 }

--- a/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Foundation\Console\ClosureCommand;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Tests\Integration\Generators\TestCase;
+
+class OptimizeClearCommandTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [ServiceProviderWithOptimizeClear::class];
+    }
+
+    public function testCanListenToOptimizingEvent(): void
+    {
+        $this->artisan('optimize:clear')
+            ->assertSuccessful()
+            ->expectsOutputToContain('my package');
+    }
+}
+
+class ServiceProviderWithOptimizeClear extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->commands([
+            new ClosureCommand('my_package:clear', fn () => 0),
+        ]);
+
+        $this->registerOptimizeCommands(
+            key: 'my package',
+            optimizeClear: 'my_package:clear',
+        );
+    }
+}

--- a/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
@@ -17,7 +17,7 @@ class OptimizeClearCommandTest extends TestCase
     {
         $this->artisan('optimize:clear')
             ->assertSuccessful()
-            ->expectsOutputToContain('my package');
+            ->expectsOutputToContain('ServiceProviderWithOptimizeClear');
     }
 }
 
@@ -29,9 +29,8 @@ class ServiceProviderWithOptimizeClear extends ServiceProvider
             new ClosureCommand('my_package:clear', fn () => 0),
         ]);
 
-        $this->registerOptimizeCommands(
-            key: 'my package',
-            optimizeClear: 'my_package:clear',
+        $this->optimizes(
+            clear: 'my_package:clear',
         );
     }
 }

--- a/tests/Integration/Foundation/Console/OptimizeCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Foundation\Console\ClosureCommand;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Tests\Integration\Generators\TestCase;
+
+class OptimizeCommandTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [ServiceProviderWithOptimize::class];
+    }
+
+    public function testCanListenToOptimizingEvent(): void
+    {
+        $this->artisan('optimize')
+            ->assertSuccessful()
+            ->expectsOutputToContain('my package');
+    }
+}
+
+class ServiceProviderWithOptimize extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->commands([
+            new ClosureCommand('my_package:cache', fn () => 0),
+        ]);
+
+        $this->registerOptimizeCommands(
+            key: 'my package',
+            optimize: 'my_package:cache',
+        );
+    }
+}

--- a/tests/Integration/Foundation/Console/OptimizeCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeCommandTest.php
@@ -29,9 +29,9 @@ class ServiceProviderWithOptimize extends ServiceProvider
             new ClosureCommand('my_package:cache', fn () => 0),
         ]);
 
-        $this->registerOptimizeCommands(
-            key: 'my package',
+        $this->optimizes(
             optimize: 'my_package:cache',
+            key: 'my package',
         );
     }
 }


### PR DESCRIPTION
## Motivation
 
From the docs:

> When deploying your application to production, there are a variety of files that should be cached, including your configuration, events, routes, and views. Laravel provides a single, convenient `optimize` Artisan command that will cache all of these files.

Other than the caching commands the framework uses by default, third-party packages often also have similar commands:

- [blade-ui-kit/blade-icons](https://github.com/blade-ui-kit/blade-icons): `icons:cache` && `icons:clear`
- [spatie/laravel-event-sourcing](https://github.com/spatie/laravel-event-sourcing): `event-sourcing:cache-event-handlers` && `event-sourcing:clear-event-handlers`
- [spatie/laravel-data](https://github.com/spatie/laravel-data): `data:cache-structures`

Of course, developers are expected to read integration guides so they can install and configure packages accordingly. However, sometimes deployment optimization steps like these are forgotten about (I'm personally the prime example of that 🙈). Packages usually _just work_ if you forget this but are running with sub-optimal performance costing more compute time ⏱️ , energy ⚡  and money 💰  as a result.

Wouldn't it be great that every package you install does these optimization steps automatically?

## Implementation

This addition surfaces an extension point packages can use to run their own _optimization_ handlers to be automatically run when the `artisan optimize` and `artisan optimize:clear` commands run.

~It works by having an event be dispatched (`Optimizing` and `OptimizeClearing`) whenever the `artisan optimize` command runs. Packages can then register an event listener in their service providers that run the optimization step they need to do.~

A previous implementation worked by dispatching special events that package developers could hook into. After consideration, I've taken a different approach similar to how _publishes_ are registered in Service Providers.

The `ServiceProvider` class now offers a `registerOptimizeCommands()` method that can be used to register a command that should run during the `optimize` and `optimize:clear` commands. It also allows you to provide a `key` which is used to show the step in the command output. 

Example:

```php
class PackageServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        $this->commands([
            MyPackage\CacheCommand::class,
            MyPackage\ClearCommand::class
        ]);

        $this->registerOptimizeCommands(
            key: 'my package',
            optimize: 'my_package:cache',
            optimizeClear: 'my_package:clear',
        );
    }
}
```

Running the `optimize` command will now also output all the optimization commands that ran:

```
$ php artisan optimize

   INFO  Caching framework bootstrap, configuration, and metadata.  

  config .................................................................... 39.29ms DONE
  events ..................................................................... 2.28ms DONE
  routes .................................................................... 36.46ms DONE
  views .................................................................... 647.20ms DONE
  my package ................................................................. 0.23ms DONE
```

## Todo

- [x] Find a way to show progress/tasks of packages doing their caching/clearing in the output of the command.
- [ ] The `optimize` and `optimize:clear` commands were backported to earlier versions of Laravel, do we want to do that with this PR too?