### PR TITLE
[11.x] PHPDoc Improvements

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -158,7 +158,7 @@ class Arr
      * Determine if the given key exists in the provided array.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int  $key
+     * @param  string|int|float  $key
      * @return bool
      */
     public static function exists($array, $key)


### PR DESCRIPTION
Update the PHPDoc to the Arr::exists function to show it also accepts float as a param value

```bash
> Arr::exists(['1.2' => 1], 1.2);
= true
```