### PR TITLE
[11.X] Fix 0 being treated as falsey when making translation replacements

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -185,7 +185,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line !== null? $line : $key, $replace);
+        return $this->makeReplacements($line !== null ? $line : $key, $replace);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -185,7 +185,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
+        return $this->makeReplacements($line !== null? $line : $key, $replace);
     }
 
     /**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -322,7 +322,8 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo'));
     }
 
-    public function testTagReplacementsHandleZeroAsString(){
+    public function testTagReplacementsHandleZeroAsString()
+    {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => '0']);
         $this->assertSame('0', $t->get('foo'));

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -322,6 +322,12 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo'));
     }
 
+    public function testTagReplacementsHandleZeroAsString(){
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => '0']);
+        $this->assertSame('0', $t->get('foo'));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
Was working with a json language string formatted as:
```
{
     "lg_cal_fdow": "0",
}
```
When I ran tinker and gave it the language tag `__("lg_cal_fdow")` the returned value was `"lg_cal_fdow"` instead of `0`. This was occurring because the Elvis operator `?:` considers `0` to be falsely. This fix checks for `null` directly. 