### PR TITLE
[11.x] Add customization optimization commands

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache\Console;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -10,6 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'cache:clear')]
+#[AsOptimize(name: 'cache', clear: true)]
 class ClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Console/Attributes/AsOptimize.php
+++ b/src/Illuminate/Console/Attributes/AsOptimize.php
@@ -7,15 +7,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 class AsOptimize
 {
-
     /**
      * Create a new class instance.
      *
-     * @param string $name
-     * @param bool $clear
+     * @param  string  $name
+     * @param  bool  $clear
      */
     public function __construct(public string $name, public bool $clear = false)
     {
     }
-    
 }

--- a/src/Illuminate/Console/Attributes/AsOptimize.php
+++ b/src/Illuminate/Console/Attributes/AsOptimize.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class AsOptimize
+{
+
+    /**
+     * Create a new class instance.
+     *
+     * @param string $name
+     * @param bool $clear
+     */
+    public function __construct(public string $name, public bool $clear = false)
+    {
+    }
+    
+}

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'clear-compiled')]
+#[AsOptimize(name: 'compiled', clear: true)]
 class ClearCompiledCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
@@ -10,6 +11,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
 #[AsCommand(name: 'config:cache')]
+#[AsOptimize(name: 'config')]
 class ConfigCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'config:clear')]
+#[AsOptimize(name: 'config', clear: true)]
 class ConfigClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'event:cache')]
+#[AsOptimize(name: 'events')]
 class EventCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'event:clear')]
+#[AsOptimize(name: 'events', clear: true)]
 class EventClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -34,14 +34,14 @@ class OptimizeClearCommand extends Command
         $this->components->info('Clearing cached bootstrap files.');
 
         $commands = collect($this->getApplication()->all())
-            ->mapWithKeys(fn($command, $name) => [$name => collect((new \ReflectionClass($command))->getAttributes(AsOptimize::class))->first()])
-            ->filter(fn(?ReflectionAttribute $attribute) => $attribute !== null)
-            ->filter(fn(ReflectionAttribute $attribute) => ($attribute->getArguments()['clear']) === true)
-            ->mapWithKeys(fn(ReflectionAttribute $attribute, $command) => [
-                $attribute->getArguments()['name'] => fn() => $this->callSilent($command) == 0
+            ->mapWithKeys(fn ($command, $name) => [$name => collect((new \ReflectionClass($command))->getAttributes(AsOptimize::class))->first()])
+            ->filter(fn (?ReflectionAttribute $attribute) => $attribute !== null)
+            ->filter(fn (ReflectionAttribute $attribute) => $attribute->getArguments()['clear'] === true)
+            ->mapWithKeys(fn (ReflectionAttribute $attribute, $command) => [
+                $attribute->getArguments()['name'] => fn () => $this->callSilent($command) == 0,
             ]);
 
-        $commands->each(fn($task, $description) => $this->components->task($description, $task));
+        $commands->each(fn ($task, $description) => $this->components->task($description, $task));
 
         $this->newLine();
     }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -34,14 +34,14 @@ class OptimizeCommand extends Command
         $this->components->info('Caching framework bootstrap, configuration, and metadata.');
 
         $commands = collect($this->getApplication()->all())
-            ->mapWithKeys(fn($command, $name) => [$name => collect((new \ReflectionClass($command))->getAttributes(AsOptimize::class))->first()])
-            ->filter(fn(?ReflectionAttribute $attribute) => $attribute !== null)
-            ->filter(fn(ReflectionAttribute $attribute) => ($attribute->getArguments()['clear']) === false)
-            ->mapWithKeys(fn(ReflectionAttribute $attribute, $command) => [
-                $attribute->getArguments()['name'] => fn() => $this->callSilent($command) == 0
+            ->mapWithKeys(fn ($command, $name) => [$name => collect((new \ReflectionClass($command))->getAttributes(AsOptimize::class))->first()])
+            ->filter(fn (?ReflectionAttribute $attribute) => $attribute !== null)
+            ->filter(fn (ReflectionAttribute $attribute) => $attribute->getArguments()['clear'] === false)
+            ->mapWithKeys(fn (ReflectionAttribute $attribute, $command) => [
+                $attribute->getArguments()['name'] => fn () => $this->callSilent($command) == 0,
             ]);
 
-        $commands->each(fn($task, $description) => $this->components->task($description, $task));
+        $commands->each(fn ($task, $description) => $this->components->task($description, $task));
 
         $this->newLine();
     }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
@@ -9,6 +10,7 @@ use Illuminate\Routing\RouteCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'route:cache')]
+#[AsOptimize(name: 'routes')]
 class RouteCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'route:clear')]
+#[AsOptimize(name: 'routes', clear: true)]
 class RouteClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -10,6 +11,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 #[AsCommand(name: 'view:cache')]
+#[AsOptimize(name: 'views')]
 class ViewCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Attributes\AsOptimize;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'view:clear')]
+#[AsOptimize(name: 'views', clear: true)]
 class ViewClearCommand extends Command
 {
     /**


### PR DESCRIPTION
### Summary:

Allows you to add operations during commands `artisan optimize` and `artisan optimize:clear`


I wrote all the details in this discussion
https://github.com/laravel/framework/discussions/52971