### PR TITLE
Add whereRelationKey Clause

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -419,6 +419,18 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a basic where clause to a relationship query on a specific key or keys.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  mixed  $id
+     * @return $this
+     */
+    public function whereRelationKey($relation, $id)
+    {
+        return $this->whereHas($relation, fn ($query) => $query->whereKey($id));
+    }
+
+    /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation


### PR DESCRIPTION
A classic usage of `whereHas` or `whereRelation` is to filter the relation by a certain (or multiple) keys. This allows for a simpler syntax:
```php
#Before
Post::whereHas('comments', fn ($q) => $q->whereKey($id));
#or
Post::whereRelation('comments', fn ($q) => $q->whereKey($id));

#After
Post::whereRelationKey('comments', $id);
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
