### PR TITLE
[11.x] add availability for where method to filter by associate array in the collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -739,9 +739,9 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items by the given associative array
+     * Filter items by the given associative array.
      *
-     * @param  array $array
+     * @param  array  $array
      * @return static
      */
     public function whereAssocArray($array)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -585,13 +585,17 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair.
      *
-     * @param  callable|string  $key
+     * @param  callable|array|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return static
      */
     public function where($key, $operator = null, $value = null)
     {
+        if (Arr::accessible($key) && Arr::isAssoc($key)) {
+            return $this->whereAssocArray($key);
+        }
+
         return $this->filter($this->operatorForWhere(...func_get_args()));
     }
 
@@ -732,6 +736,23 @@ trait EnumeratesValues
 
             return $value instanceof $type;
         });
+    }
+
+    /**
+     * Filter items by the given associative array
+     *
+     * @param  array $array
+     * @return static
+     */
+    public function whereAssocArray($array)
+    {
+        $result = $this;
+
+        foreach ($array as $key => $value) {
+            $result = $result->where($key, '=', $value);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -716,6 +716,26 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get options data to use in select box.
+     *
+     * @param  string  $label
+     * @param  string  $value
+     * @param  string  $labelKey
+     * @param  string  $valueKey
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getOptions($label = 'name', $value = 'id', $labelKey = 'label', $valueKey = 'value')
+    {
+        return $this->applyScopes()
+        ->pluck($label, $value)
+        ->map(fn($labelItem, $valueItem) => [
+            $labelKey => $labelItem,
+            $valueKey => $valueItem,
+        ])
+        ->values();
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -728,7 +728,7 @@ class Builder implements BuilderContract
     {
         return $this->applyScopes()
         ->pluck($label, $value)
-        ->map(fn($labelItem, $valueItem) => [
+        ->map(fn ($labelItem, $valueItem) => [
             $labelKey => $labelItem,
             $valueKey => $valueItem,
         ])


### PR DESCRIPTION
### **Add Availability for the where Method to Filter by Associative Array in Laravel Collections**
This contribution enhances the `where` method in Laravel Collections to support filtering based on an associative array of conditions. Previously, the `where` method only allowed filtering by a single key-value pair. With this improvement, developers can now provide multiple key-value pairs in an array, and the collection will be filtered by matching all of these conditions.
Key Features:
- **Multiple Conditions:** Allows passing an associative array to the `where` method for filtering items that match all specified key-value pairs.
- **Enhanced Flexibility:** Makes it easier to filter collections based on more complex criteria without chaining multiple `where` conditions.
- **Seamless Integration:** The new feature integrates directly with the existing `where` method, maintaining the simplicity and readability of Laravel's expressive syntax.
```
$collection = collect([
    ['name' => 'John', 'age' => 28, 'status' => 'active'],
    ['name' => 'Jane', 'age' => 34, 'status' => 'inactive'],
    ['name' => 'Doe', 'age' => 22, 'status' => 'active'],
]);

$filtered = $collection->where([
    'age' => 28,
    'status' => 'active'
]);

// The result will contain only the items where both 'age' => 28 and 'status' => 'active'
```