### PR TITLE
[11.x] Improve `Schema::hasTable()` performance

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -144,8 +144,7 @@ class Builder
     {
         $table = $this->connection->getTablePrefix().$table;
 
-        /** @phpstan-ignore arguments.count (SQLite accepts a withSize argument) */
-        foreach ($this->getTables(false) as $value) {
+        foreach ($this->getTables() as $value) {
             if (strtolower($table) === strtolower($value['name'])) {
                 return true;
             }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -77,6 +77,23 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if the given table exists.
+     *
+     * @param  string  $database
+     * @param  string  $table
+     * @return string
+     */
+    public function compileTableExists($database, $table)
+    {
+        return sprintf(
+            'select exists (select 1 from information_schema.tables where '
+            ."table_schema = %s and table_name = %s and table_type in ('BASE TABLE', 'SYSTEM VERSIONED')) as `exists`",
+            $this->quoteString($database),
+            $this->quoteString($table)
+        );
+    }
+
+    /**
      * Compile the query to determine the tables.
      *
      * @param  string  $database

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -79,7 +79,7 @@ class PostgresGrammar extends Grammar
     {
         return sprintf(
             'select exists (select 1 from pg_class c, pg_namespace n where '
-            ."n.nspname = %s and c.relname = %s and c.relkind in ('r', 'p') and n.oid = c.relnamespace) as 'exists'",
+            ."n.nspname = %s and c.relname = %s and c.relkind in ('r', 'p') and n.oid = c.relnamespace)",
             $this->quoteString($schema),
             $this->quoteString($table)
         );

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -69,6 +69,23 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if the given table exists.
+     *
+     * @param  string  $schema
+     * @param  string  $table
+     * @return string
+     */
+    public function compileTableExists($schema, $table)
+    {
+        return sprintf(
+            'select exists (select 1 from pg_class c, pg_namespace n where '
+            ."n.nspname = %s and c.relname = %s and c.relkind in ('r', 'p') and n.oid = c.relnamespace) as 'exists'",
+            $this->quoteString($schema),
+            $this->quoteString($table)
+        );
+    }
+
+    /**
      * Compile the query to determine the tables.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -69,6 +69,20 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if the given table exists.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function compileTableExists($table)
+    {
+        return sprintf(
+            'select exists (select 1 from sqlite_master where name = %s and type = \'table\') as "exists"',
+            $this->quoteString(str_replace('.', '__', $table))
+        );
+    }
+
+    /**
      * Compile the query to determine the tables.
      *
      * @param  bool  $withSize

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -79,16 +79,15 @@ class SqlServerGrammar extends Grammar
     /**
      * Compile the query to determine if the given table exists.
      *
-     * @param  string  $schema
+     * @param  string|null  $schema
      * @param  string  $table
      * @return string
      */
     public function compileTableExists($schema, $table)
     {
         return sprintf(
-            'select exists (select 1 from sys.tables where schema_id = schema_id(%s) and name = %s) as [exists]',
-            $this->quoteString($schema),
-            $this->quoteString($table)
+            'select (case when object_id(%s, \'U\') is null then 0 else 1 end) as [exists]',
+            $this->quoteString($this->wrapTable($schema ? $schema.'.'.$table : $table))
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -77,6 +77,22 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if the given table exists.
+     *
+     * @param  string  $schema
+     * @param  string  $table
+     * @return string
+     */
+    public function compileTableExists($schema, $table)
+    {
+        return sprintf(
+            'select exists (select 1 from sys.tables where schema_id = schema_id(%s) and name = %s) as [exists]',
+            $this->quoteString($schema),
+            $this->quoteString($table)
+        );
+    }
+
+    /**
      * Compile the query to determine the tables.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -87,7 +87,7 @@ class SqlServerGrammar extends Grammar
     {
         return sprintf(
             'select (case when object_id(%s, \'U\') is null then 0 else 1 end) as [exists]',
-            $this->quoteString($this->wrap($schema ? $schema.'.'.$table : $table))
+            $this->quoteString($schema ? $schema.'.'.$table : $table)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -87,7 +87,7 @@ class SqlServerGrammar extends Grammar
     {
         return sprintf(
             'select (case when object_id(%s, \'U\') is null then 0 else 1 end) as [exists]',
-            $this->quoteString($this->wrapTable($schema ? $schema.'.'.$table : $table))
+            $this->quoteString($this->wrap($schema ? $schema.'.'.$table : $table))
         );
     }
 

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -31,6 +31,23 @@ class MySqlBuilder extends Builder
     }
 
     /**
+     * Determine if the given table exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function hasTable($table)
+    {
+        $table = $this->connection->getTablePrefix().$table;
+
+        $database = $this->connection->getDatabaseName();
+
+        return (bool) $this->connection->scalar(
+            $this->grammar->compileTableExists($database, $table)
+        );
+    }
+
+    /**
      * Get the tables for the database.
      *
      * @return array

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -49,14 +49,9 @@ class PostgresBuilder extends Builder
 
         $table = $this->connection->getTablePrefix().$table;
 
-        foreach ($this->getTables() as $value) {
-            if (strtolower($table) === strtolower($value['name'])
-                && strtolower($schema) === strtolower($value['schema'])) {
-                return true;
-            }
-        }
-
-        return false;
+        return (bool) $this->connection->scalar(
+            $this->grammar->compileTableExists($schema, $table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -32,6 +32,21 @@ class SQLiteBuilder extends Builder
     }
 
     /**
+     * Determine if the given table exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function hasTable($table)
+    {
+        $table = $this->connection->getTablePrefix().$table;
+
+        return (bool) $this->connection->scalar(
+            $this->grammar->compileTableExists($table)
+        );
+    }
+
+    /**
      * Get the tables for the database.
      *
      * @param  bool  $withSize

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -42,7 +42,6 @@ class SqlServerBuilder extends Builder
     {
         [$schema, $table] = $this->parseSchemaAndTable($table);
 
-        $schema ??= $this->getDefaultSchema();
         $table = $this->connection->getTablePrefix().$table;
 
         return (bool) $this->connection->scalar(

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -45,14 +45,9 @@ class SqlServerBuilder extends Builder
         $schema ??= $this->getDefaultSchema();
         $table = $this->connection->getTablePrefix().$table;
 
-        foreach ($this->getTables() as $value) {
-            if (strtolower($table) === strtolower($value['name'])
-                && strtolower($schema) === strtolower($value['schema'])) {
-                return true;
-            }
-        }
-
-        return false;
+        return (bool) $this->connection->scalar(
+            $this->grammar->compileTableExists($schema, $table)
+        );
     }
 
     /**

--- a/tests/Database/DatabaseMariaDbSchemaBuilderTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaBuilderTest.php
@@ -20,15 +20,12 @@ class DatabaseMariaDbSchemaBuilderTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $grammar = m::mock(MariaDbGrammar::class);
-        $processor = m::mock(MariaDbProcessor::class);
         $connection->shouldReceive('getDatabaseName')->andReturn('db');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
         $builder = new MariaDbBuilder($connection);
-        $grammar->shouldReceive('compileTables')->once()->andReturn('sql');
-        $processor->shouldReceive('processTables')->once()->andReturn([['name' => 'prefix_table']]);
+        $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn([['name' => 'prefix_table']]);
+        $connection->shouldReceive('scalar')->once()->with('sql')->andReturn(1);
 
         $this->assertTrue($builder->hasTable('table'));
     }

--- a/tests/Database/DatabaseMySQLSchemaBuilderTest.php
+++ b/tests/Database/DatabaseMySQLSchemaBuilderTest.php
@@ -20,15 +20,12 @@ class DatabaseMySQLSchemaBuilderTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $grammar = m::mock(MySqlGrammar::class);
-        $processor = m::mock(MySqlProcessor::class);
         $connection->shouldReceive('getDatabaseName')->andReturn('db');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
         $builder = new MySqlBuilder($connection);
-        $grammar->shouldReceive('compileTables')->once()->andReturn('sql');
-        $processor->shouldReceive('processTables')->once()->andReturn([['name' => 'prefix_table']]);
+        $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn([['name' => 'prefix_table']]);
+        $connection->shouldReceive('scalar')->once()->with('sql')->andReturn(1);
 
         $this->assertTrue($builder->hasTable('table'));
     }

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -52,14 +52,11 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn(null);
         $connection->shouldReceive('getConfig')->with('schema')->andReturn(null);
         $grammar = m::mock(PostgresGrammar::class);
-        $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $grammar->shouldReceive('compileTables')->andReturn('sql');
-        $connection->shouldReceive('selectFromWriteConnection')->with('sql')->andReturn([['schema' => 'public', 'name' => 'foo']]);
+        $grammar->shouldReceive('compileTableExists')->andReturn('sql');
+        $connection->shouldReceive('scalar')->with('sql')->andReturn(1);
         $connection->shouldReceive('getTablePrefix');
         $builder = $this->getBuilder($connection);
-        $processor->shouldReceive('processTables')->andReturn([['schema' => 'public', 'name' => 'foo']]);
 
         $this->assertTrue($builder->hasTable('foo'));
         $this->assertTrue($builder->hasTable('public.foo'));
@@ -70,14 +67,11 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection = $this->getConnection();
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('myapp,public');
         $grammar = m::mock(PostgresGrammar::class);
-        $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $grammar->shouldReceive('compileTables')->andReturn('sql');
-        $connection->shouldReceive('selectFromWriteConnection')->with('sql')->andReturn([['schema' => 'myapp', 'name' => 'foo']]);
+        $grammar->shouldReceive('compileTableExists')->andReturn('sql');
+        $connection->shouldReceive('scalar')->with('sql')->andReturn(1);
         $connection->shouldReceive('getTablePrefix');
         $builder = $this->getBuilder($connection);
-        $processor->shouldReceive('processTables')->andReturn([['schema' => 'myapp', 'name' => 'foo']]);
 
         $this->assertTrue($builder->hasTable('foo'));
         $this->assertTrue($builder->hasTable('myapp.foo'));
@@ -89,14 +83,11 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn(null);
         $connection->shouldReceive('getConfig')->with('schema')->andReturn(['myapp', 'public']);
         $grammar = m::mock(PostgresGrammar::class);
-        $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $grammar->shouldReceive('compileTables')->andReturn('sql');
-        $connection->shouldReceive('selectFromWriteConnection')->with('sql')->andReturn([['schema' => 'myapp', 'name' => 'foo']]);
+        $grammar->shouldReceive('compileTableExists')->andReturn('sql');
+        $connection->shouldReceive('scalar')->with('sql')->andReturn(1);
         $connection->shouldReceive('getTablePrefix');
         $builder = $this->getBuilder($connection);
-        $processor->shouldReceive('processTables')->andReturn([['schema' => 'myapp', 'name' => 'foo']]);
 
         $this->assertTrue($builder->hasTable('foo'));
         $this->assertTrue($builder->hasTable('myapp.foo'));
@@ -108,14 +99,11 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('username')->andReturn('foouser');
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('$user');
         $grammar = m::mock(PostgresGrammar::class);
-        $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $grammar->shouldReceive('compileTables')->andReturn('sql');
-        $connection->shouldReceive('selectFromWriteConnection')->with('sql')->andReturn([['schema' => 'foouser', 'name' => 'foo']]);
+        $grammar->shouldReceive('compileTableExists')->andReturn('sql');
+        $connection->shouldReceive('scalar')->with('sql')->andReturn(1);
         $connection->shouldReceive('getTablePrefix');
         $builder = $this->getBuilder($connection);
-        $processor->shouldReceive('processTables')->andReturn([['schema' => 'foouser', 'name' => 'foo']]);
 
         $this->assertTrue($builder->hasTable('foo'));
         $this->assertTrue($builder->hasTable('foouser.foo'));
@@ -126,14 +114,11 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection = $this->getConnection();
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $grammar = m::mock(PostgresGrammar::class);
-        $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $grammar->shouldReceive('compileTables')->andReturn('sql');
-        $connection->shouldReceive('selectFromWriteConnection')->with('sql')->andReturn([['schema' => 'myapp', 'name' => 'foo']]);
+        $grammar->shouldReceive('compileTableExists')->andReturn('sql');
+        $connection->shouldReceive('scalar')->with('sql')->andReturn(1);
         $connection->shouldReceive('getTablePrefix');
         $builder = $this->getBuilder($connection);
-        $processor->shouldReceive('processTables')->andReturn([['schema' => 'myapp', 'name' => 'foo']]);
 
         $this->assertTrue($builder->hasTable('myapp.foo'));
     }

--- a/tests/Database/DatabasePostgresSchemaBuilderTest.php
+++ b/tests/Database/DatabasePostgresSchemaBuilderTest.php
@@ -20,16 +20,13 @@ class DatabasePostgresSchemaBuilderTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $grammar = m::mock(PostgresGrammar::class);
-        $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
         $connection->shouldReceive('getConfig')->with('schema')->andReturn('schema');
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $builder = new PostgresBuilder($connection);
-        $grammar->shouldReceive('compileTables')->twice()->andReturn('sql');
-        $processor->shouldReceive('processTables')->twice()->andReturn([['schema' => 'public', 'name' => 'prefix_table']]);
+        $grammar->shouldReceive('compileTableExists')->twice()->andReturn('sql');
         $connection->shouldReceive('getTablePrefix')->twice()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->twice()->with('sql')->andReturn([['schema' => 'public', 'name' => 'prefix_table']]);
+        $connection->shouldReceive('scalar')->twice()->with('sql')->andReturn(1);
 
         $this->assertTrue($builder->hasTable('table'));
         $this->assertTrue($builder->hasTable('public.table'));


### PR DESCRIPTION
Fixes #53002 

The `Schema::hasTable()` method is using the `Schema::getTable()` method internally, which could sometimes result in an expensive query. This PR improves the performance of `Schema::hasTable()` by using more lightweight queries.

PS: I previously added many integration tests for these methods and their edge cases.