### PR TITLE
[11.x] feat: add Str::doesntContain() method and supporting tests

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -329,6 +329,19 @@ class Str
     }
 
     /**
+     * Determine if a given string doesn't contain a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public static function doesntContain($haystack, $needles, $ignoreCase = false)
+    {
+        return ! static::contains($haystack, $needles, $ignoreCase);
+    }
+
+    /**
      * Convert the case of a string.
      *
      * @param  string  $string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -377,6 +377,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals($expected, Str::containsAll($haystack, $needles, $ignoreCase));
     }
 
+    #[DataProvider('strDoesntContainProvider')]
+    public function testStrDoesntContain($haystack, $needles, $expected, $ignoreCase = false)
+    {
+        $this->assertEquals($expected, Str::doesntContain($haystack, $needles, $ignoreCase));
+    }
+
     public function testConvertCase()
     {
         // Upper Case Conversion
@@ -1282,6 +1288,13 @@ class SupportStrTest extends TestCase
             ['Taylor Otwell', ['taylor'], true, true],
             ['Taylor Otwell', ['taylor', 'xxx'], false, false],
             ['Taylor Otwell', ['taylor', 'xxx'], false, true],
+        ];
+    }
+
+    public static function strDoesntContainProvider()
+    {
+        return [
+            ['Tar', 'ylo', true, true],
         ];
     }
 


### PR DESCRIPTION
Hi :wave:,

In my Laravel projects where I utilise the `Str::contains()` method, I often find that I need the inverse functionality of this. Whilst I can just prepend with `!` to get the inverse, readability in the method name can make better sense.

This PR introduces a new `Str::doesntContain()` method that internally utilises the same functionality as `contains` except does the inversing for the end user whilst retaining a readable function name! Simple but effective!