### PR TITLE
[11.x] Fix resource not escaped correctly in substituteBindingsIntoRawSql()

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1526,7 +1526,7 @@ class Grammar extends BaseGrammar
      */
     public function substituteBindingsIntoRawSql($sql, $bindings)
     {
-        $bindings = array_map(fn ($value) => $this->escape($value), $bindings);
+        $bindings = array_map(fn ($value) => $this->escape($value, is_resource($value) || gettype($value) === 'resource (closed)'), $bindings);
 
         $query = '';
 


### PR DESCRIPTION
I have encountered a small bug, inside `Grammar::substituteBindingsIntoRawSql()`. When `$bindings` contain a resource (e.g. file resource), then it is not escaped correctly. Furthermore, in an edge-case, when a resource is already closed, then that too leads to a PHP `TypeError` being thrown. This PR fixes that issue.

### Additional Information

The reason why I came across this, was when using [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) to log executed queries. In my situation, a small file (_resource_) was successfully written to the database, and its resource handler was closed. However, when the debugbar attempted to log the executed query, it failed and yielded the following `TypeError`:

```
str_contains(): Argument #1 ($haystack) must be of type string, resource given at [...]Database/Connection.php:1119
```

I have reviewed the [source code](https://github.com/barryvdh/laravel-debugbar/pull/1627) of laravel debugbar, but it seems that `substituteBindingsIntoRawSql()` might be the more appropriate place to fix this issue.
