### PR TITLE
Fix: Correct typehint on repository retrieval methods

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -101,11 +101,9 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @template TCacheValue
-     *
      * @param  array|string  $key
-     * @param  TCacheValue|(\Closure(): TCacheValue)  $default
-     * @return (TCacheValue is null ? mixed : TCacheValue)
+     * @param  (\Closure(): mixed)  $default
+     * @return mixed
      */
     public function get($key, $default = null): mixed
     {
@@ -198,11 +196,9 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache and delete it.
      *
-     * @template TCacheValue
-     *
      * @param  array|string  $key
-     * @param  TCacheValue|(\Closure(): TCacheValue)  $default
-     * @return (TCacheValue is null ? mixed : TCacheValue)
+     * @param  (\Closure(): mixed)  $default
+     * @return mixed
      */
     public function pull($key, $default = null)
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -102,7 +102,7 @@ class Repository implements ArrayAccess, CacheContract
      * Retrieve an item from the cache by key.
      *
      * @param  array|string  $key
-     * @param  (\Closure(): mixed)  $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null): mixed
@@ -197,7 +197,7 @@ class Repository implements ArrayAccess, CacheContract
      * Retrieve an item from the cache and delete it.
      *
      * @param  array|string  $key
-     * @param  (\Closure(): mixed)  $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null)

--- a/types/Cache/Repository.php
+++ b/types/Cache/Repository.php
@@ -8,14 +8,14 @@ use function PHPStan\Testing\assertType;
 $cache = resolve(Repository::class);
 
 assertType('mixed', $cache->get('key'));
-assertType('int', $cache->get('cache', 27));
-assertType('int', $cache->get('cache', function (): int {
+assertType('mixed', $cache->get('cache', 27));
+assertType('mixed', $cache->get('cache', function (): int {
     return 26;
 }));
 
 assertType('mixed', $cache->pull('key'));
-assertType('int', $cache->pull('cache', 28));
-assertType('int', $cache->pull('cache', function (): int {
+assertType('mixed', $cache->pull('cache', 28));
+assertType('mixed', $cache->pull('cache', function (): int {
     return 30;
 }));
 assertType('int', $cache->sear('cache', function (): int {


### PR DESCRIPTION
Hey. I believe the Typehints on these methods are incorrect.

The return type currently reads as 

**If a non null default is specified, then the return type will be the default. Otherwise, the return type will be null**

This doesn't take into account whether a value for this key is present. See a (very) minimal reproduction in [PHPStan](https://phpstan.org/r/1d402d66-d564-4b7a-80ba-194fb1111a31).

My understanding is that the dumped type here should not be `5`, as this expression would return `'bar'`. As such, a typehint more than mixed cannot be offered here.

It may be worth noting that this was not an issue interrupting any actual code - I noticed it whilst investigating [an issue I was having with Laravel Idea](https://github.com/laravel-idea/plugin/issues/1078). 

For reference - the Cache facade only offers a return type of mixed

```php
/**
* @method static mixed get(array|string $key, mixed|\Closure $default = null)
*/
```