### PR TITLE
[11.x] `whereBelongsTo` support for `MorphTo` relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -578,13 +578,13 @@ trait QueriesRelationships
 
         if ($relationship instanceof MorphTo) {
             $this->where(fn ($query) => (
-                $relatedCollection->each(fn ($model) => (
-                    $query->orWhere(fn ($innerQuery) => (
+                $relatedCollection->each(fn ($model) =>
+                    $query->orWhere(fn ($innerQuery) =>
                         $innerQuery->where($relationship->getQualifiedMorphTypeColumn(), \get_class($model))
                             ->where($relationship->getQualifiedForeignKeyName(), $model->getKey())
-                    ))
-                ))
-            ));
+                    )
+                )
+            ), boolean: $boolean);
         } else {
             $this->whereIn(
                 $relationship->getQualifiedForeignKeyName(),

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -406,6 +406,16 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Get the fully qualified morph type column of the relationship.
+     *
+     * @return string
+     */
+    public function getQualifiedMorphTypeColumn()
+    {
+        return $this->child->qualifyColumn($this->morphType);
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1259,28 +1259,35 @@ class DatabaseEloquentBuilderTest extends TestCase
             'parent_type' => EloquentBuilderTestWhereBelongsToStub::class,
         ]);
 
-        $parent = new EloquentBuilderTestWhereBelongsToStub([
+        $parent = new EloquentBuilderTestPolymorphicParentWhereBelongsToStub([
             'id' => 1,
-            'parent_id' => 1,
         ]);
 
         $this->mockConnectionForModel($related, 'SQLite');
 
         $query = $related->newQuery()->whereBelongsTo($parent, 'parent');
         $this->assertSame('select * from "foo_table" where (("foo_table"."parent_type" = ? and "foo_table"."parent_id" = ?))', $query->toSql());
-        $this->assertEquals([EloquentBuilderTestWhereBelongsToStub::class, 1], $query->getBindings());
+        $this->assertEquals([EloquentBuilderTestPolymorphicParentWhereBelongsToStub::class, 1], $query->getBindings());
 
-        $parents = new Collection([new EloquentBuilderTestWhereBelongsToStub([
+        $parents = new Collection([new EloquentBuilderTestPolymorphicParentWhereBelongsToStub([
             'id' => 2,
-            'parent_id' => 1,
-        ]), new EloquentBuilderTestWhereBelongsToStub([
+        ]), new EloquentBuilderTestPolymorphicParentWhereBelongsToStub([
             'id' => 3,
-            'parent_id' => 1,
         ])]);
     
         $query = $related->newQuery()->whereBelongsTo($parents, 'parent');
         $this->assertSame('select * from "foo_table" where (("foo_table"."parent_type" = ? and "foo_table"."parent_id" = ?) or ("foo_table"."parent_type" = ? and "foo_table"."parent_id" = ?))', $query->toSql());
-        $this->assertEquals([EloquentBuilderTestWhereBelongsToStub::class, 2, EloquentBuilderTestWhereBelongsToStub::class, 3], $query->getBindings());
+        $this->assertEquals([EloquentBuilderTestPolymorphicParentWhereBelongsToStub::class, 2, EloquentBuilderTestPolymorphicParentWhereBelongsToStub::class, 3], $query->getBindings());
+
+        $parents = new Collection([new EloquentBuilderTestPolymorphicParentWhereBelongsToStub([
+            'id' => 4,
+        ]), new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 1,
+        ])]);
+    
+        $query = $related->newQuery()->whereBelongsTo($parents, 'parent');
+        $this->assertSame('select * from "foo_table" where (("foo_table"."parent_type" = ? and "foo_table"."parent_id" = ?) or ("foo_table"."parent_type" = ? and "foo_table"."parent_id" = ?))', $query->toSql());
+        $this->assertEquals([EloquentBuilderTestPolymorphicParentWhereBelongsToStub::class, 4, EloquentBuilderTestWhereBelongsToStub::class, 1], $query->getBindings());
     }
 
     public function testDeleteOverride()
@@ -2659,6 +2666,13 @@ class EloquentBuilderTestWhereBelongsToStub extends Model
     {
         return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
     }
+}
+
+class EloquentBuilderTestPolymorphicParentWhereBelongsToStub extends Model
+{
+    protected $fillable = [
+        'id',
+    ];
 }
 
 class EloquentBuilderTestPolymorphicWhereBelongsToStub extends Model


### PR DESCRIPTION
Hello,

This PR adds an improvement to Eloquent `whereBelongsTo` method, to correctly query a `MorphTo` polymorphic relationship.
I've also added tests to ensure the resulting query is as expected.

The idea/discussion is at #53038.

Thank you!