### PR TITLE
[11.x] Remove useless statement

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -75,11 +75,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        $name = trim($this->argument('name'));
-
-        $name = str_replace(['\\', '.'], '/', $this->argument('name'));
-
-        return $name;
+        return str_replace(['\\', '.'], '/', $this->argument('name'));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request just gets rid of a useless statement in `ViewMakeCommand::getPath` method.