### PR TITLE
Helper functions updated, remove null values (data_forget)

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -185,7 +185,7 @@ if (! function_exists('data_forget')) {
         } elseif (is_object($target)) {
             if ($segments && isset($target->{$segment})) {
                 data_forget($target->{$segment}, $segments);
-            } elseif (isset($target->{$segment})) {
+            } elseif (property_exists($target, $segment)) {
                 unset($target->{$segment});
             }
         }


### PR DESCRIPTION
Instead of using `isset`, it is safer to use `property_exists`. This also ensures that if the value of `$segment = null`, the object key is also removed.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
