### PR TITLE
[11.x] Introduce `where[Date,Time,Year,Month,Day]Between` methods in query builder

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Carbon\Carbon;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1581,6 +1581,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "or where date between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|null>  $values
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereDateBetween($column, iterable $values, $not = false)
+    {
+        return $this->whereDateBetween($column, $values, 'or', $not);
+    }
+
+    /**
      * Add a "where time" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1639,6 +1652,19 @@ class Builder implements BuilderContract
             ->all();
 
         return $this->addDateBasedWhereBetween('Time', $column, $values, $boolean, $not);
+    }
+
+    /**
+     * Add a "or where time between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|null>  $values
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereTimeBetween($column, iterable $values, $not = false)
+    {
+        return $this->whereTimeBetween($column, $values, 'or', $not);
     }
 
     /**
@@ -1728,6 +1754,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "or where day between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereDayBetween($column, iterable $values, $not = false)
+    {
+        return $this->whereDayBetween($column, $values, 'or', $not);
+    }
+
+    /**
      * Add an "or where day" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1814,6 +1853,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "or where month between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereMonthBetween($column, iterable $values, $not = false)
+    {
+        return $this->whereMonthBetween($column, $values, 'or', $not);
+    }
+
+    /**
      * Add an "or where month" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1889,6 +1941,19 @@ class Builder implements BuilderContract
             ->all();
 
         return $this->addDateBasedWhereBetween('Year', $column, $values, $boolean, $not);
+    }
+
+    /**
+     * Add a "or where year between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereYearBetween($column, iterable $values, $not = false)
+    {
+        return $this->whereYearBetween($column, $values, 'or', $not);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1565,6 +1565,8 @@ class Builder implements BuilderContract
             $values = [$values->getStartDate(), $values->getEndDate()];
         }
 
+        $values = array_slice(Arr::flatten($values), 0, 2);
+
         $values = collect($values)
             ->map(function ($value) {
                 if ($value instanceof DateTimeInterface) {
@@ -1623,6 +1625,8 @@ class Builder implements BuilderContract
         if ($values instanceof CarbonPeriod) {
             $values = [$values->getStartDate(), $values->getEndDate()];
         }
+
+        $values = array_slice(Arr::flatten($values), 0, 2);
 
         $values = collect($values)
             ->map(function ($value) {
@@ -1703,6 +1707,8 @@ class Builder implements BuilderContract
         if ($values instanceof CarbonPeriod) {
             $values = [$values->getStartDate(), $values->getEndDate()];
         }
+
+        $values = array_slice(Arr::flatten($values), 0, 2);
 
         $values = collect($values)
             ->map(function ($value) {
@@ -1788,6 +1794,8 @@ class Builder implements BuilderContract
             $values = [$values->getStartDate(), $values->getEndDate()];
         }
 
+        $values = array_slice(Arr::flatten($values), 0, 2);
+
         $values = collect($values)
             ->map(function ($value) {
                 if ($value instanceof DateTimeInterface) {
@@ -1868,6 +1876,8 @@ class Builder implements BuilderContract
             $values = [$values->getStartDate(), $values->getEndDate()];
         }
 
+        $values = array_slice(Arr::flatten($values), 0, 2);
+
         $values = collect($values)
             ->map(function ($value) {
                 if ($value instanceof DateTimeInterface) {
@@ -1935,7 +1945,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 
-        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');
+        $this->addBinding($this->cleanBindings($values), 'where');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1594,6 +1594,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where date not between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|null>  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereDateNotBetween($column, iterable $values, $boolean = 'or')
+    {
+        return $this->whereDateBetween($column, $values, $boolean, true);
+    }
+
+    /**
      * Add a "where time" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1665,6 +1678,19 @@ class Builder implements BuilderContract
     public function orWhereTimeBetween($column, iterable $values, $not = false)
     {
         return $this->whereTimeBetween($column, $values, 'or', $not);
+    }
+
+    /**
+     * Add a "where time not between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|null>  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereTimeNotBetween($column, iterable $values, $boolean = 'or')
+    {
+        return $this->whereTimeBetween($column, $values, $boolean, true);
     }
 
     /**
@@ -1767,6 +1793,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where day not between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereDayNotBetween($column, iterable $values, $boolean = 'or')
+    {
+        return $this->whereDayBetween($column, $values, $boolean, true);
+    }
+
+    /**
      * Add an "or where day" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1866,6 +1905,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where month not between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereMonthNotBetween($column, iterable $values, $boolean = 'or')
+    {
+        return $this->whereMonthBetween($column, $values, $boolean, true);
+    }
+
+    /**
      * Add an "or where month" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1954,6 +2006,19 @@ class Builder implements BuilderContract
     public function orWhereYearBetween($column, iterable $values, $not = false)
     {
         return $this->whereYearBetween($column, $values, 'or', $not);
+    }
+
+    /**
+     * Add a "where year not between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereYearNotBetween($column, iterable $values, $boolean = 'or')
+    {
+        return $this->whereYearBetween($column, $values, $boolean, true);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query;
 
 use BackedEnum;
 use Carbon\CarbonPeriod;
+use Carbon\Month;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
@@ -1878,6 +1879,10 @@ class Builder implements BuilderContract
             ->map(function ($value) {
                 if ($value instanceof DateTimeInterface) {
                     return $value->format('m');
+                }
+
+                if ($value instanceof Month) {
+                    $value = $value->value;
                 }
 
                 if (! $value instanceof ExpressionContract) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1724,7 +1724,7 @@ class Builder implements BuilderContract
             })
             ->all();
 
-        return $this->addDateBasedWhereBetween('Time', $column, $values, $boolean, $not);
+        return $this->addDateBasedWhereBetween('Day', $column, $values, $boolean, $not);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1552,7 +1552,7 @@ class Builder implements BuilderContract
 
     /**
      * Add a "where date between" statement to the query.
-     * 
+     *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  iterable<\DateTimeInterface|string|null>  $values
      * @param  string  $boolean
@@ -1715,7 +1715,7 @@ class Builder implements BuilderContract
                 if ($value instanceof DateTimeInterface) {
                     return $value->format('d');
                 }
-    
+
                 if (! $value instanceof ExpressionContract) {
                     return sprintf('%02d', $value);
                 }
@@ -1801,7 +1801,7 @@ class Builder implements BuilderContract
                 if ($value instanceof DateTimeInterface) {
                     return $value->format('m');
                 }
-    
+
                 if (! $value instanceof ExpressionContract) {
                     return sprintf('%02d', $value);
                 }
@@ -1931,7 +1931,7 @@ class Builder implements BuilderContract
 
     /**
      * Add a date based  (year, month, day, time) where between statement to the query.
-     * 
+     *
      * @param  string  $type
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $operator

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1551,6 +1551,34 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where date between" statement to the query.
+     * 
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|null>  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereDateBetween($column, iterable $values, $boolean = 'and', $not = false)
+    {
+        if ($values instanceof CarbonPeriod) {
+            $values = [$values->getStartDate(), $values->getEndDate()];
+        }
+
+        $values = collect($values)
+            ->map(function ($value) {
+                if ($value instanceof DateTimeInterface) {
+                    return $value->format('Y-m-d');
+                }
+
+                return $value;
+            })
+            ->all();
+
+        return $this->addDateBasedWhereBetween('Date', $column, $values, $boolean, $not);
+    }
+
+    /**
      * Add a "where time" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1579,6 +1607,34 @@ class Builder implements BuilderContract
         }
 
         return $this->addDateBasedWhere('Time', $column, $operator, $value, $boolean);
+    }
+
+    /**
+     * Add a "where time between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|null>  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereTimeBetween($column, iterable $values, $boolean = 'and', $not = false)
+    {
+        if ($values instanceof CarbonPeriod) {
+            $values = [$values->getStartDate(), $values->getEndDate()];
+        }
+
+        $values = collect($values)
+            ->map(function ($value) {
+                if ($value instanceof DateTimeInterface) {
+                    return $value->format('H:i:s');
+                }
+
+                return $value;
+            })
+            ->all();
+
+        return $this->addDateBasedWhereBetween('Time', $column, $values, $boolean, $not);
     }
 
     /**
@@ -1634,6 +1690,38 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where day between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereDayBetween($column, iterable $values, $boolean = 'and', $not = false)
+    {
+        if ($values instanceof CarbonPeriod) {
+            $values = [$values->getStartDate(), $values->getEndDate()];
+        }
+
+        $values = collect($values)
+            ->map(function ($value) {
+                if ($value instanceof DateTimeInterface) {
+                    return $value->format('d');
+                }
+    
+                if (! $value instanceof ExpressionContract) {
+                    return sprintf('%02d', $value);
+                }
+
+                return $value;
+            })
+            ->all();
+
+        return $this->addDateBasedWhereBetween('Time', $column, $values, $boolean, $not);
+    }
+
+    /**
      * Add an "or where day" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1686,6 +1774,38 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where month between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereMonthBetween($column, iterable $values, $boolean = 'and', $not = false)
+    {
+        if ($values instanceof CarbonPeriod) {
+            $values = [$values->getStartDate(), $values->getEndDate()];
+        }
+
+        $values = collect($values)
+            ->map(function ($value) {
+                if ($value instanceof DateTimeInterface) {
+                    return $value->format('m');
+                }
+    
+                if (! $value instanceof ExpressionContract) {
+                    return sprintf('%02d', $value);
+                }
+
+                return $value;
+            })
+            ->all();
+
+        return $this->addDateBasedWhereBetween('Month', $column, $values, $boolean, $not);
+    }
+
+    /**
      * Add an "or where month" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1734,6 +1854,34 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where year between" statement to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  iterable<\DateTimeInterface|string|int|null>  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereYearBetween($column, iterable $values, $boolean = 'and', $not = false)
+    {
+        if ($values instanceof CarbonPeriod) {
+            $values = [$values->getStartDate(), $values->getEndDate()];
+        }
+
+        $values = collect($values)
+            ->map(function ($value) {
+                if ($value instanceof DateTimeInterface) {
+                    return $value->format('Y');
+                }
+
+                return $value;
+            })
+            ->all();
+
+        return $this->addDateBasedWhereBetween('Year', $column, $values, $boolean, $not);
+    }
+
+    /**
      * Add an "or where year" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1767,6 +1915,27 @@ class Builder implements BuilderContract
         if (! $value instanceof ExpressionContract) {
             $this->addBinding($value, 'where');
         }
+
+        return $this;
+    }
+
+    /**
+     * Add a date based  (year, month, day, time) where between statement to the query.
+     * 
+     * @param  string  $type
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    protected function addDateBasedWhereBetween($type, $column, iterable $values, $boolean = 'and', $not = false)
+    {
+        $type = $type.'Between';
+
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
+
+        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1881,7 +1881,7 @@ class Builder implements BuilderContract
                     return $value->format('m');
                 }
 
-                if ($value instanceof Month) {
+                if (class_exists(Month::class) && $value instanceof Month) {
                     $value = $value->value;
                 }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -515,6 +515,66 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where date between" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDateBetween(Builder $query, $where)
+    {
+        return $this->dateBasedWhereBetween('date', $query, $where);
+    }
+
+    /**
+     * Compile a "where time between" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereTimeBetween(Builder $query, $where)
+    {
+        return $this->dateBasedWhereBetween('time', $query, $where);
+    }
+
+    /**
+     * Compile a "where day between" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDayBetween(Builder $query, $where)
+    {
+        return $this->dateBasedWhereBetween('day', $query, $where);
+    }
+
+    /**
+     * Compile a "where month between" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereMonthBetween(Builder $query, $where)
+    {
+        return $this->dateBasedWhereBetween('month', $query, $where);
+    }
+
+    /**
+     * Compile a "where year" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereYearBetween(Builder $query, $where)
+    {
+        return $this->dateBasedWhereBetween('year', $query, $where);
+    }
+
+    /**
      * Compile a date based where clause.
      *
      * @param  string  $type
@@ -527,6 +587,25 @@ class Grammar extends BaseGrammar
         $value = $this->parameter($where['value']);
 
         return $type.'('.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+    }
+
+    /**
+     * Compile a date based where clause.
+     *
+     * @param  string  $type
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhereBetween($type, Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+        
+        return $type.'('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -604,7 +604,7 @@ class Grammar extends BaseGrammar
         $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
 
         $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
-        
+
         return $type.'('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
     }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -146,7 +146,7 @@ class PostgresGrammar extends Grammar
         // if the type is year, month, or day, we should use the extract function for comparasion
         if (in_array($type, ['year', 'month', 'day'])) {
             return 'extract('.$type.' from '.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
-        } 
+        }
 
         // for date and time, we can use the column directly
         return $this->wrap($where['column']).'::'.$type.' '.$between.' '.$min.' and '.$max;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -128,7 +128,7 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Compile a date based where clause.
+     * Compile a date based between where clause.
      *
      * @param  string  $type
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -149,7 +149,7 @@ class PostgresGrammar extends Grammar
         } 
 
         // for date and time, we can use the column directly
-        return $this->wrap($where['column']).'::'. $type .' '.$between.' '.$min.' and '.$max;
+        return $this->wrap($where['column']).'::'.$type.' '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -128,6 +128,31 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a date based where clause.
+     *
+     * @param  string  $type
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhereBetween($type, Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        // if the type is year, month, or day, we should use the extract function for comparasion
+        if (in_array($type, ['year', 'month', 'day'])) {
+            return 'extract('.$type.' from '.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
+        } 
+
+        // for date and time, we can use the column directly
+        return $this->wrap($where['column']).'::'. $type .' '.$between.' '.$min.' and '.$max;
+    }
+
+    /**
      * Compile a "where fulltext" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -163,7 +163,7 @@ class SQLiteGrammar extends Grammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        $format = match($type) {
+        $format = match ($type) {
             'date' => '%Y-%m-%d',
             'year' => '%Y',
             'month' => '%m',

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -148,6 +148,31 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a date based where between clause.
+     *
+     * @param  string  $type
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhereBetween($type, Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        // if the type is date or time, we should use the casting for comparasion
+        if (in_array($type, ['date', 'time'])) {
+            return 'cast('.$this->wrap($where['column']).' as '. $type .') '.$between.' '.$min.' and '.$max;
+        }
+
+        // for others, we can use the functions directly
+        return $type.'('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
+    }
+
+    /**
      * Compile a "where time" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -169,7 +169,7 @@ class SqlServerGrammar extends Grammar
         }
 
         // for others, we can use the functions directly
-        return $type.'('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
+        return 'cast('.$this->wrap($where['column']).' as '.$type.') '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -165,11 +165,11 @@ class SqlServerGrammar extends Grammar
 
         // if the type is date or time, we should use the casting for comparasion
         if (in_array($type, ['date', 'time'])) {
-            return 'cast('.$this->wrap($where['column']).' as '. $type .') '.$between.' '.$min.' and '.$max;
+            return 'cast('.$this->wrap($where['column']).' as '.$type.') '.$between.' '.$min.' and '.$max;
         }
 
         // for others, we can use the functions directly
-        return 'cast('.$this->wrap($where['column']).' as '.$type.') '.$between.' '.$min.' and '.$max;
+        return $type.'('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1249,6 +1249,33 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where day("created_at") between ? and ? or day("updated_at") between ? and ?', $builder->toSql());
     }
 
+    public function testWhereDateFunctionsNotBetween() {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()])
+            ->whereDateNotBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ? or date("updated_at") not between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [now(), now()])
+            ->whereTimeNotBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ? or time("updated_at") not between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [now(), now()])
+            ->whereYearNotBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ? or year("updated_at") not between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [now(), now()])
+            ->whereMonthNotBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ? or month("updated_at") not between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [now(), now()])
+            ->whereDayNotBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ? or day("updated_at") not between ? and ?', $builder->toSql());
+    }
+
     public function testWhereBetweenDateArguments()
     {
         // primitive types

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use BadMethodCallException;
+use Carbon\Month;
 use Closure;
 use DateTime;
 use Illuminate\Contracts\Database\Query\ConditionExpression;
@@ -1401,6 +1402,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonthBetween('created_at', [['1', '10', '12']]);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [Month::January, Month::October]);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1222,6 +1222,33 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
     }
 
+    public function testOrWhereDateFunctionsBetween() {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()])
+            ->orWhereDateBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ? or date("updated_at") between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [now(), now()])
+            ->orWhereTimeBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ? or time("updated_at") between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [now(), now()])
+            ->orWhereYearBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ? or year("updated_at") between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [now(), now()])
+            ->orWhereMonthBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ? or month("updated_at") between ? and ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [now(), now()])
+            ->orWhereDayBetween('updated_at', [now(), now()]);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ? or day("updated_at") between ? and ?', $builder->toSql());
+    }
+
     public function testWhereBetweenDateArguments()
     {
         // primitive types

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use BadMethodCallException;
-use Carbon\Month;
 use Closure;
 use DateTime;
 use Illuminate\Contracts\Database\Query\ConditionExpression;
@@ -1406,11 +1405,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMonthBetween('created_at', [Month::January, Month::October]);
-        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonthBetween('created_at', [['1'], ['10', '12']]);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
@@ -1437,6 +1431,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereMonthBetween('created_at', collect([now(), now()]));
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => now()->format('m'), 1 => now()->format('m')], $builder->getBindings());
+    }
+
+    public function testWhereMonthBetweenAcceptsMonthEnum()
+    {
+        if (! class_exists(\Carbon\Month::class)) {
+            $this->markTestSkipped('Carbon 3.0 is not installed.');
+        }
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [\Carbon\Month::January, \Carbon\Month::October]);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
     }
 
     public function testWhereDayBetween()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -919,12 +919,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereDateBetween('created_at', ['2024-10-01', '2024-10-10']);
         $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '2024-10-01', 1 => '2024-10-10'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDateBetween('created_at', [['2024-10-01', '2024-10-10', '2024-10-03']]);
         $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '2024-10-01', 1 => '2024-10-10'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDateBetween('created_at', [['2024-10-01'], ['2024-10-10', '2024-10-15']]);
         $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
@@ -960,12 +960,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereTimeBetween('created_at', ['20:00:00', '21:00:00']);
         $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '20:00:00', 1 => '21:00:00'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereTimeBetween('created_at', [['20:00:00', '21:00:00', '22:00:00']]);
         $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '20:00:00', 1 => '21:00:00'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereTimeBetween('created_at', [['20:00:00'], ['21:00:00', '22:00:00']]);
         $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
@@ -1001,12 +1001,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereMonthBetween('created_at', ['1', '10']);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonthBetween('created_at', [['1', '10', '12']]);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonthBetween('created_at', [['1'], ['10', '12']]);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
@@ -1042,12 +1042,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereDayBetween('created_at', ['1', '10']);
         $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDayBetween('created_at', [['1', '10', '12']]);
         $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDayBetween('created_at', [['1'], ['10', '12']]);
         $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
@@ -1083,12 +1083,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereYearBetween('created_at', ['2022', '2024']);
         $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '2022', 1 => '2024'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereYearBetween('created_at', [['2022', '2024', '2025']]);
         $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => '2022', 1 => '2024'], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereYearBetween('created_at', [['2022'], ['2024', '2025']]);
         $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -946,7 +946,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
         $builder->select('*')->from('users')->whereDateBetween('created_at', $period);
         $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay()->format('Y-m-d'), now()->addMonth()->startOfDay()->format('Y-m-d')], $builder->getBindings());
+        $this->assertEquals([$period->getStartDate()->format('Y-m-d'), $period->getEndDate()->format('Y-m-d')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDateBetween('created_at', collect([now(), now()]));
@@ -993,6 +993,47 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereTimeBetween('created_at', collect([now(), now()]));
         $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => now()->format('H:i:s'), 1 => now()->format('H:i:s')], $builder->getBindings());
+    }
+
+    public function testWhereMonthBetween()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', ['1', '10']);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [['1', '10', '12']]);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [['1'], ['10', '12']]);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [new Raw('5'), new Raw('12')]);
+        $this->assertSame('select * from "users" where month("created_at") between 5 and 12', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', $period);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay()->format('m'), now()->addDay()->startOfDay()->format('m')], $builder->getBindings());
+
+        // custom long carbon period date
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', $period);
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay()->format('m'), now()->addMonth()->startOfDay()->format('m')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', collect([now(), now()]));
+        $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('m'), 1 => now()->format('m')], $builder->getBindings());
     }
 
     public function testOrWhereBetween()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -628,6 +628,69 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => now()->format('d'), 1 => now()->addDays(62)->format('d')], $builder->getBindings());
     }
 
+    public function testWhereDateFunctionsBetweenSqlServer()
+    {
+        // test where date function
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', ['2024-11-11', '2024-11-12']);
+        $this->assertSame('select * from [users] where cast([created_at] as date) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024-11-11', 1 => '2024-11-12'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()]);
+        $this->assertSame('select * from [users] where cast([created_at] as date) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [new Raw('NOW()'), new Raw('NOW()')]);
+        $this->assertSame('select * from [users] where cast([created_at] as date) between NOW() and NOW()', $builder->toSql());
+
+        // test where year function
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', ['2024', '2025']);
+        $this->assertSame('select * from [users] where year([created_at]) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024', 1 => '2025'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [now(), now()]);
+        $this->assertSame('select * from [users] where year([created_at]) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y'), 1 => now()->format('Y')], $builder->getBindings());
+
+        // test where time function
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', ['12:00:00', '15:00:00']);
+        $this->assertSame('select * from [users] where cast([created_at] as time) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '12:00:00', 1 => '15:00:00'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $timestamp = now();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [$timestamp, $timestamp]);
+        $this->assertSame('select * from [users] where cast([created_at] as time) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => $timestamp->format('H:i:s'), 1 => $timestamp->format('H:i:s')], $builder->getBindings());
+
+        // test where month function
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [1, '12']);
+        $this->assertSame('select * from [users] where month([created_at]) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '12'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [now(), now()->addMonths(2)]);
+        $this->assertSame('select * from [users] where month([created_at]) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('m'), 1 => now()->addMonths(2)->format('m')], $builder->getBindings());
+
+        // test where month function
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [1, '30']);
+        $this->assertSame('select * from [users] where day([created_at]) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '30'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [now(), now()->addDays(62)]);
+        $this->assertSame('select * from [users] where day([created_at]) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('d'), 1 => now()->addDays(62)->format('d')], $builder->getBindings());
+    }
+
     public function testWhereDayMySql()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -565,6 +565,69 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => now()->format('d'), 1 => now()->addDays(62)->format('d')], $builder->getBindings());
     }
 
+    public function testWhereDateFunctionsBetweenSqlite()
+    {
+        // test where date function
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', ['2024-11-11', '2024-11-12']);
+        $this->assertSame('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => '2024-11-11', 1 => '2024-11-12'], $builder->getBindings());
+
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()]);
+        $this->assertSame('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
+
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [new Raw('NOW()'), new Raw('NOW()')]);
+        $this->assertSame('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") between cast(NOW() as text) and cast(NOW() as text)', $builder->toSql());
+
+        // test where year function
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', ['2024', '2025']);
+        $this->assertSame('select * from "users" where strftime(\'%Y\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => '2024', 1 => '2025'], $builder->getBindings());
+
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [now(), now()]);
+        $this->assertSame('select * from "users" where strftime(\'%Y\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y'), 1 => now()->format('Y')], $builder->getBindings());
+
+        // test where time function
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', ['12:00:00', '15:00:00']);
+        $this->assertSame('select * from "users" where strftime(\'%H:%M:%S\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => '12:00:00', 1 => '15:00:00'], $builder->getBindings());
+
+        $builder = $this->getSqliteBuilder();
+        $timestamp = now();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [$timestamp, $timestamp]);
+        $this->assertSame('select * from "users" where strftime(\'%H:%M:%S\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => $timestamp->format('H:i:s'), 1 => $timestamp->format('H:i:s')], $builder->getBindings());
+
+        // test where month function
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [1, '12']);
+        $this->assertSame('select * from "users" where strftime(\'%m\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '12'], $builder->getBindings());
+
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [now(), now()->addMonths(2)]);
+        $this->assertSame('select * from "users" where strftime(\'%m\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => now()->format('m'), 1 => now()->addMonths(2)->format('m')], $builder->getBindings());
+
+        // test where month function
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [1, '30']);
+        $this->assertSame('select * from "users" where strftime(\'%d\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '30'], $builder->getBindings());
+
+        $builder = $this->getSqliteBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [now(), now()->addDays(62)]);
+        $this->assertSame('select * from "users" where strftime(\'%d\', "created_at") between cast(? as text) and cast(? as text)', $builder->toSql());
+        $this->assertEquals([0 => now()->format('d'), 1 => now()->addDays(62)->format('d')], $builder->getBindings());
+    }
+
     public function testWhereDayMySql()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1222,7 +1222,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
     }
 
-    public function testOrWhereDateFunctionsBetween() {
+    public function testOrWhereDateFunctionsBetween()
+    {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()])
             ->orWhereDateBetween('updated_at', [now(), now()]);
@@ -1249,7 +1250,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where day("created_at") between ? and ? or day("updated_at") between ? and ?', $builder->toSql());
     }
 
-    public function testWhereDateFunctionsNotBetween() {
+    public function testWhereDateFunctionsNotBetween()
+    {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()])
             ->whereDateNotBetween('updated_at', [now(), now()]);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1438,7 +1438,7 @@ class DatabaseQueryBuilderTest extends TestCase
         if (! class_exists(\Carbon\Month::class)) {
             $this->markTestSkipped('Carbon 3.0 is not installed.');
         }
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonthBetween('created_at', [\Carbon\Month::January, \Carbon\Month::October]);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -913,6 +913,88 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
+    public function testWhereDateBetween()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', ['2024-10-01', '2024-10-10']);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024-10-01', 1 => '2024-10-10'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [['2024-10-01', '2024-10-10', '2024-10-03']]);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024-10-01', 1 => '2024-10-10'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [['2024-10-01'], ['2024-10-10', '2024-10-15']]);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024-10-01', 1 => '2024-10-10'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [new Raw('"2024-10-01"'), new Raw('"2024-10-10"')]);
+        $this->assertSame('select * from "users" where date("created_at") between "2024-10-01" and "2024-10-10"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
+        $builder->select('*')->from('users')->whereDateBetween('created_at', $period);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay()->format('Y-m-d'), now()->addDay()->startOfDay()->format('Y-m-d')], $builder->getBindings());
+
+        // custom long carbon period date
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
+        $builder->select('*')->from('users')->whereDateBetween('created_at', $period);
+        $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay()->format('Y-m-d'), now()->addMonth()->startOfDay()->format('Y-m-d')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', collect([now(), now()]));
+        $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
+    }
+
+    public function testWhereTimeBetween()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', ['20:00:00', '21:00:00']);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '20:00:00', 1 => '21:00:00'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [['20:00:00', '21:00:00', '22:00:00']]);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '20:00:00', 1 => '21:00:00'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [['20:00:00'], ['21:00:00', '22:00:00']]);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '20:00:00', 1 => '21:00:00'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [new Raw('"20:00:00"'), new Raw('"21:00:00"')]);
+        $this->assertSame('select * from "users" where time("created_at") between "20:00:00" and "21:00:00"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', $period);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay()->format('H:i:s'), now()->addDay()->startOfDay()->format('H:i:s')], $builder->getBindings());
+
+        // custom long carbon period date
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', $period);
+        $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay()->format('H:i:s'), now()->addMonth()->startOfDay()->format('H:i:s')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', collect([now(), now()]));
+        $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('H:i:s'), 1 => now()->format('H:i:s')], $builder->getBindings());
+    }
+
     public function testOrWhereBetween()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -423,6 +423,85 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from `users` where date(`created_at`) = NOW()', $builder->toSql());
     }
 
+    public function testWhereDateFunctionsBetweenMySql()
+    {
+        // test where date function
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', ['2024-11-11', '2024-11-12']);
+        $this->assertSame('select * from `users` where date(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024-11-11', 1 => '2024-11-12'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()]);
+        $this->assertSame('select * from `users` where date(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [new Raw('NOW()'), new Raw('NOW() + INTERVAL 1 DAY')]);
+        $this->assertSame('select * from `users` where date(`created_at`) between NOW() and NOW() + INTERVAL 1 DAY', $builder->toSql());
+
+        // test where year function
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', ['2024', '2025']);
+        $this->assertSame('select * from `users` where year(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2024', 1 => '2025'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [now(), now()]);
+        $this->assertSame('select * from `users` where year(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y'), 1 => now()->format('Y')], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [new Raw('YEAR(NOW())'), new Raw('YEAR(NOW() + INTERVAL 2 YEAR)')]);
+        $this->assertSame('select * from `users` where year(`created_at`) between YEAR(NOW()) and YEAR(NOW() + INTERVAL 2 YEAR)', $builder->toSql());
+
+        // test where time function
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', ['12:00:00', '15:00:00']);
+        $this->assertSame('select * from `users` where time(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '12:00:00', 1 => '15:00:00'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $timestamp = now();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [$timestamp, $timestamp]);
+        $this->assertSame('select * from `users` where time(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => $timestamp->format('H:i:s'), 1 => $timestamp->format('H:i:s')], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [new Raw('TIME(NOW())'), new Raw('TIME(NOW() + INTERVAL 2 HOUR)')]);
+        $this->assertSame('select * from `users` where time(`created_at`) between TIME(NOW()) and TIME(NOW() + INTERVAL 2 HOUR)', $builder->toSql());
+
+        // test where month function
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [1, '12']);
+        $this->assertSame('select * from `users` where month(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '12'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [now(), now()->addMonths(2)]);
+        $this->assertSame('select * from `users` where month(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('m'), 1 => now()->addMonths(2)->format('m')], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [new Raw('MONTH(NOW())'), new Raw('MONTH(NOW() + INTERVAL 2 MONTH)')]);
+        $this->assertSame('select * from `users` where month(`created_at`) between MONTH(NOW()) and MONTH(NOW() + INTERVAL 2 MONTH)', $builder->toSql());
+
+        // test where month function
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [1, '30']);
+        $this->assertSame('select * from `users` where day(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '30'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [now(), now()->addDays(62)]);
+        $this->assertSame('select * from `users` where day(`created_at`) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('d'), 1 => now()->addDays(62)->format('d')], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [new Raw('DAY(NOW())'), new Raw('DAY(NOW() + INTERVAL 2 DAY)')]);
+        $this->assertSame('select * from `users` where day(`created_at`) between DAY(NOW()) and DAY(NOW() + INTERVAL 2 DAY)', $builder->toSql());
+    }
+
     public function testWhereDayMySql()
     {
         $builder = $this->getMySqlBuilder();
@@ -952,6 +1031,79 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereDateBetween('created_at', collect([now(), now()]));
         $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->format('Y-m-d')], $builder->getBindings());
+    }
+
+    public function testWhereBetweenDateArguments()
+    {
+        // primitive types
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', ['2024-10-01', '2024-10-10']);
+        $this->assertEquals([0 => '2024-10-01', 1 => '2024-10-10'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', ['20:00:00', '21:00:00']);
+        $this->assertEquals([0 => '20:00:00', 1 => '21:00:00'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [2024, '2025']);
+        $this->assertEquals([0 => '2024', 1 => '2025'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', ['1', 12]);
+        $this->assertEquals([0 => '01', 1 => '12'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [1, '22']);
+        $this->assertEquals([0 => '01', 1 => '22'], $builder->getBindings());
+
+        // DateTimeInterface
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDateBetween('created_at', [now(), now()->addDays(2)]);
+        $this->assertEquals([0 => now()->format('Y-m-d'), 1 => now()->addDays(2)->format('Y-m-d')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $start = now();
+        $end = now()->addHours(3);
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', [$start, $end->addHours(1)]);
+        $this->assertEquals([0 => $start->format('H:i:s'), 1 => $end->format('H:i:s')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [now(), now()->addYears(2)]);
+        $this->assertEquals([0 => now()->format('Y'), 1 => now()->addYears(2)->format('Y')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', [now(), now()->addMonths(3)]);
+        $this->assertEquals([0 => now()->format('m'), 1 => now()->addMonths(3)->format('m')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [now(), now()->addDays(3)]);
+        $this->assertEquals([0 => now()->format('d'), 1 => now()->addDays(3)->format('d')], $builder->getBindings());
+
+        // CarbonPeriod
+        $builder = $this->getBuilder();
+        $period = now()->toPeriod(now()->addDays(2));
+        $builder->select('*')->from('users')->whereDateBetween('created_at', $period);
+        $this->assertEquals([0 => $period->getStartDate()->format('Y-m-d'), 1 => $period->getEndDate()->format('Y-m-d')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->toPeriod(now()->addHours(2)->addSeconds(10));
+        $builder->select('*')->from('users')->whereTimeBetween('created_at', $period);
+        $this->assertEquals([0 => $period->getStartDate()->format('H:i:s'), 1 => $period->getEndDate()->format('H:i:s')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->toPeriod(now()->addYears(10));
+        $builder->select('*')->from('users')->whereYearBetween('created_at', $period);
+        $this->assertEquals([0 => $period->getStartDate()->format('Y'), 1 => $period->getEndDate()->format('Y')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->toPeriod(now()->addMonths(10));
+        $builder->select('*')->from('users')->whereMonthBetween('created_at', $period);
+        $this->assertEquals([0 => $period->getStartDate()->format('m'), 1 => $period->getEndDate()->format('m')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->toPeriod(now()->addDays(15));
+        $builder->select('*')->from('users')->whereDayBetween('created_at', $period);
+        $this->assertEquals([0 => $period->getStartDate()->format('d'), 1 => $period->getEndDate()->format('d')], $builder->getBindings());
     }
 
     public function testWhereTimeBetween()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -939,7 +939,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
         $builder->select('*')->from('users')->whereDateBetween('created_at', $period);
         $this->assertSame('select * from "users" where date("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay()->format('Y-m-d'), now()->addDay()->startOfDay()->format('Y-m-d')], $builder->getBindings());
+        $this->assertEquals([$period->getStartDate()->format('Y-m-d'), $period->getEndDate()->format('Y-m-d')], $builder->getBindings());
 
         // custom long carbon period date
         $builder = $this->getBuilder();
@@ -980,14 +980,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
         $builder->select('*')->from('users')->whereTimeBetween('created_at', $period);
         $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay()->format('H:i:s'), now()->addDay()->startOfDay()->format('H:i:s')], $builder->getBindings());
+        $this->assertEquals([$period->getStartDate()->format('H:i:s'), $period->getEndDate()->format('H:i:s')], $builder->getBindings());
 
         // custom long carbon period date
         $builder = $this->getBuilder();
         $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
         $builder->select('*')->from('users')->whereTimeBetween('created_at', $period);
         $this->assertSame('select * from "users" where time("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay()->format('H:i:s'), now()->addMonth()->startOfDay()->format('H:i:s')], $builder->getBindings());
+        $this->assertEquals([$period->getStartDate()->format('H:i:s'), $period->getEndDate()->format('H:i:s')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereTimeBetween('created_at', collect([now(), now()]));
@@ -1018,22 +1018,104 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
+        $period = now()->startOfDay()->toPeriod(now()->subMonths(11)->startOfDay());
         $builder->select('*')->from('users')->whereMonthBetween('created_at', $period);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay()->format('m'), now()->addDay()->startOfDay()->format('m')], $builder->getBindings());
+        $this->assertEquals([$period->getStartDate()->format('m'), $period->getEndDate()->format('m')], $builder->getBindings());
 
         // custom long carbon period date
         $builder = $this->getBuilder();
-        $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
+        $period = now()->startOfDay()->toPeriod(now()->addMonths(10)->startOfDay());
         $builder->select('*')->from('users')->whereMonthBetween('created_at', $period);
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
-        $this->assertEquals([now()->startOfDay()->format('m'), now()->addMonth()->startOfDay()->format('m')], $builder->getBindings());
+        $this->assertEquals([$period->getStartDate()->format('m'), $period->getEndDate()->format('m')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMonthBetween('created_at', collect([now(), now()]));
         $this->assertSame('select * from "users" where month("created_at") between ? and ?', $builder->toSql());
         $this->assertEquals([0 => now()->format('m'), 1 => now()->format('m')], $builder->getBindings());
+    }
+
+    public function testWhereDayBetween()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', ['1', '10']);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [['1', '10', '12']]);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [['1'], ['10', '12']]);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '01', 1 => '10'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', [new Raw('5'), new Raw('12')]);
+        $this->assertSame('select * from "users" where day("created_at") between 5 and 12', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addDays(24)->startOfDay());
+        $builder->select('*')->from('users')->whereDayBetween('created_at', $period);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([$period->getStartDate()->format('d'), $period->getEndDate()->format('d')], $builder->getBindings());
+
+        // custom long carbon period date
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->subDays(33)->startOfDay());
+        $builder->select('*')->from('users')->whereDayBetween('created_at', $period);
+        $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([$period->getStartDate()->format('d'), $period->getEndDate()->format('d')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayBetween('created_at', collect([now(), now()]));
+        $this->assertSame('select * from "users" where day("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('d'), 1 => now()->format('d')], $builder->getBindings());
+    }
+
+    public function testWhereYearBetween()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', ['2022', '2024']);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2022', 1 => '2024'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [['2022', '2024', '2025']]);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2022', 1 => '2024'], $builder->getBindings());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [['2022'], ['2024', '2025']]);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => '2022', 1 => '2024'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', [new Raw('2021'), new Raw('2025')]);
+        $this->assertSame('select * from "users" where year("created_at") between 2021 and 2025', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->addYears(5)->startOfDay());
+        $builder->select('*')->from('users')->whereYearBetween('created_at', $period);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([$period->getStartDate()->format('Y'), $period->getEndDate()->format('Y')], $builder->getBindings());
+
+        // custom long carbon period date
+        $builder = $this->getBuilder();
+        $period = now()->startOfDay()->toPeriod(now()->subYears(11)->startOfDay());
+        $builder->select('*')->from('users')->whereYearBetween('created_at', $period);
+        $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([$period->getStartDate()->format('Y'), $period->getEndDate()->format('Y')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearBetween('created_at', collect([now(), now()]));
+        $this->assertSame('select * from "users" where year("created_at") between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => now()->format('Y'), 1 => now()->format('Y')], $builder->getBindings());
     }
 
     public function testOrWhereBetween()

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -308,6 +308,39 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereDate('created_at', new Carbon('2018-01-02'))->count());
     }
 
+    public function testWhereDateBetween()
+    {
+        $this->assertSame(2, DB::table('posts')->whereDateBetween('created_at', ['2017-11-12', '2018-01-02'])->count());
+        $this->assertSame(1, DB::table('posts')->whereDateBetween('created_at', [new Carbon('2017-12-12'), new Carbon('2018-01-03')])->count());
+        $this->assertSame(2, DB::table('posts')->whereDateBetween('created_at', (new Carbon('2017-11-12'))->toPeriod(new Carbon('2018-03-02')))->count());
+    }
+
+    public function testWhereTimeBetween()
+    {
+        $this->assertSame(2, DB::table('posts')->whereTimeBetween('created_at', ['00:00:00', '15:00:00'])->count());
+        $this->assertSame(1, DB::table('posts')->whereTimeBetween('created_at', ['12:00:00', '14:00:00'])->count());
+    }
+
+    public function testWhereYearBetween()
+    {
+        $this->assertSame(1, DB::table('posts')->whereYearBetween('created_at', [2018, 2019])->count());
+        $this->assertSame(2, DB::table('posts')->whereYearBetween('created_at', (new Carbon('2017-01-01'))->toPeriod(new Carbon('2018-01-01')))->count());
+    }
+
+    public function testWhereMonthBetween()
+    {
+        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', ['11', '12'])->count());
+        $this->assertSame(2, DB::table('posts')->whereMonthBetween('created_at', [1, '12'])->count());
+        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [1, 3])->count());
+    }
+
+    public function testWhereDayBetween()
+    {
+        $this->assertSame(2, DB::table('posts')->whereMonthBetween('created_at', [1, 31])->count());
+        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [10, '31'])->count());
+        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', ['01', '10'])->count());
+    }
+
     #[DefineEnvironment('defineEnvironmentWouldThrowsPDOException')]
     public function testWhereDateWithInvalidOperator()
     {

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Carbon\Month;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
@@ -332,6 +333,7 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', ['11', '12'])->count());
         $this->assertSame(2, DB::table('posts')->whereMonthBetween('created_at', [1, '12'])->count());
         $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [1, 3])->count());
+        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [Month::January, Month::April])->count());
     }
 
     public function testWhereDayBetween()

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -334,7 +334,7 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [1, 3])->count());
     }
 
-    public function testWhereMonthBetweenUsinCarbon()
+    public function testWhereMonthBetweenUsingCarbon()
     {
         if (! class_exists(\Carbon\Month::class)) {
             $this->markTestSkipped('Carbon 3.0 is not installed.');

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -336,7 +336,7 @@ class QueryBuilderTest extends DatabaseTestCase
 
     public function testWhereMonthBetweenUsinCarbon()
     {
-        if(! class_exists(\Carbon\Month::class)) {
+        if (! class_exists(\Carbon\Month::class)) {
             $this->markTestSkipped('Carbon 3.0 is not installed.');
         }
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Carbon\Month;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
@@ -333,7 +332,15 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', ['11', '12'])->count());
         $this->assertSame(2, DB::table('posts')->whereMonthBetween('created_at', [1, '12'])->count());
         $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [1, 3])->count());
-        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [Month::January, Month::April])->count());
+    }
+
+    public function testWhereMonthBetweenUsinCarbon()
+    {
+        if(! class_exists(\Carbon\Month::class)) {
+            $this->markTestSkipped('Carbon 3.0 is not installed.');
+        }
+
+        $this->assertSame(1, DB::table('posts')->whereMonthBetween('created_at', [\Carbon\Month::January, \Carbon\Month::March])->count());
     }
 
     public function testWhereDayBetween()


### PR DESCRIPTION
Added following methods to `Illuminate\Database\Query\Builder` class:
`whereDateBetween()`
`whereTimeBetween()`
`whereYearBetween()`
`whereMonthBetween()`
`whereDayBetween()`
`orWhereDateBetween()`
`orWhereTimeBetween()`
`orWhereYearBetween()`
`orWhereMonthBetween()`
`orWhereDayBetween()`
`whereDateNotBetween()`
`whereTimeNotBetween()`
`whereYearNotBetween()`
`whereMonthNotBetween()`
`whereDayNotBetween()`
 
Eeach function works similar to existing `whereBetween` function and `CarbonPeriod` as well.

Usage examples:
```php
// using DateTimeInterface
$orders = Order::whereDateBetween('created_at', [Carbon::parse('2024-01-01'), Carbon::parse('2024-12-31')])->count();

// using CarbonPeriod 
$orders = Order::whereYearBetween('created_at', now()->subYears(3)->toPeriod(now()->addYears(5)))->count(); 

// using Carbon\Month enum
$orders = Order::whereMonthBetween('created_at', [\Carbon\Month::January, \Carbon\Month::March])->count(); 

// using basic types
$articles = Post::whereYearBetween('published_at', [2022, 2026])->count(); 
```

- [x] PosgreSQL support
- [x] SQLite support
- [x] SqlServer support
- [x] Add `orWhere[Date|Time|Year|Month|Day]Between` support
- [x] Add `where[Date|Time|Year|Month|Day]NotBetween` support
- [x] ~~Add `orWhere[Date|Time|Year|Month|Day]NotBetween` support~~
- [x] ~~Currently date functions don't support indexing, Solve that using casting~~
- [x] More testing

I hope you'll find this pull request helpful.
Any suggestions are welcome 