### PR TITLE
[11.x] PHPDoc Improvements

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastController.php
+++ b/src/Illuminate/Broadcasting/BroadcastController.php
@@ -30,7 +30,9 @@ class BroadcastController extends Controller
      * See: https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return array|null
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
     public function authenticateUser(Request $request)
     {


### PR DESCRIPTION
- `Broadcast::resolveAuthenticatedUser()` returns `array|null`. So, `BroadcastController::authenticateUser()` returns `array|null`.
- A `@throws` tag is also added to `BroadcastController::authenticateUser()`.