### PR TITLE
Add type argument to schema blueprint `id` and `foreignId`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -737,11 +737,19 @@ class Blueprint
      * Create a new auto-incrementing big integer (8-byte) column on the table.
      *
      * @param  string  $column
+     * @param  string  $type
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function id($column = 'id')
+    public function id($column = 'id', $type = 'bigInteger')
     {
-        return $this->bigIncrements($column);
+        return match ($type) {
+            'integer' => $this->increments($column),
+            'tinyInteger' => $this->tinyIncrements($column),
+            'smallInteger' => $this->smallIncrements($column),
+            'mediumInteger' => $this->mediumIncrements($column),
+            'bigInteger' => $this->bigIncrements($column),
+            default => throw new \InvalidArgumentException("Invalid type: {$type}"),
+        };
     }
 
     /**
@@ -1011,12 +1019,13 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
+     * @param  string  $type
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function foreignId($column, $type = 'bigInteger')
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
-            'type' => 'bigInteger',
+            'type' => $type,
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -491,6 +491,47 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('foo', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` int unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` tinyint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` mediumint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'invalid type');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingForeignID()
@@ -526,6 +567,44 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertSame([
             'alter table `users` add `company_id` bigint unsigned not null',
             'alter table `users` add constraint `my_index` foreign key (`company_id`) references `companies` (`id`)',
+        ], $statements);
+    }
+
+    public function testAddingForeignIdSpecifyingColumnType()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` int unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` tinyint unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` smallint unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` mediumint unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` bigint unsigned not null',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -491,6 +491,47 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` bigint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('foo', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` int unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` tinyint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` mediumint unsigned not null auto_increment primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'invalid type');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingForeignID()
@@ -526,6 +567,44 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame([
             'alter table `users` add `company_id` bigint unsigned not null',
             'alter table `users` add constraint `my_index` foreign key (`company_id`) references `companies` (`id`)',
+        ], $statements);
+    }
+
+    public function testAddingForeignIdSpecifyingColumnType()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` int unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` tinyint unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` smallint unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` mediumint unsigned not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` bigint unsigned not null',
         ], $statements);
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -409,6 +409,47 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" bigserial not null primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('foo', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" serial not null primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" smallserial not null primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" smallserial not null primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" serial not null primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" bigserial not null primary key', $statements[0]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'invalid type');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingForeignID()
@@ -444,6 +485,44 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame([
             'alter table "users" add column "company_id" bigint not null',
             'alter table "users" add constraint "my_index" foreign key ("company_id") references "companies" ("id")',
+        ], $statements);
+    }
+
+    public function testAddingForeignIdSpecifyingColumnType()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" smallint not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" smallint not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" bigint not null',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -300,6 +300,47 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('foo', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'invalid type');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingForeignID()
@@ -368,6 +409,44 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
             'insert into "__temp__users" ("company_id") select "company_id" from "users"',
             'drop table "users"',
             'alter table "__temp__users" rename to "users"',
+        ], $statements);
+    }
+
+    public function testAddingForeignIdSpecifyingColumnType()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -347,6 +347,47 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" bigint not null identity primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('foo', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" int not null identity primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "id" tinyint not null identity primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "id" smallint not null identity primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "id" int not null identity primary key', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "id" bigint not null identity primary key', $statements[0]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->id('id', 'invalid type');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingForeignID()
@@ -382,6 +423,44 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame([
             'alter table "users" add "company_id" bigint not null',
             'alter table "users" add constraint "my_index" foreign key ("company_id") references "companies" ("id")',
+        ], $statements);
+    }
+
+    public function testAddingForeignIdSpecifyingColumnType()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'integer');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add "company_id" int not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'tinyInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add "company_id" tinyint not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'smallInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add "company_id" smallint not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'mediumInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add "company_id" int not null',
+        ], $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id', 'bigInteger');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add "company_id" bigint not null',
         ], $statements);
     }
 


### PR DESCRIPTION
This PR updates schema blueprint `id` and `foreignId` methods to accept various integer column types including `integer`, `tinyInteger`, `smallInteger`, `mediumInteger`, and `bigInteger`.

It defaults to `bigInteger` so it will continue working as before if no type is given.

## Example

```php
$table->id('id', 'integer');
$table->id(type: 'tinyInteger');

$table->foreignId('user_id', 'mediumInteger');
```
