### PR TITLE
Add stop() method to Process and Pool

### DIFF
--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -51,6 +51,19 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Stop the process if it is still running.
+     *
+     * @param float $timeout
+     * @param int|null  $signal
+     *
+     * @return int|null The process exit code or null if the process is not running
+     */
+    public function stop(float $timeout = 10, ?int $signal = null)
+    {
+        return $this->process->stop($timeout, $signal);
+    }
+
+    /**
      * Determine if the process is still running.
      *
      * @return bool

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -56,7 +56,7 @@ class InvokedProcess implements InvokedProcessContract
      * @param float $timeout
      * @param int|null $signal
      *
-     * @return int|null The process exit code or null if the process is not running
+     * @return int|null
      */
     public function stop(float $timeout = 10, ?int $signal = null)
     {

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -54,7 +54,7 @@ class InvokedProcess implements InvokedProcessContract
      * Stop the process if it is still running.
      *
      * @param float $timeout
-     * @param int|null  $signal
+     * @param int|null $signal
      *
      * @return int|null The process exit code or null if the process is not running
      */

--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -36,7 +36,7 @@ class InvokedProcessPool implements Countable
     }
 
     /**
-     * Stops all processes that are still running
+     * Stop all processes that are still running
      *
      * @param float $timeout
      * @param int|null  $signal

--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -36,6 +36,19 @@ class InvokedProcessPool implements Countable
     }
 
     /**
+     * Stops all processes that are still running
+     *
+     * @param float $timeout
+     * @param int|null  $signal
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function stop(float $timeout = 10, ?int $signal = null)
+    {
+        return $this->running()->each->stop($timeout, $signal);
+    }
+
+    /**
      * Get the processes in the pool that are still currently running.
      *
      * @return \Illuminate\Support\Collection


### PR DESCRIPTION
I had a process pool:

```php
$this->pool = Process::pool(function (Pool $pool) {
    $pool->path(base_path())->command('sleep 5');
    $pool->path(base_path())->command('sleep 10');
})->start();
```

And I needed to stop all processes in the pool gracefully if they were running.

I was reaching for:
```
$this->pool->stop()
```

...which didn't exist, so I decided to add it.

We already have `$this->pool->signal(...)`, but the Symfony `stop()` method adds some additional logic to ensure that the process is gracefully shut down (if possible): https://github.com/symfony/process/blob/7.1/Process.php#L908-L935

There doesn't seem to be any relevant test cases to add here, the main thing is the actual logic if `stop()` which is covered by https://github.com/symfony/process/blob/7.1/Tests/ProcessTest.php#L130