### PR TITLE
feat: interactive env:encrypt & env:decrypt

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -63,6 +63,10 @@ class EnvironmentDecryptCommand extends Command
         $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
 
         if (! $key) {
+            $key = $this->ask('Decryption key');
+        }
+
+        if (! $key) {
             $this->fail('A decryption key is required.');
         }
 

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Laravel\Prompts\password;
+
 #[AsCommand(name: 'env:decrypt')]
 class EnvironmentDecryptCommand extends Command
 {
@@ -62,8 +64,8 @@ class EnvironmentDecryptCommand extends Command
     {
         $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
 
-        if (! $key) {
-            $key = $this->ask('Decryption key');
+        if (! $key && $this->input->isInteractive()) {
+            $key = password('What is the decryption key?');
         }
 
         if (! $key) {

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -22,7 +22,8 @@ class EnvironmentEncryptCommand extends Command
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
                     {--prune : Delete the original environment file}
-                    {--force : Overwrite the existing encrypted environment file}';
+                    {--force : Overwrite the existing encrypted environment file}
+                    {--interactive : Prompt the encryption key}';
 
     /**
      * The console command description.
@@ -62,13 +63,17 @@ class EnvironmentEncryptCommand extends Command
 
         $key = $this->option('key');
 
+        if (! $key && $this->option('interactive')) {
+            $key = $this->ask('Encryption key');
+        }
+
         $keyPassed = $key !== null;
 
         $environmentFile = $this->option('env')
-                            ? Str::finish(dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR).'.env.'.$this->option('env')
-                            : $this->laravel->environmentFilePath();
+            ? Str::finish(dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR) . '.env.' . $this->option('env')
+            : $this->laravel->environmentFilePath();
 
-        $encryptedFile = $environmentFile.'.encrypted';
+        $encryptedFile = $environmentFile . '.encrypted';
 
         if (! $keyPassed) {
             $key = Encrypter::generateKey($cipher);
@@ -99,7 +104,7 @@ class EnvironmentEncryptCommand extends Command
 
         $this->components->info('Environment successfully encrypted.');
 
-        $this->components->twoColumnDetail('Key', $keyPassed ? $key : 'base64:'.base64_encode($key));
+        $this->components->twoColumnDetail('Key', $keyPassed ? $key : 'base64:' . base64_encode($key));
         $this->components->twoColumnDetail('Cipher', $cipher);
         $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -69,8 +69,8 @@ class EnvironmentEncryptCommand extends Command
             $ask = select(
                 label: 'What encryption key would you like to use?',
                 options: [
-                    'generate' => 'Generate a new encryption key',
-                    'ask' => 'Provide your own encryption key',
+                    'generate' => 'Generate a random encryption key',
+                    'ask' => 'Provide an encryption key',
                 ],
                 default: 'generate'
             );

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -70,10 +70,10 @@ class EnvironmentEncryptCommand extends Command
         $keyPassed = $key !== null;
 
         $environmentFile = $this->option('env')
-            ? Str::finish(dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR) . '.env.' . $this->option('env')
-            : $this->laravel->environmentFilePath();
+                            ? Str::finish(dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR).'.env.'.$this->option('env')
+                            : $this->laravel->environmentFilePath();
 
-        $encryptedFile = $environmentFile . '.encrypted';
+        $encryptedFile = $environmentFile.'.encrypted';
 
         if (! $keyPassed) {
             $key = Encrypter::generateKey($cipher);
@@ -104,7 +104,7 @@ class EnvironmentEncryptCommand extends Command
 
         $this->components->info('Environment successfully encrypted.');
 
-        $this->components->twoColumnDetail('Key', $keyPassed ? $key : 'base64:' . base64_encode($key));
+        $this->components->twoColumnDetail('Key', $keyPassed ? $key : 'base64:'.base64_encode($key));
         $this->components->twoColumnDetail('Cipher', $cipher);
         $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -70,7 +70,7 @@ class EnvironmentEncryptCommand extends Command
                 label: 'What encryption key would you like to use?',
                 options: [
                     'generate' => 'Generate a new encryption key',
-                    'ask' => 'Provide your own encryption key'
+                    'ask' => 'Provide your own encryption key',
                 ],
                 default: 'generate'
             );

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -9,6 +9,9 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
+
 #[AsCommand(name: 'env:encrypt')]
 class EnvironmentEncryptCommand extends Command
 {
@@ -22,8 +25,7 @@ class EnvironmentEncryptCommand extends Command
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
                     {--prune : Delete the original environment file}
-                    {--force : Overwrite the existing encrypted environment file}
-                    {--interactive : Prompt the encryption key}';
+                    {--force : Overwrite the existing encrypted environment file}';
 
     /**
      * The console command description.
@@ -63,8 +65,19 @@ class EnvironmentEncryptCommand extends Command
 
         $key = $this->option('key');
 
-        if (! $key && $this->option('interactive')) {
-            $key = $this->ask('Encryption key');
+        if (! $key && $this->input->isInteractive()) {
+            $ask = select(
+                label: 'What encryption key would you like to use?',
+                options: [
+                    'generate' => 'Generate a new encryption key',
+                    'ask' => 'Provide your own encryption key'
+                ],
+                default: 'generate'
+            );
+
+            if ($ask == 'ask') {
+                $key = password('What is the encryption key?');
+            }
         }
 
         $keyPassed = $key !== null;

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -34,6 +34,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->andReturn(false);
 
         $this->artisan('env:encrypt', ['--cipher' => 'invalid'])
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('Unsupported cipher')
             ->assertExitCode(1);
     }
@@ -62,6 +63,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->andReturn(false);
 
         $this->artisan('env:encrypt', ['--env' => 'production'])
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('.env.production.encrypted')
             ->assertExitCode(0);
 
@@ -80,6 +82,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->shouldReceive('get');
 
         $this->artisan('env:encrypt')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
 
@@ -92,6 +95,7 @@ class EnvironmentEncryptCommandTest extends TestCase
         $this->filesystem->shouldReceive('exists')->andReturn(false);
 
         $this->artisan('env:encrypt')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('Environment file not found.')
             ->assertExitCode(1);
     }
@@ -101,6 +105,7 @@ class EnvironmentEncryptCommandTest extends TestCase
         $this->filesystem->shouldReceive('exists')->andReturn(true);
 
         $this->artisan('env:encrypt')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('Encrypted environment file already exists.')
             ->assertExitCode(1);
     }
@@ -115,6 +120,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->andReturn(true);
 
         $this->artisan('env:encrypt', ['--force' => true])
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
 
@@ -166,6 +172,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->andReturn(false);
 
         $this->artisan('env:encrypt', ['--prune' => true])
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
 
@@ -175,4 +182,23 @@ class EnvironmentEncryptCommandTest extends TestCase
         $this->filesystem->shouldHaveReceived('delete')
             ->with(base_path('.env'));
     }
+
+    public function testItEncryptsWithInteractivelyGivenKeyAndDisplaysIt()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt')
+            ->expectsQuestion('What encryption key would you like to use?', 'ask')
+            ->expectsQuestion('What is the encryption key?', $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP')
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->expectsOutputToContain($key)
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+    }
+
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -200,5 +200,4 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
     }
-
 }


### PR DESCRIPTION
When using `env:encrypt` and especially `env:decrypt`, it was bugging me that I had to provide the encryption key in the command line and it therefore ended up in my command line history. I did not want to use the LARAVEL_ENV_ENCRYPTION_KEY environment variable as I do not want the encryption key to be stored on the development machine.

Hereby a PR to add a simple interactive mode for `env:descrypt` that would `ask()` for the decryption key and prevent it from ending up in history. For `env:encrypt` I added an `--interactive` option to not break the current behavior of automatically generating an encryption key.