### PR TITLE
[11.x] Str: Add extension support for `Str::inlineMarkdown()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -717,14 +717,19 @@ class Str
      *
      * @param  string  $string
      * @param  array  $options
+     * @param  array  $extensions
      * @return string
      */
-    public static function inlineMarkdown($string, array $options = [])
+    public static function inlineMarkdown($string, array $options = [], array $extensions = [])
     {
         $environment = new Environment($options);
 
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
         $environment->addExtension(new InlinesOnlyExtension());
+
+        foreach ($extensions as $extension) {
+            $environment->addExtension($extension);
+        }
 
         $converter = new MarkdownConverter($environment);
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -478,11 +478,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Convert inline Markdown into HTML.
      *
      * @param  array  $options
+     * @param  array  $extensions
      * @return static
      */
-    public function inlineMarkdown(array $options = [])
+    public function inlineMarkdown(array $options = [], array $extensions = [])
     {
-        return new static(Str::inlineMarkdown($this->value, $options));
+        return new static(Str::inlineMarkdown($this->value, $options, $extensions));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1158,6 +1158,19 @@ class SupportStringableTest extends TestCase
     {
         $this->assertEquals("<em>hello world</em>\n", $this->stringable('*hello world*')->inlineMarkdown());
         $this->assertEquals("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", $this->stringable('[**Laravel**](https://laravel.com)')->inlineMarkdown());
+
+        $extension = new class implements ExtensionInterface
+        {
+            public bool $configured = false;
+
+            public function register(EnvironmentBuilderInterface $environment): void
+            {
+                $this->configured = true;
+            }
+        };
+
+        $this->stringable('# hello world')->inlineMarkdown([], [$extension]);
+        $this->assertTrue($extension->configured);
     }
 
     public function testMask()


### PR DESCRIPTION
This pull request adds extension support to `Str::inlineMarkdown()` and `str()->inlineMarkdown()` so that the configurability is inline with the regular `markdown()` method.