### PR TITLE
Map output of concurrecy calls to the index of the input

### DIFF
--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -18,6 +18,7 @@ class ForkDriver implements Driver
     public function run(Closure|array $tasks): array
     {
         $tasks = Arr::wrap($tasks);
+
         $keys = array_keys($tasks);
         $values = array_values($tasks);
 

--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -18,7 +18,14 @@ class ForkDriver implements Driver
     public function run(Closure|array $tasks): array
     {
         /** @phpstan-ignore class.notFound */
-        return Fork::new()->run(...Arr::wrap($tasks));
+        $tasks = Arr::wrap($tasks);
+        $keys = array_keys($tasks);
+        $values = array_values($tasks);
+
+        /** @phpstan-ignore class.notFound */
+        $results = Fork::new()->run(...$values);
+
+        return array_combine($keys, $results);
     }
 
     /**

--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -17,7 +17,6 @@ class ForkDriver implements Driver
      */
     public function run(Closure|array $tasks): array
     {
-        /** @phpstan-ignore class.notFound */
         $tasks = Arr::wrap($tasks);
         $keys = array_keys($tasks);
         $values = array_values($tasks);

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -58,6 +58,7 @@ PHP);
         $this->assertArrayHasKey('first', $syncOutput);
         $this->assertArrayHasKey('second', $syncOutput);
 
+        /** As of now, the spatie/fork package is not included by default.
         $forkOutput = Concurrency::driver('fork')->run([
             'first' => fn() => 1 + 1,
             'second' => fn() => 2 + 2,
@@ -68,5 +69,6 @@ PHP);
         $this->assertArrayHasKey('second', $forkOutput);
         $this->assertEquals(2, $forkOutput['first']);
         $this->assertEquals(4, $forkOutput['second']);
+        */
     }
 }

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -37,4 +37,25 @@ PHP);
         $this->assertEquals(2, $first);
         $this->assertEquals(4, $second);
     }
+
+
+    public function testOutputIsMappedToArrayInput()
+    {
+        $input = [
+            'first' => fn() => 1 + 1,
+            'second' => fn() => 2 + 2,
+        ];
+
+        $processOutput = Concurrency::driver('process')->run($input);
+
+        $this->assertIsArray($processOutput);
+        $this->assertArrayHasKey('first', $processOutput);
+        $this->assertArrayHasKey('second', $processOutput);
+
+        $syncOutput = Concurrency::driver('sync')->run($input);
+
+        $this->assertIsArray($syncOutput);
+        $this->assertArrayHasKey('first', $syncOutput);
+        $this->assertArrayHasKey('second', $syncOutput);
+    }
 }

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -59,16 +59,16 @@ PHP);
         $this->assertArrayHasKey('second', $syncOutput);
 
         /** As of now, the spatie/fork package is not included by default.
-        $forkOutput = Concurrency::driver('fork')->run([
-            'first' => fn() => 1 + 1,
-            'second' => fn() => 2 + 2,
-        ]);
-
-        $this->assertIsArray($forkOutput);
-        $this->assertArrayHasKey('first', $forkOutput);
-        $this->assertArrayHasKey('second', $forkOutput);
-        $this->assertEquals(2, $forkOutput['first']);
-        $this->assertEquals(4, $forkOutput['second']);
-        */
+         * $forkOutput = Concurrency::driver('fork')->run([
+         * 'first' => fn() => 1 + 1,
+         * 'second' => fn() => 2 + 2,
+         * ]);.
+         *
+         * $this->assertIsArray($forkOutput);
+         * $this->assertArrayHasKey('first', $forkOutput);
+         * $this->assertArrayHasKey('second', $forkOutput);
+         * $this->assertEquals(2, $forkOutput['first']);
+         * $this->assertEquals(4, $forkOutput['second']);
+         */
     }
 }

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -57,5 +57,16 @@ PHP);
         $this->assertIsArray($syncOutput);
         $this->assertArrayHasKey('first', $syncOutput);
         $this->assertArrayHasKey('second', $syncOutput);
+
+        $forkOutput = Concurrency::driver('fork')->run([
+            'first' => fn() => 1 + 1,
+            'second' => fn() => 2 + 2,
+        ]);
+
+        $this->assertIsArray($forkOutput);
+        $this->assertArrayHasKey('first', $forkOutput);
+        $this->assertArrayHasKey('second', $forkOutput);
+        $this->assertEquals(2, $forkOutput['first']);
+        $this->assertEquals(4, $forkOutput['second']);
     }
 }

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Console;
+namespace Illuminate\Tests\Integration\Concurrency;
 
+use Illuminate\Support\Facades\Concurrency;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -38,12 +38,11 @@ PHP);
         $this->assertEquals(4, $second);
     }
 
-
     public function testOutputIsMappedToArrayInput()
     {
         $input = [
-            'first' => fn() => 1 + 1,
-            'second' => fn() => 2 + 2,
+            'first' => fn () => 1 + 1,
+            'second' => fn () => 2 + 2,
         ];
 
         $processOutput = Concurrency::driver('process')->run($input);


### PR DESCRIPTION
Changes the output of the concurrency calls in the Process and Fork drivers, to respect the index on the input.
This was already being done when using the sync driver, this brings the output of the other drivers into sync.

Meaning that this is now possible regardless of driver:

```
$result = Concurrency::run([
    'task1' => function () {
        return 'Result of task 1';
    },
    'task2' => function () {
        return 'Result of task 2';
    },
]);

```

With an output that matches the index of the input, essentially allowing you to index the output from each of the calls:
```
['task1' => 'Result of task 1', 'task2' => 'Result of task 2']
```

I found this useful when dealing with a dynamic number of closures, where to use previous mapping solutions
`[$first, $second] = Concurrency::run(...)` was tricky.