### PR TITLE
RedirectIfAuthenticated: Allow `redirectUsing` to accept null values for resetting behavior

### DIFF
--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -70,7 +70,7 @@ class RedirectIfAuthenticated
     /**
      * Specify the callback that should be used to generate the redirect path.
      *
-     * @param  callable  $redirectToCallback
+     * @param  callable|null $redirectToCallback
      * @return void
      */
     public static function redirectUsing(?callable $redirectToCallback)

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -73,7 +73,7 @@ class RedirectIfAuthenticated
      * @param  callable  $redirectToCallback
      * @return void
      */
-    public static function redirectUsing(callable $redirectToCallback)
+    public static function redirectUsing(?callable $redirectToCallback)
     {
         static::$redirectToCallback = $redirectToCallback;
     }


### PR DESCRIPTION
### Description:
This change introduces an update to the `RedirectIfAuthenticated` middleware. The goal is to allow resetting the middleware's behavior to its default state by passing `null` to the `redirectUsing` method.

Currently, once a custom callback is set using `redirectUsing(callable $redirectToCallback)`, there is no direct way to reset it to the default behavior. This enhancement allows null values to be passed, effectively resetting the middleware to its original redirection behavior.

The `redirectUsing` method has been updated as follows:

```php
// Original method signature
public static function redirectUsing(callable $redirectToCallback)
{
    static::$redirectToCallback = $redirectToCallback;
}

// Updated method signature to allow null
public static function redirectUsing(?callable $redirectToCallback)
{
    static::$redirectToCallback = $redirectToCallback;
}