### PR TITLE
[11.x] Introduce whereDateDiff methods in query builder

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -128,7 +128,7 @@ class PostgresGrammar extends Grammar
         return 'extract('.$type.' from '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
     }
 
-po    /**
+    /**
      * Compile a "where DateDiff" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -162,6 +162,20 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a "where DateDiff" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDateDiff(Builder $query, $where)
+    {
+        $unit = strtolower($where['unit']);
+
+        return "DATEDIFF({$unit}, {$this->wrap($where['column2'])}, {$this->wrap($where['column1'])}) {$where['operator']} ?";
+    }
+
+    /**
      * Compile a "JSON contains" statement into SQL.
      *
      * @param  string  $column

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -377,6 +377,25 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(0, $sql->count());
     }
 
+    public function testWhereDateDiff()
+    {
+        $this->assertSame(1, DB::table('posts')->whereId(1)->whereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)->count());
+        $this->assertSame(1, DB::table('posts')->whereId(1)->whereDateDiff('created_at', '2017-11-12 13:14:15', '=', 0)->count());
+        $this->assertSame(1, DB::table('posts')->whereId(1)->whereDateDiff('Dec 31 2023', 'Dec 31 2023', '=', 0)->count());
+        $this->assertSame(1, DB::table('posts')->whereId(1)->whereDateDiff('2017-11-12 13:14:15', 'created_at', '=', 0)->count());
+        $this->assertSame(1, DB::table('posts')->whereId(1)->whereDateDiff('2017-11-12 13:14:15', '2017-11-12 13:14:15', '=', 0)->count());
+        $this->assertSame(1, DB::table('posts')->whereId(1)->whereDateDiff('Dec 01 2025', '2022-11-12 13:14:15', '=', 3, 'year')->count());
+    }
+
+
+    public function testOrWhereDateDiff()
+    {
+        $this->assertSame(1, DB::table('posts')->whereId(1)->orWhereDateDiff('created_at', '2017-11-12 13:14:15', '=', 0)->count());
+        $this->assertSame(1, DB::table('posts')->whereId(1)->orWhereDateDiff('2017-11-12 13:14:15', 'created_at', '=', 0)->count());
+        $this->assertSame(2, DB::table('posts')->whereId(1)->orWhereDateDiff('2017-11-12 13:14:15', '2017-11-12 13:14:15', '=', 0)->count());
+        $this->assertSame(2, DB::table('posts')->whereId(1)->orWhereDateDiff('Dec 01 2025', '2022-11-12 13:14:15', '=', 3, 'year')->count());
+    }
+
     public function testOrWhereDay()
     {
         $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDay('created_at', '02')->count());


### PR DESCRIPTION
### **Introduction of whereDateDiff function to Laravel Query Builder**

_This pull request introduces a new function whereDateDiff to the Illuminate\Database\Query\Builder class. The function supports MySQL, SQLite, SQL Server, and PostgreSQL._

### Function Signature
`whereDateDiff($column1, $column2, $operator, $value, $unit = 'day', $boolean = 'and')`

### $unit Parameter
The `$unit` parameter specifies the time unit for the date difference calculation. It can be one of the following values:

- 'year': Calculates the difference in years
- 'month': Calculates the difference in months
- 'week': Calculates the difference in weeks
- 'day': Calculates the difference in days (default)
- 'hour': Calculates the difference in hours
- 'minute': Calculates the difference in minutes
- 'second': Calculates the difference in seconds

_If not specified, the function defaults to using 'day' as the unit._

### Usage Examples

> DB::table('posts')->whereId(1)->whereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)

`or`

> Post::whereId(1)->whereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)

`or`

> Post::whereId(1)->orWhereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)

**_MySQL Example_**

> User::whereDateDiff('Dec 31 2023', 'Dec 31 2023', '=', 0, 'day')->toSql()
_This generates:_

> select * from `users` where DATEDIFF('2023-12-31 00:00:00', '2023-12-31 00:00:00') = ?

**_SQLite Example_**

> DB::table('posts')->whereId(1)->whereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)->toSql()
_This generates:_

> select * from "posts" where "id" = ? and CAST(julianday("posts"."created_at") - julianday('2017-11-12 13:14:15') AS INTEGER) = ?

**_SQL Server Example_**

> DB::table('posts')->whereId(1)->whereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)->toSql()
_This generates:_

> select * from [posts] where [id] = ? and DATEDIFF(day, '2017-11-12 13:14:15', [posts].[created_at]) = ?

**_PostgreSQL Example_**

> DB::table('posts')->whereId(1)->whereDateDiff('posts.created_at', '2017-11-12 13:14:15', '=', 0)->toSql()
_This generates:_

> select * from "posts" where "id" = ? and (DATE_PART('day', "posts"."created_at"::timestamp - '2017-11-12 13:14:15'::timestamp))::integer = ?

**Supported Databases**

- [x]  MySQL
- [x]  SQLite
- [x]  SQL Server
- [x]  PostgreSQL












