### PR TITLE
[11.x] feat: narrow types for throw_if and throw_unless

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -393,7 +393,7 @@ if (! function_exists('throw_if')) {
      * @param  TValue  $condition
      * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
-     * @return TValue
+     * @return ($condition is true ? never : TValue)
      *
      * @throws TException
      */
@@ -421,7 +421,7 @@ if (! function_exists('throw_unless')) {
      * @param  TValue  $condition
      * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
-     * @return TValue
+     * @return ($condition is true ? TValue : never)
      *
      * @throws TException
      */

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -41,9 +41,27 @@ assertType('User', tap(new User(), function ($user) {
 }));
 assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 
-assertType('bool', throw_if(true, Exception::class));
+function testThrowIf(float|int $foo): void
+{
+    assertType('never', throw_if(true, Exception::class));
+    assertType('bool', throw_if(false, Exception::class));
+    assertType('false', throw_if(empty($foo)));
+    throw_if(is_float($foo));
+    assertType('int', $foo);
+    throw_if($foo == false);
+    assertType('int<min, -1>|int<1, max>', $foo);
+}
 
-assertType('bool', throw_unless(true, Exception::class));
+function testThrowUnless(float|int $foo): void
+{
+    assertType('bool', throw_unless(true, Exception::class));
+    assertType('never', throw_unless(false, Exception::class));
+    assertType('true', throw_unless(empty($foo)));
+    throw_unless(is_int($foo));
+    assertType('int', $foo);
+    throw_unless($foo == false);
+    assertType('0', $foo);
+}
 
 assertType('int', transform('filled', fn () => 1, true));
 assertType('int', transform(['filled'], fn () => 1));


### PR DESCRIPTION
Hello!

This PR correctly causes the types to be narrowed for the `throw_{if_unless}` functions.

Thanks!