### PR TITLE
[11.x] Allow using strings when controlling UUID generation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1813,7 +1813,7 @@ class Str
      */
     public static function createUuidsUsing(?callable $factory = null)
     {
-        static::$uuidFactory = function () use ($factory) {
+        static::$uuidFactory = is_null($factory) ? null : function () use ($factory) {
             $uuid = $factory();
 
             if (is_string($uuid)) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1813,7 +1813,15 @@ class Str
      */
     public static function createUuidsUsing(?callable $factory = null)
     {
-        static::$uuidFactory = $factory;
+        static::$uuidFactory = function () use ($factory) {
+            $uuid = $factory();
+
+            if (is_string($uuid)) {
+                $uuid = (new UuidFactory)->fromString($uuid);
+            }
+
+            return $uuid;
+        };
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1397,6 +1397,21 @@ class SupportStrTest extends TestCase
         }
     }
 
+    public function testItCanControlUuidGenerationWithStrings()
+    {
+        Str::createUuidsUsing(fn () => '6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4');
+        $uuid = Str::uuid();
+        $this->assertInstanceOf(UuidInterface::class, $uuid);
+        $this->assertSame('6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4', (string) $uuid);
+        Str::createUuidsNormally();
+
+        Str::createUuidsUsingSequence(['6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4']);
+        $uuid = Str::uuid();
+        $this->assertInstanceOf(UuidInterface::class, $uuid);
+        $this->assertSame('6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4', (string) $uuid);
+        Str::createUuidsNormally();
+    }
+
     public function testItCanSpecifyASequenceOfUuidsToUtilise()
     {
         Str::createUuidsUsingSequence([


### PR DESCRIPTION
This PR allows improves the use of strings when controlling UUIDs in your testsuite. A Uuid object is now always returned.

```php
Str::uuid(); // instanceof Uuid
Str::uuid()->toString(); // is_string

Str::createUuidsUsingSequence(['6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4']);

// Before...

Str::uuid(); // '6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4'

// Now...

Str::uuid(); // instanceof Uuid
Str::uuid()->toString(); // '6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4'
```

This also applies to the more generic `createUuidsUsing`:

```php
Str::uuid(); // instanceof Uuid
Str::uuid()->toString(); // is_string


Str::createUuidsUsing(fn () => '6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4');

// Before...

Str::uuid(); // '6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4'

// Now...

Str::uuid(); // instanceof Uuid
Str::uuid()->toString(); // '6201c046-a8d7-47e5-8ac7-cd0cbdb3b9f4'
```