### PR TITLE
[11.x]  Prevent calling tries() twice

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -143,7 +143,7 @@ abstract class Queue
             'uuid' => (string) Str::uuid(),
             'displayName' => $this->getDisplayName($job),
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
-            'maxTries' => $this->getJobTries($job) ?? null,
+            'maxTries' => $this->getJobTries($job),
             'maxExceptions' => $job->maxExceptions ?? null,
             'failOnTimeout' => $job->failOnTimeout ?? false,
             'backoff' => $this->getJobBackoff($job),
@@ -191,13 +191,11 @@ abstract class Queue
             return;
         }
 
-        if (isset($job->tries)) {
-            return $job->tries;
+        if (is_null($tries = $job->tries ?? $job->tries())) {
+            return;
         }
 
-        if (method_exists($job, 'tries') && ! is_null($job->tries())) {
-            return $job->tries();
-        }
+        return $tries;
     }
 
     /**


### PR DESCRIPTION
The changes introduced in https://github.com/laravel/framework/pull/49473 add an a check for a `tries` method on job classes. It checks if the `tries` method returns null by calling it and then it calls it again to get the result.

This change prevents calling the method twice.