### PR TITLE
Add beforeWhere and afterWhere methods to Collection 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1186,7 +1186,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get the item before the given item and meets the provided callback.
+     * Get the item before the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  (callable(TValue,TKey): bool)  $callable
@@ -1235,7 +1235,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get the item after the given item and meets the provided callback.
+     * Get the item after the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  (callable(TValue,TKey): bool)  $callable

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1186,6 +1186,31 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the item before the given item and meets the provided callback.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function beforeWhere($value, callable $callback, $strict = false)
+    {
+        $key = $this->search($value, $strict);
+
+        if ($key === false) {
+            return null;
+        }
+
+        $position = $this->keys()->search($key);
+
+        if ($position === 0) {
+            return null;
+        }
+
+        return $this->slice(0, $position)->reverse()->first($callback);
+    }
+
+    /**
      * Get the item after the given item.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
@@ -1207,6 +1232,31 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         return $this->get($keys->get($position + 1));
+    }
+
+    /**
+     * Get the item after the given item and meets the provided callback.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function afterWhere($value, callable $callback, $strict = false)
+    {
+        $key = $this->search($value, $strict);
+
+        if ($key === false) {
+            return null;
+        }
+
+        $position = ($keys = $this->keys())->search($key);
+
+        if ($position === $keys->count() - 1) {
+            return null;
+        }
+
+        return $this->slice($position + 1)->first($callback);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1189,7 +1189,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the item before the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
-     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  (callable(TValue,TKey): bool)  $callback
      * @param  bool  $strict
      * @return TValue|null
      */
@@ -1238,7 +1238,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the item after the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
-     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  (callable(TValue,TKey): bool)  $callback
      * @param  bool  $strict
      * @return TValue|null
      */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -903,7 +903,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function before($value, $strict = false);
 
     /**
-     * Get the item before the given item and meets the provided callback.
+     * Get the item before the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  (callable(TValue,TKey): bool)  $callable
@@ -922,7 +922,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function after($value, $strict = false);
 
     /**
-     * Get the item after the given item and meets the provided callback.
+     * Get the item after the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  (callable(TValue,TKey): bool)  $callable

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -903,6 +903,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function before($value, $strict = false);
 
     /**
+     * Get the item before the given item and meets the provided callback.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function beforeWhere($value, callable $callback, $strict = false);
+
+    /**
      * Get the item after the given item.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
@@ -910,6 +920,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return TValue|null
      */
     public function after($value, $strict = false);
+
+    /**
+     * Get the item after the given item and meets the provided callback.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  bool  $strict
+     * @return TValue|null
+     */
+    public function afterWhere($value, callable $callback, $strict = false);
 
     /**
      * Shuffle the items in the collection.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -906,7 +906,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the item before the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
-     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  (callable(TValue,TKey): bool)  $callback
      * @param  bool  $strict
      * @return TValue|null
      */
@@ -925,7 +925,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the item after the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
-     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  (callable(TValue,TKey): bool)  $callback
      * @param  bool  $strict
      * @return TValue|null
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1148,7 +1148,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get the item before the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
-     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  (callable(TValue,TKey): bool)  $callback
      * @param  bool  $strict
      * @return TValue|null
      */
@@ -1209,7 +1209,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get the item after the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
-     * @param  (callable(TValue,TKey): bool)  $callable
+     * @param  (callable(TValue,TKey): bool)  $callback
      * @param  bool  $strict
      * @return TValue|null
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1145,7 +1145,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the item before the given item and meets the provided callback.
+     * Get the item before the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  (callable(TValue,TKey): bool)  $callable
@@ -1206,7 +1206,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the item after the given item and meets the provided callback.
+     * Get the item after the given item passing the given truth test.
      *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  (callable(TValue,TKey): bool)  $callable


### PR DESCRIPTION
### This PR introduces two new methods to the Collection and LazyCollection classes.

**`beforeWhere` method**

The `beforeWhere` method returns the item before the given item and passes a provdied truth test. It returns null if the given item is the first item, not found or no previous item passes the test.

```
$collection = collect([1, 2, 3, 4, 2, 5, 'name' => 'taylor', 6, 'framework' => 'laravel', 7]);

$collection->beforeWhere(2, function($value) {
   return $value > 0;
}); // 1

$collection->beforeWhere(7, function($value) {
   return is_string($value) && strlen($value) < 7;
}); // 'taylor'

$collection->beforeWhere(
    function($value) {
        return $value > 2 && $value < 5;
    },
    function($value) {
        return $value > 0;
    }
); // 2

$collection->beforeWhere('taylor', function($value) {
    return $value > 6;
}); // null

$collection->beforeWhere(1, function($value) {
    return $value > 0;
}); // null

```

**`afterWhere` method**

The `afterWhere` method returns the item after the given item and passes a provdied truth test. It returns null if the given item is the last item, not found or no next item passes the test.

```
$collection = collect([1, 2, 3, 4, 2, 5, 'name' => 'taylor', 6, 'framework' => 'laravel', 7]);

$collection->afterWhere(1, function($value) {
   return $value > 2;
}); // 3

$collection->afterWhere(1, function($value) {
   return is_string($value);
}); // 'taylor'

$collection->afterWhere(
    function($value) {
        return is_string($value) && strlen($value) === 6;
    },
    function($value) {
        return is_string($value);
    }
); // 'laravel'

$collection->afterWhere(1, function($value) {
   return is_numeric($value) && $value > 7;
}); // null

$collection->afterWhere(7, function($value) {
   return $value > 0;
}); // null

```