### PR TITLE
[11.x] feat: add useful defaultLocale and defaultCurrency helpers to Number facade

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,6 +25,26 @@ class Number
     protected static $currency = 'USD';
 
     /**
+     * Returns the default locale specified
+     *
+     * @return string
+     */
+    public static function defaultLocale()
+    {
+        return static::$locale;
+    }
+
+    /**
+     * Returns the default currency specified
+     *
+     * @return string
+     */
+    public static function defaultCurrency()
+    {
+        return static::$currency;
+    }
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,7 +25,7 @@ class Number
     protected static $currency = 'USD';
 
     /**
-     * Returns the default locale specified
+     * Returns the default locale specified.
      *
      * @return string
      */
@@ -35,7 +35,7 @@ class Number
     }
 
     /**
-     * Returns the default currency specified
+     * Returns the default currency specified.
      *
      * @return string
      */

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,26 +25,6 @@ class Number
     protected static $currency = 'USD';
 
     /**
-     * Returns the default locale specified.
-     *
-     * @return string
-     */
-    public static function defaultLocale()
-    {
-        return static::$locale;
-    }
-
-    /**
-     * Returns the default currency specified.
-     *
-     * @return string
-     */
-    public static function defaultCurrency()
-    {
-        return static::$currency;
-    }
-
-    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -347,6 +327,26 @@ class Number
     public static function useCurrency(string $currency)
     {
         static::$currency = $currency;
+    }
+
+    /**
+     * Get the default locale.
+     *
+     * @return string
+     */
+    public static function defaultLocale()
+    {
+        return static::$locale;
+    }
+
+    /**
+     * Get the default currency.
+     *
+     * @return string
+     */
+    public static function defaultCurrency()
+    {
+        return static::$currency;
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -10,15 +10,11 @@ class SupportNumberTest extends TestCase
 {
     public function testDefaultLocale()
     {
-        Number::useLocale('de');
-
-        $this->assertSame('de', Number::defaultLocale());
+        $this->assertSame('en', Number::defaultLocale());
     }
 
     public function testDefaultCurrency()
     {
-        Number::useCurrency('USD');
-
         $this->assertSame('USD', Number::defaultCurrency());
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -8,6 +8,20 @@ use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
+    public function testDefaultLocale()
+    {
+        Number::useLocale('de');
+
+        $this->assertSame('de', Number::defaultLocale());
+    }
+
+    public function testDefaultCurrency()
+    {
+        Number::useCurrency('USD');
+
+        $this->assertSame('USD', Number::defaultCurrency());
+    }
+
     #[RequiresPhpExtension('intl')]
     public function testFormat()
     {


### PR DESCRIPTION
Hi :wave:,

The following is a very simple PR that allows us to return whatever the application's default `$currency` and `$locale` are. I was initially considering changing the variables from `protected` to `public` so that we wouldn't need these functions, I'm still open to this.

Usage:

```php
Number::defaultLocale() // returns default locale
Number::defaultCurrency() // returns default currency
```