### PR TITLE
[11.x] feat: add `timestamp_if_true()` helper function with supporting test

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -3,6 +3,7 @@
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\HigherOrderTapProxy;
@@ -430,6 +431,22 @@ if (! function_exists('throw_unless')) {
         throw_if(! $condition, $exception, ...$parameters);
 
         return $condition;
+    }
+}
+
+if (! function_exists('timestamp_if_true')) {
+    /**
+     * Return the current timestamp if the given array item value is set and truthy.
+     *
+     * @param  array  $data
+     * @param  string $key
+     * @return \Illuminate\Support\Carbon|null
+     */
+    function timestamp_if_true(array $data, string $key): ?Carbon
+    {
+        return filter_var(Arr::get($data, $key), FILTER_VALIDATE_BOOLEAN)
+            ? now()
+            : null;
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -439,7 +439,7 @@ if (! function_exists('timestamp_if_true')) {
      * Return the current timestamp if the given array item value is set and truthy.
      *
      * @param  array  $data
-     * @param  string $key
+     * @param  string  $key
      * @return \Illuminate\Support\Carbon|null
      */
     function timestamp_if_true(array $data, string $key): ?Carbon

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -843,7 +843,6 @@ class SupportHelpersTest extends TestCase
     {
         $data = ['activated' => false];
         $timestamp = timestamp_if_true($data, 'activated');
-        
         $this->assertNull($timestamp);
     }
 
@@ -851,7 +850,6 @@ class SupportHelpersTest extends TestCase
     {
         $data = [];
         $timestamp = timestamp_if_true($data, 'activated');
-        
         $this->assertNull($timestamp);
     }
 
@@ -859,7 +857,6 @@ class SupportHelpersTest extends TestCase
     {
         $data = ['activated' => 1]; // Truthy but not strictly boolean
         $timestamp = timestamp_if_true($data, 'activated');
-        
         $this->assertInstanceOf(Carbon::class, $timestamp);
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Countable;
 use Error;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
@@ -822,6 +823,44 @@ class SupportHelpersTest extends TestCase
         $this->expectExceptionMessage('Test Message');
 
         throw_if(true, RuntimeException::class, 'Test Message');
+    }
+
+    public function testReturnsCurrentTimestampWhenTrue()
+    {
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
+        $data = ['activated' => true];
+        $timestamp = timestamp_if_true($data, 'activated');
+
+        $this->assertInstanceOf(Carbon::class, $timestamp);
+        $this->assertTrue($timestamp->equalTo($now), 'Returned timestamp should match the frozen time');
+
+        Carbon::setTestNow();
+    }
+
+    public function testReturnsNullWhenFalse()
+    {
+        $data = ['activated' => false];
+        $timestamp = timestamp_if_true($data, 'activated');
+        
+        $this->assertNull($timestamp);
+    }
+
+    public function testReturnsNullWhenKeyIsNotSet()
+    {
+        $data = [];
+        $timestamp = timestamp_if_true($data, 'activated');
+        
+        $this->assertNull($timestamp);
+    }
+
+    public function testReturnsNullWhenKeyIsTruthyButNotBoolean()
+    {
+        $data = ['activated' => 1]; // Truthy but not strictly boolean
+        $timestamp = timestamp_if_true($data, 'activated');
+        
+        $this->assertInstanceOf(Carbon::class, $timestamp);
     }
 
     public function testOptional()


### PR DESCRIPTION
### Description

This pull request introduces the `timestamp_if_true()` helper function to the framework. The helper function checks whether a given array item value is set and truthy, and if so, it returns the current timestamp using Carbon. If the value is falsey or not present, the function returns `null`.

### Motivation

In some of our project we frequently need to conditionally assign a timestamp based on the presence and truthiness of an array value, such as flags in form data like `locked_at`, `cancelled_at` or configuration arrays. This new helper function simplifies the code by encapsulating this common logic and provides a clean, concise way to achieve this, improving readability and reducing code duplication.

### Usage Example

```php
$data = ['locked_at' => true];

$timestamp = timestamp_if_true($data, 'locked_at');

// $timestamp will be an instance of Carbon if 'locked_at' is truthy,
// or null if 'locked_at' is falsey or not present.
```

### Implementation

- **Helper Function**: The `timestamp_if_true()` function is introduced to check if the specified array key holds a truthy value. It uses `filter_var()` with `FILTER_VALIDATE_BOOLEAN` to allow flexibility with truthy values such as `1` and `'1'`.

### Benefits

- **Improves Code Readability**: This function simplifies conditional timestamping logic, making the code more expressive and easier to maintain.
- **Avoids Code Duplication**: Common logic is extracted into a reusable helper.
- **Backward Compatibility**: This is a non-breaking change, adding a minor feature that is fully backward-compatible with existing functionality.

### Tests

- Returns a `Carbon` timestamp when the array value is `true`.
- Returns `null` when the array value is `false` or when the key is not set.
- Handles truthy values (such as `1`) by returning a timestamp.
- Ensures that the current timestamp returned by the function is consistent by using `Carbon::setTestNow()` in the relevant test.

### Contribution Checklist

- [x] I've read and followed the [Laravel Contribution Guide](https://github.com/laravel/framework/blob/10.x/CONTRIBUTING.md).
- [x] The code adheres to Laravel's [coding style](https://github.com/laravel/framework/blob/10.x/CONTRIBUTING.md#coding-style).
- [x] I have added a unit test for this new helper function.

### Related Issues/Discussions

None.
