### PR TITLE
 Fix Class Name Conversion for make:* Commands with Hyphenated Names

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -423,7 +423,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         $name = str_replace('/', '\\', $name);
 
         $nameParts = collect(explode('\\', $name))->map(function ($part) {
-            return Str::contains($part, '-') ? Str::studly($part) : Str::ucfirst($part);
+            return Str::contains($part, '-') ? Str::studly($part) : $part;
         });
 
         return $nameParts->implode('\\');

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -419,15 +419,16 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     protected function getNameInput()
     {
         $name = trim($this->argument('name'));
-        $name = Str::before($name, '.php');
+        if (Str::endsWith($name, '.php')) {
+            $name = Str::substr($name, 0, -4);
+        }
         $name = str_replace('/', '\\', $name);
-
         $nameParts = collect(explode('\\', $name))->map(function ($part) {
             return Str::contains($part, '-') ? Str::studly($part) : $part;
         });
-
         return $nameParts->implode('\\');
     }
+
 
     /**
      * Get the root namespace for the class.

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -386,7 +386,8 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function replaceClass($stub, $name)
     {
-        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
+        $class = Str::studly(Str::afterLast(str_replace('-', ' ', $name), '\\'));
 
         return str_replace(['DummyClass', '{{ class }}', '{{class}}'], $class, $stub);
     }
@@ -418,12 +419,14 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     protected function getNameInput()
     {
         $name = trim($this->argument('name'));
+        $name = Str::before($name, '.php');
+        $name = str_replace('/', '\\', $name);
 
-        if (Str::endsWith($name, '.php')) {
-            return Str::substr($name, 0, -4);
-        }
+        $nameParts = collect(explode('\\', $name))->map(function ($part) {
+            return Str::contains($part, '-') ? Str::studly($part) : Str::ucfirst($part);
+        });
 
-        return $name;
+        return $nameParts->implode('\\');
     }
 
     /**


### PR DESCRIPTION
## Problem

When using the `make:*` artisan commands in Laravel (e.g., `make:command send-test-notification`), the generated class name does not properly handle hyphenated names like `send-test-notification`. Instead of converting the class name to the expected `SendTestNotification` format, the hyphenated names cause errors in the generated class and fail to follow the standard class naming conventions.

### Issue

If a user runs the following command:

```bash
php artisan make:command send-test-notification
```

The generated class name might contain the hyphens as Send-test-notification, which is invalid and leads to errors in the codebase. This breaks naming conventions and causes issues when working with generated classes.

### Solution:
This PR introduces a fix to properly convert hyphenated names to StudlyCase (PascalCase) when using make:* commands. The fix involves modifying the logic that generates class names to ensure that any hyphenated name passed into the command is correctly transformed to a valid class name.


- Input: `php artisan make:command send-test-notification`
 - Expected Class Name: `SendTestNotification`
 


### Changes:
Updated the class generation logic to replace hyphens (-) with spaces before applying the studly() method, ensuring proper StudlyCase conversion.
The new method ensures class names follow proper naming conventions, avoiding errors caused by hyphenated names.

```bash
namespace Illuminate\Console; GeneratorCommand

protected function replaceClass($stub, $name)
{
    // Extract the class name without the namespace and convert to StudlyCase, handling hyphenated names
    $class = Str::studly(Str::afterLast(str_replace('-', ' ', $name), '\\'));

    return str_replace(['DummyClass', '{{ class }}', '{{class}}'], $class, $stub);
}

protected function getNameInput()
{
        $name = trim($this->argument('name'));
        $name = Str::before($name, '.php');
        $name = str_replace('/', '\\', $name);

        $nameParts = collect(explode('\\', $name))->map(function ($part) {
            return Str::contains($part, '-') ? Str::studly($part) :$part;
        });

        return $nameParts->implode('\\');
}
```
### Impact:
This fix ensures that any make:* commands can properly handle hyphenated names, improving developer experience and ensuring that generated classes conform to Laravel's naming conventions. There should be no backward compatibility issues, as the change only affects class name formatting during the generation process.

### Testing:

 - Run the following command:
 
        php artisan make:command send-test-notification
       
- Verify that the generated class is named SendTestNotification
- Verify that the class works without errors and adheres to Laravel’s class naming standards.

