### PR TITLE
[11.x] Simplify TableGuesser RegExp

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -4,15 +4,7 @@ namespace Illuminate\Database\Console\Migrations;
 
 class TableGuesser
 {
-    const CREATE_PATTERNS = [
-        '/^create_(\w+)_table$/',
-        '/^create_(\w+)$/',
-    ];
-
-    const CHANGE_PATTERNS = [
-        '/.+_(to|from|in)_(\w+)_table$/',
-        '/.+_(to|from|in)_(\w+)$/',
-    ];
+    const PATTERN = '/^(?<method>create)_(?<table>\w+?)(?:_table)?$|(?J)(?<method>add|drop|change).+_(?:to|from|in)_(?J)(?<table>\w+?)(?:_table)?$/'; 
 
     /**
      * Attempt to guess the table name and "creation" status of the given migration.
@@ -22,16 +14,8 @@ class TableGuesser
      */
     public static function guess($migration)
     {
-        foreach (self::CREATE_PATTERNS as $pattern) {
-            if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[1], $create = true];
-            }
-        }
-
-        foreach (self::CHANGE_PATTERNS as $pattern) {
-            if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[2], $create = false];
-            }
+        if (preg_match(self::PATTERN, $migration, $matches)) {
+            return [$matches['table'], $matches['method'] === 'create'];
         }
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Console\Migrations;
 
 class TableGuesser
 {
-    const PATTERN = '/^(?<method>create)_(?<table>\w+?)(?:_table)?$|(?J)(?<method>add|drop|change).+_(?:to|from|in)_(?J)(?<table>\w+?)(?:_table)?$/'; 
+    const PATTERN = '/^(?<method>create)_(?<table>\w+?)(?:_table)?$|(?J)(?<method>add|drop|change).+_(?:to|from|in)_(?J)(?<table>\w+?)(?:_table)?$/';
 
     /**
      * Attempt to guess the table name and "creation" status of the given migration.


### PR DESCRIPTION
This change simplifies the patterns used to guess the table name, streamlining it into one RegExp for all current use cases.

It does not change the return value, thus is not a breaking change.

# [Class history](https://github.com/laravel/framework/commits/11.x/src/Illuminate/Database/Console/Migrations/TableGuesser.php)
* e96e5ab9a9ad414b7806119fe03833d8e29c1b00 First RegExp added for create table
* be79fb8779667f169b8efaf69ae9f9013d7d2244 Second RegExp added for add/change/drop column as a separate `if`
* b1a80f0c32e16753b5f50ec1172fdf8a8d41256e Moved logic from `\Illuminate\Database\Console\Migrations\MigrateMakeCommand` to `\Illuminate\Database\Console\Migrations\TableGuesser`, left the logic as is
* 4528502420d7e3bbd85e3a819860a03c8b8b7b55 Duplicated the RegExps from 2 to 4 to account for missing explicit `_table` suffix, introducing a `foreach` wrapping around each `if`, resulting in each `if` being called twice (four calls total, one for each RegExp) (#26429)