### PR TITLE
Update Auth/EloquentUserProvider@updateRememberToken method

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -94,7 +94,7 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
-        $user->withoutTimestamps(function() use ($user, $token) {
+        $user->withoutTimestamps(function () use ($user, $token) {
             $user->update([$user->getRememberTokenName() => $token]);
         });
     }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -94,13 +94,9 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
-        $timestamps = $user->timestamps;
-
-        $user->timestamps = false;
-
-        $user->save();
-
-        $user->timestamps = $timestamps;
+        $user->withoutTimestamps(function() use ($user, $token) {
+            $user->update([$user->getRememberTokenName() => $token]);
+        });
     }
 
     /**


### PR DESCRIPTION
This PR update the `Auth/EloquentUserProvider` class `updateRememberToken` method.

Behind the scene, When a user logging out or login the remember token is updated, in that time if there any dirty attribute in the model it also triggered to save this attribute as well, but the updateRememberToken is only responsible for the remember token update.

here is the [discussion](https://github.com/laravel/framework/discussions/52821) I started and found this issue to be solve.