### PR TITLE
[11.x] Discard `PHP_CLI_SERVER_WORKERS` on Windows environment

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -357,7 +357,7 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $regex = env('PHP_CLI_SERVER_WORKERS', 1) > 1
+        $regex = ! windows_os() && env('PHP_CLI_SERVER_WORKERS', 1) > 1
             ? '/^\[\d+]\s\[([a-zA-Z0-9: ]+)\]/'
             : '/^\[([^\]]+)\]/';
 


### PR DESCRIPTION
fixes laravel/framework#53175

![CleanShot 2024-10-16 at 07 28 35](https://github.com/user-attachments/assets/5a3b6801-f4ca-4f24-af0f-876c4c058035)

`PHP_CLI_SERVER_WORKERS` is not supported in Windows. However, setting the default to `4` via `.env` would cause issue on Windows users since the regex used to parse date from server log will become incorrect.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
