### PR TITLE
[11.x] feat: refine return type for `throw_if` and `throw_unless` to reflect actual behavior with "falsey" values

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -393,7 +393,7 @@ if (! function_exists('throw_if')) {
      * @param  TValue  $condition
      * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
-     * @return ($condition is true ? never : TValue)
+     * @return ($condition is non-empty-mixed ? never : TValue)
      *
      * @throws TException
      */
@@ -421,7 +421,7 @@ if (! function_exists('throw_unless')) {
      * @param  TValue  $condition
      * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
-     * @return ($condition is true ? TValue : never)
+     * @return ($condition is non-empty-mixed ? TValue : never)
      *
      * @throws TException
      */

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -46,10 +46,9 @@ function testThrowIf(float|int $foo): void
     assertType('never', throw_if(true, Exception::class));
     assertType('bool', throw_if(false, Exception::class));
     assertType('false', throw_if(empty($foo)));
-    throw_if(is_float($foo));
-    assertType('int', $foo);
-    throw_if($foo == false);
-    assertType('int<min, -1>|int<1, max>', $foo);
+    assertType('null', throw_if(null, Exception::class));
+    assertType('string', throw_if('', Exception::class));
+    assertType('never', throw_if('foo', Exception::class));
 }
 
 function testThrowUnless(float|int $foo): void
@@ -58,9 +57,9 @@ function testThrowUnless(float|int $foo): void
     assertType('never', throw_unless(false, Exception::class));
     assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
-    assertType('int', $foo);
-    throw_unless($foo == false);
-    assertType('0', $foo);
+    assertType('never', throw_unless(null, Exception::class));
+    assertType('never', throw_unless('', Exception::class));
+    assertType('string', throw_unless('foo', Exception::class));
 }
 
 assertType('int', transform('filled', fn () => 1, true));


### PR DESCRIPTION
In #53005, the return types for `throw_if` and `throw_unless` were narrowed to specify `TValue` or `never` depending on `$condition` being exactly `true` or not:

```php
 * @return ($condition is true ? never : TValue)
```

This doesn't reflect the actual behavior of `throw_if` and `throw_unless`: Both check for "falseyness", and not strict equality to `true`. 

Crucially, the new type annotation gets in the way when e.g. `throw_unless` is used to check for the presence of something, e.g.:

```php
throw_unless($something, "Something required");
```

To keep phpstan happy, developers would have to rewrite this to e.g.:

```php
throw_unless($something !== null, "Something required");
```

Luckily, phpstan offers the `non-empty-mixed` "advanced type", allowing us to precisely specify the behavior of `throw_if` and `throw_unless`:

```php
 * @return ($condition is non-empty-mixed ? never : TValue)
```