### PR TITLE
[11.x] Console supports Laravel Prompts 0.3+

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -21,7 +21,7 @@
         "illuminate/macroable": "^11.0",
         "illuminate/support": "^11.0",
         "illuminate/view": "^11.0",
-        "laravel/prompts": "^0.1.20 || ^0.2 || ^0.3",
+        "laravel/prompts": "^0.1.20|^0.2|^0.3",
         "nunomaduro/termwind": "^2.0",
         "symfony/console": "^7.0",
         "symfony/polyfill-php83": "^1.28",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -21,7 +21,7 @@
         "illuminate/macroable": "^11.0",
         "illuminate/support": "^11.0",
         "illuminate/view": "^11.0",
-        "laravel/prompts": "^0.1.18|^0.2.0",
+        "laravel/prompts": "^0.1.20 || ^0.2 || ^0.3",
         "nunomaduro/termwind": "^2.0",
         "symfony/console": "^7.0",
         "symfony/polyfill-php83": "^1.28",


### PR DESCRIPTION
Laravel Prompts 0.3.0 was released on 1st October: https://github.com/laravel/prompts/releases/tag/v0.3.0

This is required for Laravel Zero to support Laravel Prompts 0.3.0