### PR TITLE
[11.x] Gracefully handle null passwords when verifying credentials

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -154,9 +154,15 @@ class DatabaseUserProvider implements UserProvider
      */
     public function validateCredentials(UserContract $user, #[\SensitiveParameter] array $credentials)
     {
-        return $this->hasher->check(
-            $credentials['password'], $user->getAuthPassword()
-        );
+        if (is_null($plain = $credentials['password'])) {
+            return false;
+        }
+
+        if (is_null($hashed = $user->getAuthPassword())) {
+            return false;
+        }
+
+        return $this->hasher->check($plain, $hashed);
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -152,7 +152,11 @@ class EloquentUserProvider implements UserProvider
             return false;
         }
 
-        return $this->hasher->check($plain, $user->getAuthPassword());
+        if (is_null($hashed = $user->getAuthPassword())) {
+            return false;
+        }
+
+        return $this->hasher->check($plain, $hashed);
     }
 
     /**

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -179,7 +179,7 @@ class AuthDatabaseUserProviderTest extends TestCase
     {
         $conn = m::mock(Connection::class);
         $hasher = m::mock(Hasher::class);
-        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->never();
+        $hasher->shouldReceive('check')->never();
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn(null);

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -162,7 +162,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testCredentialValidationFailed()
+    public function testCredentialValidationFails()
     {
         $conn = m::mock(Connection::class);
         $hasher = m::mock(Hasher::class);
@@ -170,6 +170,19 @@ class AuthDatabaseUserProviderTest extends TestCase
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCredentialValidationFailsGracefullyWithNullPassword()
+    {
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->never();
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn(null);
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
         $this->assertFalse($result);

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -152,6 +152,18 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testCredentialValidationFailsGracefullyWithNullPassword()
+    {
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->never();
+        $provider = new EloquentUserProvider($hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn(null);
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertFalse($result);
+    }
+
     public function testRehashPasswordIfRequired()
     {
         $hasher = m::mock(Hasher::class);

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -155,7 +155,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testCredentialValidationFailsGracefullyWithNullPassword()
     {
         $hasher = m::mock(Hasher::class);
-        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->never();
+        $hasher->shouldReceive('check')->never();
         $provider = new EloquentUserProvider($hasher, 'foo');
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn(null);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, both the `EloquentUserProvider` and `DatabaseUserProvider` classes throw an exception if the user's `getAuthPassword()` method returns null. If the user does not have a password set, and the configured hasher follows the default behaviour of verifying hashes, then a RuntimeException is thrown e.g. 

> This password does not use the Bcrypt algorithm

While technically true, this results in an end user being shown a 500 error when attempting to sign into an account where an initial password has not been set. This can happen frequently in apps where accounts are created by other users rather than by self-registration.

This PR assumes that if a user's password is `null`, the `validateCredentials` methods should handle this gracefully and simply return false rather than throwing an exception, resulting in a better experience for the end user.