### PR TITLE
Enhancement: Collection Ensure 'forceFilterCollection'

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,7 +367,7 @@ trait EnumeratesValues
             }
 
             throw new UnexpectedValueException(
-                sprintf("Collection should only include [%s] items, but '%s' found at position %d.", implode(', ', $allowedTypes), $itemType)
+                sprintf("Collection should only include [%s] items, but '%s' found at position %d.", implode(', ', $allowedTypes), $itemType, $index)
             );
         });
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -357,7 +357,7 @@ trait EnumeratesValues
                 }
                 return false;
             });
-        })->each(function ($item) use ($allowedTypes) {
+        })->each(function ($item, $index) use ($allowedTypes) {
             $itemType = get_debug_type($item);
 
             foreach ($allowedTypes as $allowedType) {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -339,7 +339,7 @@ trait EnumeratesValues
      * @template TEnsureOfType
      *
      * @param  class-string<TEnsureOfType>|array<array-key, class-string<TEnsureOfType>>  $type
-     * @param bool  $forceFilterCollection
+     * @param  bool $forceFilterCollection
      * @return static<TKey, TEnsureOfType>
      *
      * @throws \UnexpectedValueException
@@ -355,6 +355,7 @@ trait EnumeratesValues
                 if (in_array($itemType, $allowedTypes)) {
                     return true;
                 }
+
                 return false;
             });
         })->each(function ($item, $index) use ($allowedTypes) {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,7 +367,7 @@ trait EnumeratesValues
             }
 
             throw new UnexpectedValueException(
-                sprintf("Collection should only include [%s] items, but '%s' found.", implode(', ', $allowedTypes), $itemType)
+                sprintf("Collection should only include [%s] items, but '%s' found at position %d.", implode(', ', $allowedTypes), $itemType)
             );
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5516,6 +5516,13 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testEnsureAndForceFilter($collection)
+    {
+        $mixture = (new $collection([1, 2, 3, 'string', new stdClass()]))->ensure('int', true);
+        $this->assertSame([1, 2, 3], $mixture->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testPercentageWithFlatCollection($collection)
     {
         $collection = new $collection([1, 1, 2, 2, 2, 3]);


### PR DESCRIPTION
This pull request brings an enhancement to `$collection->ensure(stdClass::class)`, 

This pull request has added a boolean of `$forceFilterCollection` to the `ensure` method, which will automatically filter the collection to be only of the types that the ensure method asks for. 

Usage: 
```
$result = (new $collection([1, 2, 3, 'string', new stdClass()]))
    ->ensure('int', forceFilterCollection: true);
```
Rather than throw the exception, it will automatically filter the collection and return just `[1,2,3]`

Saves time and another try/catch when you simply want to ensure the validity of your collection. 

