### PR TITLE
[11.x] Fixes validation using `shouldConvertToBoolean` when parameter uses dot notation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2259,7 +2259,7 @@ trait ValidatesAttributes
      */
     protected function shouldConvertToBoolean($parameter)
     {
-        return in_array('boolean', Arr::get($this->rules, $parameter, []));
+        return in_array('boolean', $this->rules[$parameter] ?? []);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1696,6 +1696,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
         $this->assertCount(1, $v->messages());
         $this->assertSame('The baz field is required when foo is empty.', $v->messages()->first('baz'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator(
+            $trans,
+            ['foo' => 'bar', 'customfield' => ['1' => 'taylor']],
+            ['customfield' => ['nullable', 'array'], 'foo' => 'required_if:customfield.1,taylor']
+        );
+        $this->assertTrue($v->passes());
     }
 
     public function testRequiredIfArrayToStringConversationErrorException()


### PR DESCRIPTION
Given the following validation rules:
```
['customfield' => ['nullable', 'array'], 'foo' => 'required_if:customfield.1,taylor']
```

The use of `Arr::get()` in `shouldConvertToBoolean($parameter)` results in attributes containing dot notation being parsed. Thus, in the above example, `Arr::get($this->rules, 'customfield.1', [])` returns `array` - the second element (zero-indexed) in the `customfield` validation rules.

The intended behaviour is that it returns all of the validation rules for the `customfield.1` attribute.

Without the changes in this PR, the test case fails with the below:

```
1) Illuminate\Tests\Validation\ValidationValidatorTest::testRequiredIf
TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given

/Users/bytestream/PhpstormProjects/framework/src/Illuminate/Validation/Concerns/ValidatesAttributes.php:2262
/Users/bytestream/PhpstormProjects/framework/src/Illuminate/Validation/Concerns/ValidatesAttributes.php:2243
/Users/bytestream/PhpstormProjects/framework/src/Illuminate/Validation/Concerns/ValidatesAttributes.php:2002
/Users/bytestream/PhpstormProjects/framework/src/Illuminate/Validation/Validator.php:664
/Users/bytestream/PhpstormProjects/framework/src/Illuminate/Validation/Validator.php:459
/Users/bytestream/PhpstormProjects/framework/tests/Validation/ValidationValidatorTest.php:1706

```
