### PR TITLE
[11.x] Fix crash of method PreventsCircularRecursion::withoutRecursion() on mocked models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php
@@ -28,6 +28,10 @@ trait PreventsCircularRecursion
 
         $onceable = Onceable::tryFromTrace($trace, $callback);
 
+        if (is_null($onceable)) {
+            return call_user_func($callback);
+        }
+
         $stack = static::getRecursiveCallStack($this);
 
         if (array_key_exists($onceable->hash, $stack)) {

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -180,8 +180,8 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
 
         // Model toArray method implementation
         $toArray = $mock->withoutRecursion(
-            fn() => array_merge($mock->attributesToArray(), $mock->relationsToArray()),
-            fn() => $mock->attributesToArray(),
+            fn () => array_merge($mock->attributesToArray(), $mock->relationsToArray()),
+            fn () => $mock->attributesToArray(),
         );
         $this->assertEquals([], $toArray);
     }

--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Concerns\PreventsCircularRecursion;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
@@ -171,6 +172,18 @@ class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
         $this->assertEquals(3, $instance->instanceStack);
         $this->assertEquals(3, $second->instanceStack);
         $this->assertEquals(3, $third->instanceStack);
+    }
+
+    public function testMockedModelCallToWithoutRecursionMethodWorks(): void
+    {
+        $mock = Mockery::mock(TestModel::class)->makePartial();
+
+        // Model toArray method implementation
+        $toArray = $mock->withoutRecursion(
+            fn() => array_merge($mock->attributesToArray(), $mock->relationsToArray()),
+            fn() => $mock->attributesToArray(),
+        );
+        $this->assertEquals([], $toArray);
     }
 }
 


### PR DESCRIPTION
### Description
Method [\Illuminate\Database\Eloquent\Concerns\PreventsCircularRecursion::withoutRecursion()](https://github.com/laravel/framework/blob/a2c66ad997d583560836ae1c578bbbba6d52e26b/src/Illuminate/Database/Eloquent/Concerns/PreventsCircularRecursion.php#L25) will crash if it is invoked from eval.

That happens because [\Illuminate\Support\Onceable::tryFromTrace()](https://github.com/laravel/framework/blob/a2c66ad997d583560836ae1c578bbbba6d52e26b/src/Illuminate/Support/Onceable.php#L32) will return null when the second frame in the trace stack is eval.

A more appropriate example is when the \Illuminate\Database\Eloquent\Model::toArray() method is called on a model mocked by mockery/mockery.

close issue #52727 