### PR TITLE
[12.x] Fix laravel/prompt dependency version constraint for illuminate/console

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -21,7 +21,7 @@
         "illuminate/macroable": "^12.0",
         "illuminate/support": "^12.0",
         "illuminate/view": "^12.0",
-        "laravel/prompts": "dev-l12",
+        "laravel/prompts": "^0.3.0",
         "nunomaduro/termwind": "^2.0",
         "symfony/console": "^7.0",
         "symfony/polyfill-php83": "^1.28",


### PR DESCRIPTION
The version constraint in the main `composer.json` was updated in https://github.com/laravel/framework/commit/e0cf931ba8b73dde10d1535053f11a849592afa3 , but this one seems to be forgotten.

The `l12` branch is no longer available, causing `illuminate/console` to be no longer installable in Laravel 12.