### PR TITLE
[11.x] Add factory() Method to Eloquent HasOneOrMany Relationships for Simplified Model Creation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -206,8 +206,8 @@ abstract class HasOneOrMany extends Relation
      * @return Factory<TRelatedModel>
      * @throws RuntimeException
      */
-    public function factory($count = null, array $state = []): Factory {
-
+    public function factory($count = null, array $state = [])
+    {
         if (! method_exists($this->related, 'factory')) {
             throw new RuntimeException('Related model does not support a factory');
         }

--- a/tests/Database/DatabaseEloquentRelationFactoryTest.php
+++ b/tests/Database/DatabaseEloquentRelationFactoryTest.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Carbon\Carbon;
+use Faker\Generator;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentRelationFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+        $container->singleton(Generator::class, function ($app, $parameters) {
+            return \Faker\Factory::create('en_US');
+        });
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('options')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('profiles', function ($table) {
+            $table->increments('id');
+            $table->foreignId('user_id');
+            $table->string('bio')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('website')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('posts', function ($table) {
+            $table->increments('id');
+            $table->foreignId('user_id');
+            $table->string('title');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('comments', function ($table) {
+            $table->increments('id');
+            $table->foreignId('commentable_id');
+            $table->string('commentable_type');
+            $table->foreignId('user_id');
+            $table->string('body');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('roles', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('role_user', function ($table) {
+            $table->foreignId('role_id');
+            $table->foreignId('user_id');
+            $table->string('admin')->default('N');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        m::close();
+
+        $this->schema()->drop('users');
+
+        Container::setInstance(null);
+    }
+
+    public function test_the_factory_method_can_be_used_from_a_has_many_relation()
+    {
+        /** @var RelationFactoryTestUser $user */
+        $user = RelationFactoryTestUserFactory::new()->create();
+
+        $post = $user->posts()->factory()->create([
+            'title' => 'test',
+        ]);
+
+        $this->assertInstanceOf(RelationFactoryTestPost::class, $post);
+    }
+
+    public function test_the_factory_method_can_be_used_from_a_has_one_relation()
+    {
+        /** @var RelationFactoryTestUser $user */
+        $user = RelationFactoryTestUserFactory::new()->create();
+
+        $profile = $user->profile()->factory()->create([
+            'bio' => 'Software developer and tech enthusiast.',
+            'avatar' => 'https://www.nyan.cat/cats/original.gif',
+        ]);
+
+        $this->assertInstanceOf(RelationFactoryTestProfile::class, $profile);
+        $this->assertEquals('https://www.nyan.cat/cats/original.gif', $profile->avatar);
+        $this->assertEquals('Software developer and tech enthusiast.', $profile->bio);
+    }
+
+    public function test_the_factory_method_can_be_used_from_a_polymorphic_relation()
+    {
+        /** @var RelationFactoryTestPost $post */
+        $post = RelationFactoryTestPostFactory::new()->create();
+
+        $comment = $post->comments()->factory()->create();
+
+        $this->assertInstanceOf(RelationFactoryTestComment::class, $comment);
+    }
+
+    public function test_multiple_can_be_created_by_using_the_count_parameter_of_the_factory_method()
+    {
+        /** @var RelationFactoryTestUser $user */
+        $user = RelationFactoryTestUserFactory::new()->create();
+
+        $posts = $user->posts()->factory(2)->create();
+
+        $this->assertInstanceOf(Collection::class, $posts);
+        $this->assertCount(2, $posts);
+        $this->assertInstanceOf(RelationFactoryTestPost::class, $posts->first());
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class RelationFactoryTestUserFactory extends Factory
+{
+    protected $model = RelationFactoryTestUser::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'options' => null,
+        ];
+    }
+}
+
+class RelationFactoryTestUser extends Eloquent
+{
+    use HasFactory;
+
+    protected $table = 'users';
+
+    public function posts()
+    {
+        return $this->hasMany(RelationFactoryTestPost::class, 'user_id');
+    }
+
+    public function profile()
+    {
+        return $this->hasOne(RelationFactoryTestProfile::class);
+    }
+
+    public function roles()
+    {
+        return $this->belongsToMany(RelationFactoryTestRole::class, 'role_user', 'user_id', 'role_id')->withPivot('admin');
+    }
+}
+
+class RelationFactoryTestPostFactory extends Factory
+{
+    protected $model = RelationFactoryTestPost::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => RelationFactoryTestUserFactory::new(),
+            'title' => $this->faker->name(),
+        ];
+    }
+}
+
+class RelationFactoryTestProfileFactory extends Factory
+{
+    protected $model = RelationFactoryTestProfile::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => RelationFactoryTestUserFactory::new(),
+            'bio' => $this->faker->text(),
+            'website' => 'https://'.$this->faker->domainName(),
+            'avatar' => $this->faker->imageUrl(),
+        ];
+    }
+}
+
+class RelationFactoryTestProfile extends Eloquent
+{
+    use HasFactory;
+
+    protected $table = 'profiles';
+
+    protected static function newFactory()
+    {
+        return new RelationFactoryTestProfileFactory();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(RelationFactoryTestUser::class, 'user_id');
+    }
+}
+
+class RelationFactoryTestPost extends Eloquent
+{
+    use SoftDeletes, HasFactory;
+
+    protected $table = 'posts';
+
+    protected static function newFactory()
+    {
+        return new RelationFactoryTestPostFactory();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(RelationFactoryTestUser::class, 'user_id');
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(RelationFactoryTestUser::class, 'user_id');
+    }
+
+    public function comments()
+    {
+        return $this->morphMany(RelationFactoryTestComment::class, 'commentable');
+    }
+}
+
+class RelationFactoryTestCommentFactory extends Factory
+{
+    protected $model = RelationFactoryTestComment::class;
+
+    public function definition()
+    {
+        return [
+            'commentable_id' => RelationFactoryTestPostFactory::new(),
+            'commentable_type' => RelationFactoryTestPost::class,
+            'user_id' => fn () => RelationFactoryTestUserFactory::new(),
+            'body' => $this->faker->name(),
+        ];
+    }
+
+    public function trashed()
+    {
+        return $this->state([
+            'deleted_at' => Carbon::now()->subWeek(),
+        ]);
+    }
+}
+
+class RelationFactoryTestComment extends Eloquent
+{
+    use SoftDeletes, HasFactory;
+
+    protected $table = 'comments';
+
+    protected static function newFactory()
+    {
+        return new RelationFactoryTestCommentFactory();
+    }
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class RelationFactoryTestRoleFactory extends Factory
+{
+    protected $model = FactoryTestRole::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+}
+
+class RelationFactoryTestRole extends Eloquent
+{
+    use HasFactory;
+
+    protected $table = 'roles';
+
+    protected $touches = ['users'];
+
+    protected static function newFactory()
+    {
+        return new RelationFactoryTestRoleFactory();
+    }
+
+    public function users()
+    {
+        return $this->belongsToMany(FactoryTestUser::class, 'role_user', 'role_id', 'user_id')->withPivot('admin');
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces a new `factory()` method to the `HasOneOrMany` relationship classes in Eloquent. The new method enables developers to create related models directly from the relationship itself, streamlining the factory usage and improving the readability of the code.

Currently, when creating related models with factories, developers must either:

Call the factory of the related model and use `raw()` to handle foreign keys manually, or
Use `has()` methods on factories, which can sometimes obscure the relationship context and result in more complex code for simple tasks.
With the new `factory()` method on the relationship, the API becomes more intuitive and better readable.

### Current Verbose Usage Example

```php
$parent->relation()->create(RelatedModel::factory()->raw([
    'some_field' => 'value',
]));
```
### New Fluent Usage Example with factory() Method
```php
$parent->relation()->factory()->create([
    'some_field' => 'value',
]);
```

### Benefits:

1. **Reduced Verbosity**: Developers no longer need to manually handle the raw factory output and foreign key assignments. This simplifies the creation process, especially when working with relationships, and reduces potential errors.

2. **Improved Readability**: The new syntax not only cuts down on code, but it also makes it easier to understand what the code is doing. By calling `factory()` directly on the relationship, the intent of creating a related model is explicit and clear.

3. **Clarity Over Existing has() Syntax**: In cases where developers are using the existing `has()` method on the parent factory, the relationship between the models can become harder to read and understand, particularly when more complex logic is involved. Here’s an example of the current factory usage with the `has()` method:

```php
$user = User::factory()
            ->has(
                Post::factory()
                    ->count(3)
                    ->state(function (array $attributes, User $user) {
                        return ['user_type' => $user->type];
                    })
            )
            ->create();
```
This approach works, but:

- The relationship is implicitly buried within the factory logic, making it harder to discern at first glance.
Custom logic (such as factory states) adds another layer of complexity.
- For simple cases, it introduces a level of abstraction that is unnecessary for developers familiar with the relationship method itself.
- With the new `factory()` method, the relationship is explicit and separated from the factory's internals, improving overall readability:
```php
$user = User::factory()->create();

$posts = $user->posts()->factory(3)->state([
    'user_type' => $user->type,
])->create();
```

This approach:

Makes it very clear that you're working with the `posts()` relationship on the User model.
Allows for easy comprehension of the relationship context and customization, separating concerns cleanly.


4. **Fluent API Consistency**: The new method aligns with Laravel's overall philosophy of providing a clean, fluent, and developer-friendly API. The method feels intuitive for developers already familiar with Laravel’s factory system and simplifies working with model relationships.

5. **Automatic Foreign Key Handling**: The factory() method automatically handles setting the foreign key, meaning developers no longer need to worry about manually associating the parent and related models, reducing potential mistakes.

6. **Consistency Across Relationships**: Whether developers are working with HasOne or HasMany relationships, the factory() method provides a uniform way of creating related models, further simplifying Eloquent model handling.

### Example Scenarios:

- Single Related Model Creation:

```php
$parent->relation()->factory()->create();
```

- Multiple Related Models:

```php
$parent->relation()->factory(3)->create();
```
- Applying Factory States:
```php
$parent->relation()->factory()->state(['field' => 'value'])->create();
```

### Error Handling:
The method checks whether the related model supports factories. If a related model does not have a factory, a RuntimeException is thrown, preventing silent failures and providing a clear error message to the developer.