### PR TITLE
[11.x] Improve PHPDoc

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1634,8 +1634,10 @@ class Connection implements ConnectionInterface
     /**
      * Set the table prefix and return the grammar.
      *
-     * @param  \Illuminate\Database\Grammar  $grammar
-     * @return \Illuminate\Database\Grammar
+     * @template TGrammar of \Illuminate\Database\Grammar
+     *
+     * @param  TGrammar  $grammar
+     * @return TGrammar
      */
     public function withTablePrefix(Grammar $grammar)
     {
@@ -1670,7 +1672,7 @@ class Connection implements ConnectionInterface
      * Get the connection resolver for the given driver.
      *
      * @param  string  $driver
-     * @return mixed
+     * @return \Closure|null
      */
     public static function getResolver($driver)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -284,7 +284,7 @@ abstract class Relation implements BuilderContract
      *
      * @param  array<int, TDeclaringModel>  $models
      * @param  string|null  $key
-     * @return array<int, int|string>
+     * @return array<int, int|string|null>
      */
     protected function getKeys(array $models, $key = null)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -149,7 +149,7 @@ class Builder implements BuilderContract
     /**
      * The maximum number of records to return.
      *
-     * @var int
+     * @var int|null
      */
     public $limit;
 
@@ -177,14 +177,14 @@ class Builder implements BuilderContract
     /**
      * The maximum number of union records to return.
      *
-     * @var int
+     * @var int|null
      */
     public $unionLimit;
 
     /**
      * The number of union records to skip.
      *
-     * @var int
+     * @var int|null
      */
     public $unionOffset;
 


### PR DESCRIPTION
I came across these opportunities for improvement while increasing the PHPStan levels of my packages.

The change to `Connection::withTablePrefix()` tells PHPStan that parameter and return value are identical.