### PR TITLE
[11.x] Allow list of rate limiters without requiring unique keys

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -63,7 +63,33 @@ class RateLimiter
     {
         $resolvedName = $this->resolveLimiterName($name);
 
-        return $this->limiters[$resolvedName] ?? null;
+        $limiter = $this->limiters[$resolvedName] ?? null;
+
+        if (! is_callable($limiter)) {
+            return;
+        }
+
+        return function (...$args) use ($limiter) {
+            $result = $limiter(...$args);
+
+            if (! is_array($result)) {
+                return $result;
+            }
+
+            $duplicates = collect($result)->duplicates('key');
+
+            if ($duplicates->isEmpty()) {
+                return $result;
+            }
+
+            foreach ($result as $limit) {
+                if ($duplicates->contains($limit->key)) {
+                    $limit->key = $limit->fallbackKey();
+                }
+            }
+
+            return $result;
+        };
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -144,7 +144,7 @@ class Limit
     }
 
     /**
-     * Retrieve a fallback key for the limit.
+     * Get a potential fallback key for the limit.
      *
      * @return string
      */

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -142,4 +142,16 @@ class Limit
 
         return $this;
     }
+
+    /**
+     * Retrieve a fallback key for the limit.
+     *
+     * @return string
+     */
+    public function fallbackKey()
+    {
+        $prefix = $this->key ? '' : "{$this->key}:";
+
+        return "{$prefix}attempts:{$this->maxAttempts}:decay:{$this->decaySeconds}";
+    }
 }


### PR DESCRIPTION
This PR ensures that rate limiters specifying multiple limits will always have unique keys.

## The issue.

```php
RateLimiter::for('limiter-name', fn () => [
    Limit::perSecond(1),
    Limit::perMinute(30),
]);
```

This rate limiter will always fail. No request would ever get through. Zero. Nada.

 This is because both limits share the same key. The docs specify that _If you're assigning multiple rate limits segmented by identical by values, you should ensure that each by value is unique_

<img width="724" alt="Screenshot 2024-10-16 at 09 52 04" src="https://github.com/user-attachments/assets/01a5b6db-2dde-41c4-bcd4-50bab4de94ef">

This is fine, but also can be something easily forgotten; bit of a footgun.

## The improvement

This PR attempts to improve the situation by ensuring that when a list of limits has duplicate keys they are modified to be unique.

```php
RateLimiter::for('limiter-name', fn () => [
    Limit::perSecond(1),
    Limit::perMinute(30)->by(Auth::user()),
    Limit::perDay(500),
]);
```

In this above example, the first and the last limits would have their key modified to be unique.

Although this is a breaking change, it only breaks in already broken situations, so I see this as an overall improvement.

I don't feel like we need to update the docs. This is just a fallback fix for those rare times it is held wrong.

---
fixes https://github.com/laravel/framework/issues/53157