### PR TITLE
[11.x] Ensure `where` with array respects boolean

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -926,7 +926,7 @@ class Builder implements BuilderContract
         return $this->whereNested(function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
-                    $query->{$method}(...array_values($value));
+                    $query->{$method}(...array_values($value), boolean: $boolean);
                 } else {
                     $query->{$method}($key, '=', $value, $boolean);
                 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2324,13 +2324,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where([['foo', 1], ['bar', 2]], boolean: 'or');
+        $this->assertSame('select * from "users" where ("foo" = ? or "bar" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where(['foo' => 1, 'bar' => 2]);
         $this->assertSame('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where(['foo' => 1, 'bar' => 2], boolean: 'or');
+        $this->assertSame('select * from "users" where ("foo" = ? or "bar" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where([['foo', 1], ['bar', '<', 2]]);
         $this->assertSame('select * from "users" where ("foo" = ? and "bar" < ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where([['foo', 1], ['bar', '<', 2]], boolean: 'or');
+        $this->assertSame('select * from "users" where ("foo" = ? or "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 


### PR DESCRIPTION
It is possible to create `where` queries with an array. The array may be a hash map or a list.

```php
User::where([
    'name' => 'Tim',
    'verified' => true,
]);

// select * from users where (name = 'Tim' and verified = 1)

User::where([
    ['name', 'Tim'],
    ['created_at', '>', now()->startOfYear()->toDateString()],
]);

// select * from users where (name = 'Tim' and created_at > '2024-01-01')
```

There `where` method accepts a boolean for the query, e.g., `AND`, `OR`. The boolean is respected for the hash map but is ignored for the list.

```php
User::where([
    'name' => 'Tim',
    'verified' => true,
], boolean: 'or');

// select * from users where (name = 'Tim' or verified = 1)

User::where([
    ['name', 'Tim'],
    ['created_at', '>', now()->startOfYear()],
], boolean: 'or');

// select * from users where (name = 'Tim' and created_at > '2024-01-01')
```

This PR ensures that the boolean is respected for both approaches.

```diff
User::where([
    'name' => 'Tim',
    'verified' => true,
], boolean: 'or');

// select * from users where (name = 'Tim' or verified = 1)

User::where([
    ['name', 'Tim'],
    ['created_at', '>', now()->startOfYear()],
], boolean: 'or');

- // select * from users where (name = 'Tim' and created_at > '2024-01-01')
+ // select * from users where (name = 'Tim' or created_at > '2024-01-01')
```