### PR TITLE
[11.x] Add generic type parameters for `Eloquent\Builder` in `@param` Tag to avoid PHPStan errors

### DIFF
--- a/src/Illuminate/Database/Eloquent/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scope.php
@@ -7,7 +7,7 @@ interface Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */


### PR DESCRIPTION
Currently, the `@param` tag for the `Illuminate\Database\Eloquent\Builder` class does not specify generic type parameters. As a result, PHPStan throws errors when implements the `apply()` method of Scope . 

This PR adds the `*` generic type parameters to `Illuminate\Database\Eloquent\Builder`.