### PR TITLE
[11.x] Document callable types for `Enumerable::implode()`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -608,7 +608,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  callable|string|null  $value
+     * @param  (callable(TValue, TKey): mixed)|string|null  $value
      * @param  string|null  $glue
      * @return string
      */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -555,7 +555,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  callable|string  $value
+     * @param  (callable(TValue, TKey): mixed)|string  $value
      * @param  string|null  $glue
      * @return string
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -622,7 +622,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  callable|string  $value
+     * @param  (callable(TValue, TKey): mixed)|string  $value
      * @param  string|null  $glue
      * @return string
      */

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -538,6 +538,13 @@ assertType('Illuminate\Support\Collection<string, User>', $collection->keyBy(fun
 assertType('bool', $collection->has(0));
 assertType('bool', $collection->has([0, 1]));
 
+assertType('string', $collection->implode(function ($user, $index) {
+    assertType('User', $user);
+    assertType('int', $index);
+
+    return 'string';
+}));
+
 assertType('Illuminate\Support\Collection<int, User>', $collection->intersect([new User]));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->intersectByKeys([new User]));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -416,6 +416,13 @@ assertType('Illuminate\Support\LazyCollection<string, User>', $collection->keyBy
 assertType('bool', $collection->has(0));
 assertType('bool', $collection->has([0, 1]));
 
+assertType('string', $collection->implode(function ($user, $index) {
+    assertType('User', $user);
+    assertType('int', $index);
+
+    return 'string';
+}));
+
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->intersect([new User]));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->intersectByKeys([new User]));


### PR DESCRIPTION
I ran into an issue where PHPStan didn't check if the callable parameters for `implode()` matched the types of my collection. I've documented the callable types for `Collection::implode()` and `LazyCollection::implode()`. These methods forward the callable to `map()`, which is documented as `callable(TValue, TKey): TMapValue`.