### PR TITLE
Revert "[11.x] Improve performance of Redis queue block_for when a worker has multiple queues to service"

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -55,15 +55,6 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $migrationBatchSize = -1;
 
     /**
-     * Indicates if a secondary queue had a job available between checks of the primary queue.
-     *
-     * Only applicable when monitoring multiple named queues with a single instance.
-     *
-     * @var bool
-     */
-    protected $secondaryQueueHadJob = false;
-
-    /**
      * Create a new Redis queue instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
@@ -230,23 +221,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
-    public function pop($queue = null, $index = 0)
+    public function pop($queue = null)
     {
         $this->migrate($prefixed = $this->getQueue($queue));
 
-        $block = ! $this->secondaryQueueHadJob && $index == 0;
-
-        [$job, $reserved] = $this->retrieveNextJob($prefixed, $block);
-
-        if ($index == 0) {
-            $this->secondaryQueueHadJob = false;
-        }
+        [$job, $reserved] = $this->retrieveNextJob($prefixed);
 
         if ($reserved) {
-            if ($index > 0) {
-                $this->secondaryQueueHadJob = true;
-            }
-
             return new RedisJob(
                 $this->container, $this, $job,
                 $reserved, $this->connectionName, $queue ?: $this->default

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -346,8 +346,8 @@ class Worker
      */
     protected function getNextJob($connection, $queue)
     {
-        $popJobCallback = function ($queue, $index = 0) use ($connection) {
-            return $connection->pop($queue, $index);
+        $popJobCallback = function ($queue) use ($connection) {
+            return $connection->pop($queue);
         };
 
         $this->raiseBeforeJobPopEvent($connection->getConnectionName());
@@ -360,8 +360,8 @@ class Worker
                 );
             }
 
-            foreach (explode(',', $queue) as $index => $queue) {
-                if (! is_null($job = $popJobCallback($queue, $index))) {
+            foreach (explode(',', $queue) as $queue) {
+                if (! is_null($job = $popJobCallback($queue))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
 
                     return $job;


### PR DESCRIPTION
Reverts laravel/framework#52826

This caused an issue with Horizon - reverting seems like the best course of action.