### PR TITLE
[11.x] feat: introduce Number::divide()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -156,7 +156,7 @@ class Number
      * @param  int|float  $numerator
      * @param  int  $denominator
      */
-    public static function divide(int|float $numerator, int $denominator)
+    public static function divide(int|float $numerator, int|float $denominator)
     {
         return $denominator == 0 ? 0 : ($numerator / $denominator);
     }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -153,8 +153,8 @@ class Number
     /**
      * Divide a number
      *
-     * @param  int|float  $number
-     * @param  int  $precision
+     * @param  int|float  $numerator
+     * @param  int  $denominator
      */
     public static function divide(int|float $numerator, int $denominator)
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -151,7 +151,7 @@ class Number
     }
 
     /**
-     * Divide a number
+     * Divide a number.
      *
      * @param  int|float  $numerator
      * @param  int  $denominator

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -151,6 +151,17 @@ class Number
     }
 
     /**
+     * Divide a number
+     *
+     * @param  int|float  $number
+     * @param  int  $precision
+     */
+    public static function divide(int|float $numerator, int $denominator)
+    {
+        return $denominator == 0 ? 0 : ($numerator / $denominator);
+    }
+
+    /**
      * Convert the number to its human-readable equivalent.
      *
      * @param  int|float  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -155,6 +155,7 @@ class Number
      *
      * @param  int|float  $numerator
      * @param  int|float  $denominator
+     * @return int|float
      */
     public static function divide(int|float $numerator, int|float $denominator)
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -154,7 +154,7 @@ class Number
      * Divide a number.
      *
      * @param  int|float  $numerator
-     * @param  int  $denominator
+     * @param  int|float  $denominator
      */
     public static function divide(int|float $numerator, int|float $denominator)
     {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -91,11 +91,11 @@ class SupportNumberTest extends TestCase
 
     public function testDivide()
     {
-        $this->assertSame('0', Number::divide(0, 0));
-        $this->assertSame('0.5', Number::divide(1, 2));
-        $this->assertSame('0.25', Number::divide(0.5, 2));
-        $this->assertSame('0', Number::divide(0, 2));
-        $this->assertSame('0', Number::divide(2, 0));
+        $this->assertSame(0, Number::divide(0, 0));
+        $this->assertSame(0.5, Number::divide(1, 2));
+        $this->assertSame(0.25, Number::divide(0.5, 2));
+        $this->assertSame(0, Number::divide(0, 2));
+        $this->assertSame(0, Number::divide(2, 0));
     }
 
     public function testOrdinal()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -97,9 +97,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame(0, Number::divide(0, 2));
         $this->assertSame(0, Number::divide(2, 0));
 
-        $this->assertSame(0, Number::divide(0, 0.5));
-        $this->assertSame(4, Number::divide(1, 0.25));
-        $this->assertSame(1, Number::divide(0.5, 0.5));
+        $this->assertSame(0.0, Number::divide(0, 0.5));
+        $this->assertSame(4.0, Number::divide(1, 0.25));
+        $this->assertSame(1.0, Number::divide(0.5, 0.5));
     }
 
     public function testOrdinal()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -89,6 +89,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('100,000', Number::spell(100000, until: 50000));
     }
 
+    public function testDivide()
+    {
+        $this->assertSame('0', Number::divide(0));
+        $this->assertSame('0.5', Number::divide(1, 2));
+        $this->assertSame('0.25', Number::divide(0.5, 2));
+        $this->assertSame('0', Number::divide(0, 2));
+        $this->assertSame('0', Number::divide(2, 0));
+    }
+
     public function testOrdinal()
     {
         $this->assertSame('1st', Number::ordinal(1));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -91,7 +91,7 @@ class SupportNumberTest extends TestCase
 
     public function testDivide()
     {
-        $this->assertSame('0', Number::divide(0));
+        $this->assertSame('0', Number::divide(0, 0));
         $this->assertSame('0.5', Number::divide(1, 2));
         $this->assertSame('0.25', Number::divide(0.5, 2));
         $this->assertSame('0', Number::divide(0, 2));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -96,6 +96,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame(0.25, Number::divide(0.5, 2));
         $this->assertSame(0, Number::divide(0, 2));
         $this->assertSame(0, Number::divide(2, 0));
+
+        $this->assertSame(0, Number::divide(0, 0.5));
+        $this->assertSame(4, Number::divide(1, 0.25));
+        $this->assertSame(1, Number::divide(0.5, 0.5));
     }
 
     public function testOrdinal()


### PR DESCRIPTION
Hi :wave:

I'm opening another PR here to introduce a nice handy `Number::divide()` method that takes in two values and returns the result. It takes into account the "Division by zero" error which can often be encountered in projects. It's inherited from a function I wrote in my own project that I've used in a number of places.

Starting super simple here, not overcomplicating it, we could in the future introduce a `precision` flag, but wanted to keep this as lightweight as possible!

I've used this over 70 times in my application