### PR TITLE
[11.x] Correctly parse multi dimensional arrays in multipart http requests

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1005,8 +1005,16 @@ class PendingRequest
      */
     protected function parseMultipartBodyFormat(array $data)
     {
-        return collect($data)->map(function ($value, $key) {
-            return is_array($value) ? $value : ['name' => $key, 'contents' => $value];
+        $fields = explode('&', http_build_query($data));
+
+        return collect($fields)->map(function ($field) {
+            list($name, $field) = explode('=', $field);
+
+            return [
+                'name' => urldecode($name),
+                'contents' => urldecode($field)
+            ];
+
         })->values()->all();
     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1017,11 +1017,11 @@ class PendingRequest
 
             $extendedFields = $extendedFields->merge(
                 array_map(function ($field) {
-                    list($name, $field) = explode('=', $field);
+                    [$name, $field] = explode('=', $field);
 
                     return [
                         'name' => urldecode($name),
-                        'contents' => urldecode($field)
+                        'contents' => urldecode($field),
                     ];
                 }, $simpleFieldsAsQuery)
             );

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -703,11 +703,41 @@ class HttpClientTest extends TestCase
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/multipart' &&
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foobar' &&
+                $request[0]['contents'] === 'data' &&
+                $request[0]['headers']['X-Test-Header'] === 'foo' &&
+                $request[1]['name'] === 'foo' &&
+                $request[1]['contents'] === 'bar';
+        });
+    }
+
+    public function testCanSendDeeplyNestedArrayMultipartData()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'bar',
+            'foobar' => [
+                'foo' => [
+                    [
+                        'name' => 'baz'
+                    ],
+                    [
+                        'name' => 'foobar'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'foo' &&
                 $request[0]['contents'] === 'bar' &&
-                $request[1]['name'] === 'foobar' &&
-                $request[1]['contents'] === 'data' &&
-                $request[1]['headers']['X-Test-Header'] === 'foo';
+                $request[1]['name'] === 'foobar[foo][0][name]' &&
+                $request[1]['contents'] === 'baz' &&
+                $request[2]['name'] === 'foobar[foo][1][name]' &&
+                $request[2]['contents'] === 'foobar';
         });
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -711,6 +711,36 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSendDeeplyNestedArrayMultipartData()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'bar',
+            'foobar' => [
+                'foo' => [
+                    [
+                        'name' => 'baz'
+                    ],
+                    [
+                        'name' => 'foobar'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foo' &&
+                $request[0]['contents'] === 'bar' &&
+                $request[1]['name'] === 'foobar[foo][0][name]' &&
+                $request[1]['contents'] === 'baz' &&
+                $request[2]['name'] === 'foobar[foo][1][name]' &&
+                $request[2]['contents'] === 'foobar';
+        });
+    }
+
     public function testItCanSendToken()
     {
         $this->factory->fake();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -720,13 +720,13 @@ class HttpClientTest extends TestCase
             'foobar' => [
                 'foo' => [
                     [
-                        'name' => 'baz'
+                        'name' => 'baz',
                     ],
                     [
-                        'name' => 'foobar'
-                    ]
-                ]
-            ]
+                        'name' => 'foobar',
+                    ],
+                ],
+            ],
         ]);
 
         $this->factory->assertSent(function (Request $request) {


### PR DESCRIPTION
When sending multi dimensional arrays inside an http requests, the framework currently doesn't handle the conversion and results as a failure `A 'contents' key is required`.

This failure is described here in https://github.com/laravel/framework/issues/37174 and results from this Guzzle issue https://github.com/guzzle/guzzle/issues/1679.

With this PR, the framework will now handles multi-dimensional arrays and convert it into properly formed one level multipart form data array.

Meaning this array:
```php
[
  'users' => [
    ['name' => 'Taylor', 'car' => 'Lambo'],
    ['name' => 'Romain', 'car' => 'Not Lambo']
  ]
];
```
Will be converted into this array, which will be correctly handled by Guzzle:
```php
[
  ['name' => 'users[0][name]', 'contents' => 'Taylor']
  ['name' => 'users[0][car]', 'contents' => 'Lambo']
  ['name' => 'users[1][name]', 'contents' => 'Romain']
  ['name' => 'users[1][car]', 'contents' => 'Not Lambo']
]
```
The trick used for the conversion is inspired by a comment in the Guzzle issue.

The existing `testCanSendMultipartDataWithBothSimplifiedAndExtendedParameters` test was modified only because the conversion re-order the multipart fields, the already expanded fields are passed before the simple ones.

This fields reorganization doesn't affect the success of the request.

I also added a test to mix file upload with nested array extra data.
As an example, this kind of Http call is needed to use [this SignNow API endpoint](https://docs.signnow.com/docs/signnow/document/operations/create-a-document-fieldextract).