### PR TITLE
[11.x] Update Authorizable methods with BackedEnum support

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -9,7 +9,7 @@ trait Authorizable
     /**
      * Determine if the entity has the given abilities.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -21,7 +21,7 @@ trait Authorizable
     /**
      * Determine if the entity has any of the given abilities.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -33,7 +33,7 @@ trait Authorizable
     /**
      * Determine if the entity does not have the given abilities.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -45,7 +45,7 @@ trait Authorizable
     /**
      * Determine if the entity does not have the given abilities.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|\BackedEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */


### PR DESCRIPTION
#52677 added the ability to define and inspect gates using enums.

This updates the docblocks of Authorizable trait as you can now write : 
```php
$user->can(Abilities::VIEW_DASHBOARD)
```