### PR TITLE
[11.x] Get First Random Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -317,6 +317,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the first result in random order.
+     *
+     * @param  array|string  $columns
+     * @return TModel|null
+     */
+    public function firstRandom($columns = ['*'])
+    {
+        return $this->inRandomOrder()->first($columns);
+    }
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  (\Closure(static): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3036,6 +3036,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the first result in random order.
+     *
+     * @param  array|string  $columns
+     * @return object|null
+     */
+    public function firstRandom($columns = ['*'])
+    {
+        return $this->inRandomOrder()->first($columns);
+    }
+
+    /**
      * Execute a query for a single record by ID or call a callback.
      *
      * @template TValue

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2993,6 +2993,27 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
+    public function testFirstRandomMySql()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->firstRandom();
+        $this->assertSame('select * from "users" order by RANDOM() limit 1', $builder->toSql());
+    }
+
+    public function testFirstRandomPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->from('users')->firstRandom();
+        $this->assertSame('select * from "users" order by RANDOM() limit 1', $builder->toSql());
+    }
+
+    public function testFirstRandomSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->from('users')->firstRandom();
+        $this->assertSame('select * from [users] order by NEWID() limit 1', $builder->toSql());
+    }
+
     public function testFirstOrFailMethodReturnsFirstResult()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2993,27 +2993,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
-    public function testFirstRandomMySql()
-    {
-        $builder = $this->getBuilder();
-        $builder->from('users')->firstRandom();
-        $this->assertSame('select * from "users" order by RANDOM() limit 1', $builder->toSql());
-    }
-
-    public function testFirstRandomPostgres()
-    {
-        $builder = $this->getPostgresBuilder();
-        $builder->from('users')->firstRandom();
-        $this->assertSame('select * from "users" order by RANDOM() limit 1', $builder->toSql());
-    }
-
-    public function testFirstRandomSqlServer()
-    {
-        $builder = $this->getSqlServerBuilder();
-        $builder->from('users')->firstRandom();
-        $this->assertSame('select * from [users] order by NEWID() limit 1', $builder->toSql());
-    }
-
     public function testFirstOrFailMethodReturnsFirstResult()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
In testing, it is very common to use it like this:

`Model::inRandomOrder()->first();`

But this gets repeated a lot, and we can simplify it like this:

`Model::firstRandom();`