### PR TITLE
[11.x] Refactor: Return null when $key is null

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -994,7 +994,7 @@ if (! function_exists('__')) {
     function __($key = null, $replace = [], $locale = null)
     {
         if (is_null($key)) {
-            return $key;
+            return null;
         }
 
         return trans($key, $replace, $locale);


### PR DESCRIPTION
Return `null` instead of `$key` when we are sure that `$key` is null.