### PR TITLE
[11.x] Introduce `Collection::containsManyItems` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -713,6 +713,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection contains many items.
+     *
+     * @return bool
+     */
+    public function containsManyItems(): bool
+    {
+        return $this->count() > 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -625,6 +625,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function containsOneItem();
 
     /**
+     * Determine if the collection contains many items.
+     *
+     * @return bool
+     */
+    public function containsManyItems(): bool;
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -709,6 +709,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if the collection contains many items.
+     *
+     * @return bool
+     */
+    public function containsManyItems(): bool
+    {
+        return $this->take(2)->count() === 2;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -824,6 +824,15 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse((new $collection([1, 2]))->containsOneItem());
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testContainsManyItems($collection): void
+    {
+        $this->assertFalse((new $collection([]))->containsManyItems());
+        $this->assertFalse((new $collection([1]))->containsManyItems());
+        $this->assertTrue((new $collection([1, 2]))->containsManyItems());
+        $this->assertTrue((new $collection([1, 2, 3]))->containsManyItems());
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -588,6 +588,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testContainsManyItemsIsLazy(): void
+    {
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->containsManyItems();
+        });
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
I often find myself needing to check if a collection has more than one item. While Laravel provides useful methods like `count`, `isEmpty`, `isNotEmpty`, and `containsOneItem`, there's nothing built-in to quickly check for multiple items.

This pull request adds a `Collection::containsManyItems` method to make this check simpler and more intuitive. It's a small addition, but it makes code a bit cleaner and avoids having to manually compare collection sizes.