### PR TITLE
[11.x] Feat: remove HasFactory in model when not required

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -263,7 +263,7 @@ class ModelMakeCommand extends GeneratorCommand
             $replacements['{{ factoryImport }}'] = 'use Illuminate\Database\Eloquent\Factories\HasFactory;';
         } else {
             $replacements['{{ factoryCode }}'] = '//';
-            $replacements[PHP_EOL.'{{ factoryImport }}'] = '';
+            $replacements["\n{{ factoryImport }}"] = '';
         }
 
         return $replacements;

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -263,7 +263,7 @@ class ModelMakeCommand extends GeneratorCommand
             $replacements['{{ factoryImport }}'] = 'use Illuminate\Database\Eloquent\Factories\HasFactory;';
         } else {
             $replacements['{{ factoryCode }}'] = '//';
-            $replacements['{{ factoryImport }}'.PHP_EOL] = '';
+            $replacements[PHP_EOL.'{{ factoryImport }}'] = '';
         }
 
         return $replacements;

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -264,6 +264,7 @@ class ModelMakeCommand extends GeneratorCommand
         } else {
             $replacements['{{ factoryCode }}'] = '//';
             $replacements["{{ factoryImport }}\n"] = '';
+            $replacements["{{ factoryImport }}\r\n"] = '';
         }
 
         return $replacements;

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -259,10 +259,10 @@ class ModelMakeCommand extends GeneratorCommand
                 use HasFactory;
             EOT;
 
-            $replacements['{{ factoryCode }}'] = $factoryCode;
+            $replacements['{{ factory }}'] = $factoryCode;
             $replacements['{{ factoryImport }}'] = 'use Illuminate\Database\Eloquent\Factories\HasFactory;';
         } else {
-            $replacements['{{ factoryCode }}'] = '//';
+            $replacements['{{ factory }}'] = '//';
             $replacements["{{ factoryImport }}\n"] = '';
             $replacements["{{ factoryImport }}\r\n"] = '';
         }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -263,7 +263,7 @@ class ModelMakeCommand extends GeneratorCommand
             $replacements['{{ factoryImport }}'] = 'use Illuminate\Database\Eloquent\Factories\HasFactory;';
         } else {
             $replacements['{{ factoryCode }}'] = '//';
-            $replacements["\n{{ factoryImport }}"] = '';
+            $replacements["{{ factoryImport }}\n"] = '';
         }
 
         return $replacements;

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -249,7 +249,6 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function buildFactoryReplacements()
     {
-
         $replacements = [];
 
         if ($this->option('factory')) {

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -235,13 +235,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $replace = [];
-
-        if ($this->option('factory')) {
-            $replace['{{ factoryDocBlock }}'] = $this->buildFactoryReplacements();
-        } else {
-            $replace["\n    {{ factoryDocBlock }}"] = '';
-        }
+        $replace = $this->buildFactoryReplacements();
 
         return str_replace(
             array_keys($replace), array_values($replace), parent::buildClass($name)
@@ -249,17 +243,31 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Build the replacements for a factory DocBlock.
+     * Build the replacements for a factory.
      *
-     * @return string
+     * @return array<string, string>
      */
     protected function buildFactoryReplacements()
     {
-        $factoryNamespace = '\\Database\\Factories\\'.Str::studly($this->argument('name')).'Factory';
 
-        return <<<EOT
-        /** @use HasFactory<$factoryNamespace> */
-        EOT;
+        $replacements = [];
+
+        if ($this->option('factory')) {
+            $factoryNamespace = '\\Database\\Factories\\'.Str::studly($this->argument('name')).'Factory';
+
+            $factoryCode = <<<EOT
+            /** @use HasFactory<$factoryNamespace> */
+                use HasFactory;
+            EOT;
+
+            $replacements['{{ factoryCode }}'] = $factoryCode;
+            $replacements['{{ factoryImport }}'] = 'use Illuminate\Database\Eloquent\Factories\HasFactory;';
+        } else {
+            $replacements['{{ factoryCode }}'] = '//';
+            $replacements['{{ factoryImport }}'.PHP_EOL] = '';
+        }
+
+        return $replacements;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -7,5 +7,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class {{ class }} extends Model
 {
-    {{ factoryCode }}
+    {{ factory }}
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -2,11 +2,10 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+{{ factoryImport }}
 use Illuminate\Database\Eloquent\Model;
 
 class {{ class }} extends Model
 {
-    {{ factoryDocBlock }}
-    use HasFactory;
+    {{ factoryCode }}
 }

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -26,8 +26,11 @@ class ModelMakeCommandTest extends TestCase
         ], 'app/Models/Foo.php');
 
         $this->assertFileDoesNotContains([
-            '{{ factoryDocBlock }}',
+            '{{ factoryImport }}',
+            'use Illuminate\Database\Eloquent\Factories\HasFactory;',
+            '{{ factoryCode }}',
             '/** @use HasFactory<\Database\Factories\FooFactory> */',
+            'use HasFactory;',
         ], 'app/Models/Foo.php');
 
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');
@@ -99,10 +102,16 @@ class ModelMakeCommandTest extends TestCase
 
         $this->assertFileContains([
             'namespace App\Models;',
+            'use Illuminate\Database\Eloquent\Factories\HasFactory;',
             'use Illuminate\Database\Eloquent\Model;',
             'class Foo extends Model',
             '/** @use HasFactory<\Database\Factories\FooFactory> */',
             'use HasFactory;',
+        ], 'app/Models/Foo.php');
+
+        $this->assertFileNotContains([
+            '{{ factoryImport }}',
+            '{{ factoryCode }}',
         ], 'app/Models/Foo.php');
 
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -28,7 +28,7 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFileDoesNotContains([
             '{{ factoryImport }}',
             'use Illuminate\Database\Eloquent\Factories\HasFactory;',
-            '{{ factoryCode }}',
+            '{{ factory }}',
             '/** @use HasFactory<\Database\Factories\FooFactory> */',
             'use HasFactory;',
         ], 'app/Models/Foo.php');
@@ -111,7 +111,7 @@ class ModelMakeCommandTest extends TestCase
 
         $this->assertFileNotContains([
             '{{ factoryImport }}',
-            '{{ factoryCode }}',
+            '{{ factory }}',
         ], 'app/Models/Foo.php');
 
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');


### PR DESCRIPTION
A few days ago, I made a [PR](https://github.com/laravel/framework/pull/52855) to improve the `make:model` command to include the factory generic `PHPDoc` when needed. Based on comments from @Jubeki and @jasonmccreary, it seems that it would be cool to remove `HasFactory` if we are not generating a factory at all.

examples: 
#### Command
```bash
php artisan make:model Post
```
#### Output
```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Model;

class Post extends Model
{
    //
}
```

#### Command
```php
php artisan make:model Comment -f
```
#### Output
```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Database\Eloquent\Model;

class Comment extends Model
{
    /** @use HasFactory<\Database\Factories\CommentFactory> */
    use HasFactory;
}
```