### PR TITLE
Allow mass assignment with mutators when using model::guarded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -214,6 +214,10 @@ trait GuardsAttributes
      */
     protected function isGuardableColumn($key)
     {
+        if ($this->hasSetMutator($key) || $this->hasAttributeSetMutator($key)) {
+            return true;
+        }
+
         if (! isset(static::$guardableColumns[get_class($this)])) {
             $columns = $this->getConnection()
                         ->getSchemaBuilder()
@@ -222,6 +226,7 @@ trait GuardsAttributes
             if (empty($columns)) {
                 return true;
             }
+
             static::$guardableColumns[get_class($this)] = $columns;
         }
 


### PR DESCRIPTION
When using mass assignment to populate model attributes, mutators are ignored if the mutator attribute doesn't mirror the table column and `model::guarded` is filled. 

Example from the Laravel Documentation:


```php

<?php
 
namespace App\Models;
 
use Illuminate\Database\Eloquent\Casts\Attribute;
use Illuminate\Database\Eloquent\Model;
 
class User extends Model
{
     protected $guarded = []; // works
     protected $fillable = ['address']; // works
     protected $guarded  = ['some_unrelated_column']; // doesn't work
    
    /**
     * Interact with the user's address.
     */
    protected function address(): Attribute
    {
        return Attribute::make(
            get: fn (mixed $value, array $attributes) => new Address(
                $attributes['address_line_one'],
                $attributes['address_line_two'],
            ),
            set: fn (Address $value) => [
                'address_line_one' => $value->lineOne,
                'address_line_two' => $value->lineTwo,
            ],
        );
    }
}

$user = new User;
$user->fill(['address' => new Address(...)]);
```

I modified two tests to demonstrate the issue:
 - Test `DatabaseEloquentModelTest::testFillable` already passes without this PR.
 - Test `DatabaseEloquentModelTest::testGuarded` fails, illustrating the problem.