### PR TITLE
[11.x] Resource Route Paths

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -101,6 +101,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Set the route names for controller actions.
+     *
+     * @param  array|string  $paths
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function paths($paths)
+    {
+        $this->options['paths'] = $paths;
+
+        return $this;
+    }
+
+    /**
      * Set the route name for a controller action.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -288,7 +288,7 @@ class ResourceRegistrar
      */
     protected function addResourceCreate($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/'.static::$verbs['create'];
+        $uri = $this->getResourceUri($name).'/'.($options['paths']['create'] ?? static::$verbs['create']);
 
         unset($options['missing']);
 
@@ -350,7 +350,7 @@ class ResourceRegistrar
     {
         $name = $this->getShallowName($name, $options);
 
-        $uri = $this->getResourceUri($name).'/{'.$base.'}/'.static::$verbs['edit'];
+        $uri = $this->getResourceUri($name).'/{'.$base.'}/'.($options['paths']['edit'] ?? static::$verbs['edit']);
 
         $action = $this->getResourceAction($name, $controller, 'edit', $options);
 
@@ -407,7 +407,7 @@ class ResourceRegistrar
      */
     protected function addSingletonCreate($name, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/'.static::$verbs['create'];
+        $uri = $this->getResourceUri($name).'/'.($options['paths']['create'] ?? static::$verbs['create']);
 
         unset($options['missing']);
 
@@ -466,7 +466,7 @@ class ResourceRegistrar
     {
         $name = $this->getShallowName($name, $options);
 
-        $uri = $this->getResourceUri($name).'/'.static::$verbs['edit'];
+        $uri = $this->getResourceUri($name).'/'.($options['paths']['edit'] ?? static::$verbs['edit']);
 
         $action = $this->getResourceAction($name, $controller, 'edit', $options);
 


### PR DESCRIPTION
We often use Route::resource in our projects to generate seven standard routes with a single command, simplifying the process:

index (GET /resource)
create (GET /resource/create)
store (POST /resource)
show (GET /resource/{id})
edit (GET /resource/{id}/edit)
update (PUT/PATCH /resource/{id})
destroy (DELETE /resource/{id})

This setup works well, but sometimes we need to customize paths for create and edit actions, like using "add" instead of "create" for medicines.

Now, we can customize these paths using:

```php
Route::resource('users', UserController::class)->paths([
    'create' => 'add',
    'edit' => 'change',
]);
```

This makes our routes more intuitive based on the resource context.

![Screenshot 2024-10-16 at 11 22 14 PM](https://github.com/user-attachments/assets/6482aa08-8b58-487a-a541-c741d948636d)
