### PR TITLE
[PHP84] Bump aws/aws-sdk-php for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "require-dev": {
         "ext-gmp": "*",
         "ably/ably-php": "^1.0",
-        "aws/aws-sdk-php": "^3.235.5",
+        "aws/aws-sdk-php": "^3.322.9",
         "fakerphp/faker": "^1.23",
         "league/flysystem-aws-s3-v3": "^3.25.1",
         "league/flysystem-ftp": "^3.25.1",
@@ -170,7 +170,7 @@
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0|^6.0).",
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.235.5).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
         "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",

--- a/src/Illuminate/Foundation/Console/JobMiddlewareMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMiddlewareMakeCommand.php
@@ -27,7 +27,7 @@ class JobMiddlewareMakeCommand extends GeneratorCommand
     protected $description = 'Create a new job middleware class';
 
     /**
-     * The type of class being generated.
+     * The type of class JobMiddlewareMakeCommand generated.
      *
      * @var string
      */
@@ -75,7 +75,7 @@ class JobMiddlewareMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the job middleware already exists'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class JobMiddlewareMakeCommand if the job middleware already exists'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/JobMiddlewareMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMiddlewareMakeCommand.php
@@ -27,7 +27,7 @@ class JobMiddlewareMakeCommand extends GeneratorCommand
     protected $description = 'Create a new job middleware class';
 
     /**
-     * The type of class JobMiddlewareMakeCommand generated.
+     * The type of class being generated.
      *
      * @var string
      */
@@ -75,7 +75,7 @@ class JobMiddlewareMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class JobMiddlewareMakeCommand if the job middleware already exists'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the job middleware already exists'],
         ];
     }
 }

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "suggest": {
-        "aws/aws-sdk-php": "Required to use the SES mail driver (^3.235.5).",
+        "aws/aws-sdk-php": "Required to use the SES mail driver (^3.322.9).",
         "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
         "symfony/http-client": "Required to use the Symfony API mail transports (^7.1.4).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.1.4).",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -43,7 +43,7 @@
         "ext-mbstring": "Required to use the database failed job providers.",
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.235.5).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.322.9).",
         "illuminate/redis": "Required to use the Redis queue driver (^11.0).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (^5.0)."
     },


### PR DESCRIPTION
Fix deprecations of aws/aws-sdk-php implicit nullable type.