### PR TITLE
[11.x] Add successful and failed methods to `ProcessPoolResults`

### DIFF
--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -85,8 +85,9 @@ class ProcessPoolResults implements ArrayAccess
      *
      * @return bool
      */
-    public function successful() {
-        return collect($this->results)->every(fn($poolResult) => $poolResult->successful());
+    public function successful() 
+    {
+        return $this->collect($this->results)->every(fn($poolResult) => $poolResult->successful());
     }
 
     /**
@@ -94,7 +95,8 @@ class ProcessPoolResults implements ArrayAccess
      *
      * @return bool
      */
-    public function failed() {
-        return !$this->successful();
+    public function failed() 
+    {
+        return ! $this->successful();
     }
 }

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -87,7 +87,7 @@ class ProcessPoolResults implements ArrayAccess
      */
     public function successful() 
     {
-        return $this->collect($this->results)->every(fn($poolResult) => $poolResult->successful());
+        return $this->collect($this->results)->every(fn ($poolResult) => $poolResult->successful());
     }
 
     /**
@@ -95,7 +95,7 @@ class ProcessPoolResults implements ArrayAccess
      *
      * @return bool
      */
-    public function failed() 
+    public function failed()
     {
         return ! $this->successful();
     }

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -26,6 +26,26 @@ class ProcessPoolResults implements ArrayAccess
     }
 
     /**
+     * Determine if all of the processes in the pool were successful.
+     *
+     * @return bool
+     */
+    public function successful()
+    {
+        return $this->collect()->every(fn ($p) => $p->successful());
+    }
+
+    /**
+     * Determine if any of the processes in the pool failed.
+     *
+     * @return bool
+     */
+    public function failed()
+    {
+        return ! $this->successful();
+    }
+
+    /**
      * Get the results as a collection.
      *
      * @return \Illuminate\Support\Collection
@@ -78,25 +98,5 @@ class ProcessPoolResults implements ArrayAccess
     public function offsetUnset($offset): void
     {
         unset($this->results[$offset]);
-    }
-
-    /**
-     * Determine if the process was successful.
-     *
-     * @return bool
-     */
-    public function successful() 
-    {
-        return $this->collect()->every(fn ($poolResult) => $poolResult->successful());
-    }
-
-    /**
-     * Determine if the process failed.
-     *
-     * @return bool
-     */
-    public function failed()
-    {
-        return ! $this->successful();
     }
 }

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -87,7 +87,7 @@ class ProcessPoolResults implements ArrayAccess
      */
     public function successful() 
     {
-        return $this->collect($this->results)->every(fn ($poolResult) => $poolResult->successful());
+        return $this->collect()->every(fn ($poolResult) => $poolResult->successful());
     }
 
     /**

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -79,4 +79,22 @@ class ProcessPoolResults implements ArrayAccess
     {
         unset($this->results[$offset]);
     }
+
+    /**
+     * Determine if the process was successful.
+     *
+     * @return bool
+     */
+    public function successful() {
+        return collect($this->results)->every(fn($poolResult) => $poolResult->successful());
+    }
+
+    /**
+     * Determine if the process failed.
+     *
+     * @return bool
+     */
+    public function failed() {
+        return !$this->successful();
+    }
 }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -47,6 +47,31 @@ class ProcessTest extends TestCase
 
         $this->assertTrue(str_contains($results[0]->output(), 'ProcessTest.php'));
         $this->assertTrue(str_contains($results[1]->output(), 'ProcessTest.php'));
+
+        $this->assertTrue($results->successful());
+    }
+
+    public function testProcessPoolFailed()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            'cat *' => $factory->result(exitCode: 1),
+        ]);
+
+        $pool = $factory->pool(function ($pool) {
+            return [
+                $pool->path(__DIR__)->command($this->ls()),
+                $pool->path(__DIR__)->command('cat test'),
+            ];
+        });
+
+        $results = $pool->start()->wait();
+
+        $this->assertTrue($results[0]->successful());
+        $this->assertTrue($results[1]->failed());
+
+        $this->assertTrue($results->failed());
     }
 
     public function testInvokedProcessPoolCount()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adds helper methods to `ProcessPoolResults`, allowing for quick determination of whether a pool was successful or has failed. It mirrors the functionality of the `ProcessResults` class, so they feel more similar to use.
