### PR TITLE
[12.x] Better support for multi-dbs in the `RefreshDatabase` trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -28,19 +28,11 @@ trait RefreshDatabase
     }
 
     /**
-     * Determine if an in-memory database is being used.
+     * Determine if any of the connections transacting is using in-memory databases.
      *
      * @return bool
      */
-    protected function usingInMemoryDatabase(string $name)
-    {
-        return config("database.connections.{$name}.database") === ':memory:';
-    }
-
-    /**
-     * Determines if any of the connections transacting is using in-memory databases.
-     */
-    protected function usingInMemoryDatabases(): bool
+    protected function usingInMemoryDatabases()
     {
         foreach ($this->connectionsToTransact() as $name) {
             if ($this->usingInMemoryDatabase($name)) {
@@ -49,6 +41,16 @@ trait RefreshDatabase
         }
 
         return false;
+    }
+
+    /**
+     * Determine if a given database connection is an in-memory database.
+     *
+     * @return bool
+     */
+    protected function usingInMemoryDatabase(string $name)
+    {
+        return config("database.connections.{$name}.database") === ':memory:';
     }
 
     /**
@@ -83,6 +85,16 @@ trait RefreshDatabase
         }
 
         $this->beginDatabaseTransaction();
+    }
+
+    /**
+     * Migrate the database.
+     *
+     * @return void
+     */
+    protected function migrateDatabases()
+    {
+        $this->artisan('migrate:fresh', $this->migrateFreshUsing());
     }
 
     /**
@@ -134,14 +146,6 @@ trait RefreshDatabase
     {
         return property_exists($this, 'connectionsToTransact')
                             ? $this->connectionsToTransact : [config('database.default')];
-    }
-
-    /**
-     * Perform the database migration command.
-     */
-    protected function migrateDatabases(): void
-    {
-        $this->artisan('migrate:fresh', $this->migrateFreshUsing());
     }
 
     /**


### PR DESCRIPTION
When working with multiple databases and some of them are in-memory while others are regular disk-based databases, we usually have to override some of the traits methods to make it work. Also, the database restoration process doesn't handle multiple DBs that well.

With these changes, when an app needs to support multiple databases, the user will have to do a few steps:

1. Set the `$connectionsToTransact` protected property on the TestCase listing all connections they use
1. Override the `migrateDatabases` method and call all the `migrate:fresh` commands for all their connections

The trait should now completely handle restoring the databases between tests, regardless of which database connection uses in-memory databases.

---

I'm sending this to 12.x because the API of the `RefreshDatabase` trait has changed. If this change is not considered BC, let me know so that I can send it to 11.x instead.

I'm using this trait in the app I'm working on that needs several databases and it's working.
