### PR TITLE
feat: allow overriding default Schema Blueprint on Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -8,13 +8,14 @@ use Illuminate\Database\Connection;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
+use RuntimeException;
 
 class Builder
 {
     use Macroable;
 
     /**
-     * @var class-string The default Blueprint class
+     * @var class-string The default Blueprint in use.
      */
     private static string $defaultBlueprintClass = Blueprint::class;
 
@@ -586,13 +587,23 @@ class Builder
             return call_user_func($this->resolver, $table, $callback, $prefix);
         }
 
+        if (self::$defaultBlueprintClass !== Blueprint::class
+            && !is_subclass_of(self::$defaultBlueprintClass, Blueprint::class)
+        ) {
+            throw new RuntimeException(sprintf(
+                'DefaultBlueprintClass must extend or be %s class. Got: %s',
+                Blueprint::class,
+                self::$defaultBlueprintClass,
+            ));
+        }
+
         return Container::getInstance()->make(self::$defaultBlueprintClass, compact('table', 'callback', 'prefix'));
     }
 
     /**
      * @param class-string $class
      */
-    public static function overrideDefaultBlueprintClass(string $class): void
+    public static function setDefaultBlueprintClass(string $class): void
     {
         self::$defaultBlueprintClass = $class;
     }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -588,7 +588,7 @@ class Builder
         }
 
         if (self::$defaultBlueprintClass !== Blueprint::class
-            && !is_subclass_of(self::$defaultBlueprintClass, Blueprint::class)
+            && ! is_subclass_of(self::$defaultBlueprintClass, Blueprint::class)
         ) {
             throw new RuntimeException(sprintf(
                 'DefaultBlueprintClass must extend or be %s class. Got: %s',
@@ -601,7 +601,7 @@ class Builder
     }
 
     /**
-     * @param class-string $class
+     * @param  class-string  $class
      */
     public static function setDefaultBlueprintClass(string $class): void
     {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -14,6 +14,11 @@ class Builder
     use Macroable;
 
     /**
+     * @var class-string The default Blueprint class
+     */
+    private static string $defaultBlueprintClass = Blueprint::class;
+
+    /**
      * The database connection instance.
      *
      * @var \Illuminate\Database\Connection
@@ -581,7 +586,15 @@ class Builder
             return call_user_func($this->resolver, $table, $callback, $prefix);
         }
 
-        return Container::getInstance()->make(Blueprint::class, compact('table', 'callback', 'prefix'));
+        return Container::getInstance()->make(self::$defaultBlueprintClass, compact('table', 'callback', 'prefix'));
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function overrideDefaultBlueprintClass(string $class): void
+    {
+        self::$defaultBlueprintClass = $class;
     }
 
     /**

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use DateTime;
 use ErrorException;
 use Exception;
+use http\Exception\BadMethodCallException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
@@ -542,6 +543,9 @@ class DatabaseConnectionTest extends TestCase
             $table->timestamps();
         });
         $this->assertTrue(OverriddenSchemaBlueprint::$invokedSpy);
+
+        // Enable back the original-default Blueprint
+        Builder::setDefaultBlueprintClass(Blueprint::class);
     }
 
     public function testGetRawQueryLog()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Database;
 use DateTime;
 use ErrorException;
 use Exception;
-use http\Exception\BadMethodCallException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;

--- a/tests/Database/Fixtures/Models/OverriddenSchemaBlueprint.php
+++ b/tests/Database/Fixtures/Models/OverriddenSchemaBlueprint.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Illuminate\Tests\Database\Fixtures\Models;

--- a/tests/Database/Fixtures/Models/OverriddenSchemaBlueprint.php
+++ b/tests/Database/Fixtures/Models/OverriddenSchemaBlueprint.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\Grammar;
+
+final class OverriddenSchemaBlueprint extends Blueprint
+{
+    public static bool $invokedSpy = false;
+
+    protected $commands = [];
+
+    public function timestamps($precision = 0): void
+    {
+        parent::timestamps($precision);
+        $this->applyTimestampDefaults();
+    }
+
+    private function applyTimestampDefaults(): void
+    {
+        // other DB statements...
+        self::$invokedSpy = true;
+    }
+
+    public function toSql(Connection $connection, Grammar $grammar)
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Status quo

Currently, the default `Blueprint` class is `Blueprint::class` when no other Blueprint (which can be defined with blueprintResolver). However this is within the context of the Schema instance

```php
# migration
public function up(): void
{
    // You would have to do this in all migrations...
    // the dev have to remember to add this "boilerplate" all the time
    $schema = DB::connection()->getSchemaBuilder();
    $schema->blueprintResolver(function ($table, $callback) {
        return new CustomBlueprint($table, $callback);
    });
    $schema->create('chemas', function (CustomBlueprint $table) {
        $table->ulid('id')->primary();
        $table->text('foo_bar')->nullable();
        $table->timestamps();
    });
}
```

## Changes

Introduce the possibility of globally overriding the default `Blueprint` class used, 
so it can be set on `ServiceProvider->boot()` level 

```php
# DatabaseServiceProvider
public function boot(): void
{
    Builder::setDefaultBlueprintClass(CustomBlueprint::class);
}

//////////////////////////////////////////////////////////////////////

# migration
public function up(): void
{
    Schema::create('chemas', function (CustomBlueprint $table) {
        $table->ulid('id')->primary();
        $table->text('foo_bar')->nullable();
        $table->timestamps();
    });
}
```

---

I was researching around trying to find a work around, but I couldn't find it, so I thought about doing this PR. In case I missed something or there is an alternative that would lead to this same outcome, I would love to know it! :) 