### PR TITLE
[11.x] Allows Unit & Backed Enums for registering named `RateLimiter` & `RateLimited` middleware

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Cache;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\InteractsWithTime;
+use UnitEnum;
 
 class RateLimiter
 {
@@ -38,13 +40,15 @@ class RateLimiter
     /**
      * Register a named limiter configuration.
      *
-     * @param  string  $name
+     * @param  BackedEnum|UnitEnum|string  $name
      * @param  \Closure  $callback
      * @return $this
      */
-    public function for(string $name, Closure $callback)
+    public function for($name, Closure $callback)
     {
-        $this->limiters[$name] = $callback;
+        $resolvedName = $this->resolveLimiterName($name);
+
+        $this->limiters[$resolvedName] = $callback;
 
         return $this;
     }
@@ -52,12 +56,14 @@ class RateLimiter
     /**
      * Get the given named rate limiter.
      *
-     * @param  string  $name
+     * @param  BackedEnum|UnitEnum|string  $name
      * @return \Closure|null
      */
-    public function limiter(string $name)
+    public function limiter($name)
     {
-        return $this->limiters[$name] ?? null;
+        $resolvedName = $this->resolveLimiterName($name);
+
+        return $this->limiters[$resolvedName] ?? null;
     }
 
     /**
@@ -247,5 +253,20 @@ class RateLimiter
     public function cleanRateLimiterKey($key)
     {
         return preg_replace('/&([a-z])[a-z]+;/i', '$1', htmlentities($key));
+    }
+
+    /**
+     * Resolve the rate limiter name
+     *
+     * @param BackedEnum|UnitEnum|string $name
+     * @return string
+     */
+    private function resolveLimiterName($name): string
+    {
+        return match (true) {
+            $name instanceof BackedEnum => $name->value,
+            $name instanceof UnitEnum => $name->name,
+            default => (string) $name,
+        };
     }
 }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -40,7 +40,7 @@ class RateLimiter
     /**
      * Register a named limiter configuration.
      *
-     * @param  BackedEnum|UnitEnum|string  $name
+     * @param  \BackedEnum|\UnitEnum|string  $name
      * @param  \Closure  $callback
      * @return $this
      */
@@ -56,7 +56,7 @@ class RateLimiter
     /**
      * Get the given named rate limiter.
      *
-     * @param  BackedEnum|UnitEnum|string  $name
+     * @param  \BackedEnum|\UnitEnum|string  $name
      * @return \Closure|null
      */
     public function limiter($name)
@@ -258,7 +258,7 @@ class RateLimiter
     /**
      * Resolve the rate limiter name
      *
-     * @param BackedEnum|UnitEnum|string $name
+     * @param  \BackedEnum|\UnitEnum|string $name
      * @return string
      */
     private function resolveLimiterName($name): string

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -35,7 +35,7 @@ class RateLimited
     /**
      * Create a new middleware instance.
      *
-     * @param  BackedEnum|UnitEnum|string  $limiterName
+     * @param  \BackedEnum|\UnitEnum|string  $limiterName
      * @return void
      */
     public function __construct($limiterName)

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Queue\Middleware;
 
+use BackedEnum;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Container\Container;
 use Illuminate\Support\Arr;
+use UnitEnum;
 
 class RateLimited
 {
@@ -33,14 +35,18 @@ class RateLimited
     /**
      * Create a new middleware instance.
      *
-     * @param  string  $limiterName
+     * @param  BackedEnum|UnitEnum|string  $limiterName
      * @return void
      */
     public function __construct($limiterName)
     {
         $this->limiter = Container::getInstance()->make(RateLimiter::class);
 
-        $this->limiterName = $limiterName;
+        $this->limiterName = match (true) {
+            $limiterName instanceof BackedEnum => $limiterName->value,
+            $limiterName instanceof UnitEnum => $limiterName->name,
+            default => (string) $limiterName,
+        };
     }
 
     /**

--- a/tests/Cache/RateLimiterTest.php
+++ b/tests/Cache/RateLimiterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class RateLimiterTest extends TestCase
+{
+    public static function registerNamedRateLimiterDataProvider(): array
+    {
+        return [
+            'uses BackedEnum' => [BackedEnumNamedRateLimiter::API, 'api'],
+            'uses UnitEnum' => [UnitEnumNamedRateLimiter::THIRD_PARTY, 'THIRD_PARTY'],
+            'uses normal string' => ['yolo', 'yolo'],
+            'uses int' => [100, '100'],
+        ];
+    }
+
+    #[DataProvider('registerNamedRateLimiterDataProvider')]
+    public function testRegisterNamedRateLimiter(mixed $name, string $expected): void
+    {
+        $reflectedLimitersProperty = new ReflectionProperty(RateLimiter::class, 'limiters');
+        $reflectedLimitersProperty->setAccessible(true);
+
+        $rateLimiter = new RateLimiter($this->createMock(Cache::class));
+        $rateLimiter->for($name, fn () => Limit::perMinute(100));
+
+        $limiters = $reflectedLimitersProperty->getValue($rateLimiter);
+
+        $this->assertArrayHasKey($expected, $limiters);
+
+        $limiterClosure = $rateLimiter->limiter($name);
+
+        $this->assertNotNull($limiterClosure);
+    }
+}
+
+enum BackedEnumNamedRateLimiter: string
+{
+    case API = 'api';
+}
+
+enum UnitEnumNamedRateLimiter
+{
+    case THIRD_PARTY;
+}


### PR DESCRIPTION
Hi team,

This PR enables us to use both `BackedEnum` & `UnitEnum` to register named `RateLimiter`, and the `RateLimited` middleware.

I believe many of us really want to use Enum for this case and avoid using hardcoded strings across our codebase.

![image](https://github.com/user-attachments/assets/1699e860-a96c-4f0e-bbd5-deea420908a8)
