### PR TITLE
[11.x] Adds `--workers=num` option to `ServeCommand`

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -280,6 +280,11 @@ class ServeCommand extends Command
                         $this->serverRunningHasBeenDisplayed = true;
 
                         $this->components->info("Server running on [http://{$this->host()}:{$this->port()}].");
+
+                        if ($this->getNumOfWorkers() > 1) {
+                            $this->components->info("Using {$this->getNumOfWorkers()} worker processes.");
+                        }
+
                         $this->comment('  <fg=yellow;options=bold>Press Ctrl+C to stop the server</>');
 
                         $this->newLine();
@@ -348,6 +353,16 @@ class ServeCommand extends Command
     }
 
     /**
+     * Get number of workers
+     *
+     * @return int
+     */
+    protected function getNumOfWorkers()
+    {
+        return $this->option('workers') ?: env('PHP_CLI_SERVER_WORKERS', 1);
+    }
+
+    /**
      * Get the date from the given PHP server output.
      *
      * @param  string  $line
@@ -355,7 +370,7 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $workers = $this->option('workers') ?: env('PHP_CLI_SERVER_WORKERS', 1);
+        $workers = $this->getNumOfWorkers();
 
         $regex = $workers > 1
             ? '/^\[\d+]\s\[([a-zA-Z0-9: ]+)\]/'
@@ -400,8 +415,8 @@ class ServeCommand extends Command
                     : [$key => false];
             })
             ->when(
-                $workers = $this->option('workers'),
-                fn ($envs) => $envs->offsetSet('PHP_CLI_SERVER_WORKERS', $workers)
+                $this->getNumOfWorkers() > 1,
+                fn ($envs) => $envs->offsetSet('PHP_CLI_SERVER_WORKERS', $this->getNumOfWorkers())
             )
             ->all();
     }


### PR DESCRIPTION
Hi team,

Adding more ❤️  for our boy `php artisan serve`

So this PR adds the `--workers=xxx` option to `ServeCommand`, by default it is `1`. It still respects the `PHP_CLI_SERVER_WORKERS`.

## Background & Notes

As a person who uses `serve` command daily, I find it really tedious to put `PHP_CLI_SERVER_WORKERS=xyz` in front of `php artisan serve`.

I can definitely create an alias or set ENV globally, but if we can define the number of workers directly, it's much better (increasing DX, easy to remember)

Additionally, it would help newcomers & new learners to play/use Laravel efficiently in development too, since they won't likely know the `PHP_CLI_SERVER_WORKERS`

![image](https://github.com/user-attachments/assets/14eceebc-c4cc-4da6-8ff2-a42643949ca2)

