### PR TITLE
[11.x] PHPDoc Improvements

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -478,8 +478,8 @@ class Kernel implements KernelContract
     /**
      * Add the given middleware to the middleware priority list relative to other middleware.
      *
-     * @param  string  $middleware
      * @param  string|array  $existing
+     * @param  string  $middleware
      * @param  bool  $after
      * @return $this
      */


### PR DESCRIPTION
Fixed the order of the params in the PHPDoc, they seemed to be out of order