### PR TITLE
[11.x] Add helper method to determine stray request prevention state

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -268,6 +268,16 @@ class Factory
     }
 
     /**
+     * Determine if stray requests are being prevented.
+     *
+     * @return bool
+     */
+    public function preventingStrayRequests()
+    {
+        return $this->preventStrayRequests;
+    }
+
+    /**
      * Indicate that an exception should not be thrown if any request is not faked.
      *
      * @return $this

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2907,6 +2907,15 @@ class HttpClientTest extends TestCase
         $this->factory->get('https://laravel.com');
     }
 
+    public function testPreventingStrayRequests()
+    {
+        $this->assertFalse($this->factory->preventingStrayRequests());
+
+        $this->factory->preventStrayRequests();
+
+        $this->assertTrue($this->factory->preventingStrayRequests());
+    }
+
     public function testItCanAddAuthorizationHeaderIntoRequestUsingBeforeSendingCallback()
     {
         $this->factory->fake();


### PR DESCRIPTION
This pull request introduces the `preventingStrayRequests` method, which allows developers to check whether the system is configured to prevent real (stray) API requests. The method is useful in testing environments to ensure all requests are faked and can be used in production or development environments to conditionally log, debug, or handle requests.