### PR TITLE
[11.x] Add ability to override user resolver in Gate class

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -856,6 +856,19 @@ class Gate implements GateContract
     }
 
     /**
+     * Set the callback to be used to resolve users.
+     *
+     * @param  \Closure  $userResolver
+     * @return $this
+     */
+    public function resolveUsersUsing(Closure $userResolver)
+    {
+        $this->userResolver = $userResolver;
+
+        return $this;
+    }
+
+    /**
      * Get all of the defined abilities.
      *
      * @return array


### PR DESCRIPTION
### Summary:
This PR introduces a new method, `resolveUsersUsing`, to the `Gate` class, allowing developers to override the default user resolution logic when evaluating gates or passing user instances to policies. 

### Problem:
Currently, the `Gate` class relies on the default authentication guard to resolve the user. However, there's no easy method to override this behavior and provide custom user resolution logic, such as using another auth guard, or resolving users from different authentication guards (e.g., admins and users).

### Solution:
The `resolveUsersUsing` method allows developers to define their own user resolver via a closure, enabling flexible user resolution. This opens up the possibility of using gates with multiple auth guards and returning different user instances depending on which guard is authenticated.

### Example Usage:
```php
Gate::resolveUsersUsing(function () {
    return Auth::guard('admin')->user() ?? Auth::user();
});