### PR TITLE
Translate exception messages using the __() helper for better internationalization support

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -984,13 +984,13 @@ class Handler implements ExceptionHandlerContract
     protected function convertExceptionToArray(Throwable $e)
     {
         return config('app.debug') ? [
-            'message' => $e->getMessage(),
+            'message' => __($e->getMessage()),
             'exception' => get_class($e),
             'file' => $e->getFile(),
             'line' => $e->getLine(),
             'trace' => collect($e->getTrace())->map(fn ($trace) => Arr::except($trace, ['args']))->all(),
         ] : [
-            'message' => $this->isHttpException($e) ? $e->getMessage() : 'Server Error',
+            'message' => $this->isHttpException($e) ? __($e->getMessage()) : __('Server Error'),
         ];
     }
 


### PR DESCRIPTION
Make it more user friendly for my Dutch users:

<img width="457" alt="Scherm­afbeelding 2024-10-15 om 16 23 38" src="https://github.com/user-attachments/assets/0ddcc3c1-44ad-4256-8087-08a88615fa11">

Versus original:

<img width="451" alt="Scherm­afbeelding 2024-10-15 om 16 24 47" src="https://github.com/user-attachments/assets/5bb7b203-a98c-4fdc-bf1c-1d08ca8d9eee">