### PR TITLE
[11.x] Revert auto-discovering `routes/console.php` as this will cause breaking change with the default `withRouting($console)`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -282,11 +282,7 @@ class ApplicationBuilder
      */
     public function withCommands(array $commands = [])
     {
-        if (empty($commands) && is_file($this->app->basePath('routes/console.php'))) {
-            $commands = [$this->app->basePath('routes/console.php')];
-        }
-
-        if (empty($commands) && is_dir($this->app->path('Console/Commands'))) {
+        if (empty($commands)) {
             $commands = [$this->app->path('Console/Commands')];
         }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -282,14 +282,12 @@ class ApplicationBuilder
      */
     public function withCommands(array $commands = [])
     {
-        if (empty($commands)) {
-            if (is_file($this->app->basePath('routes/console.php'))) {
-                $commands = [$this->app->basePath('routes/console.php')];
-            }
+        if (empty($commands) && is_file($this->app->basePath('routes/console.php'))) {
+            $commands = [$this->app->basePath('routes/console.php')];
+        }
 
-            if (is_dir($this->app->path('Console/Commands'))) {
-                $commands = [...$commands, $this->app->path('Console/Commands')];
-            }
+        if (empty($commands) && is_dir($this->app->path('Console/Commands'))) {
+            $commands = [$this->app->path('Console/Commands')];
         }
 
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($commands) {


### PR DESCRIPTION
fixes #52929

Reverts #52903 #52867

