### PR TITLE
[11.x] Add `make:job-middleware` artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/JobMiddlewareMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMiddlewareMakeCommand.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace Illuminate\Routing\Console;
+namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:middleware')]
-class MiddlewareMakeCommand extends GeneratorCommand
+#[AsCommand(name: 'make:job-middleware')]
+class JobMiddlewareMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;
 
@@ -16,14 +17,14 @@ class MiddlewareMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'make:middleware';
+    protected $name = 'make:job-middleware';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Create a new HTTP middleware class';
+    protected $description = 'Create a new job middleware class';
 
     /**
      * The type of class being generated.
@@ -39,7 +40,7 @@ class MiddlewareMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->resolveStubPath('/stubs/middleware.stub');
+        return $this->resolveStubPath('/stubs/job.middleware.stub');
     }
 
     /**
@@ -51,8 +52,8 @@ class MiddlewareMakeCommand extends GeneratorCommand
     protected function resolveStubPath($stub)
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__.$stub;
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**
@@ -63,6 +64,18 @@ class MiddlewareMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\Http\Middleware';
+        return $rootNamespace.'\Jobs\Middleware';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the job middleware already exists'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/job.middleware.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.middleware.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+
+class {{ class }}
+{
+    /**
+     * Process the queued job.
+     *
+     * @param  \Closure(object): void  $next
+     */
+    public function handle(object $job, Closure $next): void
+    {
+        $next($job);
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -56,6 +56,7 @@ use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
+use Illuminate\Foundation\Console\JobMiddlewareMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
 use Illuminate\Foundation\Console\LangPublishCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
@@ -199,6 +200,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'FactoryMake' => FactoryMakeCommand::class,
         'InterfaceMake' => InterfaceMakeCommand::class,
         'JobMake' => JobMakeCommand::class,
+        'JobMiddlewareMake' => JobMiddlewareMakeCommand::class,
         'LangPublish' => LangPublishCommand::class,
         'ListenerMake' => ListenerMakeCommand::class,
         'MailMake' => MailMakeCommand::class,
@@ -503,6 +505,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(JobMakeCommand::class, function ($app) {
             return new JobMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerJobMiddlewareMakeCommand()
+    {
+        $this->app->singleton(JobMiddlewareMakeCommand::class, function ($app) {
+            return new JobMiddlewareMakeCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Generators/JobMiddlewareMakeCommandTest.php
+++ b/tests/Integration/Generators/JobMiddlewareMakeCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class JobMiddlewareMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Jobs/Middleware/Foo.php',
+        'tests/Feature/Jobs/Middleware/FooTest.php',
+    ];
+
+    public function testItCanGenerateJobFile()
+    {
+        $this->artisan('make:job-middleware', ['name' => 'Foo'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Jobs\Middleware;',
+            'class Foo',
+        ], 'app/Jobs/Middleware/Foo.php');
+
+        $this->assertFilenameNotExists('tests/Feature/Jobs/Middleware/FooTest.php');
+    }
+
+    public function testItCanGenerateJobFileWithTest()
+    {
+        $this->artisan('make:job-middleware', ['name' => 'Foo', '--test' => true])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Jobs/Middleware/Foo.php');
+        $this->assertFilenameExists('tests/Feature/Jobs/Middleware/FooTest.php');
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a new `make:job-middleware` artisan command that will create a new Job Middleware class in `App\Jobs\Middleware`. This stub is based on the docs.

One other minor change is to update the description for `make:middleware` to clarify it creates HTTP middleware.

An alternative to this would be to add `--job` flag to `make:middleware` that will conditionally create a Job middleware instead of HTTP middleware (could also add a corresponding `--http` flag just for completeness sake) — let me know if that is preferred.