### PR TITLE
[11.x] Fix Cookie::queue to support domain-specific cookies

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -150,8 +150,12 @@ class CookieJar implements JarContract
             $this->queued[$cookie->getName()] = [];
         }
 
-        if (! isset($this->queued[$cookie->getDomain()])) {
-            $this->queued[$cookie->getDomain()] = [];
+        if (! isset($this->queued[$cookie->getName()][$cookie->getPath()])) {
+            $this->queued[$cookie->getName()][$cookie->getPath()] = [];
+        }
+
+        if (! isset($this->queued[$cookie->getName()][$cookie->getPath()][$cookie->getDomain()])) {
+            $this->queued[$cookie->getName()][$cookie->getPath()][$cookie->getDomain()] = [];
         }
 
         $this->queued[$cookie->getName()][$cookie->getPath()][$cookie->getDomain()] = $cookie;
@@ -175,17 +179,26 @@ class CookieJar implements JarContract
      *
      * @param  string  $name
      * @param  string|null  $path
+     * @param  string|null $domain
      * @return void
      */
-    public function unqueue($name, $path = null)
+    public function unqueue($name, $path = null, $domain = null)
     {
-        if ($path === null) {
+        if ($path === null && $domain === null) {
             unset($this->queued[$name]);
 
             return;
         }
 
-        unset($this->queued[$name][$path]);
+        if (empty($domain) && !empty($path)) {
+            unset($this->queued[$name][$path]);
+        }
+
+        if (empty($path) && !empty($domain)) {
+            unset($this->queued[$name][$domain]);
+        }
+
+        unset($this->queued[$name][$path][$domain]);
 
         if (empty($this->queued[$name])) {
             unset($this->queued[$name]);

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -150,7 +150,11 @@ class CookieJar implements JarContract
             $this->queued[$cookie->getName()] = [];
         }
 
-        $this->queued[$cookie->getName()][$cookie->getPath()] = $cookie;
+        if (! isset($this->queued[$cookie->getDomain()])) {
+            $this->queued[$cookie->getDomain()] = [];
+        }
+
+        $this->queued[$cookie->getName()][$cookie->getPath()][$cookie->getDomain()] = $cookie;
     }
 
     /**


### PR DESCRIPTION
### Description
This PR addresses the issue where setting two cookies using `Cookie::queue(...)` with the same name and path but different domains results in only one cookie being sent to the client, as the latter overwrites the prior. The issue is detailed in [#53159](https://github.com/laravel/framework/issues/53159).

#### Problem Description
The issue arises from how `CookieJar` currently stores queued cookies, only considering the cookie's name and path while ignoring the domain. The `Symfony ResponseHeaderBag::setCookie()` method, on the other hand, correctly differentiates cookies by domain in addition to name and path.

#### Solution
This PR updates `CookieJar` to take domains into account when queuing cookies. Specifically:
- The `queue` method now stores queued cookies using the cookie's name, path, and domain as keys, ensuring cookies with the same name and path but different domains do not overwrite each other.
  
#### Testing
- Added multiple test cases to verify that cookies with the same name but different domains or paths are queued and sent independently:
  1. Cookies with the same name and path but different domains are queued without overwriting each other.
  2. Cookies with the same name but different paths are handled correctly.
  3. Cookies with the same name, path, and domain result in the latter cookie overwriting the former (as expected).
  4. Verified behavior for `secure`, `httpOnly`, and other attributes.
