### PR TITLE
[11.x] Test for forgetting non-flexible keys for file driver

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -247,7 +247,6 @@ class FileStore implements Store, LockProvider
      */
     public function forget($key)
     {
-
         if ($this->files->exists($file = $this->path($key))) {
             return tap($this->files->delete($file), function ($forgotten) use ($key) {
                 if ($forgotten && $this->files->exists($file = $this->path("illuminate:cache:flexible:created:{$key}"))) {

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -247,9 +247,11 @@ class FileStore implements Store, LockProvider
      */
     public function forget($key)
     {
-        if ($this->files->exists($file = $this->path($key))) {
-            $this->files->delete($this->path("illuminate:cache:flexible:created:{$key}"));
+        if ($this->files->exists($file = $this->path("illuminate:cache:flexible:created:{$key}"))) {
+            $this->files->delete($file);
+        }
 
+        if ($this->files->exists($file = $this->path($key))) {
             return $this->files->delete($file);
         }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -247,12 +247,13 @@ class FileStore implements Store, LockProvider
      */
     public function forget($key)
     {
-        if ($this->files->exists($file = $this->path("illuminate:cache:flexible:created:{$key}"))) {
-            $this->files->delete($file);
-        }
 
         if ($this->files->exists($file = $this->path($key))) {
-            return $this->files->delete($file);
+            return tap($this->files->delete($file), function ($forgotten) use ($key) {
+                if ($forgotten && $this->files->exists($file = $this->path("illuminate:cache:flexible:created:{$key}"))) {
+                    $this->files->delete($file);
+                }
+            });
         }
 
         return false;

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -350,6 +350,30 @@ class CacheFileStoreTest extends TestCase
         $this->assertFileDoesNotExist($flexiblePath);
     }
 
+    public function itOnlyForgetsFlexibleKeysIfParentIsForgotten()
+    {
+        $store = new FileStore(new Filesystem, __DIR__);
+
+        $key = Str::random();
+        $path = $store->path($key);
+        $flexiblePath = "illuminate:cache:flexible:created:{$key}";
+
+        touch($flexiblePath);
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertFileExists($flexiblePath);
+
+        $store->forget($key);
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertFileExists($flexiblePath);
+
+        $store->put($key, 'value', 5);
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertFileDoesNotExist($flexiblePath);
+    }
+
     protected function mockFilesystem()
     {
         return $this->createMock(Filesystem::class);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -7,6 +7,7 @@ use Illuminate\Cache\FileStore;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -328,6 +329,25 @@ class CacheFileStoreTest extends TestCase
         $store = new FileStore($files, __DIR__.'--wrong');
         $result = $store->flush();
         $this->assertFalse($result, 'Flush should not clean directory');
+    }
+
+    public function testItHandlesForgettingNonFlexibleKeys()
+    {
+        $store = new FileStore(new Filesystem, __DIR__);
+
+        $key = Str::random();
+        $path = $store->path($key);
+        $flexiblePath = "illuminate:cache:flexible:created:{$key}";
+
+        $store->put($key, 'value', 5);
+
+        $this->assertFileExists($path);
+        $this->assertFileDoesNotExist($flexiblePath);
+
+        $store->forget($key);
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertFileDoesNotExist($flexiblePath);
     }
 
     protected function mockFilesystem()


### PR DESCRIPTION
There has [been a report](https://github.com/laravel/framework/pull/52891#issuecomment-2389216693) that recent changes regarding flexible keys have caused exceptions to be thrown in scenarios involving fibers in foreach within a long running process. I've been unable to reproduce the issue.

This PR addresses the exception and also slightly improves the general flow for flexible keys by checking for the existence of the flexible key before attempting to delete it and only attempting to delete the flexible key when the main key, the non-flexible version, was successfully forgotten.