### PR TITLE
11.x Add nullable to hashedValue in the docblocks

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -87,7 +87,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      *

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -59,7 +59,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      *


### PR DESCRIPTION
hashedValue in the BcryptHasher and ArgonHasher could be null at this point. Especially since the introduction of https://github.com/laravel/framework/pull/52297/files where we check if the value is null in order to skip the verification of the hashedValue.
