### PR TITLE
[11.x] PHPDoc Improvements

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -144,7 +144,7 @@ class Builder implements BuilderContract
     /**
      * The orderings for the query.
      *
-     * @var array
+     * @var array|null
      */
     public $orders;
 
@@ -193,7 +193,7 @@ class Builder implements BuilderContract
     /**
      * The orderings for the union query.
      *
-     * @var array
+     * @var array|null
      */
     public $unionOrders;
 
@@ -768,7 +768,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Database\Query\Builder  $parentQuery
      * @param  string  $type
-     * @param  string  $table
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @return \Illuminate\Database\Query\JoinClause
      */
     protected function newJoinClause(self $parentQuery, $type, $table)
@@ -781,7 +781,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Database\Query\Builder  $parentQuery
      * @param  string  $type
-     * @param  string  $table
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @return \Illuminate\Database\Query\JoinLateralClause
      */
     protected function newJoinLateralClause(self $parentQuery, $type, $table)


### PR DESCRIPTION
This PR improves the docblocks in the Builder class:

Updates the `$orders` and `$unionOrders` properties to indicate they can also accept null.

Adds `\Illuminate\Contracts\Database\Query\Expression` as a valid type for the `$table` parameter in the `newJoinClause` and `newJoinLateralClause` methods.