### PR TITLE
[11.x] `Stringable` and `AsIterable*` castables force instance when null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -15,17 +15,28 @@ class AsArrayObject implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected bool $forceInstance;
+
+            public function __construct(array $arguments)
+            {
+                $this->forceInstance = ($arguments[0] ?? '') === 'force';
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
-                    return;
+                    return $this->defaultValue();
                 }
 
                 $data = Json::decode($attributes[$key]);
 
-                return is_array($data) ? new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS) : null;
+                if (! is_array($data)) {
+                    return $this->defaultValue();
+                }
+
+                return new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS);
             }
 
             public function set($model, $key, $value, $attributes)
@@ -37,6 +48,19 @@ class AsArrayObject implements Castable
             {
                 return $value->getArrayCopy();
             }
+
+            protected function defaultValue(): ?ArrayObject
+            {
+                return $this->forceInstance ? new ArrayObject : null;
+            }
         };
+    }
+
+    /**
+     * Always get an array.
+     */
+    public static function force(): string
+    {
+        return static::class.':force';
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -22,24 +22,24 @@ class AsEnumArrayObject implements Castable
         return new class($arguments) implements CastsAttributes
         {
             protected string $enumClass;
-            protected bool $forceArray;
+            protected bool $forceInstance;
 
             public function __construct(array $arguments)
             {
                 $this->enumClass = $arguments[0];
-                $this->forceArray = $arguments[1] ?? false;
+                $this->forceInstance = $arguments[1] ?? false;
             }
 
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
-                    return $this->forceArray ? new ArrayObject: null;
+                    return $this->forceInstance ? new ArrayObject : null;
                 }
 
                 $data = Json::decode($attributes[$key]);
 
                 if (! is_array($data)) {
-                    return $this->forceArray ? new ArrayObject: null;
+                    return $this->forceInstance ? new ArrayObject : null;
                 }
 
                 return new ArrayObject((new Collection($data))->map(function ($value) {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -27,19 +27,19 @@ class AsEnumCollection implements Castable
             public function __construct(array $arguments)
             {
                 $this->enumClass = $arguments[0];
-                $this->forceInstance = $arguments[1] ?? false;
+                $this->forceInstance = ($arguments[1] ?? '') === 'force';
             }
 
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
-                    return $this->forceInstance ? new Collection : null;
+                    return $this->defaultValue();
                 }
 
                 $data = Json::decode($attributes[$key]);
 
                 if (! is_array($data)) {
-                    return $this->forceInstance ? new Collection : null;
+                    return $this->defaultValue();
                 }
 
                 return (new Collection($data))->map(function ($value) {
@@ -75,13 +75,18 @@ class AsEnumCollection implements Castable
 
                 return $enum instanceof BackedEnum ? $enum->value : $enum->name;
             }
+
+            protected function defaultValue(): ?Collection
+            {
+                return $this->forceInstance ? new Collection : null;
+            }
         };
     }
 
     /**
      * Specify the Enum for the cast.
      *
-     * @param  class-string  $class
+     * @param  class-string<\UnitEnum>  $class
      * @param  bool  $force
      * @return string
      */
@@ -92,5 +97,16 @@ class AsEnumCollection implements Castable
         }
 
         return static::class.':'.$class;
+    }
+
+    /**
+     * Always get a collection instance.
+     *
+     * @param class-string<\UnitEnum> $class
+     * @return string
+     */
+    public static function force(string $class): string
+    {
+        return static::class.':'.$class.',force';
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -22,24 +22,24 @@ class AsEnumCollection implements Castable
         return new class($arguments) implements CastsAttributes
         {
             protected string $enumClass;
-            protected bool $forceCollection;
+            protected bool $forceInstance;
 
             public function __construct(array $arguments)
             {
                 $this->enumClass = $arguments[0];
-                $this->forceCollection = $arguments[1] ?? false;
+                $this->forceInstance = $arguments[1] ?? false;
             }
 
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
-                    return $this->forceCollection ? new Collection: null;
+                    return $this->forceInstance ? new Collection : null;
                 }
 
                 $data = Json::decode($attributes[$key]);
 
                 if (! is_array($data)) {
-                    return $this->forceCollection ? new Collection: null;
+                    return $this->forceInstance ? new Collection : null;
                 }
 
                 return (new Collection($data))->map(function ($value) {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -21,31 +21,31 @@ class AsEnumCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
+            protected string $enumClass;
+            protected bool $forceCollection;
 
             public function __construct(array $arguments)
             {
-                $this->arguments = $arguments;
+                $this->enumClass = $arguments[0];
+                $this->forceCollection = $arguments[1] ?? false;
             }
 
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
-                    return;
+                    return $this->forceCollection ? new Collection: null;
                 }
 
                 $data = Json::decode($attributes[$key]);
 
                 if (! is_array($data)) {
-                    return;
+                    return $this->forceCollection ? new Collection: null;
                 }
 
-                $enumClass = $this->arguments[0];
-
-                return (new Collection($data))->map(function ($value) use ($enumClass) {
-                    return is_subclass_of($enumClass, BackedEnum::class)
-                        ? $enumClass::from($value)
-                        : constant($enumClass.'::'.$value);
+                return (new Collection($data))->map(function ($value) {
+                    return is_subclass_of($this->enumClass, BackedEnum::class)
+                        ? $this->enumClass::from($value)
+                        : constant($this->enumClass.'::'.$value);
                 });
             }
 
@@ -82,10 +82,15 @@ class AsEnumCollection implements Castable
      * Specify the Enum for the cast.
      *
      * @param  class-string  $class
+     * @param  bool  $force
      * @return string
      */
-    public static function of($class)
+    public static function of(string $class, bool $force = false): string
     {
+        if ($force) {
+            return static::class.':'.$class.',force';
+        }
+
         return static::class.':'.$class;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 class AsStringable implements Castable
 {
@@ -16,17 +17,41 @@ class AsStringable implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected bool $forceInstance;
+
+            public function __construct(array $arguments)
+            {
+                $this->forceInstance = ($arguments[0] ?? '') === 'force';
+            }
+
             public function get($model, $key, $value, $attributes)
             {
-                return isset($value) ? Str::of($value) : null;
+                if (! isset($value)) {
+                    return $this->defaultValue();
+                }
+
+                return Str::of($value);
             }
 
             public function set($model, $key, $value, $attributes)
             {
                 return isset($value) ? (string) $value : null;
             }
+
+            protected function defaultValue(): ?Stringable
+            {
+                return $this->forceInstance ? new Stringable : null;
+            }
         };
+    }
+
+    /**
+     * Always get a Stringable instance.
+     */
+    public static function force(): string
+    {
+        return static::class.':force';
     }
 }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use ValueError;
@@ -24,6 +26,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             $table->integer('integer_status')->nullable();
             $table->json('integer_status_collection')->nullable();
             $table->json('integer_status_array')->nullable();
+            $table->json('integer_status_collection_forced')->nullable();
+            $table->json('integer_status_array_forced')->nullable();
             $table->string('arrayable_status')->nullable();
         });
 
