### PR TITLE
Allow method specific middleware for Resources

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -47,10 +47,10 @@ class PendingResourceRegistration
     /**
      * Create a new pending resource registration instance.
      *
-     * @param  \Illuminate\Routing\ResourceRegistrar  $registrar
-     * @param  string  $name
-     * @param  string  $controller
-     * @param  array  $options
+     * @param \Illuminate\Routing\ResourceRegistrar $registrar
+     * @param string $name
+     * @param string $controller
+     * @param array $options
      * @return void
      */
     public function __construct(ResourceRegistrar $registrar, $name, $controller, array $options)
@@ -64,7 +64,7 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should apply to.
      *
-     * @param  array|string|mixed  $methods
+     * @param array|string|mixed $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function only($methods)
@@ -77,7 +77,7 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should exclude.
      *
-     * @param  array|string|mixed  $methods
+     * @param array|string|mixed $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function except($methods)
@@ -90,7 +90,7 @@ class PendingResourceRegistration
     /**
      * Set the route names for controller actions.
      *
-     * @param  array|string  $names
+     * @param array|string $names
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function names($names)
@@ -103,8 +103,8 @@ class PendingResourceRegistration
     /**
      * Set the route name for a controller action.
      *
-     * @param  string  $method
-     * @param  string  $name
+     * @param string $method
+     * @param string $name
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function name($method, $name)
@@ -117,7 +117,7 @@ class PendingResourceRegistration
     /**
      * Override the route parameter names.
      *
-     * @param  array|string  $parameters
+     * @param array|string $parameters
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function parameters($parameters)
@@ -130,8 +130,8 @@ class PendingResourceRegistration
     /**
      * Override a route parameter's name.
      *
-     * @param  string  $previous
-     * @param  string  $new
+     * @param string $previous
+     * @param string $new
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function parameter($previous, $new)
@@ -144,18 +144,27 @@ class PendingResourceRegistration
     /**
      * Add middleware to the resource routes.
      *
-     * @param  mixed  $middleware
+     * @param mixed $middleware
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function middleware($middleware)
     {
         $middleware = Arr::wrap($middleware);
+        $method_middleware = [];
+
+        foreach ($middleware as $key => $value) {
+            if (is_string($key)) {
+                $method_middleware[$key] = Arr::wrap($value);
+                unset($middleware[$key]);
+            }
+        }
 
         foreach ($middleware as $key => $value) {
             $middleware[$key] = (string) $value;
         }
 
         $this->options['middleware'] = $middleware;
+        $this->options['method_middleware'] = $method_middleware;
 
         return $this;
     }
@@ -163,13 +172,13 @@ class PendingResourceRegistration
     /**
      * Specify middleware that should be removed from the resource routes.
      *
-     * @param  array|string  $middleware
+     * @param array|string $middleware
      * @return $this|array
      */
     public function withoutMiddleware($middleware)
     {
         $this->options['excluded_middleware'] = array_merge(
-            (array) ($this->options['excluded_middleware'] ?? []), Arr::wrap($middleware)
+            (array)($this->options['excluded_middleware'] ?? []), Arr::wrap($middleware)
         );
 
         return $this;
@@ -178,7 +187,7 @@ class PendingResourceRegistration
     /**
      * Add "where" constraints to the resource routes.
      *
-     * @param  mixed  $wheres
+     * @param mixed $wheres
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function where($wheres)
@@ -191,7 +200,7 @@ class PendingResourceRegistration
     /**
      * Indicate that the resource routes should have "shallow" nesting.
      *
-     * @param  bool  $shallow
+     * @param bool $shallow
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function shallow($shallow = true)
@@ -204,7 +213,7 @@ class PendingResourceRegistration
     /**
      * Define the callable that should be invoked on a missing model exception.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return $this
      */
     public function missing($callback)
@@ -217,7 +226,7 @@ class PendingResourceRegistration
     /**
      * Indicate that the resource routes should be scoped using the given binding fields.
      *
-     * @param  array  $fields
+     * @param array $fields
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function scoped(array $fields = [])
@@ -230,7 +239,7 @@ class PendingResourceRegistration
     /**
      * Define which routes should allow "trashed" models to be retrieved when resolving implicit model bindings.
      *
-     * @param  array  $methods
+     * @param array $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function withTrashed(array $methods = [])
@@ -261,7 +270,7 @@ class PendingResourceRegistration
      */
     public function __destruct()
     {
-        if (! $this->registered) {
+        if (!$this->registered) {
             $this->register();
         }
     }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -617,6 +617,10 @@ class ResourceRegistrar
 
         if (isset($options['middleware'])) {
             $action['middleware'] = $options['middleware'];
+
+            if (isset($options['method_middleware'][$method])) {
+                $action['middleware'] = array_merge($action['middleware'], $options['method_middleware'][$method]);
+            }
         }
 
         if (isset($options['excluded_middleware'])) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -45,7 +45,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use UnexpectedValueException;
 
-include_once __DIR__.'/Enums.php';
+include_once __DIR__ . '/Enums.php';
 
 class RoutingRouteTest extends TestCase
 {
@@ -75,7 +75,7 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
         $router->get('foo/{age}', ['domain' => 'api.{name}.bar', function ($name, $age) {
-            return $name.$age;
+            return $name . $age;
         }]);
         $this->assertSame('taylor25', $router->dispatch(Request::create('http://api.taylor.bar/foo/25', 'GET'))->getContent());
 
@@ -97,19 +97,19 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
         $router->get('foo/{bar}/{baz?}', function ($name, $age = 25) {
-            return $name.$age;
+            return $name . $age;
         });
         $this->assertSame('taylor25', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/{name}/boom/{age?}/{location?}', function ($name, $age = 25, $location = 'AR') {
-            return $name.$age.$location;
+            return $name . $age . $location;
         });
         $this->assertSame('taylor30AR', $router->dispatch(Request::create('foo/taylor/boom/30', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('{bar}/{baz?}', function ($name, $age = 25) {
-            return $name.$age;
+            return $name . $age;
         });
         $this->assertSame('taylor25', $router->dispatch(Request::create('taylor', 'GET'))->getContent());
 
@@ -122,7 +122,7 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
         $router->get('{foo?}/{baz?}', ['as' => 'foo', function ($name = 'taylor', $age = 25) {
-            return $name.$age;
+            return $name . $age;
         }]);
         $this->assertSame('taylor25', $router->dispatch(Request::create('/', 'GET'))->getContent());
         $this->assertSame('fred25', $router->dispatch(Request::create('fred', 'GET'))->getContent());
@@ -251,7 +251,7 @@ class RoutingRouteTest extends TestCase
         $middleware = function ($request, $next) use ($response) {
             $this->assertSame($response, $next($request));
 
-            return new Response($response->getContent().' caught');
+            return new Response($response->getContent() . ' caught');
         };
         $router->get('foo/bar', ['middleware' => $middleware, function () use ($response) {
             throw new HttpResponseException($response);
@@ -265,7 +265,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->get('foo/bar', [
-            'uses' => RouteTestClosureMiddlewareController::class.'@index',
+            'uses' => RouteTestClosureMiddlewareController::class . '@index',
             'middleware' => ['foo', 'bar', 'baz'],
         ]);
         $router->aliasMiddleware('foo', function ($request, $next) {
@@ -299,7 +299,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->get('foo/bar', [
-            'uses' => RouteTestClosureMiddlewareController::class.'@index',
+            'uses' => RouteTestClosureMiddlewareController::class . '@index',
             'middleware' => 'foo',
         ]);
         $router->aliasMiddleware('foo', function ($request, $next) {
@@ -340,15 +340,15 @@ class RoutingRouteTest extends TestCase
     public function testFluentRoutingWithControllerAction()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
+        $router->get('foo/bar')->uses(RouteTestControllerStub::class . '@index');
         $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->group(['namespace' => 'App'], function ($router) {
-            $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
+            $router->get('foo/bar')->uses(RouteTestControllerStub::class . '@index');
         });
         $action = $router->getRoutes()->getRoutes()[0]->getAction();
-        $this->assertSame('App\\'.RouteTestControllerStub::class.'@index', $action['controller']);
+        $this->assertSame('App\\' . RouteTestControllerStub::class . '@index', $action['controller']);
     }
 
     public function testMiddlewareGroups()
@@ -416,7 +416,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $controllerRoute = $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
+        $controllerRoute = $router->get('foo/bar')->uses(RouteTestControllerStub::class . '@index');
         $closureRoute = $router->get('foo', function () {
             return 'foo';
         });
@@ -499,7 +499,7 @@ class RoutingRouteTest extends TestCase
 
         $container->bind(RoutingTestUserModel::class, function () {
         });
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
 
         $router->get('foo/{team}/{post}', [
             'middleware' => SubstituteBindings::class,
@@ -573,7 +573,7 @@ class RoutingRouteTest extends TestCase
         $route->bind($request1);
         $this->assertTrue($route->hasParameter('id'));
         $this->assertFalse($route->hasParameter('foo'));
-        $this->assertSame('1', (string) $route->parameter('id'));
+        $this->assertSame('1', (string)$route->parameter('id'));
         $this->assertSame('png', $route->parameter('ext'));
 
         $request2 = Request::create('images/12.png', 'GET');
@@ -664,10 +664,10 @@ class RoutingRouteTest extends TestCase
     public function testRouteParametersDefaultValue()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class.'@returnParameter'])->defaults('bar', 'foo');
+        $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class . '@returnParameter'])->defaults('bar', 'foo');
         $this->assertSame('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
 
-        $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class.'@returnParameter'])->defaults('bar', 'foo');
+        $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class . '@returnParameter'])->defaults('bar', 'foo');
         $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router->get('foo/{bar?}', function ($bar = '') {
@@ -682,41 +682,41 @@ class RoutingRouteTest extends TestCase
 
         // Has one argument but receives two
         unset($_SERVER['__test.controller_callAction_parameters']);
-        $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@oneArgument');
-        $router->dispatch(Request::create($str.'/one/two', 'GET'));
+        $router->get(($str = Str::random()) . '/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class . '@oneArgument');
+        $router->dispatch(Request::create($str . '/one/two', 'GET'));
         $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // Has two arguments and receives two
         unset($_SERVER['__test.controller_callAction_parameters']);
-        $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@twoArguments');
-        $router->dispatch(Request::create($str.'/one/two', 'GET'));
+        $router->get(($str = Str::random()) . '/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class . '@twoArguments');
+        $router->dispatch(Request::create($str . '/one/two', 'GET'));
         $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // Has two arguments but with different names from the ones passed from the route
         unset($_SERVER['__test.controller_callAction_parameters']);
-        $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@differentArgumentNames');
-        $router->dispatch(Request::create($str.'/one/two', 'GET'));
+        $router->get(($str = Str::random()) . '/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class . '@differentArgumentNames');
+        $router->dispatch(Request::create($str . '/one/two', 'GET'));
         $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // Has two arguments with same name but argument order is reversed
         unset($_SERVER['__test.controller_callAction_parameters']);
-        $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@reversedArguments');
-        $router->dispatch(Request::create($str.'/one/two', 'GET'));
+        $router->get(($str = Str::random()) . '/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class . '@reversedArguments');
+        $router->dispatch(Request::create($str . '/one/two', 'GET'));
         $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // No route parameters while method has parameters
         unset($_SERVER['__test.controller_callAction_parameters']);
-        $router->get(($str = Str::random()).'', RouteTestAnotherControllerWithParameterStub::class.'@oneArgument');
+        $router->get(($str = Str::random()) . '', RouteTestAnotherControllerWithParameterStub::class . '@oneArgument');
         $router->dispatch(Request::create($str, 'GET'));
         $this->assertEquals([], $_SERVER['__test.controller_callAction_parameters']);
 
         // With model bindings
         unset($_SERVER['__test.controller_callAction_parameters']);
-        $router->get(($str = Str::random()).'/{user}/{defaultNull?}/{team?}', [
+        $router->get(($str = Str::random()) . '/{user}/{defaultNull?}/{team?}', [
             'middleware' => SubstituteBindings::class,
-            'uses' => RouteTestAnotherControllerWithParameterStub::class.'@withModels',
+            'uses' => RouteTestAnotherControllerWithParameterStub::class . '@withModels',
         ]);
-        $router->dispatch(Request::create($str.'/1', 'GET'));
+        $router->dispatch(Request::create($str . '/1', 'GET'));
 
         $values = array_values($_SERVER['__test.controller_callAction_parameters']);
 
@@ -963,7 +963,7 @@ class RoutingRouteTest extends TestCase
         $request1 = Request::create('images/1.png', 'GET');
         $this->assertTrue($route->matches($request1));
         $route->bind($request1);
-        $this->assertSame('1', (string) $route->parameter('id'));
+        $this->assertSame('1', (string)$route->parameter('id'));
         $this->assertSame('png', $route->parameter('ext'));
 
         $request2 = Request::create('images/12.png', 'GET');
@@ -1001,7 +1001,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->bind('bar', RouteBindingStub::class.'@find');
+        $router->bind('bar', RouteBindingStub::class . '@find');
         $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
 
@@ -1101,7 +1101,7 @@ class RoutingRouteTest extends TestCase
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
         $container->instance(Registrar::class, $router);
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
         $container->bind(RouteModelInterface::class, RouteModelBindingStub::class);
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
@@ -1113,14 +1113,14 @@ class RoutingRouteTest extends TestCase
     public function testRouteDependenciesCanBeResolvedThroughAttributes()
     {
         $container = new Container;
-        $container->singleton('config', fn () => new Repository([
+        $container->singleton('config', fn() => new Repository([
             'app' => [
                 'timezone' => 'Europe/Paris',
             ],
         ]));
         $router = new Router(new Dispatcher, $container);
         $container->instance(Registrar::class, $router);
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
         $router->get('foo', [
             'middleware' => SubstituteBindings::class,
             'uses' => function (#[Config('app.timezone')] string $value) {
@@ -1136,7 +1136,7 @@ class RoutingRouteTest extends TestCase
         $container = new Container();
         $router = new Router(new Dispatcher, $container);
         $container->instance(Registrar::class, $router);
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
 
         $container->afterResolvingAttribute(RoutingTestOnTenant::class, function (RoutingTestOnTenant $attribute, RoutingTestHasTenantImpl $hasTenantImpl, Container $container) {
             $hasTenantImpl->onTenant($attribute->tenant);
@@ -1212,7 +1212,7 @@ class RoutingRouteTest extends TestCase
     public function testCurrentRouteUses()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', ['as' => 'foo.bar', 'uses' => RouteTestControllerStub::class.'@index']);
+        $router->get('foo/bar', ['as' => 'foo.bar', 'uses' => RouteTestControllerStub::class . '@index']);
 
         $this->assertNull($router->currentRouteAction());
 
@@ -1224,14 +1224,14 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->uses(['*BarController*', '*FooController*'], '*RouteTestControllerStub*'));
         $this->assertFalse($router->uses(['*BarController*', '*FooController*']));
 
-        $this->assertEquals($router->currentRouteAction(), RouteTestControllerStub::class.'@index');
-        $this->assertTrue($router->currentRouteUses(RouteTestControllerStub::class.'@index'));
+        $this->assertEquals($router->currentRouteAction(), RouteTestControllerStub::class . '@index');
+        $this->assertTrue($router->currentRouteUses(RouteTestControllerStub::class . '@index'));
     }
 
     public function testRouteGroupingFromFile()
     {
         $router = $this->getRouter();
-        $router->group(['prefix' => 'api'], __DIR__.'/fixtures/routes.php');
+        $router->group(['prefix' => 'api'], __DIR__ . '/fixtures/routes.php');
 
         $route = last($router->getRoutes()->get());
         $request = Request::create('api/users', 'GET');
@@ -1635,6 +1635,31 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.destroy'));
     }
 
+    public function testResourceRouteSpecificMiddleware()
+    {
+        $router = $this->getRouter();
+
+        $router->resource('foo', RouteTestResourceControllerStub::class)
+            ->middleware([
+                'web',
+                'index' => RouteTestControllerMiddleware::class,
+                'show' => [RouteTestControllerMiddlewareTwo::class],
+            ]);
+
+        $indexRoute = $router->getRoutes()->getRoutesByName()['foo.index'];
+        $showRoute = $router->getRoutes()->getRoutesByName()['foo.show'];
+
+        $this->assertSame([
+            'web',
+            RouteTestControllerMiddleware::class,
+        ], $indexRoute->middleware());
+
+        $this->assertSame([
+            'web',
+            RouteTestControllerMiddlewareTwo::class
+        ], $showRoute->middleware());
+    }
+
     public function testRouterFiresRoutedEvent()
     {
         $container = new Container;
@@ -1643,7 +1668,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', function () {
             return '';
         });
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
 
         $request = Request::create('http://foo.com/foo/bar', 'GET');
         $route = new Route('GET', 'foo/bar', ['http', function () {
@@ -1674,7 +1699,7 @@ class RoutingRouteTest extends TestCase
         $container = new Container;
         $router = new Router($events = new Dispatcher, $container);
         $container->instance(Registrar::class, $router);
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
         $router->get('foo/bar', function () {
             return '';
         });
@@ -1715,7 +1740,7 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
 
-        $router->get('foo/bar', RouteTestControllerStub::class.'@index');
+        $router->get('foo/bar', RouteTestControllerStub::class . '@index');
 
         $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
@@ -1744,15 +1769,15 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
         $action = $router->getRoutes()->getRoutes()[0]->getAction()['controller'];
-        $this->assertEquals(RouteTestControllerStub::class.'@index', $action);
+        $this->assertEquals(RouteTestControllerStub::class . '@index', $action);
     }
 
     public function testCallableControllerRouting()
     {
         $router = $this->getRouter();
 
-        $router->get('foo/bar', RouteTestControllerCallableStub::class.'@bar');
-        $router->get('foo/baz', RouteTestControllerCallableStub::class.'@baz');
+        $router->get('foo/bar', RouteTestControllerCallableStub::class . '@bar');
+        $router->get('foo/baz', RouteTestControllerCallableStub::class . '@baz');
 
         $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertSame('baz', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
@@ -1772,7 +1797,7 @@ class RoutingRouteTest extends TestCase
             RouteTestControllerMiddlewareTwo::class,
         ]);
 
-        $router->get('foo/bar', RouteTestControllerMiddlewareGroupStub::class.'@index');
+        $router->get('foo/bar', RouteTestControllerMiddlewareGroupStub::class . '@index');
 
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
@@ -1826,7 +1851,7 @@ class RoutingRouteTest extends TestCase
                 $this->assertInstanceOf(RoutingTestTeamWithoutUserModel::class, $testTeam);
                 $this->assertInstanceOf(RoutingTestUserModel::class, $user);
 
-                return $testTeam->value.'|'.$user->value;
+                return $testTeam->value . '|' . $user->value;
             },
         ])->withoutScopedBindings();
 
@@ -1843,7 +1868,7 @@ class RoutingRouteTest extends TestCase
                 $this->assertInstanceOf(RoutingTestUserModel::class, $user);
                 $this->assertInstanceOf(RoutingTestPostModel::class, $post);
 
-                return $user->value.'|'.$post->value;
+                return $user->value . '|' . $post->value;
             },
         ]);
 
@@ -1858,7 +1883,7 @@ class RoutingRouteTest extends TestCase
             $this->assertInstanceOf(RoutingTestUserModel::class, $user);
             $this->assertInstanceOf(RoutingTestPostModel::class, $post);
 
-            return $team->value.'|'.$user->value.'|'.$post->value;
+            return $team->value . '|' . $user->value . '|' . $post->value;
         };
 
         $router->get('foo/{team}/{user:slug}/{post}', [
@@ -1901,7 +1926,7 @@ class RoutingRouteTest extends TestCase
                 $this->assertInstanceOf(RoutingTestUserModel::class, $user);
                 $this->assertInstanceOf(RoutingTestTeamModel::class, $testTeam);
 
-                return $user->value.'|'.$testTeam->value;
+                return $user->value . '|' . $testTeam->value;
             },
         ]);
 
@@ -1962,7 +1987,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->as('foo.')
-            ->missing(fn () => new RedirectResponse('/', 302))
+            ->missing(fn() => new RedirectResponse('/', 302))
             ->group(function () use ($router) {
                 $router->get('foo/{bar}', [
                     'middleware' => SubstituteBindings::class,
@@ -2026,7 +2051,7 @@ class RoutingRouteTest extends TestCase
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
         $container->instance(Registrar::class, $router);
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
 
         $container->bind(RoutingTestUserModel::class, RoutingTestExtendedUserModel::class);
         $router->get('foo/{bar}', [
@@ -2273,8 +2298,8 @@ class RoutingRouteTest extends TestCase
 
         $container->instance(Registrar::class, $router);
 
-        $container->bind(ControllerDispatcherContract::class, fn ($app) => new ControllerDispatcher($app));
-        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
+        $container->bind(ControllerDispatcherContract::class, fn($app) => new ControllerDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
 
         return $router;
     }
@@ -2285,11 +2310,19 @@ class RouteTestControllerStub extends Controller
     public function __construct()
     {
         $this->middleware(RouteTestControllerMiddleware::class);
-        $this->middleware(RouteTestControllerParameterizedMiddlewareOne::class.':0');
-        $this->middleware(RouteTestControllerParameterizedMiddlewareTwo::class.':foo,bar');
+        $this->middleware(RouteTestControllerParameterizedMiddlewareOne::class . ':0');
+        $this->middleware(RouteTestControllerParameterizedMiddlewareTwo::class . ':foo,bar');
         $this->middleware(RouteTestControllerExceptMiddleware::class, ['except' => 'index']);
     }
 
+    public function index()
+    {
+        return 'Hello World';
+    }
+}
+
+class RouteTestResourceControllerStub extends Controller
+{
     public function index()
     {
         return 'Hello World';
@@ -2381,7 +2414,7 @@ class RouteTestClosureMiddlewareController extends Controller
             $response = $next($request);
 
             return $response->setContent(
-                $response->content().'-'.$request['foo-middleware'].'-controller-closure'
+                $response->content() . '-' . $request['foo-middleware'] . '-controller-closure'
             );
         });
     }
@@ -2405,6 +2438,14 @@ class RouteTestControllerMiddleware
 }
 
 class RouteTestControllerMiddlewareTwo
+{
+    public function handle($request, $next)
+    {
+        return new Response('caught');
+    }
+}
+
+class RouteTestControllerMiddlewareThree
 {
     public function handle($request, $next)
     {
@@ -2505,7 +2546,7 @@ class RouteModelBindingClosureStub
 {
     public function findAlternate($value)
     {
-        return strtolower($value).'alt';
+        return strtolower($value) . 'alt';
     }
 }
 
@@ -2523,7 +2564,7 @@ class RoutingTestMiddlewareGroupTwo
 {
     public function handle($request, $next, $parameter = null)
     {
-        return new Response('caught '.$parameter);
+        return new Response('caught ' . $parameter);
     }
 }
 
@@ -2690,7 +2731,8 @@ final class RoutingTestOnTenant
 {
     public function __construct(
         public readonly RoutingTestTenant $tenant
-    ) {
+    )
+    {
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
> **Note:** This is essentially a RFC for the API. I think this implementation is messy, and feels out of place in the Laravel code. I'm primarily looking for the Laravel team's thoughts on this problem / API. If the API seems acceptable I would love some suggestions on how to make it more stylistically inline with the Laravel codebase.

## Currently
Currently, the `Route::resource(...)->middleware(...)` function applies the given middleware to _every_ resource method.

## Problem
Often, the routes on each resource have different middleware. The prime example is authorization middleware. The `show` method needs `can:view,foo` and the `edit` method needs `can:update,foo`. Currently, there is no way to apply a middleware to a specific route on a resource from within the routes file. 

### Workarounds

There _are_ ways to apply middleware to individual routes from inside the controller, but I am not a fan of this approach for a couple reasons. Generally, since 90% of our middleware is defined in the route file it feels inconsistent to put some of them in the controller. It makes it harder to get the whole picture of your routes.

You can make the check in the method itself with gate checks or the `authorize` function, however this approach isn't equivalent to defining them in routes. In particular, it isn't viable when using `laravel/precognition` because the validation will happen _before_ the authorization, which could be a security vulnerability.

You can also attach the middleware in the constructor. This is the best solution for now, but it feels a bit akward. It also forces you to extend the `Controller` class. I personally have no problem with that, but I believe I have heard some people say they prefer their controllers to be plain classes.

## Suggested Solution

In this PR I am suggesting a change to the `middleware` method which would allow it to apply middleware to specific methods for a resource. 

```php
Route::resource('teams', TeamController::class)->middleware([
    'auth',
    'verified',
    'show' => 'can:view,team',
    'edit' => ['can:update,team', 'doSomethingElse'],
]);
```

The method would behave as is for any unkeyed middleware. i.e. `auth` and `verified` would be applied to all resource routes.

The developer would also be able to use method names as keys, mapping them to a single middleware or an array of middleware.

### Risks

**Inconsistency:** The behaviour of the current `middleware` function is line with other similarly named middleware. For example, `Route::get('/teams', [TeamController::class, 'index'])->middleware('can:view,team')`. Accepting this API would mean making it inconsistent with existing functions. This inconsistency _could_ be confusing for devs. Personally, I doubt this would be an issue given the context of it being a Resource route.

**Do keys do anything now?:** I am personally not aware of a reason why you would key your middleware array. There could be some purpose, but I haven't found anything.

### Alternative Solutions
#### Inverted Mapping
The API I prototyped maps methods to middleware. An alternative could be to map middleware to methods:
```php
Route::resource('teams', TeamController::class)->middleware([
    'auth',
    'verified',
    'can:view,team' => 'index',
    'can:update,team' => 'edit',
    'doSomethingElse' => ['index', 'edit']
]);
```

#### New Method

If we were uncomfortable with modifying `->middleware()` we could introduce a new method. Maybe something like:
```php
Route::resource('teams', TeamController::class)
    ->middleware(['auth', 'verified'])
    ->routeMiddleware('index', 'can:view,team')
    ->routeMiddleware('edit', ['can:update,team']);
```

## Additional Considerations
If an API like this were to be introduced, I think a corresponding API for `withoutMiddleware` would be reasonable.
