### PR TITLE
[11.x] fix PHPDoc for \Illuminate\Redis\Connections\Connection::$events

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -32,7 +32,7 @@ abstract class Connection
     /**
      * The event dispatcher instance.
      *
-     * @var \Illuminate\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected $events;
 


### PR DESCRIPTION
`Connection::unsetEventDispatcher` can cause `$events` to be `null`.