### PR TITLE
[11.x] Fix determining pivot timestamp column name(s) when parent relation missing one or both of timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -113,14 +113,14 @@ class BelongsToMany extends Relation
     /**
      * The custom pivot table column for the created_at timestamp.
      *
-     * @var string
+     * @var string|null
      */
     protected $pivotCreatedAt;
 
     /**
      * The custom pivot table column for the updated_at timestamp.
      *
-     * @var string
+     * @var string|null
      */
     protected $pivotUpdatedAt;
 
@@ -1478,7 +1478,7 @@ class BelongsToMany extends Relation
      */
     public function createdAt()
     {
-        return $this->pivotCreatedAt ?: $this->parent->getCreatedAtColumn();
+        return $this->pivotCreatedAt ?? $this->parent->getCreatedAtColumn() ?? Model::CREATED_AT;
     }
 
     /**
@@ -1488,7 +1488,7 @@ class BelongsToMany extends Relation
      */
     public function updatedAt()
     {
-        return $this->pivotUpdatedAt ?: $this->parent->getUpdatedAtColumn();
+        return $this->pivotUpdatedAt ?? $this->parent->getUpdatedAtColumn() ?? Model::UPDATED_AT;
     }
 
     /**


### PR DESCRIPTION
Currently timestamped pivots try to determine its timestamp column names from its parent relation. But parent model can have its `CREATED_AT`/`UPDATED_AT` columns nulled out. This will lead to unexpected `null` return value from `BelongsToMany::createdAt/updatedAt` methods.

This PR adds fallback values (default `created_at`/`updated_at` column names) to fix this issue.