### PR TITLE
[11.x] Fixed issue where Cache::forget() works differently if keys created with Cache::flexible when using Redis, DynamoDB, Memcached or Apc

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -101,6 +101,8 @@ class ApcStore extends TaggableStore
      */
     public function forget($key)
     {
+        $this->apc->delete("{$this->prefix}illuminate:cache:flexible:created:{$key}");
+
         return $this->apc->delete($this->prefix.$key);
     }
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -439,6 +439,15 @@ class DynamoDbStore implements LockProvider, Store
             'TableName' => $this->table,
             'Key' => [
                 $this->keyAttribute => [
+                    'S' => "{$this->prefix}illuminate:cache:flexible:created:{$key}",
+                ],
+            ],
+        ]);
+
+        $this->dynamo->deleteItem([
+            'TableName' => $this->table,
+            'Key' => [
+                $this->keyAttribute => [
                     'S' => $this->prefix.$key,
                 ],
             ],

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -211,6 +211,8 @@ class MemcachedStore extends TaggableStore implements LockProvider
      */
     public function forget($key)
     {
+        $this->memcached->delete("{$this->prefix}illuminate:cache:flexible:created:{$key}");
+
         return $this->memcached->delete($this->prefix.$key);
     }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -235,6 +235,8 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function forget($key)
     {
+        $this->connection()->del("{$this->prefix}illuminate:cache:flexible:created:{$key}");
+
         return (bool) $this->connection()->del($this->prefix.$key);
     }
 


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/52891.

Currently when calling `Cache::forget()` on any store, it will delete the cache item. Since the introduction of `Cache::flexible()` two items are created, the cache item itself and a "created" key.

For example:

```php
// This will create two keys, 'foo' and 'illuminate:cache:flexible:created:foo'
Cache::flexible('foo', 100, fn() => 'bar'); 
```

When using the store `file` or `database`, both cache items will be deleted. But when using Redis, the `'illuminate:cache:flexible:created:foo` will not be deleted.

I've created this PR to address this issue and making sure all stores work the same way, deleting all created keys when `Cache::forget()` is being called.