### PR TITLE
[11.x] Create form requests if the option was selected from the make:model options

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -56,6 +56,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('controller', true);
             $this->input->setOption('policy', true);
             $this->input->setOption('resource', true);
+            $this->input->setOption('requests', true);
         }
 
         if ($this->option('factory')) {
@@ -76,6 +77,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('policy')) {
             $this->createPolicy();
+        }
+
+        if ($this->option('requests')) {
+            $this->createRequest();
         }
     }
 
@@ -142,7 +147,6 @@ class ModelMakeCommand extends GeneratorCommand
             'name' => "{$controller}Controller",
             '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
-            '--requests' => $this->option('requests') || $this->option('all'),
             '--test' => $this->option('test'),
             '--pest' => $this->option('pest'),
         ]));
@@ -160,6 +164,28 @@ class ModelMakeCommand extends GeneratorCommand
         $this->call('make:policy', [
             'name' => "{$policy}Policy",
             '--model' => $this->qualifyClass($this->getNameInput()),
+        ]);
+    }
+
+    /**
+     * Create request files for the model.
+     *
+     * @return void
+     */
+    protected function createRequest()
+    {
+        $request = Str::studly(class_basename($this->argument('name')));
+
+        $storeRequestClass = "Store{$request}Request";
+
+        $this->call('make:request', [
+            'name' => $storeRequestClass,
+        ]);
+
+        $updateRequestClass = "Update{$request}Request";
+
+        $this->call('make:request', [
+            'name' => $updateRequestClass,
         ]);
     }
 

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -179,4 +179,37 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFilenameNotExists('database/seeders/FooSeeder.php');
         $this->assertFilenameExists('tests/Feature/Models/FooTest.php');
     }
+
+    public function testItCanGenerateModelFileWithRequestOption()
+    {
+        $this->artisan('make:model', ['name' => 'Foo', '--requests' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Models;',
+            'use Illuminate\Database\Eloquent\Model;',
+            'class Foo extends Model',
+        ], 'app/Models/Foo.php');
+
+        $this->assertFilenameExists('app/Http/Requests/StoreFooRequest.php');
+
+        $this->assertFilenameExists('app/Http/Requests/UpdateFooRequest.php');
+
+        $this->assertFileContains([
+            'namespace App\Http\Requests;',
+            'use Illuminate\Foundation\Http\FormRequest;',
+            'class StoreFooRequest extends FormRequest',
+        ], 'app/Http/Requests/StoreFooRequest.php');
+
+        $this->assertFileContains([
+            'namespace App\Http\Requests;',
+            'use Illuminate\Foundation\Http\FormRequest;',
+            'class UpdateFooRequest extends FormRequest',
+        ], 'app/Http/Requests/UpdateFooRequest.php');
+
+        $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');
+        $this->assertFilenameNotExists('database/factories/FooFactory.php');
+        $this->assertFilenameNotExists('database/seeders/FooSeeder.php');
+        $this->assertFilenameNotExists('tests/Feature/Models/FooTest.php');
+    }
 }


### PR DESCRIPTION
### Summary

This PR creates form request files if the form requests option was selected in the `make:model` command 


### Before
if the form requests option was selected, without the controller option being selected - only the model file will be created.

Also, if the `--requests ` was added to the `make:model` command - the request files were not being created.

<img width="712" alt="image" src="https://github.com/user-attachments/assets/351d69d9-65c6-427d-a7cc-f0c04cdd79b4">

<img width="539" alt="image" src="https://github.com/user-attachments/assets/6c13da2b-4479-4c58-bce3-c08a4e4af558">


### After

<img width="728" alt="image" src="https://github.com/user-attachments/assets/62f9fd0a-d3f1-4931-a1b1-898f2f445e7c">

<img width="763" alt="image" src="https://github.com/user-attachments/assets/a2df1dc0-be9a-42cf-a8a2-ce68d5125280">

