### PR TITLE
[11.x] Fixes handling `Js::from(collect());`

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
 use Stringable;
+use UnitEnum;
 
 class Js implements Htmlable, Stringable
 {
@@ -70,7 +71,9 @@ class Js implements Htmlable, Stringable
             return $data->toHtml();
         }
 
-        $data = enum_value($data);
+        if ($data instanceof UnitEnum) {
+            $data = enum_value($data);
+        }
 
         $json = static::encode($data, $flags, $depth);
 

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -43,16 +43,12 @@ if (! function_exists('Illuminate\Support\enum_value')) {
      */
     function enum_value($value, $default = null)
     {
-        if (empty($value)) {
-            return $value;
-        }
-
         return transform($value, fn ($value) => match (true) {
             $value instanceof \BackedEnum => $value->value,
             $value instanceof \UnitEnum => $value->name,
 
             default => $value,
-        }, $default);
+        }, $default ?? $value);
     }
 }
 

--- a/tests/Support/SupportEnumValueFunctionTest.php
+++ b/tests/Support/SupportEnumValueFunctionTest.php
@@ -43,5 +43,6 @@ class SupportEnumValueFunctionTest extends TestCase
         yield [true, true];
         yield [1337, 1337];
         yield [1.0, 1.0];
+        yield [$collect = collect(), $collect];
     }
 }

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -19,6 +19,8 @@ class SupportJsTest extends TestCase
         $this->assertSame('1', (string) Js::from(1));
         $this->assertSame('1.1', (string) Js::from(1.1));
         $this->assertSame('[]', (string) Js::from([]));
+        $this->assertSame('[]', (string) Js::from(collect()));
+        $this->assertSame('null', (string) Js::from(null));
         $this->assertSame("'Hello world'", (string) Js::from('Hello world'));
         $this->assertEquals(
             "'\\u003Cdiv class=\\u0022foo\\u0022\\u003E\\u0027quoted html\\u0027\\u003C\\/div\\u003E'",


### PR DESCRIPTION
* Reduce `enum_value()` usage on `Illuminate\Support\Js` to only when `$data` is instance of `UnitEnum`.
* `enum_value()` should always return `$value` unless `$default` is set other than `null`.

fixes #53205 

