### PR TITLE
[11.x] Add CollectedBy attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class CollectedBy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string  $collectionClass
+     * @return void
+     */
+    public function __construct(public string $collectionClass)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
@@ -10,7 +10,7 @@ class CollectedBy
     /**
      * Create a new attribute instance.
      *
-     * @param  class-string  $collectionClass
+     * @param  class-string<\Illuminate\Database\Eloquent\Collection<*, *>>  $collectionClass
      * @return void
      */
     public function __construct(public string $collectionClass)

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -30,13 +30,15 @@ trait HasCollection
      */
     public function resolveCollectionAttribute()
     {
-        $reflectionClass = new ReflectionClass(static::class);
-        $attributes = $reflectionClass->getAttributes(CollectedBy::class);
+        return once(function () {
+            $reflectionClass = new ReflectionClass(static::class);
+            $attributes = $reflectionClass->getAttributes(CollectedBy::class);
 
-        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
-            return;
-        }
+            if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
+                return;
+            }
 
-        return $attributes[0]->getArguments()[0];
+            return $attributes[0]->getArguments()[0];
+        });
     }
 }

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -11,6 +11,8 @@ use ReflectionClass;
 trait HasCollection
 {
     /**
+     * The resolved collection class names by model.
+     *
      * @var array<class-string<static>, class-string<TCollection>>
      */
     protected static array $resolvedCollectionClasses = [];
@@ -23,7 +25,7 @@ trait HasCollection
      */
     public function newCollection(array $models = [])
     {
-        static::$resolvedCollectionClasses[static::class] ??= $this->resolveCollectionAttribute() ?? static::$collectionClass;
+        static::$resolvedCollectionClasses[static::class] ??= ($this->resolveCollectionFromAttribute() ?? static::$collectionClass);
 
         return new static::$resolvedCollectionClasses[static::class]($models);
     }
@@ -33,9 +35,10 @@ trait HasCollection
      *
      * @return class-string<TCollection>|null
      */
-    public function resolveCollectionAttribute()
+    public function resolveCollectionFromAttribute()
     {
         $reflectionClass = new ReflectionClass(static::class);
+
         $attributes = $reflectionClass->getAttributes(CollectedBy::class);
 
         if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -11,6 +11,11 @@ use ReflectionClass;
 trait HasCollection
 {
     /**
+     * @var array<class-string<static>, class-string<TCollection>>
+     */
+    protected static array $resolvedCollectionClasses = [];
+
+    /**
      * Create a new Eloquent Collection instance.
      *
      * @param  array<array-key, \Illuminate\Database\Eloquent\Model>  $models
@@ -18,9 +23,9 @@ trait HasCollection
      */
     public function newCollection(array $models = [])
     {
-        $collectionClass = $this->resolveCollectionAttribute() ?? static::$collectionClass;
+        static::$resolvedCollectionClasses[static::class] ??= $this->resolveCollectionAttribute() ?? static::$collectionClass;
 
-        return new $collectionClass($models);
+        return new static::$resolvedCollectionClasses[static::class]($models);
     }
 
     /**
@@ -30,15 +35,13 @@ trait HasCollection
      */
     public function resolveCollectionAttribute()
     {
-        return once(function () {
-            $reflectionClass = new ReflectionClass(static::class);
-            $attributes = $reflectionClass->getAttributes(CollectedBy::class);
+        $reflectionClass = new ReflectionClass(static::class);
+        $attributes = $reflectionClass->getAttributes(CollectedBy::class);
 
-            if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
-                return;
-            }
+        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
+            return;
+        }
 
-            return $attributes[0]->getArguments()[0];
-        });
+        return $attributes[0]->getArguments()[0];
     }
 }

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Database\Eloquent\Attributes\CollectedBy;
+use ReflectionClass;
+
 /**
  * @template TCollection of \Illuminate\Database\Eloquent\Collection
  */
@@ -15,6 +18,21 @@ trait HasCollection
      */
     public function newCollection(array $models = [])
     {
-        return new static::$collectionClass($models);
+        $collectionClass = $this->resolveCollectionAttribute() ?? static::$collectionClass;
+
+        return new $collectionClass($models);
+    }
+
+    /**
+     * Resolve the collection class name from the CollectedBy attribute.
+     *
+     * @return ?class-string<TCollection>
+     */
+    public function resolveCollectionAttribute()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+        $attribute = $reflectionClass->getAttributes(CollectedBy::class)[0];
+
+        return $attribute ? $attribute->getArguments()[0] : null;
     }
 }

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -31,8 +31,12 @@ trait HasCollection
     public function resolveCollectionAttribute()
     {
         $reflectionClass = new ReflectionClass(static::class);
-        $attribute = $reflectionClass->getAttributes(CollectedBy::class)[0];
+        $attributes = $reflectionClass->getAttributes(CollectedBy::class);
 
-        return $attribute ? $attribute->getArguments()[0] : null;
+        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
+            return;
+        }
+
+        return $attributes[0]->getArguments()[0];
     }
 }

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -26,7 +26,7 @@ trait HasCollection
     /**
      * Resolve the collection class name from the CollectedBy attribute.
      *
-     * @return ?class-string<TCollection>
+     * @return class-string<TCollection>|null
      */
     public function resolveCollectionAttribute()
     {

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -62,6 +62,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $builder = m::mock(Builder::class);
         $related = m::mock(Model::class);
         $related->shouldReceive('newCollection')->passthru();
+        $related->shouldReceive('resolveCollectionAttribute')->passthru();
         $builder->shouldReceive('getModel')->andReturn($related);
         $related->shouldReceive('qualifyColumn');
         $builder->shouldReceive('join', 'where');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -62,7 +62,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $builder = m::mock(Builder::class);
         $related = m::mock(Model::class);
         $related->shouldReceive('newCollection')->passthru();
-        $related->shouldReceive('resolveCollectionAttribute')->passthru();
+        $related->shouldReceive('resolveCollectionFromAttribute')->passthru();
         $builder->shouldReceive('getModel')->andReturn($related);
         $related->shouldReceive('qualifyColumn');
         $builder->shouldReceive('join', 'where');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3939,8 +3939,6 @@ class EloquentModelWithMutators extends Model
 }
 
 #[CollectedBy(CustomEloquentCollection::class)]
