### PR TITLE
[11.x] Fix handling exceptions thrown in eval()'d code

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -106,9 +106,10 @@ class Frame
      */
     public function line()
     {
-        if (! (\is_file($this->frame['file']) && is_readable($this->frame['file']))) {
+        if (! is_file($this->frame['file']) || ! is_readable($this->frame['file'])) {
             return 0;
         }
+
         $maxLines = count(file($this->frame['file']) ?: []);
 
         return $this->frame['line'] > $maxLines ? 1 : $this->frame['line'];
@@ -134,9 +135,10 @@ class Frame
      */
     public function snippet()
     {
-        if (! (\is_file($this->frame['file']) && is_readable($this->frame['file']))) {
+        if (! is_file($this->frame['file']) || ! is_readable($this->frame['file'])) {
             return '';
         }
+
         $contents = file($this->frame['file']) ?: [];
 
         $start = max($this->line() - 6, 0);

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -106,6 +106,9 @@ class Frame
      */
     public function line()
     {
+        if (! (\is_file($this->frame['file']) && is_readable($this->frame['file']))) {
+            return 0;
+        }
         $maxLines = count(file($this->frame['file']) ?: []);
 
         return $this->frame['line'] > $maxLines ? 1 : $this->frame['line'];
@@ -131,6 +134,9 @@ class Frame
      */
     public function snippet()
     {
+        if (! (\is_file($this->frame['file']) && is_readable($this->frame['file']))) {
+            return '';
+        }
         $contents = file($this->frame['file']) ?: [];
 
         $start = max($this->line() - 6, 0);


### PR DESCRIPTION
This fix issue #53203 

## Before
If an exception is thrown from an eval()'d code, the error handler throws and shows a strange error screen, hiding the real one:
<img width="1054" alt="Capture d’écran 2024-10-17 à 22 21 31" src="https://github.com/user-attachments/assets/aa30d82e-c694-4efe-a532-fab1b7a05375">

## After
After this fix it shows:
![Capture d’écran 2024-10-18 à 09 10 34](https://github.com/user-attachments/assets/edcdeeb1-0c7b-47d3-9197-9fe88b2169bd)
