### PR TITLE
[11.x] Add phpstan assertions for last in Collection isEmpty and isNotEmpty

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -690,8 +690,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Determine if the collection is empty or not.
      *
      * @phpstan-assert-if-true null $this->first()
+     * @phpstan-assert-if-true null $this->last()
      *
      * @phpstan-assert-if-false TValue $this->first()
+     * @phpstan-assert-if-false TValue $this->last()
      *
      * @return bool
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -366,8 +366,10 @@ trait EnumeratesValues
      * Determine if the collection is not empty.
      *
      * @phpstan-assert-if-true TValue $this->first()
+     * @phpstan-assert-if-true TValue $this->last()
      *
      * @phpstan-assert-if-false null $this->first()
+     * @phpstan-assert-if-false null $this->last()
      *
      * @return bool
      */


### PR DESCRIPTION
#51998 and #52184 added PHPStan assertions for `Collection::first()` in `Collection::isEmpty()` and `Collection::isNotEmpty()`

This PR adds the same for `Collection::last()` as it would be very useful

```php
/**
 * @var Collection<int, string>
 */
$collection = new Collection(['laravel']);

if ($collection->isNotEmpty()) {
    // before this PR:
    \PHPStan\dumpType($collection->last()); // Dumped type: string|null
    
    // after this PR:
    \PHPStan\dumpType($collection->last()); // Dumped type: string
}
```
