### PR TITLE
[11.x] Introduce RouteParameter attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/RouteParameter.php
+++ b/src/Illuminate/Container/Attributes/RouteParameter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class RouteParameter implements ContextualAttribute
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(public string $parameter)
+    {
+    }
+
+    /**
+     * Resolve the route parameter.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->make('request')->route($attribute->parameter);
+    }
+}

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -14,6 +14,7 @@ use Illuminate\Container\Attributes\Config;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Container\Attributes\Database;
 use Illuminate\Container\Attributes\Log;
+use Illuminate\Container\Attributes\RouteParameter;
 use Illuminate\Container\Attributes\Storage;
 use Illuminate\Container\Attributes\Tag;
 use Illuminate\Container\Container;
@@ -24,7 +25,9 @@ use Illuminate\Contracts\Container\ContextualAttribute;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Http\Request;
 use Illuminate\Log\LogManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -195,6 +198,20 @@ class ContextualAttributeBindingTest extends TestCase
         });
 
         $container->make(LogTest::class);
+    }
+
+    public function testRouteParameterAttribute()
+    {
+        $container = new Container;
+        $container->singleton('request', function () {
+            $request = m::mock(Request::class);
+            $request->shouldReceive('route')->with('foo')->andReturn(m::mock(Model::class));
+            $request->shouldReceive('route')->with('bar')->andReturn('bar');
+
+            return $request;
+        });
+
+        $container->make(RouteParameterTest::class);
     }
 
     public function testStorageAttribute()
@@ -424,6 +441,13 @@ final class GuardTest
 final class LogTest
 {
     public function __construct(#[Log('foo')] LoggerInterface $foo, #[Log('bar')] LoggerInterface $bar)
+    {
+    }
+}
+
+final class RouteParameterTest
+{
+    public function __construct(#[RouteParameter('foo')] Model $foo, #[RouteParameter('bar')] string $bar)
     {
     }
 }


### PR DESCRIPTION
Accessing route parameter outside the Controller, in the FormRequest for example, can be done in various ways. In order to have correct IDE completion and good static analysis, we can do :  

```php
class UpdatePost extends FormRequest
{
    public function authorize(#[CurrentUser] User $user): bool
    {
        /** @var Post $post */
        $post = $this->route('post');
        
        return $post->user_id === $user->id;
    }
    
    public function rules(): array
    {
        /** @var Post $post */
        $post = $this->route('post');

        return [
            'slug' => ['required', 'string', Rule::unique(Post::class, 'slug')->ignore($post->id);
            // ...
        ];
    }
}
```

```php
/** 
 * @property-read Post $post
 */
class UpdatePost extends FormRequest
{
    public function authorize(#[CurrentUser] User $user): bool
    {
        return $this->post->user_id === $user->id;
    }
    
    public function rules(): array
    {
        return [
            'slug' => ['required', 'string', Rule::unique(Post::class, 'slug')->ignore($this->post->id);
            // ...
        ];
    }
}
```
Both ways feel a bit tricky to me and not very elegant IMHO.

That's why I propose the introduction of the `RouteParameter` attribute which can streamline the syntax, leveraging existing `ContextualAttribute` and the container : 

```php
class UpdatePost extends FormRequest
{
    public function authorize(#[CurrentUser] User $user, #[RouteParameter('post')] Post $post): bool
    {
        return $post->user_id === $user->id;
    }
    
    public function rules(#[RouteParameter('post')] Post $post): array
    {
        return [
            'slug' => ['required', 'string', Rule::unique(Post::class, 'slug')->ignore($post->id);
            // ...
        ];
    }
}
```

The attribute can be used on any type of route parameter : Model, enum, string, ...