### PR TITLE
Add metadata to mailable view data

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -352,7 +352,19 @@ class Mailable implements MailableContract, Renderable
             }
         }
 
-        return $data;
+        return array_merge($data, $this->additionalMessageData());
+    }
+
+    /**
+     * Get additional meta-data to pass along with the view data.
+     *
+     * @return array<string, mixed>
+     */
+    protected function additionalMessageData(): array
+    {
+        return [
+            '__laravel_mailable' => get_class($this),
+        ];
     }
 
     /**

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -9,9 +9,13 @@ class MailMailableDataTest extends TestCase
 {
     public function testMailableDataIsNotLost()
     {
-        $testData = ['first_name' => 'James'];
-
         $mailable = new MailableStub;
+
+        $testData = [
+            'first_name' => 'James',
+            '__laravel_mailable' => get_class($mailable),
+        ];
+
         $mailable->build(function ($m) use ($testData) {
             $m->view('view', $testData);
         });

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -592,6 +592,7 @@ class MailMailableTest extends TestCase
             'first_name' => 'Taylor',
             'lastName' => 'Otwell',
             'framework' => 'Laravel',
+            '__laravel_mailable' => get_class($mailable),
         ];
 
         $this->assertSame($expected, $mailable->buildViewData());


### PR DESCRIPTION
## Background
While developing a package that filters outgoing emails by recipient using the `MessageSending` event, I noticed a discrepancy between notifications and mailables. Notifications include metadata like the notification class in the viewData (which is also provided to the event). However, when sending a `Mailable`, this functionality is not present and it is impossible to identify the originating class from the event.

_What is currently present for notification context:_

```php
/**
 * Get additional meta-data to pass along with the view data.
 *
 * @param  \Illuminate\Notifications\Notification  $notification
 * @return array
 */
protected function additionalMessageData($notification)
{
    return [
        '__laravel_notification_id' => $notification->id,
        '__laravel_notification' => get_class($notification),
        '__laravel_notification_queued' => in_array(
            ShouldQueue::class,
            class_implements($notification)
        ),
    ];
}

```

## Proposed Changes
This pull request introduces an `additionalMessageData` method to the `Mailable` class to enhance the provided viewData, mirroring the functionality present in the `MailChannel` class used for notifications. The aim is to provide consistent metadata in the `MessageSending` event across both notifications and mailables. As this is also passed to the `MessageSending` event, this enables event listeners to identify the message source.

## Considerations
This PR does not fully mimic the notifications metadata. Currently i have only included the `Mailable` class to the meta data as I am not aware of a similar `id` attribute on mailables and checking for the implementation of the `ShouldQueue` interface might not be enough to identify if the mailable was queued (due to ways to queue a mailable without it's implementation). I might be wrong, but the "__laravel_notification_queued" information on notifications might also not be 100% accurate depending on the way it is queued, so it might be ok to include the same information for mailables for consistency?