### PR TITLE
[11.x] feat: introduce option to change default Number currency

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -128,7 +128,7 @@ class Limit
      */
     public static function perMonth($maxAttempts, $decayMonths = 1, $daysInMonth = 28)
     {
-        return new static('', $maxAttempts, 60 * 60 * 24 * 7 * $daysInMonth * $decayMonths);
+        return new static('', $maxAttempts, 60 * 60 * 24 * $daysInMonth * $decayMonths);
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -108,6 +108,18 @@ class Limit
     }
 
     /**
+     * Create a new rate limit using days as decay time.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decayWeeks
+     * @return static
+     */
+    public static function perWeek($maxAttempts, $decayWeeks = 1)
+    {
+        return new static('', $maxAttempts, 60 * 60 * 24 * 7 * $decayWeeks);
+    }
+
+    /**
      * Create a new unlimited rate limit.
      *
      * @return static

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -120,6 +120,18 @@ class Limit
     }
 
     /**
+     * Create a new rate limit using months as decay time.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decayMonths
+     * @return static
+     */
+    public static function perMonth($maxAttempts, $decayMonths = 1, $daysInMonth = 28)
+    {
+        return new static('', $maxAttempts, 60 * 60 * 24 * 7 * $daysInMonth * $decayMonths);
+    }
+
+    /**
      * Create a new unlimited rate limit.
      *
      * @return static

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -108,7 +108,7 @@ class Limit
     }
 
     /**
-     * Create a new rate limit using days as decay time.
+     * Create a new rate limit using weeks as decay time.
      *
      * @param  int  $maxAttempts
      * @param  int  $decayWeeks

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -108,30 +108,6 @@ class Limit
     }
 
     /**
-     * Create a new rate limit using weeks as decay time.
-     *
-     * @param  int  $maxAttempts
-     * @param  int  $decayWeeks
-     * @return static
-     */
-    public static function perWeek($maxAttempts, $decayWeeks = 1)
-    {
-        return new static('', $maxAttempts, 60 * 60 * 24 * 7 * $decayWeeks);
-    }
-
-    /**
-     * Create a new rate limit using months as decay time.
-     *
-     * @param  int  $maxAttempts
-     * @param  int  $decayMonths
-     * @return static
-     */
-    public static function perMonth($maxAttempts, $decayMonths = 1, $daysInMonth = 28)
-    {
-        return new static('', $maxAttempts, 60 * 60 * 24 * $daysInMonth * $decayMonths);
-    }
-
-    /**
      * Create a new unlimited rate limit.
      *
      * @return static

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -18,6 +18,13 @@ class Number
     protected static $locale = 'en';
 
     /**
+     * The current default currency.
+     *
+     * @var string
+     */
+    protected static $currency = 'USD';
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -115,13 +122,13 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null)
+    public static function currency(int|float $number, string $in = '', ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
 
-        return $formatter->formatCurrency($number, $in);
+        return $formatter->formatCurrency($number, empty($in) ? static::$currency : $in);
     }
 
     /**
@@ -285,6 +292,22 @@ class Number
     }
 
     /**
+     * Execute the given callback using the given currency.
+     *
+     * @param  string  $currency
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function withCurrency(string $currency, callable $callback)
+    {
+        $previousLCurrency = static::$currency;
+
+        static::useCurrency($currency);
+
+        return tap($callback(), fn () => static::useCurrency($previousLCurrency));
+    }
+
+    /**
      * Set the default locale.
      *
      * @param  string  $locale
@@ -293,6 +316,17 @@ class Number
     public static function useLocale(string $locale)
     {
         static::$locale = $locale;
+    }
+
+    /**
+     * Set the default currency.
+     *
+     * @param  string  $currency
+     * @return void
+     */
+    public static function useCurrency(string $currency)
+    {
+        static::$currency = $currency;
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -128,7 +128,7 @@ class Number
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
 
-        return $formatter->formatCurrency($number, empty($in) ? static::$currency : $in);
+        return $formatter->formatCurrency($number, ! empty($in) ? $in : static::$currency);
     }
 
     /**


### PR DESCRIPTION
Hi :wave:,

This PR introduces the functionality to globally change the default currency of the `Number` helper, much like the locale. Right now the default is passed aa a function argument, however, it can be useful to change the global currency.

The use case here is that the default currency is still USD for backwards compatibility with applications, and the `$in` variable second arg is still retained.

I've introduced a `$currency` variable, defaulted to US. 
