### PR TITLE
[11.x] Fixes parameter declaration for `ServiceProvider::optimizes()`

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -477,12 +477,12 @@ abstract class ServiceProvider
     /**
      * Register commands that should run on "optimize" or "optimize:clear".
      *
-     * @param  string  $optimize
-     * @param  string  $clear
+     * @param  string|null  $optimize
+     * @param  string|null  $clear
      * @param  string|null  $key
      * @return void
      */
-    protected function optimizes(string $optimize = null, string $clear = null, ?string $key = null)
+    protected function optimizes(?string $optimize = null, ?string $clear = null, ?string $key = null)
     {
         $key ??= (string) Str::of(get_class($this))
             ->classBasename()


### PR DESCRIPTION
While the deprecation exists in PHP 8.4, the docblock are still in-correct and doesn't match the 3rd params.

```
Illuminate\Support\ServiceProvider::optimizes(): Implicitly marking parameter $optimize as nullable is deprecated, the explicit nullable type must be used instead
Illuminate\Support\ServiceProvider::optimizes(): Implicitly marking parameter $clear as nullable is deprecated, the explicit nullable type must be used instead
```

Introduced via #52928

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
