### PR TITLE
[11.x] Fixes `make:model` for Form Requests

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -72,6 +72,8 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('controller') || $this->option('resource') || $this->option('api')) {
             $this->createController();
+        } elseif ($this->option('requests')) {
+            $this->createFormRequests();
         }
 
         if ($this->option('policy')) {
@@ -146,6 +148,24 @@ class ModelMakeCommand extends GeneratorCommand
             '--test' => $this->option('test'),
             '--pest' => $this->option('pest'),
         ]));
+    }
+
+    /**
+     * Create form requests for the model.
+     *
+     * @return void
+     */
+    protected function createFormRequests()
+    {
+        $request = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:request', [
+            'name' => "Store{$request}Request",
+        ]);
+
+        $this->call('make:request', [
+            'name' => "Update{$request}Request",
+        ]);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -151,7 +151,7 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Create form requests for the model.
+     * Create the form requests for the model.
      *
      * @return void
      */


### PR DESCRIPTION
If you do `make:model` and get the prompts to select what you want generated with the model, you can choose "Form Requests" but if you don't also choose "Resource Controller" you never get any form requests. 

This PR fixes that so that form requests are generated even if you don't choose a controller to generate with it.