### PR TITLE
[11.x] PHPDoc Improvements

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1352,7 +1352,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Fire all of the after resolving attribute callbacks.
      *
-     * @param  \ReflectionAttribute[]  $abstract
+     * @param  \ReflectionAttribute[]  $attributes
      * @param  mixed  $object
      * @return void
      */


### PR DESCRIPTION
Fixed a PHPDoc, misspelling on the variable name