@@ -66,6 +70,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => null,
             'integer_status_array' => null,
             'arrayable_status' => null,
+            'integer_status_collection_forced' => null,
+            'integer_status_array_forced' => null,
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
@@ -77,6 +83,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals(null, $model->integer_status_collection);
         $this->assertEquals(null, $model->integer_status_array);
         $this->assertEquals(null, $model->arrayable_status);
+        $this->assertInstanceOf(Collection::class, $model->integer_status_collection_forced);
+        $this->assertInstanceOf(ArrayObject::class, $model->integer_status_array_forced);
     }
 
     public function testEnumsAreCastableToArray()
@@ -116,6 +124,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => null,
             'integer_status_array' => null,
             'arrayable_status' => null,
+            'integer_status_collection_forced' => null,
+            'integer_status_array_forced' => null,
         ]);
 
         $this->assertEquals([
@@ -126,6 +136,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => null,
             'integer_status_array' => null,
             'arrayable_status' => null,
+            'integer_status_collection_forced' => [],
+            'integer_status_array_forced' => [],
         ], $model->toArray());
     }
 
@@ -139,6 +151,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
             'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
+            'integer_status_collection_forced' => null,
+            'integer_status_array_forced' => null,
         ]);
 
         $model->save();
@@ -152,6 +166,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
+            'integer_status_collection_forced' => '',
+            'integer_status_array_forced' => '',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
         })->all());
