### PR TITLE
[11.X] Add ability to return updated model instance after update

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1062,7 +1062,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $updated = $this->fill($attributes)->save($options);
 
-        return $updated ? $this->fresh() : false;
+        return $updated ? $this : false;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1048,6 +1048,24 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Update the model in the database and return the updated model instance.
+     *
+     * @param  array  $attributes
+     * @param  array  $options
+     * @return bool
+     */
+    public function updateAndFetch(array $attributes = [], array $options = [])
+    {
+        if (! $this->exists) {
+            return false;
+        }
+
+        $updated = $this->fill($attributes)->save($options);
+
+        return $updated ? $this->fresh() : false;
+    }
+
+    /**
      * Increment a column's value by a given amount without raising any events.
      *
      * @param  string  $column

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -126,6 +126,19 @@ class EloquentModelTest extends DatabaseTestCase
             'analyze' => true,
         ]);
     }
+
+    public function testUpdateReturnsUpdatedModel()
+    {
+        $user = TestModel2::create(['name' => 'John Doe', 'title' => 'hello']);
+
+        $updatedUser = $user->updateAndFetch(['title' => 'hello web']);
+
+        $this->assertInstanceOf(TestModel2::class, $updatedUser);
+
+        $this->assertEquals('hello web', $updatedUser->title);
+
+        $this->assertEquals('John Doe', $updatedUser->name);
+    }
 }
 
 class TestModel1 extends Model


### PR DESCRIPTION
#### Overview:
This pull request introduces a new method, `updateAndFetch()`, to the Eloquent model. The purpose of this method is to update a model instance with the provided attributes and return the fresh (updated) version of the model.

#### Changes:
- Added `updateAndFetch()` method to the `Illuminate\Database\Eloquent\Model` class.
  - This method performs the update using `fill()` and `save()`.
  - If the update is successful, it returns the fresh version of the updated model.
  - If the update fails, it returns `false`.
  
#### Example Usage:
```php
$user = User::find(1);

// Update the user and return the updated instance
$updatedUser = $user->updateAndFetch(['email' => 'newemail@example.com']);

// Check if the update was successful and use the updated data
if ($updatedUser) {
    echo $updatedUser->email; // Outputs 'newemail@example.com'
}
```

#### Tests:
- Added a test `testUpdateReturnsUpdatedModel()` in `tests/Integration/Database/EloquentModelTest.php` to ensure that:
  - The method correctly updates the model instance.
  - The method returns the updated instance after the update.

#### Benefits:
- Reduces boilerplate code when updating a model and immediately retrieving the updated instance.
- Provides a more intuitive way to handle updates in Eloquent models.

#### Backward Compatibility:
- This change is fully backward compatible as it introduces a new method without modifying the existing `update()` method.