### PR TITLE
[11.x] Fixes regression with `queue:work` Command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -115,7 +115,7 @@ class WorkCommand extends Command
         // connection being run for the queue operation currently being executed.
         $queue = $this->getQueue($connection);
 
-        if (! $this->hasOption('json') && Terminal::hasSttyAvailable()) {
+        if (! $this->outputUsingJson() && Terminal::hasSttyAvailable()) {
             $this->components->info(
                 sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
             );
@@ -201,7 +201,7 @@ class WorkCommand extends Command
      */
     protected function writeOutput(Job $job, $status, Throwable $exception = null)
     {
-        $this->hasOption('json')
+        $this->outputUsingJson()
             ? $this->writeOutputAsJson($job, $status, $exception)
             : $this->writeOutputForCli($job, $status);
     }
@@ -345,5 +345,19 @@ class WorkCommand extends Command
     protected function downForMaintenance()
     {
         return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
+    }
+
+    /**
+     * Determine if the worker should output using JSON.
+     *
+     * @return bool
+     */
+    protected function outputUsingJson()
+    {
+        if (! $this->hasOption('json')) {
+            return false;
+        }
+
+        return $this->option('json');
     }
 }


### PR DESCRIPTION
`hasOption()` will always return true if it is define, this cause Laravel Framework 11.27.1 installation to always output using json.


### v11.27.0

![CleanShot 2024-10-09 at 12 07 03](https://github.com/user-attachments/assets/a7504a01-b245-4a52-ba7b-c56866e75c4e)

### v11.27.1

![CleanShot 2024-10-09 at 12 07 27](https://github.com/user-attachments/assets/b6f16e7b-4ff1-492b-bd9d-aa086f101d4e)


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
