### PR TITLE
[11.x] Add QueriedBy attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/QueriedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/QueriedBy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class QueriedBy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<\Illuminate\Database\Eloquent\Builder<*>>  $builderClass
+     * @return void
+     */
+    public function __construct(public string $builderClass)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/HasBuilder.php
+++ b/src/Illuminate/Database/Eloquent/HasBuilder.php
@@ -2,11 +2,21 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Database\Eloquent\Attributes\QueriedBy;
+use ReflectionClass;
+
 /**
  * @template TBuilder of \Illuminate\Database\Eloquent\Builder
  */
 trait HasBuilder
 {
+    /**
+     * The resolved builder class names by model.
+     *
+     * @var array<class-string<static>, class-string<TBuilder>>
+     */
+    protected static array $resolvedBuilderClasses = [];
+
     /**
      * Begin querying the model.
      *
@@ -109,6 +119,24 @@ trait HasBuilder
     public static function onWriteConnection()
     {
         return parent::onWriteConnection();
+    }
+
+    /**
+     * Resolve the builder class name from the QueriedBy attribute.
+     *
+     * @return class-string<TBuilder>|null
+     */
+    public function resolveBuilderFromAttribute()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+
+        $attributes = $reflectionClass->getAttributes(QueriedBy::class);
+
+        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
+            return;
+        }
+
+        return $attributes[0]->getArguments()[0];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -37,6 +37,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\GuardsAttributes,
         Concerns\PreventsCircularRecursion,
         ForwardsCalls;
+    /** @use HasBuilder<\Illuminate\Database\Eloquent\Builder<static>> */
+    use HasBuilder;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static>> */
     use HasCollection;
 
@@ -1601,7 +1603,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        return new static::$builder($query);
+        static::$resolvedBuilderClasses[static::class] ??= ($this->resolveBuilderFromAttribute() ?? static::$builder);
+
+        return new static::$resolvedBuilderClasses[static::class]($query);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -17,6 +17,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\QueriedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -3178,6 +3179,16 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
+
+    public function testQueriedByAttribute()
+    {
+        $baseBuilderMock = m::mock(BaseBuilder::class);
+
+        $model = new EloquentModelWithQueriedByAttribute;
+        $collection = $model->newEloquentBuilder($baseBuilderMock);
+
+        $this->assertInstanceOf(CustomEloquentBuilder::class, $collection);
+    }
 }
 
 class EloquentTestObserverStub
@@ -3944,5 +3955,14 @@ class EloquentModelWithCollectedByAttribute extends Model
 }
 
 class CustomEloquentCollection extends Collection
+{
+}
+
+#[QueriedBy(CustomEloquentBuilder::class)]
+class EloquentModelWithQueriedByAttribute extends Model
+{
+}
+
+class CustomEloquentBuilder extends Builder
 {
 }

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Types\Model;
 
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
+use Illuminate\Database\Eloquent\Attributes\QueriedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\HasBuilder;
 use Illuminate\Database\Eloquent\HasCollection;
 use Illuminate\Database\Eloquent\Model;
 use User;
@@ -32,6 +35,7 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->withoutTrashed());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->prunable());
     assertType('Illuminate\Database\Eloquent\Relations\MorphMany<Illuminate\Notifications\DatabaseNotification, User>', $user->notifications());
+    assertType('Illuminate\Types\Model\ArticleBuilder<Illuminate\Types\Model\Article>', Article::query());
 
     assertType('Illuminate\Database\Eloquent\Collection<(int|string), User>', $user->newCollection([new User()]));
     assertType('Illuminate\Types\Model\Posts<(int|string), Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
@@ -77,11 +81,15 @@ final class Comments extends Collection
 {
 }
 
+#[QueriedBy(ArticleBuilder::class)]
 #[CollectedBy(Articles::class)]
 class Article extends Model
 {
     /** @use HasCollection<Articles<array-key, static>> */
     use HasCollection;
+
+    /** @use HasBuilder<ArticleBuilder<static>> */
+    use HasBuilder;
 }
 
 /**
@@ -90,5 +98,13 @@ class Article extends Model
  *
  * @extends Collection<TKey, TModel> */
 class Articles extends Collection
+{
+}
+
+/**
+ * @template TModel of Article
+ *
+ * @extends Builder<TModel> */
+class ArticleBuilder extends Builder
 {
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Along the same vein as the recently added `CollectedBy` attribute (#53122), I propose to add the `QueriedBy` attribute which allows users to configure which Builder class to use without having to override the `newEloquentBuilder` method.

```php
#[QueriedBy(PostBuilder::class)]
class Post extends Model
{
    // ...
}
```

The implementation is basically a carbon copy of the `CollectedBy` attribute, with memoizing via a static array variable on the Model class.