### PR TITLE
[11.x] Introduce Collection/LazyCollection isAssoc and isList methods

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -537,6 +537,30 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection is associative.
+     *
+     * The collection is "associative" if it doesn't have sequential numerical keys beginning with zero.
+     *
+     * @return bool
+     */
+    public function isAssoc()
+    {
+        return Arr::isAssoc($this->items);
+    }
+
+    /**
+     * Determine if the collection is a list.
+     *
+     * The collection is a "list" if all keys are sequential integers starting from 0 with no gaps in between.
+     *
+     * @return bool
+     */
+    public function isList()
+    {
+        return Arr::isList($this->items);
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @template TNewKey of array-key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -556,6 +556,30 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if the collection is associative.
+     *
+     * The collection is "associative" if it doesn't have sequential numerical keys beginning with zero.
+     *
+     * @return bool
+     */
+    public function isAssoc()
+    {
+        return Arr::isAssoc($this->all());
+    }
+
+    /**
+     * Determine if the collection is a list.
+     *
+     * The collection is a "list" if all keys are sequential integers starting from 0 with no gaps in between.
+     *
+     * @return bool
+     */
+    public function isList()
+    {
+        return Arr::isList($this->all());
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @template TNewKey of array-key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3338,6 +3338,42 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testIsAssoc($collection)
+    {
+        $this->assertTrue((new $collection(['a' => 'a', 0 => 'b']))->isAssoc());
+        $this->assertTrue((new $collection([1 => 'a', 0 => 'b']))->isAssoc());
+        $this->assertTrue((new $collection([1 => 'a', 2 => 'b']))->isAssoc());
+        $this->assertTrue((new $collection([1 => 'foo', 'bar']))->isAssoc());
+        $this->assertTrue((new $collection([0 => 'foo', 'bar' => 'baz']))->isAssoc());
+        $this->assertTrue((new $collection([0 => 'foo', 2 => 'bar']))->isAssoc());
+        $this->assertTrue((new $collection(['foo' => 'bar', 'baz' => 'qux']))->isAssoc());
+
+        $this->assertFalse((new $collection([]))->isAssoc());
+        $this->assertFalse((new $collection([0 => 'a', 1 => 'b']))->isAssoc());
+        $this->assertFalse((new $collection(['a', 'b']))->isAssoc());
+        $this->assertFalse((new $collection([1, 2, 3]))->isAssoc());
+        $this->assertFalse((new $collection(['foo', 2, 3]))->isAssoc());
+        $this->assertFalse((new $collection([0 => 'foo', 'bar']))->isAssoc());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testIsList($collection)
+    {
+        $this->assertTrue((new $collection([]))->isList());
+        $this->assertTrue((new $collection([1, 2, 3]))->isList());
+        $this->assertTrue((new $collection(['foo', 2, 3]))->isList());
+        $this->assertTrue((new $collection(['foo', 'bar']))->isList());
+        $this->assertTrue((new $collection([0 => 'foo', 'bar']))->isList());
+        $this->assertTrue((new $collection([0 => 'foo', 1 => 'bar']))->isList());
+
+        $this->assertFalse((new $collection([1 => 'foo', 'bar']))->isList());
+        $this->assertFalse((new $collection([1 => 'foo', 0 => 'bar']))->isList());
+        $this->assertFalse((new $collection([0 => 'foo', 'bar' => 'baz']))->isList());
+        $this->assertFalse((new $collection([0 => 'foo', 2 => 'bar']))->isList());
+        $this->assertFalse((new $collection(['foo' => 'bar', 'baz' => 'qux']))->isList());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testKeyByAttribute($collection)
     {
         $data = new $collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);


### PR DESCRIPTION
We need to check if a collection is associative or list.

This pull request adds isAssoc and isList methods that use the same-named methods already implemented in the Arr Class.