### PR TITLE
Add directive @bool to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -317,6 +317,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a bool block into valid PHP.
+     *
+     * @param  bool  $condition
+     * @return string
+     */
+    protected function compileBool($condition)
+    {
+        return "<?php if{$condition}: echo 'true'; else: 'false'; endif; ?>";
+    }
+
+    /**
      * Compile a checked block into valid PHP.
      *
      * @param  string  $condition

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -306,7 +306,7 @@ trait CompilesConditionals
     }
 
     /**
-     * Compile a bool block into valid PHP.
+     * Compile a boolean value into a raw true / false value for embedding into HTML attributes or JavaScript.
      *
      * @param  bool  $condition
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -324,7 +324,7 @@ trait CompilesConditionals
      */
     protected function compileBool($condition)
     {
-        return "<?php if{$condition}: echo 'true'; else: 'false'; endif; ?>";
+        return "<?php echo ($condition ? 'true' : 'false'); ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -306,17 +306,6 @@ trait CompilesConditionals
     }
 
     /**
-     * Compile a selected block into valid PHP.
-     *
-     * @param  string  $condition
-     * @return string
-     */
-    protected function compileSelected($condition)
-    {
-        return "<?php if{$condition}: echo 'selected'; endif; ?>";
-    }
-
-    /**
      * Compile a bool block into valid PHP.
      *
      * @param  bool  $condition
@@ -369,6 +358,17 @@ trait CompilesConditionals
     protected function compileReadonly($condition)
     {
         return "<?php if{$condition}: echo 'readonly'; endif; ?>";
+    }
+
+    /**
+     * Compile a selected block into valid PHP.
+     *
+     * @param  string  $condition
+     * @return string
+     */
+    protected function compileSelected($condition)
+    {
+        return "<?php if{$condition}: echo 'selected'; endif; ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeBoolTest extends AbstractBladeTestCase
+{
+    public function testBool()
+    {
+
+        // For Javascript object{'isBool' : true}
+        $string = "{'isBool' : @bool(true)}";
+        $expected = "{'isBool' : <?php if(true): echo 'true'; else: 'false'; endif; ?>}";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        // For Javascript object{'isBool' : false}
+        $string = "{'isBool' : @bool(false)}";
+        $expected = "{'isBool' : <?php if(false): echo 'true'; else: 'false'; endif; ?>}";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        // For Alpine.js x-show attribute
+        $string = "<input type='text' x-show='@bool(true)' />";
+        $expected = "<input type='text' x-show='<?php if(true): echo 'true'; else: 'false'; endif; ?>' />";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        // For Alpine.js x-show attribute
+        $string = "<input type='text' x-show='@bool(false)' />";
+        $expected = "<input type='text' x-show='<?php if(false): echo 'true'; else: 'false'; endif; ?>' />";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Tests\View\Blade;
+
 class BladeBoolTest extends AbstractBladeTestCase
 {
     public function testBool()

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -8,7 +8,6 @@ class BladeBoolTest extends AbstractBladeTestCase
 {
     public function testBool()
     {
-
         // For Javascript object{'isBool' : true}
         $string = "{'isBool' : @bool(true)}";
         $expected = "{'isBool' : <?php echo ((true) ? 'true' : 'false'); ?>}";
@@ -46,7 +45,6 @@ class BladeBoolTest extends AbstractBladeTestCase
         eval(substr($compiled, 6, -3));
         $this->assertEquals('false', ob_get_clean());
 
-
         $anotherSomeViewVarTruthy = new SomeClass();
         $compiled = $this->compiler->compileString('@bool($anotherSomeViewVarTruthy)');
 
@@ -54,17 +52,19 @@ class BladeBoolTest extends AbstractBladeTestCase
         eval(substr($compiled, 6, -3));
         $this->assertEquals('true', ob_get_clean());
 
-        $anotherSomeViewVarFalsey = NULL;
+        $anotherSomeViewVarFalsey = null;
         $compiled = $this->compiler->compileString('@bool($anotherSomeViewVarFalsey)');
 
         ob_start();
         eval(substr($compiled, 6, -3));
         $this->assertEquals('false', ob_get_clean());
-
     }
 }
 
 
-class SomeClass{
-    public function someMethod(){}
+class SomeClass
+{
+    public function someMethod()
+    {
+    }
 }

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Testing\TestView;
+
 class BladeBoolTest extends AbstractBladeTestCase
 {
     public function testBool()
@@ -9,22 +11,60 @@ class BladeBoolTest extends AbstractBladeTestCase
 
         // For Javascript object{'isBool' : true}
         $string = "{'isBool' : @bool(true)}";
-        $expected = "{'isBool' : <?php if(true): echo 'true'; else: 'false'; endif; ?>}";
+        $expected = "{'isBool' : <?php echo ((true) ? 'true' : 'false'); ?>}";
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         // For Javascript object{'isBool' : false}
         $string = "{'isBool' : @bool(false)}";
-        $expected = "{'isBool' : <?php if(false): echo 'true'; else: 'false'; endif; ?>}";
+        $expected = "{'isBool' : <?php echo ((false) ? 'true' : 'false'); ?>}";
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         // For Alpine.js x-show attribute
         $string = "<input type='text' x-show='@bool(true)' />";
-        $expected = "<input type='text' x-show='<?php if(true): echo 'true'; else: 'false'; endif; ?>' />";
+        $expected = "<input type='text' x-show='<?php echo ((true) ? 'true' : 'false'); ?>' />";
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         // For Alpine.js x-show attribute
         $string = "<input type='text' x-show='@bool(false)' />";
-        $expected = "<input type='text' x-show='<?php if(false): echo 'true'; else: 'false'; endif; ?>' />";
+        $expected = "<input type='text' x-show='<?php echo ((false) ? 'true' : 'false'); ?>' />";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCompileBool(): void
+    {
+        $someViewVarTruthy = 123;
+        $compiled = $this->compiler->compileString('@bool($someViewVarTruthy)');
+
+        ob_start();
+        eval(substr($compiled, 6, -3));
+        $this->assertEquals('true', ob_get_clean());
+
+        $someViewVarFalsey = '0';
+        $compiled = $this->compiler->compileString('@bool($someViewVarFalsey)');
+
+        ob_start();
+        eval(substr($compiled, 6, -3));
+        $this->assertEquals('false', ob_get_clean());
+
+
+        $anotherSomeViewVarTruthy = new SomeClass();
+        $compiled = $this->compiler->compileString('@bool($anotherSomeViewVarTruthy)');
+
+        ob_start();
+        eval(substr($compiled, 6, -3));
+        $this->assertEquals('true', ob_get_clean());
+
+        $anotherSomeViewVarFalsey = NULL;
+        $compiled = $this->compiler->compileString('@bool($anotherSomeViewVarFalsey)');
+
+        ob_start();
+        eval(substr($compiled, 6, -3));
+        $this->assertEquals('false', ob_get_clean());
+
+    }
+}
+
+
+class SomeClass{
+    public function someMethod(){}
 }

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -1,9 +1,6 @@
 <?php
 
 namespace Illuminate\Tests\View\Blade;
-
-use Illuminate\Testing\TestView;
-
 class BladeBoolTest extends AbstractBladeTestCase
 {
     public function testBool()
@@ -60,7 +57,6 @@ class BladeBoolTest extends AbstractBladeTestCase
         $this->assertEquals('false', ob_get_clean());
     }
 }
-
 
 class SomeClass
 {


### PR DESCRIPTION
Add @bool directive functionality to Blade, allowing boolean values to be printed directly into strings or used in object construction.

Examples: 

**JS**

```
<script>
    let config = {
        isActive: @bool($isActive),
        hasAccess: @bool($hasAccess)
    };
</script>
```

**Alpine**

```
<div x-data="{ isActive: @bool($isActive) }">
    <button :class="{ 'active': isActive }">Toggle</button>
</div>
```

Bootstrap:
```
<div class="dropdown">
  <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="@bool($hasPopup)" aria-expanded="@bool($isExpanded)">
    Dropdown button
  </button>
  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
    <a class="dropdown-item" href="#">Action</a>
    <a class="dropdown-item" href="#">Another action</a>
    <a class="dropdown-item" href="#">Something else here</a>
  </div>
</div>
```

