### PR TITLE
[11.x] feat: restore type-narrowing bahavior for `throw_*` helpers

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -393,7 +393,7 @@ if (! function_exists('throw_if')) {
      * @param  TValue  $condition
      * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
-     * @return ($condition is non-empty-mixed ? never : TValue)
+     * @return ($condition is true ? never : ($condition is non-empty-mixed ? never : TValue))
      *
      * @throws TException
      */
@@ -421,7 +421,7 @@ if (! function_exists('throw_unless')) {
      * @param  TValue  $condition
      * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
-     * @return ($condition is non-empty-mixed ? TValue : never)
+     * @return ($condition is false ? never : ($condition is non-empty-mixed ? TValue : never))
      *
      * @throws TException
      */

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -41,22 +41,37 @@ assertType('User', tap(new User(), function ($user) {
 }));
 assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 
-function testThrowIf(float|int $foo): void
+function testThrowIf(float|int $foo, DateTime $bar = null): void
 {
     assertType('never', throw_if(true, Exception::class));
     assertType('bool', throw_if(false, Exception::class));
     assertType('false', throw_if(empty($foo)));
+    throw_if(is_float($foo));
+    assertType('int', $foo);
+    throw_if($foo == false);
+    assertType('int<min, -1>|int<1, max>', $foo);
+
+    // Truthy/falsey argument
+    throw_if($bar);
+    assertType('null', $bar);
     assertType('null', throw_if(null, Exception::class));
     assertType('string', throw_if('', Exception::class));
     assertType('never', throw_if('foo', Exception::class));
 }
 
-function testThrowUnless(float|int $foo): void
+function testThrowUnless(float|int $foo, DateTime $bar = null): void
 {
     assertType('bool', throw_unless(true, Exception::class));
     assertType('never', throw_unless(false, Exception::class));
     assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
+    assertType('int', $foo);
+    throw_unless($foo == false);
+    assertType('0', $foo);
+    throw_unless($bar instanceof DateTime);
+    assertType('DateTime', $bar);
+
+    // Truthy/falsey argument
     assertType('never', throw_unless(null, Exception::class));
     assertType('never', throw_unless('', Exception::class));
     assertType('string', throw_unless('foo', Exception::class));


### PR DESCRIPTION
Follow-up to #53154 from yesterday, based on input from @calebdw.

Restore the type-narrowing behavior  of `throw_if`  / `throw_unless` when passed a strictly boolean condition:

```php
/** @var float|int $foo */
throw_if(is_float($foo));
assertType('int', $foo);
```
