### PR TITLE
[11.x] Fix `getDefaultUserProvider` docblock

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -48,11 +48,11 @@ trait CreatesUserProviders
      * @param  string|null  $provider
      * @return array|null
      */
-    protected function getProviderConfiguration($provider)
+    protected function getProviderConfiguration($provider = null)
     {
-        if ($provider = $provider ?: $this->getDefaultUserProvider()) {
-            return $this->app['config']['auth.providers.'.$provider];
-        }
+        $provider ??= $this->getDefaultUserProvider();
+
+        return $this->app['config']['auth.providers.'.$provider];
     }
 
     /**
@@ -86,6 +86,6 @@ trait CreatesUserProviders
      */
     public function getDefaultUserProvider()
     {
-        return $this->app['config']['auth.defaults.provider'];
+        return $this->app['config']['auth.defaults.provider'] ?? 'users';
     }
 }

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -50,9 +50,9 @@ trait CreatesUserProviders
      */
     protected function getProviderConfiguration($provider = null)
     {
-        $provider ??= $this->getDefaultUserProvider();
-
-        return $this->app['config']['auth.providers.'.$provider];
+        if ($provider ??= $this->getDefaultUserProvider()) {
+            return $this->app['config']['auth.providers.'.$provider];
+        }
     }
 
     /**
@@ -82,10 +82,10 @@ trait CreatesUserProviders
     /**
      * Get the default user provider name.
      *
-     * @return string
+     * @return string|null
      */
     public function getDefaultUserProvider()
     {
-        return $this->app['config']['auth.defaults.provider'] ?? 'users';
+        return $this->app['config']['auth.defaults.provider'];
     }
 }

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -117,10 +117,12 @@ trait GuardHelpers
      * Set the user provider used by the guard.
      *
      * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
-     * @return void
+     * @return $this
      */
     public function setProvider(UserProvider $provider)
     {
         $this->provider = $provider;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Currently, creating user provider using `createUserProvider` without explicitly passing its name will always return `null` unless `auth.defaults.provider` config entry is defined (which is [not defined out-of-the-box](https://github.com/laravel/laravel/blob/b378ce946a05b5ab80776c3b5e40fa84751084bd/config/auth.php#L16-L19) btw).

The reason is, `getDefaultUserProvider` method - contrary to its name and typehint - returns `null` when said config entry is missing.

This PR changes that to fall back to default [`'users'` provider](https://github.com/laravel/laravel/blob/b378ce946a05b5ab80776c3b5e40fa84751084bd/config/auth.php#L63) instead of `null`.