### PR TITLE
[11.x] Fixes function loading conflicts when using `@include('vendor/autoload.php')` via Laravel Envoy

### DIFF
--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Process\PhpExecutableFinder;
 
-if (! function_exists('defer')) {
+if (! function_exists('Illuminate\Support\defer')) {
     /**
      * Defer execution of the given callback.
      *
@@ -28,7 +28,7 @@ if (! function_exists('defer')) {
     }
 }
 
-if (! function_exists('php_binary')) {
+if (! function_exists('Illuminate\Support\php_binary')) {
     /**
      * Determine the PHP Binary.
      *

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -28,7 +28,7 @@ if (! function_exists('defer')) {
     }
 }
 
-if (! function_exists('defer')) {
+if (! function_exists('php_binary')) {
     /**
      * Determine the PHP Binary.
      *

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -6,32 +6,36 @@ use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Process\PhpExecutableFinder;
 
-/**
- * Defer execution of the given callback.
- *
- * @param  callable|null  $callback
- * @param  string|null  $name
- * @param  bool  $always
- * @return \Illuminate\Support\Defer\DeferredCallback
- */
-function defer(?callable $callback = null, ?string $name = null, bool $always = false)
-{
-    if ($callback === null) {
-        return app(DeferredCallbackCollection::class);
-    }
+if (! function_exists('defer')) {
+    /**
+     * Defer execution of the given callback.
+     *
+     * @param  callable|null  $callback
+     * @param  string|null  $name
+     * @param  bool  $always
+     * @return \Illuminate\Support\Defer\DeferredCallback
+     */
+    function defer(?callable $callback = null, ?string $name = null, bool $always = false)
+    {
+        if ($callback === null) {
+            return app(DeferredCallbackCollection::class);
+        }
 
-    return tap(
-        new DeferredCallback($callback, $name, $always),
-        fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
-    );
+        return tap(
+            new DeferredCallback($callback, $name, $always),
+            fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
+        );
+    }
 }
 
-/**
- * Determine the PHP Binary.
- *
- * @return string
- */
-function php_binary()
-{
-    return (new PhpExecutableFinder)->find(false) ?: 'php';
+if (! function_exists('defer')) {
+    /**
+     * Determine the PHP Binary.
+     *
+     * @return string
+     */
+    function php_binary()
+    {
+        return (new PhpExecutableFinder)->find(false) ?: 'php';
+    }
 }


### PR DESCRIPTION
With Laravel envoy we have this error:
```
user@linux:/path/laravel-project$ envoy run local_to_preprod
PHP Fatal error:  Cannot redeclare Illuminate\Support\defer() (previously declared in /home/steph_d/.config/composer/vendor/illuminate/support/functions.php:17) in /media/steph_d/data_sd/www/apps/perso/laravel-cms/vendor/laravel/framework/src/Illuminate/Support/functions.php on line 26
PHP Stack trace:
```

We need to add `function_exists` to avoid these errors.

Thanks.