### PR TITLE
[11.x] Add ability to register both a single macro as well as multiple

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -19,16 +19,21 @@ trait Macroable
     /**
      * Register a custom macro.
      *
-     * @param  string  $name
-     * @param  object|callable  $macro
+     * @param  array{string, callable}|callable[]  $args
      *
      * @param-closure-this static  $macro
      *
      * @return void
      */
-    public static function macro($name, $macro)
+    public static function macro(...$args)
     {
-        static::$macros[$name] = $macro;
+        if (func_num_args() === 2 && is_string($args[0])) {
+            $args = [ $args[0] => $args[1] ];
+        }
+
+        foreach ($args as $name => $macro) {
+            static::$macros[$name] = $macro;
+        }
     }
 
     /**

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -28,7 +28,7 @@ trait Macroable
     public static function macro(...$args)
     {
         if (func_num_args() === 2 && is_string($args[0])) {
-            $args = [ $args[0] => $args[1] ];
+            $args = [$args[0] => $args[1]];
         }
 
         foreach ($args as $name => $macro) {

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -19,7 +19,7 @@ trait Macroable
     /**
      * Register a custom macro.
      *
-     * @param  array{string, callable}|callable[]  $args
+     * @param  array{string, object|callable}|callable[]  $args
      *
      * @param-closure-this static  $macro
      *

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -29,6 +29,17 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('Taylor', $macroable::{__CLASS__}());
     }
 
+    public function testRegisterMultipleMacros()
+    {
+        $macroable = $this->macroable;
+        $macroable::macro(
+            given: fn () => 'Taylor',
+            family: fn () => 'Otwell',
+        );
+        $this->assertSame('Taylor', $macroable::given());
+        $this->assertSame('Otwell', $macroable::family());
+    }
+
     public function testHasMacro()
     {
         $macroable = $this->macroable;


### PR DESCRIPTION
Making the latter something halfway between the original macro functionality and mixins. The original functionality was kept as-is, so it's no breaking change and the method can be used the same as before.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
