### PR TITLE
[11.x] Use `null` as default cursor value for PHP Redis

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -293,7 +293,7 @@ class RedisStore extends TaggableStore implements LockProvider
         };
 
         $defaultCursorValue = match (true) {
-            $connection instanceof PhpRedisConnection => null,
+            $connection instanceof PhpRedisConnection && version_compare(phpversion('redis'), '6.1.0', '>=') => null,
             default => '0',
         };
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,10 +292,15 @@ class RedisStore extends TaggableStore implements LockProvider
             default => '',
         };
 
+        $defaultCursorValue = match (true) {
+            $connection instanceof PhpRedisConnection => null,
+            default => '0',
+        };
+
         $prefix = $connectionPrefix.$this->getPrefix();
 
-        return LazyCollection::make(function () use ($connection, $chunkSize, $prefix) {
-            $cursor = $defaultCursorValue = '0';
+        return LazyCollection::make(function () use ($connection, $chunkSize, $prefix, $defaultCursorValue) {
+            $cursor = $defaultCursorValue;
 
             do {
                 [$cursor, $tagsChunk] = $connection->scan(

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -45,7 +45,7 @@ class RedisTagSet extends TagSet
 
         return LazyCollection::make(function () use ($connection, $defaultCursorValue) {
             foreach ($this->tagIds() as $tagKey) {
-                $cursor = $defaultCursorValue = '0';
+                $cursor = $defaultCursorValue;
 
                 do {
                     [$cursor, $entries] = $connection->zscan(

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -39,7 +39,7 @@ class RedisTagSet extends TagSet
         $connection = $this->store->connection();
 
         $defaultCursorValue = match (true) {
-            $connection instanceof PhpRedisConnection => null,
+            $connection instanceof PhpRedisConnection && version_compare(phpversion('redis'), '6.1.0', '>=') => null,
             default => '0',
         };
 

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\LazyCollection;
 
@@ -35,12 +36,19 @@ class RedisTagSet extends TagSet
      */
     public function entries()
     {
-        return LazyCollection::make(function () {
+        $connection = $this->store->connection();
+
+        $defaultCursorValue = match (true) {
+            $connection instanceof PhpRedisConnection => null,
+            default => '0',
+        };
+
+        return LazyCollection::make(function () use ($connection, $defaultCursorValue) {
             foreach ($this->tagIds() as $tagKey) {
                 $cursor = $defaultCursorValue = '0';
 
                 do {
-                    [$cursor, $entries] = $this->store->connection()->zscan(
+                    [$cursor, $entries] = $connection->zscan(
                         $this->store->getPrefix().$tagKey,
                         $cursor,
                         ['match' => '*', 'count' => 1000]


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes #53087

Additional context: https://github.com/phpredis/phpredis/issues/2562

This PR attempts to fix the current issue with the changes made in PHP Redis 6.1.0 where the default cursor value of `'0'` is handled differently. With some testing, setting this to `null` fixes this issue.

I have attempted to only make its fix available to PHP Redis and continue to use the previous value of `'0'` for PRedis. If this change isn't as per the framework's standard. Happy to make changes or totally understand if this is closed. 😄