### PR TITLE
Make RelationNotFoundException less ambigious

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -822,7 +822,7 @@ class Builder implements BuilderContract
         $relation = Relation::noConstraints(function () use ($name) {
             $instance = $this->getModel()->newInstance();
 
-            if (!method_exists($instance, $name)) {
+            if (!$instance->isRelation($name)) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -820,11 +820,13 @@ class Builder implements BuilderContract
         // not have to remove these where clauses manually which gets really hacky
         // and error prone. We don't want constraints because we add eager ones.
         $relation = Relation::noConstraints(function () use ($name) {
-            try {
-                return $this->getModel()->newInstance()->$name();
-            } catch (BadMethodCallException) {
+            $instance = $this->getModel()->newInstance();
+
+            if (!method_exists($instance, $name)) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }
+
+            return $instance->$name();
         });
 
         $nested = $this->relationsNestedUnder($name);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2414,6 +2414,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyName')->andReturn('foo');
         $model->shouldReceive('getTable')->andReturn('foo_table');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
+        $model->shouldReceive('newInstance')->andReturn(clone $model);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -890,8 +890,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->expectException(RelationNotFoundException::class);
 
         $builder = $this->getBuilder();
-        $builder->setModel($this->getMockModel());
-
+        $model = $this->getMockModel();
+        $model->shouldReceive('isRelation')->andReturn(false);
+        $builder->setModel($model);
         $builder->getRelation('invalid');
     }
 
@@ -2414,7 +2415,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyName')->andReturn('foo');
         $model->shouldReceive('getTable')->andReturn('foo_table');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
-        $model->shouldReceive('newInstance')->andReturn(clone $model);
+        $model->shouldReceive('newInstance')->andReturnSelf();
 
         return $model;
     }


### PR DESCRIPTION
Catching the BadMethodCallException makes it difficult to track bugs because the BadMethodCallException might have nothing to do with the relationship.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
