### PR TITLE
[11.x] fix PHPDoc for \Illuminate\Database\Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -865,7 +865,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the elapsed time since a given starting point.
      *
-     * @param  int  $start
+     * @param  float  $start
      * @return float
      */
     protected function getElapsedTime($start)

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -106,7 +106,7 @@ class Connection implements ConnectionInterface
     /**
      * The event dispatcher instance.
      *
-     * @var \Illuminate\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected $events;
 
@@ -127,7 +127,7 @@ class Connection implements ConnectionInterface
     /**
      * The transaction manager instance.
      *
-     * @var \Illuminate\Database\DatabaseTransactionsManager
+     * @var \Illuminate\Database\DatabaseTransactionsManager|null
      */
     protected $transactionsManager;
 


### PR DESCRIPTION
`$events` and `$transactionsManager` can both be set to null using `unsetEventDispatcher()` and `unsetTransactionManager`.

As for `getElapsedTime($start)`, doc says `int $start` but if you look at how it's actually used, it's passing a float (see below).
https://github.com/laravel/framework/blob/5c9cb78beb156b501c25e571739982f05aab90c9/src/Illuminate/Database/Connection.php#L789-L791