### PR TITLE
Provide ResetPassword notification toMailUsing function with the full resetUrl.

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -60,9 +60,9 @@ class ResetPassword extends Notification
     public function toMail($notifiable)
     {
         $resetUrl = $this->resetUrl($notifiable);
-        
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $resetUrl);
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token, $resetUrl);
         }
 
         return $this->buildMailMessage($resetUrl);

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $resetUrl = $this->resetUrl($notifiable);
+        
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $resetUrl);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage($resetUrl);
     }
 
     /**


### PR DESCRIPTION
Allows overwriting the `resetUrl` function using `createUrlUsing` callback in a similar way `verificationUrl` can be overwritten with `createUrlUsing` to be included in `toMailUsing` in [VerifyEmail](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Auth/Notifications/VerifyEmail.php).

With the current implementation, in order to include a custom URL in `toMailUsing` callback, the `createUrlUsing` callback is of no use.