-class EloquentModelWithCollectedByAttribute extends Model
-{
-}
+class EloquentModelWithCollectedByAttribute extends Model {}
 
 class CustomEloquentCollection extends Collection {}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3939,6 +3939,10 @@ class EloquentModelWithMutators extends Model
 }
 
 #[CollectedBy(CustomEloquentCollection::class)]
-class EloquentModelWithCollectedByAttribute extends Model {}
+class EloquentModelWithCollectedByAttribute extends Model
+{
+}
 
-class CustomEloquentCollection extends Collection {}
+class CustomEloquentCollection extends Collection
+{
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
@@ -3169,6 +3170,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('123 Main Street', $model->address_line_one);
         $this->assertSame('Anytown', $model->address_line_two);
     }
+
+    public function testCollectedByAttribute()
+    {
+        $model = new EloquentModelWithCollectedByAttribute;
+        $collection = $model->newCollection([$model]);
+
+        $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
+    }
 }
 
 class EloquentTestObserverStub
@@ -3928,3 +3937,10 @@ class EloquentModelWithMutators extends Model
         $this->attributes['address_line_two'] = $addressLineTwo;
     }
 }
+
+#[CollectedBy(CustomEloquentCollection::class)]
+class EloquentModelWithCollectedByAttribute extends Model
+{
+}
+
+class CustomEloquentCollection extends Collection {}

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Types\Model;
 
+use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\HasCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -9,7 +10,7 @@ use User;
 
 use function PHPStan\Testing\assertType;
 
-function test(User $user, Post $post, Comment $comment): void
+function test(User $user, Post $post, Comment $comment, Article $article): void
 {
     assertType('UserFactory', User::factory(function ($attributes, $model) {
         assertType('array<string, mixed>', $attributes);
@@ -35,6 +36,7 @@ function test(User $user, Post $post, Comment $comment): void
     assertType('Illuminate\Database\Eloquent\Collection<(int|string), User>', $user->newCollection([new User()]));
     assertType('Illuminate\Types\Model\Posts<(int|string), Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
     assertType('Illuminate\Types\Model\Comments', $comment->newCollection([new Comment()]));
+    assertType('Illuminate\Types\Model\Articles', $article->newCollection([new Article()]));
 
     assertType('bool', $user->restore());
     assertType('User', $user->restoreOrCreate());
@@ -72,5 +74,21 @@ final class Comment extends Model
 
 /** @extends Collection<array-key, Comment> */
 final class Comments extends Collection
+{
+}
+
+#[CollectedBy(Articles::class)]
+class Article extends Model
+{
+    /** @use HasCollection<Articles<array-key, static>> */
+    use HasCollection;
+}
+
+/**
+ * @template TKey of array-key
+ * @template TModel of Article
+ *
+ * @extends Collection<TKey, TModel> */
+class Articles extends Collection
 {
 }

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -35,8 +35,8 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
 
     assertType('Illuminate\Database\Eloquent\Collection<(int|string), User>', $user->newCollection([new User()]));
     assertType('Illuminate\Types\Model\Posts<(int|string), Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
+    assertType('Illuminate\Types\Model\Articles<(int|string), Illuminate\Types\Model\Article>', $article->newCollection([new Article()]));
     assertType('Illuminate\Types\Model\Comments', $comment->newCollection([new Comment()]));
-    assertType('Illuminate\Types\Model\Articles', $article->newCollection([new Article()]));
 
     assertType('bool', $user->restore());
     assertType('User', $user->restoreOrCreate());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request adds a new `CollectedBy` attribute for specifying a custom Collection class for a model.

With this attribute added, one would only have to add the attribute rather than override the `newCollection` method on the Model class (or taking the undocumented route and setting the `$collectionClass` static property).

```php
#[CollectedBy(PostCollection::class)]
class Post
{
    // ...
}
```

This also brings the approach closer in line with the new `ObservedBy` and `ScopedBy` attributes.