### PR TITLE
[11.x] Adding Job Chain Payload

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -74,12 +74,12 @@ trait Queueable
      */
     public $chainCatchCallbacks;
 
-    /*
+    /**
      * The payload of the chain.
      *
-     * @var array
+     * @var mixed
      */
-    public $chainPayload = [];
+    public $chainPayload;
 
     /**
      * Set the desired connection for the job.
@@ -317,12 +317,12 @@ trait Queueable
     /**
      *  Set the chain payload.
      *
-     * @param  array  $payload
+     * @param  mixed  $chainPayload
      * @return $this
      */
-    public function chainPayload($payload)
+    public function chainPayload($chainPayload)
     {
-        $this->chainPayload = $payload;
+        $this->chainPayload = $chainPayload;
 
         return $this;
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -74,6 +74,13 @@ trait Queueable
      */
     public $chainCatchCallbacks;
 
+    /*
+     * The payload of the chain.
+     *
+     * @var array
+     */
+    public $chainPayload = [];
+
     /**
      * Set the desired connection for the job.
      *
@@ -289,6 +296,7 @@ trait Queueable
                 $next->chainConnection = $this->chainConnection;
                 $next->chainQueue = $this->chainQueue;
                 $next->chainCatchCallbacks = $this->chainCatchCallbacks;
+                $next->chainPayload = $this->chainPayload;
             }));
         }
     }
@@ -304,6 +312,19 @@ trait Queueable
         collect($this->chainCatchCallbacks)->each(function ($callback) use ($e) {
             $callback($e);
         });
+    }
+
+    /**
+     *  Set the chain payload.
+     *
+     * @param  array  $payload
+     * @return $this
+     */
+    public function chainPayload($payload)
+    {
+        $this->chainPayload = $payload;
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
@@ -792,7 +793,7 @@ class JobChainPayloadTest implements ShouldQueue
 
     public function handle()
     {
-        $this->chainPayload(array_merge($this->chainPayload, [$this->addChainPayload]));
+        $this->chainPayload(array_merge(Arr::wrap($this->chainPayload), Arr::wrap($this->addChainPayload)));
 
         static::$chainPayloads[] = $this->chainPayload;
     }


### PR DESCRIPTION
Job Chaining is awesome, sometimes you want to split a complex/big job into small sequential ones... But often i felt the need to somehow share / pass information between the jobs as you might want / need some computation from previous job...

Currently you would need to to send it to the database or cache...

Here i introduce a new idea chainPayload, so you can just add and it will be passed through the job chain.

Pretty simple but very helpful, i think 😄 

PS: I can open a PR on docs in case this gets approved.