### PR TITLE
Issue with constrained() method used after foreignIdFor(), instead of table name when $table parameter is not passed uses column name

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1011,7 +1011,7 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
-     * @param  string  $table
+     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignId($column, $table = null)
@@ -1047,7 +1047,7 @@ class Blueprint
         $modelTraits = class_uses_recursive($model);
 
         if (in_array(HasUlids::class, $modelTraits, true)) {
-            return $this->foreignUlid($column);
+            return $this->foreignUlid($column, 26, $model->getTable());
         }
 
         return $this->foreignUuid($column, $model->getTable());
@@ -1356,6 +1356,7 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
+     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignUuid($column, $table = null)
@@ -1384,14 +1385,16 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int|null  $length
+     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUlid($column, $length = 26)
+    public function foreignUlid($column, $length = 26, $table = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'char',
             'name' => $column,
             'length' => $length,
+            'table' => $table,
         ]));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1011,15 +1011,17 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
+     * @param  string  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function foreignId($column, $table = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'bigInteger',
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,
+            'table' => $table,
         ]));
     }
 
@@ -1039,7 +1041,7 @@ class Blueprint
         $column = $column ?: $model->getForeignKey();
 
         if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
-            return $this->foreignId($column);
+            return $this->foreignId($column, $model->getTable());
         }
 
         $modelTraits = class_uses_recursive($model);
@@ -1048,7 +1050,7 @@ class Blueprint
             return $this->foreignUlid($column);
         }
 
-        return $this->foreignUuid($column);
+        return $this->foreignUuid($column, $model->getTable());
     }
 
     /**
@@ -1356,11 +1358,12 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUuid($column)
+    public function foreignUuid($column, $table = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
+            'table' => $table,
         ]));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1011,17 +1011,15 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
-     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column, $table = null)
+    public function foreignId($column)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'bigInteger',
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,
-            'table' => $table,
         ]));
     }
 
@@ -1041,16 +1039,16 @@ class Blueprint
         $column = $column ?: $model->getForeignKey();
 
         if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
-            return $this->foreignId($column, $model->getTable());
+            return $this->foreignId($column)->table($model->getTable());
         }
 
         $modelTraits = class_uses_recursive($model);
 
         if (in_array(HasUlids::class, $modelTraits, true)) {
-            return $this->foreignUlid($column, 26, $model->getTable());
+            return $this->foreignUlid($column, 26)->table($model->getTable());
         }
 
-        return $this->foreignUuid($column, $model->getTable());
+        return $this->foreignUuid($column)->table($model->getTable());
     }
 
     /**
@@ -1356,15 +1354,13 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
-     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUuid($column, $table = null)
+    public function foreignUuid($column)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
-            'table' => $table,
         ]));
     }
 
@@ -1385,16 +1381,14 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int|null  $length
-     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUlid($column, $length = 26, $table = null)
+    public function foreignUlid($column, $length = 26)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'char',
             'name' => $column,
             'length' => $length,
-            'table' => $table,
         ]));
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -40,7 +40,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
         if (is_null($table) && is_null($this->table)) {
             $table = $this->table;
         }
-        
+
         return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -37,7 +37,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id', $indexName = null)
     {
-        return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
+        return $this->references($column, $indexName)->on($table ?? $this->blueprint->getTable());
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -37,7 +37,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id', $indexName = null)
     {
-        if(is_null($table) && is_null($this->table)) {
+        if (is_null($table) && is_null($this->table)) {
             $table = $this->table;
         }
         

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Support\Str;
-
 class ForeignIdColumnDefinition extends ColumnDefinition
 {
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -37,9 +37,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id', $indexName = null)
     {
-        if (is_null($table) && is_null($this->table)) {
-            $table = $this->table;
-        }
+        $table ??= $this->table;
 
         return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Schema;
 
+use Illuminate\Support\Str;
+
 class ForeignIdColumnDefinition extends ColumnDefinition
 {
     /**
@@ -35,7 +37,11 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id', $indexName = null)
     {
-        return $this->references($column, $indexName)->on($table ?? $this->blueprint->getTable());
+        if(is_null($table) && is_null($this->table)) {
+            $table = $this->table;
+        }
+        
+        return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When `constrained()` is used after `foreignIdFor()` then on the migration query for the constrained instead of the table name uses column name and pluralise it.

```
$table->foreignIdFor(User::class, 'assigned_at')->nullable()->constrained();
```

Query produced to add the constrain: 
```
alter table `tasks` add constraint `tasks_assigned_at_foreign` foreign key (`assigned_at`) references `assigned_ats` (`id`);
```
so instead of `references users` it produces `references assigned_ats` pluralised name of the column.


