### PR TITLE
Add `$bind` parameter to allow binding custom Blade directive handler to the BladeCompiler instance.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -939,17 +939,18 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $name
      * @param  callable  $handler
+     * @param  bool  $bind
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function directive($name, callable $handler)
+    public function directive($name, callable $handler, bool $bind = false)
     {
         if (! preg_match('/^\w+(?:::\w+)?$/x', $name)) {
             throw new InvalidArgumentException("The directive name [{$name}] is not valid. Directive names must only contain alphanumeric characters and underscores.");
         }
 
-        $this->customDirectives[$name] = $handler;
+        $this->customDirectives[$name] = $bind ? $handler->bindTo($this, BladeCompiler::class) : $handler;
     }
 
     /**


### PR DESCRIPTION
I was attempting to extend the functionality of the `@extends` directive but encountered issues accessing properties of the `BladeCompiler`.
With the introduction of the `$bind` parameter in the directive method, setting it to `true` allows full access to the `BladeCompiler` instance. This effectively makes the Blade compiler more flexible, as it now supports directive handlers that can access its protected properties, making it function similarly to a macroable object.

**Example:**
```php
Blade::directive(name: 'custom_directive', handler: function ($expression) {
    dd(
        class_basename($this)
    ); // prints: BladeCompiler
}, bind: true);
```

**Real Example:**
```php
Blade::directive('template_extends', function ($expression) {
    $expression = $this->stripParentheses($expression);

    // ...

    $echo = "<?php echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";

    $this->footer[] = $echo;

    return '';
}, true);
```