### PR TITLE
[11.x] Add assertDatabaseNotEmpty assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -100,6 +100,22 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert that the given table has some entries.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseNotEmpty($table, $connection = null)
+    {
+        $this->assertThat(
+            $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), 0, true)
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert the given record has been "soft deleted".
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $table

--- a/src/Illuminate/Testing/Constraints/CountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/CountInDatabase.php
@@ -30,7 +30,7 @@ class CountInDatabase extends Constraint
     protected $actualCount;
 
     /**
-     * Whether to swap the assertion to check that the count does not equal the expected count
+     * Whether to swap the assertion to check that the count does not equal the expected count.
      *
      * @var bool
      */
@@ -63,7 +63,7 @@ class CountInDatabase extends Constraint
         $this->actualCount = $this->database->table($table)->count();
 
         if ($this->not) {
-           return $this->actualCount !== $this->expectedCount;
+            return $this->actualCount !== $this->expectedCount;
         }
 
         return $this->actualCount === $this->expectedCount;
@@ -87,7 +87,7 @@ class CountInDatabase extends Constraint
 
             return sprintf(
                 "table [%s] is empty. Entries found: %s.\n",
-                $table,  $this->actualCount
+                $table, $this->actualCount
             );
         }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -171,6 +171,34 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseEmpty(new ProductStub);
     }
 
+    public function testAssertDatabaseEmptyWrong()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that table [products] is empty. Entries found: 1.');
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseEmpty(ProductStub::class);
+        $this->assertDatabaseEmpty(new ProductStub);
+    }
+
+    public function testAssertDatabaseNotEmpty()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseNotEmpty(ProductStub::class);
+        $this->assertDatabaseNotEmpty(new ProductStub);
+    }
+
+    public function testAssertDatabaseNotEmptyWrong()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that table [products] is not empty.');
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseNotEmpty(ProductStub::class);
+        $this->assertDatabaseNotEmpty(new ProductStub);
+    }
+
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
This PR adds a new `assertDatabaseNotEmpty` assertion.

I use `assertDatabaseEmpty` regularly, and often find myself typing `assertDatabaseNotEmpty` to check for the opposite when I don't need to know how many rows a table has, just that its not empty, but the method doesn't exist! At the moment, the work around I use is `$this->assertNotEmpty(Product::all())` which works, but isn't as clean as one comes to expect with Laravel.

I placed the method next to the current `assertDatabaseEmpty` method, and updated the `CountInDatabase` constraint to accept a third parameter of a boolean with a default of false, if true, this reverses the constraint in the`match` method from `===` to `!==`.

On testing, I found that the assertion failure messages no longer made sense when checking if a table is empty, or not empty, so I updated the `failureDescription` method to check that if `$this->expectedCount` is 0 (So, checking that the table is empty, or not empty) then it will display `Failed asserting that table [products] is empty. Entries found: 1.` and `Failed asserting that table [products] is not empty.` dependent on the new boolean parameter.

Usage could be something similar to:

```
app(CompleteOrderAction::class)->handle($basket);

$this->assertDatabaseNotEmpty(OrderItem::class);
```

The snippet above could take a basket with an unknown amount of items, and pass it to a CompleteOrderAction class, which then stores that order and its items, and then we can check that the OrderItem table is not empty, as it doesn't matter the exact number of rows, just that rows exist.

Thank you :) 