### PR TITLE
Add missing method to Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1991,4 +1991,34 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Determine if a given string is missing a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @return bool
+     */
+    public static function missing($haystack, $needles, $ignoreCase = false)
+    {
+        if ($ignoreCase) {
+            $haystack = mb_strtolower($haystack);
+        }
+
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
+        }
+
+        foreach ($needles as $needle) {
+            if($ignoreCase) {
+                $needle = mb_strtolower($needle);
+            }
+
+            if($needle === '' || str_contains($haystack, $needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -224,6 +224,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string is missing a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public function missing($needles, $ignoreCase = false)
+    {
+        return Str::missing($this->value, $needles, $ignoreCase);
+    }
+
+    /**
      * Convert the case of a string.
      *
      * @param  int  $mode

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -377,6 +377,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals($expected, Str::containsAll($haystack, $needles, $ignoreCase));
     }
 
+    #[DataProvider('strMissingProvider')]
+    public function testMissing($haystack, $needles, $expected, $ignoreCase = false)
+    {
+        $this->assertEquals($expected, Str::missing($haystack, $needles, $ignoreCase));
+    }
+
     public function testConvertCase()
     {
         // Upper Case Conversion
@@ -1282,6 +1288,25 @@ class SupportStrTest extends TestCase
             ['Taylor Otwell', ['taylor'], true, true],
             ['Taylor Otwell', ['taylor', 'xxx'], false, false],
             ['Taylor Otwell', ['taylor', 'xxx'], false, true],
+        ];
+    }
+    public static function strMissingProvider()
+    {
+        return [
+            ['Hello World', 'world', false, true],
+            ['Hello World', 'world', true, false],
+            ['Hello World', ['xxx', 'world'], false, true],
+            ['Hello World', ['xxx', 'World'], false, false],
+            ['Hello World', collect(['xxx', 'world']), false, true],
+            ['Hello World', collect(['xxx', 'World']), false, false],
+            ['Hello World', 'xxx', true, true],
+            ['Hello World', ['xxx'], true, true],
+            ['Hello World', '', false, true],
+            ['Hello World', '', false, false],
+            ['Hello World', ['world', ''], false, false],
+            ['Hello World', ['world', ''], false, true],
+            ['', '',  false, false],
+            ['', '',  false],
         ];
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -721,6 +721,23 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));
     }
 
+    public function testMissing()
+    {
+        $this->assertFalse($this->stringable('Hello World')->missing('world', true));
+        $this->assertTrue($this->stringable('Hello World')->missing('world', false));
+        $this->assertFalse($this->stringable('Hello World')->missing(['xxx', 'world'], true));
+        $this->assertFalse($this->stringable('Hello World')->missing(['xxx', 'World'], false));
+        $this->assertFalse($this->stringable('Hello World')->missing(collect(['xxx', 'world']), true));
+        $this->assertFalse($this->stringable('Hello World')->missing(collect(['xxx', 'World']), false));
+        $this->assertTrue($this->stringable('Hello World')->missing('xxx', true));
+        $this->assertTrue($this->stringable('Hello World')->missing(['xxx'], true));
+        $this->assertFalse($this->stringable('Hello World')->missing('',  true));
+        $this->assertFalse($this->stringable('Hello World')->missing('',  false));
+        $this->assertFalse($this->stringable('Hello World')->missing(['world', ''],  false));
+        $this->assertFalse($this->stringable('Hello World')->missing(['world', ''], true));
+        $this->assertFalse($this->stringable('')->missing('', false));
+    }
+
     public function testParseCallback()
     {
         $this->assertEquals(['Class', 'method'], $this->stringable('Class@method')->parseCallback('foo'));


### PR DESCRIPTION
This PR adds a new `missing()` method to the Str and Stringable classes to check if a given string contains a substring.  It is the inverse of Str::contains()

### Examples
```php

// Before

if(! Str::contains('hello world', 'xxx') {
if(! Str::of('hello world')->contains('xxx')) {

// After

if(Str::missing('hello world', 'xxx')) {
if(Str::of('hello world')->missing('xxx')) {
```

Includes tests covering different scenarios.

### Benefit
This method provides a more semantic way to check if a string contains a substring.

### Notes
I wasn't 100% sure whether to go with `missing()` or `doesntContain()` for the method name - I prefer `missing()`, but Collections use `doesntContain()`, so from a standardization perspective, maybe that's a better choice.