### PR TITLE
use Conditionable on Exceptions

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -5,9 +5,11 @@ namespace Illuminate\Foundation\Configuration;
 use Closure;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 
 class Exceptions
 {
+    use Conditionable;
     /**
      * Create a new exception handling configuration instance.
      *

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Conditionable;
 class Exceptions
 {
     use Conditionable;
+
     /**
      * Create a new exception handling configuration instance.
      *


### PR DESCRIPTION
This PR gives capabilities to the Exceptions class so that users can write their codes with better quality.
In this PR, `Illuminate\Support\Traits\Conditionable` is used in the `Illuminate\Foundation\Configuration\Exception` class, so the exception will accept the `when()` and `unless()` functions.
You can see a difference in the use of this function:

With out using `when()` (Execution of n conditions for n exceptions)
![image](https://github.com/user-attachments/assets/2a8b41a6-e94b-4837-972b-b061823a1ca7)

With using `when()` (Execution of 1 conditions for n exceptions)
![image](https://github.com/user-attachments/assets/515e8f4c-0227-422f-afc4-045a491c11d3)

note: I had no idea to make a new test for these changes, so I ask you to check it out, Thank's.


