### PR TITLE
[11.x] Always inherit parent attributes

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -34,7 +34,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      */
     public function __construct(array $attributes = [])
     {
-        $this->attributes = $attributes;
+        $this->setAttributes($attributes);
     }
 
     /**

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View;
 
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\View\ComponentSlot;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -68,6 +69,22 @@ class ViewComponentTest extends TestCase
         // Test overriding parent class attributes
         $component->withAttributes(['class' => 'override', 'type' => 'submit']);
         $this->assertSame('class="override" type="submit"', (string) $component->attributes);
+    }
+
+    public function testSlotAttributeParentInheritance(): void
+    {
+        $attributes = new ComponentAttributeBag(['class' => 'bar', 'type' => 'button']);
+
+        $slot = new ComponentSlot('test', [
+            'class' => 'foo',
+            'attributes' => $attributes,
+        ]);
+
+        $this->assertSame('class="foo bar" type="button"', (string) $slot->attributes);
+
+        // Test overriding parent class attributes
+        $slot->withAttributes(['class' => 'override', 'type' => 'submit']);
+        $this->assertSame('class="override" type="submit"', (string) $slot->attributes);
     }
 
     public function testPublicMethodsWithNoArgsAreConvertedToStringableCallablesInvokedAndNotCached()


### PR DESCRIPTION
This makes sure the functionality added with https://github.com/laravel/framework/pull/32576 is always applied. This way it also works with slots:

```blade
<x-something>
    <x-slot:heading :attributes="$heading->attributes->class('bg-red-500')">
        {{ $heading }}
    </x-slot:heading>
    Content
</x-something>
```

That's handled here: https://github.com/laravel/framework/blob/11.x/src/Illuminate/View/Concerns/ManagesComponents.php#L185:L198, but the attributes are passed through the constructor so they currently don't go through `setAttributes()`. When you do this now you'll end up with:

```html
<div attributes="class=\"bg-red-500\"">Heading</div>
```