### PR TITLE
[11.x] Fix HasManyThrough::one()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
@@ -24,7 +25,7 @@ class HasManyThrough extends HasOneOrManyThrough
     public function one()
     {
         return HasOneThrough::noConstraints(fn () => new HasOneThrough(
-            $this->getQuery(),
+            tap($this->getQuery(), fn (Builder $query) => $query->getQuery()->joins = []),
             $this->farParent,
             $this->throughParent,
             $this->getFirstKeyName(),

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\EloquentHasManyThroughTest;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -381,6 +382,18 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $newArticle->title .= ' v2';
         $newArticle->save();
     }
+
+    public function testOne(): void
+    {
+        $team = Team::create();
+
+        $user = User::create(['team_id' => $team->id, 'name' => Str::random()]);
+
+        Article::create(['user_id' => $user->id, 'title' => Str::random(), 'created_at' => now()->subDay()]);
+        $latestArticle = Article::create(['user_id' => $user->id, 'title' => Str::random(), 'created_at' => now()]);
+
+        $this->assertEquals($latestArticle->id, $team->latestArticle->id);
+    }
 }
 
 class User extends Model
@@ -473,6 +486,11 @@ class Team extends Model
     public function articles()
     {
         return $this->hasManyThrough(Article::class, User::class);
+    }
+
+    public function latestArticle(): HasOneThrough
+    {
+        return $this->articles()->one()->latest();
     }
 }
 


### PR DESCRIPTION
`HasManyThrough::one()` doesn't actually work because it duplicates the `JOIN` clause and breaks the query:

```sql
select "articles".*, "users"."team_id" as "laravel_through_key"
from "articles"
         inner join "users" on "users"."id" = "articles"."user_id"
         inner join "users" on "users"."id" = "articles"."user_id"
where "users"."team_id" = 1
order by "created_at" desc
limit 1
```

We need to remove it before `HasOneThrough` adds it again.