### PR TITLE
Fix for Lock on ShouldBeUnique and ShouldBeUniqueUntilProcessing

### DIFF
--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -44,7 +44,7 @@ class ArrayLock extends Lock
 
         $this->store->locks[$this->name] = [
             'owner' => $this->owner,
-            'expiresAt' => $this->seconds === 0 ? null : Carbon::now()->addSeconds($this->seconds),
+            'expiresAt' => Carbon::now()->addSeconds($this->seconds > 0 ? $this->seconds : 86400),
         ];
 
         return true;

--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -44,7 +44,7 @@ class ArrayLock extends Lock
 
         $this->store->locks[$this->name] = [
             'owner' => $this->owner,
-            'expiresAt' => Carbon::now()->addSeconds($this->seconds > 0 ? $this->seconds : 86400),
+            'expiresAt' => $this->seconds === 0 ? null : Carbon::now()->addSeconds($this->seconds),
         ];
 
         return true;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -70,10 +70,6 @@ class CallQueuedHandler
 
         $this->dispatchThroughMiddleware($job, $command);
 
-        if (! $job->isReleased() && ! $command instanceof ShouldBeUniqueUntilProcessing && ! $command instanceof ShouldBeUnique) {
-            $this->ensureUniqueJobLockIsReleased($command);
-        }
-
         if (! $job->hasFailed() && ! $job->isReleased()) {
             $this->ensureNextJobInChainIsDispatched($command);
             $this->ensureSuccessfulBatchJobIsRecorded($command);
@@ -246,7 +242,7 @@ class CallQueuedHandler
     {
         $command = $this->getCommand($data);
 
-        if (! $command instanceof ShouldBeUniqueUntilProcessing) {
+        if ($command instanceof ShouldBeUnique) {
             $this->ensureUniqueJobLockIsReleased($command);
         }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -70,7 +70,7 @@ class CallQueuedHandler
 
         $this->dispatchThroughMiddleware($job, $command);
 
-        if (! $job->isReleased() && ! $command instanceof ShouldBeUniqueUntilProcessing) {
+        if (! $job->isReleased() && ! $command instanceof ShouldBeUniqueUntilProcessing && ! $command instanceof ShouldBeUnique) {
             $this->ensureUniqueJobLockIsReleased($command);
         }
 
@@ -202,9 +202,7 @@ class CallQueuedHandler
      */
     protected function ensureUniqueJobLockIsReleased($command)
     {
-        if ($command instanceof ShouldBeUnique) {
-            (new UniqueLock($this->container->make(Cache::class)))->release($command);
-        }
+        (new UniqueLock($this->container->make(Cache::class)))->release($command);
     }
 
     /**

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -98,7 +98,7 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertTrue(Job::$ran);
     }
 
-    public function testUniqueJobLockIsReleasedForJobDispatchedAfterResponse()
+    public function testUniqueJobLockIsNotReleasedForJobDispatchedAfterResponse()
     {
         // get initial terminatingCallbacks
         $terminatingCallbacksReflectionProperty = (new \ReflectionObject($this->app))->getProperty('terminatingCallbacks');
@@ -117,10 +117,10 @@ class JobDispatchingTest extends QueueTestCase
         UniqueJob::$ran = false;
         UniqueJob::dispatch('test')->afterResponse();
         $this->app->terminate();
-        $this->assertTrue(UniqueJob::$ran);
+        $this->assertFalse(UniqueJob::$ran);
 
         // acquire job lock and confirm that job is not dispatched after response
-        $this->assertTrue(
+        $this->assertFalse(
             $this->getJobLock(UniqueJob::class, 'test')
         );
         $terminatingCallbacksReflectionProperty->setValue($this->app, $startTerminatingCallbacks);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -47,14 +47,14 @@ class UniqueJobTest extends QueueTestCase
         );
     }
 
-    public function testLockIsReleasedForSuccessfulJobs()
+    public function testLockIsNotReleasedForSuccessfulJobs()
     {
         UniqueTestJob::$handled = false;
         dispatch($job = new UniqueTestJob);
         $this->runQueueWorkerCommand(['--once' => true]);
 
         $this->assertTrue($job::$handled);
-        $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
+        $this->assertFalse($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
     }
 
     public function testLockIsReleasedForFailedJobs()


### PR DESCRIPTION
Hi,

Closes #52980.

This commit addresses incorrect behaviour in the `ShouldBeUnique` and `ShouldBeUniqueUntilProcessing` traits, ensuring locks function as intended.

- **ShouldBeUniqueUntilProcessing**:  
  - **Issue**: The lock was not being deleted as expected due to an additional check for `ShouldBeUnique` in the `ensureUniqueJobLockIsReleased` function.  
  - **Actual Behaviour**: The lock persisted indefinitely, contrary to the intended functionality of the trait, which should delete the lock before processing.  
  - **Resolution**: The lock is now deleted as soon as the job is read from the queue.

- **ShouldBeUnique**:  
  - **Issue**: The lock was deleted immediately after processing, which prevented the `uniqueFor` constraint from maintaining the lock for the specified duration.  
  - **Actual Behaviour**: The premature deletion allowed subsequent jobs to bypass the intended uniqueness timeframe.  
  - **Resolution**: The lock will remain in place until it expires, after which a new lock can be acquired, ensuring proper adherence to the `uniqueFor` constraint.

Thanks.

I'm happy to discuss better approaches to resolve this.