### PR TITLE
Added open flag in serve command enabling it to open browser directly

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -163,6 +163,10 @@ class ServeCommand extends Command
 
         $process->start($this->handleProcessOutput());
 
+        if ($this->option('open')) {
+            $this->openBrowser("http://{$this->host()}:{$this->port()}");
+        }
+
         return $process;
     }
 
@@ -393,6 +397,24 @@ class ServeCommand extends Command
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', Env::get('SERVER_PORT')],
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
             ['no-reload', null, InputOption::VALUE_NONE, 'Do not reload the development server on .env file changes'],
+            ['open', 'o', InputOption::VALUE_NONE, 'Automatically open the application in your browser'],
         ];
+    }
+
+    /**
+     * Open the given URL in the browser.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function openBrowser($url)
+    {
+        if (PHP_OS_FAMILY === 'Darwin') {
+            exec('open '.$url);
+        } elseif (PHP_OS_FAMILY === 'Windows') {
+            exec('start '.$url);
+        } else {
+            exec('xdg-open '.$url);
+        }
     }
 }


### PR DESCRIPTION
### Feature: Automatically Open Browser with php artisan serve --open/-o
This PR introduces a new option to the php artisan serve command, enabling users to automatically open the local development URL in their default browser when the server starts.

#### What's New:
Adds a `--open` or `-o` flag to the php artisan serve command.
When this flag is used, the local server `(e.g., http://127.0.0.1:8000)` will be launched directly in the browser after starting.

#### Usage:
```bash
php artisan serve --open
# or
php artisan serve -o
```
This enhancement streamlines the development workflow by eliminating the need to manually open the local server in the browser.

### Motivation
While working on Windows, I often find myself manually typing the local development URL into the browser every time I run php artisan serve. This process can become repetitive, especially when the default port (8000) is already in use, causing Laravel to assign a different port. In such cases, I need to manually adjust the URL accordingly.