@@ -167,6 +183,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => [1, 2],
             'integer_status_array' => [1, 2],
             'arrayable_status' => 'pending',
+            'integer_status_collection_forced' => null,
+            'integer_status_array_forced' => null,
         ]);
 
         $model->save();
@@ -180,6 +198,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
+            'integer_status_collection_forced' => '',
+            'integer_status_array_forced' => '',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
         })->all());
@@ -195,6 +215,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => null,
             'integer_status_array' => null,
             'arrayable_status' => null,
+            'integer_status_collection_forced' => null,
+            'integer_status_array_forced' => null,
         ]);
 
         $model->save();
@@ -208,6 +230,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status_collection' => null,
             'integer_status_array' => null,
             'arrayable_status' => null,
+            'integer_status_collection_forced' => null,
+            'integer_status_array_forced' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
 
@@ -331,15 +355,20 @@ class EloquentModelEnumCastingTestModel extends Model
     protected $guarded = [];
     protected $table = 'enum_casts';
 
-    public $casts = [
-        'string_status' => StringStatus::class,
-        'string_status_collection' => AsEnumCollection::class.':'.StringStatus::class,
-        'string_status_array' => AsEnumArrayObject::class.':'.StringStatus::class,
-        'integer_status' => IntegerStatus::class,
-        'integer_status_collection' => AsEnumCollection::class.':'.IntegerStatus::class,
-        'integer_status_array' => AsEnumArrayObject::class.':'.IntegerStatus::class,
-        'arrayable_status' => ArrayableStatus::class,
-    ];
+    protected function casts()
+    {
+        return [
+            'string_status' => StringStatus::class,
+            'string_status_collection' => AsEnumCollection::class.':'.StringStatus::class,
+            'string_status_array' => AsEnumArrayObject::class.':'.StringStatus::class,
+            'integer_status' => IntegerStatus::class,
+            'integer_status_collection' => AsEnumCollection::class.':'.IntegerStatus::class,
+            'integer_status_array' => AsEnumArrayObject::class.':'.IntegerStatus::class,
+            'arrayable_status' => ArrayableStatus::class,
+            'integer_status_collection_forced' => AsEnumCollection::of(IntegerStatus::class, true),
+            'integer_status_array_forced' => AsEnumArrayObject::of(IntegerStatus::class, true),
+        ];
+    }
 }
 
 class EloquentModelEnumCastingUniqueTestModel extends Model


### PR DESCRIPTION
### Why
Its hard (impossible) to define a generic SQL expression to `default` an `json` could to be an `empty array`.
A general pattern in laravel is to return `null` if the field is `nullable` and null, this is good for most cases but is confusing and requires more complicated code (see example below) when casting to a `stringable` or an `iterable` type.


### Enhancement of Cast Classes with force feature
The cast classes, including `AsArrayObject`, `AsCollection`, `AsEncryptedArrayObject`, `AsEncryptedCollection`, `AsEnumArrayObject`, `AsEnumCollection` and `AsStringable`, have been updated with a new feature named `force`. It allows them to return a new instance of their objects when the value is `null`. This ensures that the returned values is more predictable and its easy to work with.


### before
```php
// 'options' => AsCollection::using(OptionCollection::class),

$model->options?->isEmpty() ?? true; // condition

if (! $model->options) {
    $model->options = new OptionCollection;
} 

$model->options->push('whatever');
```


### after
```php
// 'options' => AsCollection::using(OptionCollection::class, force: true),
// or 'options' => AsCollection::force(OptionCollection::class),
// or 'options' => AsCollection::class.':'.OptionCollection::class.',force',

$model->options->isEmpty(); // condition

$model->options->push('whatever');
```

Type check is currently failing, would be cool if someone could help with it (or i will restore the original docblocks)