### PR TITLE
[12.x] Add generic return type to Container::instance()

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -488,9 +488,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template TInstance
+     *
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  TInstance  $instance
+     * @return TInstance
      */
     public function instance($abstract, $instance)
     {

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -122,9 +122,11 @@ interface Container extends ContainerInterface
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template TInstance
+     *
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  TInstance  $instance
+     * @return TInstance
      */
     public function instance($abstract, $instance);
 

--- a/types/Container/Container.php
+++ b/types/Container/Container.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Http\Request;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @var \Illuminate\Container\Container $container
+ */
+assertType('Illuminate\Http\Request', $container->instance('request', Request::capture()));

--- a/types/Contracts/Container/Container.php
+++ b/types/Contracts/Container/Container.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Http\Request;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @var \Illuminate\Contracts\Container\Container $container
+ */
+assertType('Illuminate\Http\Request', $container->instance('request', Request::capture()));


### PR DESCRIPTION
This method always returns the `$instance` that it was given, so we can narrow the return type for editors and static analysis tools. I sent this to master instead of 11.x because changing the contract can be a breaking change