### PR TITLE
[11.x] Add implodeOf and joinOf collection methods

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -628,6 +628,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Concatenate values of a given key as a stringable.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string|null  $value
+     * @param  string|null  $glue
+     * @return \Illuminate\Support\Stringable
+     */
+    public function implodeOf($value, $glue = null)
+    {
+        return Str::of($this->implode($value, $glue));
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
@@ -738,6 +750,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $finalItem = $collection->pop();
 
         return $collection->implode($glue).$finalGlue.$finalItem;
+    }
+
+    /**
+     * Join all items from the collection using a stringable. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return \Illuminate\Support\Stringable
+     */
+    public function joinOf($glue, $finalGlue = '')
+    {
+        return Str::of($this->join($glue, $finalGlue));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -632,6 +632,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Concatenate values of a given key as a stringable.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string|null  $value
+     * @param  string|null  $glue
+     * @return \Illuminate\Support\Stringable
+     */
+    public function implodeOf($value, $glue = null)
+    {
+        return $this->collect()->implodeOf(...func_get_args());
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
@@ -718,6 +730,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function join($glue, $finalGlue = '')
     {
         return $this->collect()->join(...func_get_args());
+    }
+
+    /**
+     * Join all items from the collection using a stringable. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return \Illuminate\Support\Stringable
+     */
+    public function joinOf($glue, $finalGlue = '')
+    {
+        return $this->collect()->joinOf(...func_get_args());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use JsonSerializable;
@@ -1751,6 +1752,15 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testJoinOf($collection)
+    {
+        $data = new $collection(['taylor', 'dayle']);
+        $this->assertInstanceOf(Stringable::class, $data->joinOf(','));
+        $this->assertSame('taylor,dayle', (string) $data->joinOf(','));
+        $this->assertSame('TAYLOR,DAYLE', (string) $data->joinOf(',')->upper());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testCrossJoin($collection)
     {
         // Cross join with an array
@@ -2305,6 +2315,15 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));
         $this->assertSame('taylor-foo,dayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email'], ','));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testImplodeOf($collection)
+    {
+        $data = new $collection(['taylor', 'dayle']);
+        $this->assertInstanceOf(Stringable::class, $data->implodeOf(','));
+        $this->assertSame('taylor,dayle', (string) $data->implodeOf(','));
+        $this->assertSame('TAYLOR,DAYLE', (string) $data->implodeOf(',')->upper());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
This PR adds two new collection methods: `implodeOf` and `joinOf`. These are identical to `implode` and `join` but return a new `Stringable` instance.

This means you can use a nice fluent syntax when you need to break a string into a collection and then join it back together and continue with other string operations, for example:

```php
Str::of($value)
    ->explode(' ')
    ->reject(fn ($word) => in_array($word, $block))
    ->implodeOf(' ')
    ->limit(100);
```