### PR TITLE
[11.x] Introduce interpolate Str method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1678,19 +1678,17 @@ class Str
     /**
      * Interpolate placeholders in a string with mapped values.
      *
-     * @param string $string
-     * @param array $map
-     * @param string $pattern
-     * @param bool $perserve
-     * @return string
+     * @param  string  $string
+     * @param  array  $map
+     * @param  string  $pattern
+     * @param  bool  $perserve
      */
     public static function interpolate(
         string $string,
         array $map = [],
         string $pattern = '/{{\s*(\w+)\s*}}/',
         bool $preserve = true
-    )
-    {
+    ) {
         $interpolated = preg_replace_callback(
             $pattern,
             function (array $matches) use ($map, $preserve) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1685,7 +1685,7 @@ class Str
      */
     public static function interpolate(
         string $string,
-        array $map = [],
+        array $map,
         string $pattern = '/{{\s*(\w+)\s*}}/',
         bool $preserve = true
     ) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1679,16 +1679,13 @@ class Str
      * Interpolate placeholders in a string with mapped values.
      *
      * @param  string  $string
-     * @param  array  $map
+     * @param  array<string, string>  $map
      * @param  string  $pattern
      * @param  bool  $perserve
+     * @return string
      */
-    public static function interpolate(
-        string $string,
-        array $map,
-        string $pattern = '/{{\s*(\w+)\s*}}/',
-        bool $preserve = true
-    ) {
+    public static function interpolate($string, $map, $pattern = '/{{\s*(\w+)\s*}}/', $preserve = true)
+    {
         $interpolated = preg_replace_callback(
             $pattern,
             function (array $matches) use ($map, $preserve) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1688,7 +1688,7 @@ class Str
         string $string,
         array $map = [],
         string $pattern = '/{{\s*(\w+)\s*}}/',
-        bool $preserve = false
+        bool $preserve = true
     )
     {
         $interpolated = preg_replace_callback(

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1676,6 +1676,37 @@ class Str
     }
 
     /**
+     * Interpolate placeholders in a string with mapped values.
+     *
+     * @param string $string
+     * @param array $map
+     * @param string $pattern
+     * @param bool $perserve
+     * @return string
+     */
+    public static function interpolate(
+        string $string,
+        array $map = [],
+        string $pattern = '/{{\s*(\w+)\s*}}/',
+        bool $preserve = false
+    )
+    {
+        $interpolated = preg_replace_callback(
+            $pattern,
+            function (array $matches) use ($map, $preserve) {
+                [$value, $key] = $matches;
+
+                return array_key_exists($key, $map)
+                    ? $map[$key]
+                    : ($preserve ? $value : '');
+            },
+            $string
+        );
+
+        return $interpolated ?? '';
+    }
+
+    /**
      * Take the first or last {$limit} characters of a string.
      *
      * @param  string  $string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1205,6 +1205,32 @@ class SupportStrTest extends TestCase
         );
     }
 
+    public function testInterpolate(): void
+    {
+        $this->assertSame(
+            "Hi John Doe!",
+            Str::interpolate("{{greetings}} {{  name  }}!", ['greetings' => 'Hi', 'name' => 'John Doe'])
+        );
+
+        // Preserve:false will remove placeholders not in the map
+        $this->assertSame(
+            " John Doe!",
+            Str::interpolate("{{greetings  }} {{  name}}!", ['name' => 'John Doe'], preserve:false)
+        );
+
+        // Preserve:true will keep placeholders not in the map
+        $this->assertSame(
+            "{{greetings}} John Doe!",
+            Str::interpolate("{{greetings}} {{name}}!", ['name' => 'John Doe'], preserve:true)
+        );
+
+        // Using a different placeholder pattern
+        $this->assertSame(
+            'Hello Mr. Miyagi!',
+            Str::interpolate('Hello {{ $name }}!', ['name' => 'Mr. Miyagi'], '/{{\s*\$(\w+)\s*}}/')
+        );
+    }
+
     public function testWordCount()
     {
         $this->assertEquals(2, Str::wordCount('Hello, world!'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1208,20 +1208,20 @@ class SupportStrTest extends TestCase
     public function testInterpolate(): void
     {
         $this->assertSame(
-            "Hi John Doe!",
-            Str::interpolate("{{greetings}} {{  name  }}!", ['greetings' => 'Hi', 'name' => 'John Doe'])
+            'Hi John Doe!',
+            Str::interpolate('{{greetings}} {{  name  }}!', ['greetings' => 'Hi', 'name' => 'John Doe'])
         );
 
         // Preserve:false will remove placeholders not in the map
         $this->assertSame(
-            " John Doe!",
-            Str::interpolate("{{greetings  }} {{  name}}!", ['name' => 'John Doe'], preserve:false)
+            ' John Doe!',
+            Str::interpolate('{{greetings  }} {{  name}}!', ['name' => 'John Doe'], preserve:false)
         );
 
         // Preserve:true will keep placeholders not in the map
         $this->assertSame(
-            "{{greetings}} John Doe!",
-            Str::interpolate("{{greetings}} {{name}}!", ['name' => 'John Doe'], preserve:true)
+            '{{greetings}} John Doe!',
+            Str::interpolate('{{greetings}} {{name}}!', ['name' => 'John Doe'], preserve:true)
         );
 
         // Using a different placeholder pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1227,7 +1227,7 @@ class SupportStrTest extends TestCase
         // Using a different placeholder pattern
         $this->assertSame(
             'Hello Mr. Miyagi!',
-            Str::interpolate('Hello {{ $name }}!', ['name' => 'Mr. Miyagi'], '/{{\s*\$(\w+)\s*}}/')
+            Str::interpolate('Hello {{ @name }}!', ['name' => 'Mr. Miyagi'], '/{{\s*\@(\w+)\s*}}/')
         );
     }
 


### PR DESCRIPTION
This PR introduces an `interpolate` method to the `Str` class.

This is useful when working with stubs/templates. 

For example:
```php
Str::interpolate("Hi {{ name }}, you have been granted the {{role}} role.", ['name' => 'John', 'role' => 'editor']);
// Hi John, you have been granted the editor role.
```

The difference between this and swap is the keywords/placeholders here are wrapped, also this already ignores the extra whitespaces inside the wrappings.

By default the pattern uses double curly braces `{{ palceholder }}`. But this can be modified using the pattern argument.

```php
Str::interpolate("Hi @handle!", ['handle' => 'Jane'], '/\@(\w+)/'); // Hi Jane!
```

The forth argument `preserve` determines whether to remove placeholders not in the map or preserve them. (true by default)

```php
Str::interpolate("Hi {{user}}!", [], preserve: false); // Hi !
Str::interpolate("Hi {{user}}!", [], preserve: true); // Hi {{user}}! 
``` 


Real world use case example:
@joetannenbaum here is interpolating his notification message
https://x.com/joetannenbaum/status/1839503920298594743