### PR TITLE
[11.x] Support DB aggregate by group

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3553,7 +3553,7 @@ class Builder implements BuilderContract
      * Retrieve the "count" result of the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $columns
-     * @return int|Collection
+     * @return \Illuminate\Support\Collection|int
      */
     public function count($columns = '*')
     {
@@ -3566,7 +3566,7 @@ class Builder implements BuilderContract
      * Retrieve the minimum value of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed|Collection
+     * @return \Illuminate\Support\Collection|mixed
      */
     public function min($column)
     {
@@ -3577,7 +3577,7 @@ class Builder implements BuilderContract
      * Retrieve the maximum value of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed|Collection
+     * @return \Illuminate\Support\Collection|mixed
      */
     public function max($column)
     {
@@ -3588,7 +3588,7 @@ class Builder implements BuilderContract
      * Retrieve the sum of the values of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed|Collection
+     * @return \Illuminate\Support\Collection|mixed
      */
     public function sum($column)
     {
@@ -3601,7 +3601,7 @@ class Builder implements BuilderContract
      * Retrieve the average of the values of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed|Collection
+     * @return \Illuminate\Support\Collection|mixed
      */
     public function avg($column)
     {
@@ -3612,7 +3612,7 @@ class Builder implements BuilderContract
      * Alias for the "avg" method.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed|Collection
+     * @return \Illuminate\Support\Collection|mixed
      */
     public function average($column)
     {
@@ -3624,7 +3624,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $function
      * @param  array  $columns
-     * @return mixed|Collection
+     * @return \Illuminate\Support\Collection|mixed
      */
     public function aggregate($function, $columns = ['*'])
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3553,18 +3553,20 @@ class Builder implements BuilderContract
      * Retrieve the "count" result of the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $columns
-     * @return int
+     * @return int|Collection
      */
     public function count($columns = '*')
     {
-        return (int) $this->aggregate(__FUNCTION__, Arr::wrap($columns));
+        $results = $this->aggregate(__FUNCTION__, Arr::wrap($columns));
+
+        return $results instanceof Collection ? $results : (int) $results;
     }
 
     /**
      * Retrieve the minimum value of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed
+     * @return mixed|Collection
      */
     public function min($column)
     {
@@ -3575,7 +3577,7 @@ class Builder implements BuilderContract
      * Retrieve the maximum value of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed
+     * @return mixed|Collection
      */
     public function max($column)
     {
@@ -3586,7 +3588,7 @@ class Builder implements BuilderContract
      * Retrieve the sum of the values of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed
+     * @return mixed|Collection
      */
     public function sum($column)
     {
@@ -3599,7 +3601,7 @@ class Builder implements BuilderContract
      * Retrieve the average of the values of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed
+     * @return mixed|Collection
      */
     public function avg($column)
     {
@@ -3610,7 +3612,7 @@ class Builder implements BuilderContract
      * Alias for the "avg" method.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @return mixed
+     * @return mixed|Collection
      */
     public function average($column)
     {
@@ -3622,7 +3624,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $function
      * @param  array  $columns
-     * @return mixed
+     * @return mixed|Collection
      */
     public function aggregate($function, $columns = ['*'])
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3684,8 +3684,6 @@ class Builder implements BuilderContract
             $this->orders = null;
 
             $this->bindings['order'] = [];
-        } else {
-            $this->columns = array_merge($this->groups, $columns);
         }
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3631,6 +3631,10 @@ class Builder implements BuilderContract
                         ->setAggregate($function, $columns)
                         ->get($columns);
 
+        if ($this->groups) {
+            return $results;
+        }
+
         if (! $results->isEmpty()) {
             return array_change_key_case((array) $results[0])['aggregate'];
         }
@@ -3680,6 +3684,8 @@ class Builder implements BuilderContract
             $this->orders = null;
 
             $this->bindings['order'] = [];
+        } else {
+            $this->columns = array_merge($this->groups, $columns);
         }
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -140,7 +140,6 @@ class Grammar extends BaseGrammar
 
         $sql = 'select ';
 
-        // Select the columns that are used to group the results
         if ($query->groups) {
             $sql .= $this->columnize($query->groups).', ';
         }
@@ -1139,12 +1138,12 @@ class Grammar extends BaseGrammar
     protected function compileUnionAggregate(Builder $query)
     {
         $sql = $this->compileAggregate($query, $query->aggregate);
-        $group = $query->groups ? ' '.$this->compileGroups($query, $query->groups) : '';
+        $groups = $query->groups ? ' '.$this->compileGroups($query, $query->groups) : '';
 
         $query->aggregate = null;
         $query->groups = null;
 
-        return $sql.' from ('.$this->compileSelect($query).') as '.$this->wrapTable('temp_table').$group;
+        return $sql.' from ('.$this->compileSelect($query).') as '.$this->wrapTable('temp_table').$groups;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1139,7 +1139,7 @@ class Grammar extends BaseGrammar
     protected function compileUnionAggregate(Builder $query)
     {
         $sql = $this->compileAggregate($query, $query->aggregate);
-        $group = $query->groups ? ' ' . $this->compileGroups($query, $query->groups) : '';
+        $group = $query->groups ? ' '.$this->compileGroups($query, $query->groups) : '';
 
         $query->aggregate = null;
         $query->groups = null;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -154,6 +154,10 @@ class Grammar extends BaseGrammar
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
         if (! is_null($query->aggregate)) {
+            if ($query->groups) {
+                return ', '.$this->columnize($query->groups);
+            }
+
             return;
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -25,6 +25,7 @@ use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Tests\Database\Fixtures\Enums\Bar;
 use InvalidArgumentException;
 use Mockery as m;
@@ -3179,6 +3180,51 @@ class DatabaseQueryBuilderTest extends TestCase
         });
         $results = $builder->from('users')->average('id');
         $this->assertEquals(1, $results);
+    }
+
+    public function testAggregateFunctionsWithGroupBy()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", count(*) as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->from('users')->groupBy('role')->count();
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", max("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->from('users')->groupBy('role')->max('id');
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", min("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->from('users')->groupBy('role')->min('id');
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", sum("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->from('users')->groupBy('role')->sum('id');
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", avg("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->from('users')->groupBy('role')->avg('id');
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", avg("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->from('users')->groupBy('role')->average('id');
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
     }
 
     public function testSqlServerExists()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1809,7 +1809,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
 
-        $queryResults = [(object) ['aggregate' => 2, 'role' => 'admin', 'city' => 'NY'], (object) ['aggregate' => 5, 'role' => 'user', 'city' => 'LA']];
+        $queryResults = [['aggregate' => 2, 'role' => 'admin', 'city' => 'NY'], ['aggregate' => 5, 'role' => 'user', 'city' => 'LA']];
         $builder->getConnection()
             ->shouldReceive('select')->once()
             ->with('select "role", "city", count(*) as aggregate from "users" group by "role", "city"', [], true)
@@ -1823,7 +1823,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
 
-        $queryResults = [(object) ['aggregate' => 2, 'role' => 'admin', 'city' => 'NY'], (object) ['aggregate' => 5, 'role' => 'user', 'city' => 'LA']];
+        $queryResults = [['aggregate' => 2, 'role' => 'admin'], ['aggregate' => 5, 'role' => 'user']];
         $builder->getConnection()
             ->shouldReceive('select')->once()
             ->with('select "role", count(*) as aggregate from ((select * from "users") union (select * from "members")) as "temp_table" group by "role"', [], true)

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1804,6 +1804,20 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['whereRawBinding', 'groupByRawBinding', 'havingRawBinding'], $builder->getBindings());
     }
 
+    public function testGroupByAndAggregate()
+    {
+        $builder = $this->getBuilder();
+
+        $queryResults = [(object) ['aggregate' => 2, 'role' => 'admin', 'city' => 'NY'], (object) ['aggregate' => 5, 'role' => 'user', 'city' => 'LA']];
+        $builder->getConnection()
+            ->shouldReceive('select')->once()
+            ->with('select count(*) as aggregate , "role", "city" from "users" group by "role", "city"', [], true)
+            ->andReturn($queryResults);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
+        $results = $builder->select('role')->from('users')->groupBy('role', 'city')->aggregate('count');
+        $this->assertEquals($queryResults, $results->toArray());
+    }
+
     public function testOrderBys()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Currently, the aggregate methods ignore the `group by` clause. This PR change the result of 
```php
$builder->from('users')->groupBy('role')->count()
```

to return a Collection of `[role, count]` instead of a single total count.

```diff
- select         count(*) as aggregate from "users"
+ select "role", count(*) as aggregate from "users" group by "role" 
```

Result before: `40`
Result after:
| role  | aggregate |
|-------|-----------|
| admin | 10        |
| user  | 30        |

The aggregate result is always in a column named `aggregate` and the "group by" columns are added to the result.

### Why?

I'm implementing [`withCount`](https://laravel.com/docs/11.x/eloquent-relationships#counting-related-models) for [MongoDB models](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/v5.x/eloquent-models/) and hybrid MongoDB to SQL models. This implementation is done during `eagerLoad` by doing a count by foreign key in the related table (i.e. `select foreign_id, count(*) from mytable where foreign_id in (1,2,3) group by foreign_id`). I managed to do that for MongoDB, and this PR makes it work for hybrid MongoDB to SQL models.

### Union and group by
This also works with unions. I have to change the generated SQL to apply the `group by` clause to the union result instead of the first query of the union.

For the following query:
```php
$builder->from('users')
    ->union($this->getBuilder()->from('members'))
    ->groupBy('role')
    ->aggregate('count')
```

The generated SQL is before/after the PR:
```diff
- select count(*) as aggregate from ((select * from "users" group by "role") union (select * from "members")) as "temp_table" 
+ select "role", count(*) as aggregate from ((select * from "users") union (select * from "members")) as "temp_table" group by "role"
```

If anyone need to generate the previous SQL, the query builder for the 1st subquery would have to be wrapped:
```diff
  $builder
-    ->from('users')
-    ->groupBy('role')
+    ->from($this->getBuilder()->from('users')->groupBy('role'), 'alias')
     ->union($this->getBuilder()->from('members'))
     ->aggregate('count');
```

### Return type of count/sum/avg/min/max

The return type of the aggregate methods indicate that a single value is expected: the result of the aggregation. But since the group by clause is used, the result is a collection of `[...groups, aggregate]`. I had to change the return type in phpdoc to add `Collection`. This may impact the `count` function only, as other return `mixed` that already includes `Collection`.

An alternative could have been to add a new methods `sumBy($function, $column, ...$groups)` but I think this is already the role of `->groupBy(...$groups)` to specify the expected groups.
