### PR TITLE
Add created_at Datetime Column To Migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -117,7 +117,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function log($file, $batch)
     {
-        $record = ['migration' => $file, 'batch' => $batch];
+        $record = ['migration' => $file, 'batch' => $batch, 'executed_at' => now()->format('Y-m-d H:i:s')];
 
         $this->table()->insert($record);
     }
@@ -169,6 +169,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
             $table->increments('id');
             $table->string('migration');
             $table->integer('batch');
+            $table->dateTime('executed_at');
         });
     }
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -169,7 +169,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
             $table->increments('id');
             $table->string('migration');
             $table->integer('batch');
-            $table->dateTime('executed_at');
+//            $table->dateTime('executed_at');
         });
     }
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -117,7 +117,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function log($file, $batch)
     {
-        $record = ['migration' => $file, 'batch' => $batch];
+        $record = ['migration' => $file, 'batch' => $batch, 'created_at' => now()];
 
         $this->table()->insert($record);
     }
@@ -169,7 +169,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
             $table->increments('id');
             $table->string('migration');
             $table->integer('batch');
-//            $table->dateTime('executed_at');
+            $table->dateTime('created_at');
         });
     }
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -117,7 +117,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function log($file, $batch)
     {
-        $record = ['migration' => $file, 'batch' => $batch, 'executed_at' => now()];
+        $record = ['migration' => $file, 'batch' => $batch];
 
         $this->table()->insert($record);
     }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -117,7 +117,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function log($file, $batch)
     {
-        $record = ['migration' => $file, 'batch' => $batch, 'executed_at' => now()->format('Y-m-d H:i:s')];
+        $record = ['migration' => $file, 'batch' => $batch, 'executed_at' => now()];
 
         $this->table()->insert($record);
     }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -54,14 +54,14 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testLogMethodInsertsRecordIntoMigrationTable()
     {
-//        Carbon::setTestNow(now());
+        Carbon::setTestNow(now());
 
         $repo = $this->getRepository();
         $query = m::mock(stdClass::class);
         $connectionMock = m::mock(Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
+        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1, 'created_at' => now()]);
         $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $repo->log('bar', 1);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -53,12 +54,14 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testLogMethodInsertsRecordIntoMigrationTable()
     {
+        Carbon::setTestNow(now());
+
         $repo = $this->getRepository();
         $query = m::mock(stdClass::class);
         $connectionMock = m::mock(Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
+        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1, 'executed_at' => now()]);
         $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $repo->log('bar', 1);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -54,7 +54,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testLogMethodInsertsRecordIntoMigrationTable()
     {
-        Carbon::setTestNow(now());
+//        Carbon::setTestNow(now());
 
         $repo = $this->getRepository();
         $query = m::mock(stdClass::class);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -61,7 +61,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $connectionMock = m::mock(Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1, 'executed_at' => now()]);
+        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
         $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $repo->log('bar', 1);


### PR DESCRIPTION
Add executed_at date time column to the migrations table and fill it with the current time when the migration is run.

This sort of feature will be extremely helpful for larger teams to know when a particular migration ran. Having the date time will help with debugging if there is a bad migration. The time can then be used to correlate other things happening throughout the app or figure out who ran the migration.

Having access to more information without the user having to do anything seems like a win-win. Upgrading to Laravel 12 means they would have to add the column, but that is a simple migration and it's been done before when the ID column was added.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
