### PR TITLE
[11.x] Auto discover Events outside app namespace when folder name is in kebab-case

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -100,11 +100,11 @@ class DiscoverEvents
 
         $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
 
-        return str_replace(
+        return ucfirst(Str::camel(str_replace(
             [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'],
             ['\\', app()->getNamespace()],
             ucfirst(Str::replaceLast('.php', '', $class))
-        );
+        )));
     }
 
     /**


### PR DESCRIPTION
Should fix:
https://github.com/laravel/framework/issues/52975

Reproduction repo url: https://github.com/xizprodev/laravel-with-events.

Update:
Laravel 11 events are not auto discovered outside app folder when folder name is in kebab-case.

Example structure:
app
bootstrap
...
modules
modules-core (like custom-namespace in repo example)

In this case The method `DiscoverEvents::classFromFile` return `Custom-namespace\FolderName\Listeners\CustomListenerName` instead of `CustomNamespace\FolderName\Listeners\CustomListenerName`
