### PR TITLE
[11.x] Fix border overflow on theme switcher when hovering

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/theme-switcher.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/theme-switcher.blade.php
@@ -71,7 +71,7 @@
         @click="menu = false"
     >
         <button
-            class="flex items-center gap-3 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            class="flex items-center gap-3 px-4 py-2 hover:rounded-t-md hover:bg-gray-100 dark:hover:bg-gray-700"
             :class="theme === 'light' ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'"
             @click="lightMode()"
         >
@@ -87,7 +87,7 @@
             Dark
         </button>
         <button
-            class="flex items-center gap-3 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            class="flex items-center gap-3 px-4 py-2 hover:rounded-b-md hover:bg-gray-100 dark:hover:bg-gray-700"
             :class="theme === undefined ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'"
             @click="systemMode()"
         >


### PR DESCRIPTION
On the error page of Laravel there is a theme switcher, when hovering over `light` or `system` it overflows at the top/bottom because the border radius is removed when hovering. 

This commit aims to fix this problem and make hovering smooth again!

Screenshots of my testing environment:

Before:
![image](https://github.com/user-attachments/assets/417ffc5f-5f2f-4339-81ce-a262d2a56ff1)

After:
![image](https://github.com/user-attachments/assets/a3c434d1-22e1-4f06-b972-36df8897b32e)
