### PR TITLE
Removed Duplicate Prefix on DynamoDbStore.php

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -412,7 +412,7 @@ class DynamoDbStore implements LockProvider, Store
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        return new DynamoDbLock($this, $this->prefix.$name, $seconds, $owner);
+        return new DynamoDbLock($this, $name, $seconds, $owner);
     }
 
     /**


### PR DESCRIPTION
Close https://github.com/laravel/framework/issues/52954

This PR remove the duplicated prefix when use DynamoDB as cache drive and try to lock

DynamoDB Key now:
laravel_cache_laravel_cache_my-lock

DynamoDB Key after:
laravel_cache_my-lock

As discussed in #52957, reopening this pull request on the master branch