### PR TITLE
Allow Vite entry points to be merged

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -185,7 +185,7 @@ class Vite implements Htmlable
     {
         return $this->withEntryPoints(array_unique([
             ...$this->entryPoints,
-            ...$entryPoints
+            ...$entryPoints,
         ]));
     }
 

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -176,6 +176,20 @@ class Vite implements Htmlable
     }
 
     /**
+     * Merge additional Vite entry points with the current set.
+     *
+     * @param  array  $entryPoints
+     * @return $this
+     */
+    public function mergeEntryPoints($entryPoints)
+    {
+        return $this->withEntryPoints(array_unique([
+            ...$this->entryPoints,
+            ...$entryPoints
+        ]));
+    }
+
+    /**
      * Set the filename for the manifest file.
      *
      * @param  string  $filename


### PR DESCRIPTION
This PR aims to solve an issue when Vite entry points are conditionally determined at runtime.

The existing `withEntryPoints` method in the `Vite` class replaces any entry points which have already been applied, and `$this->entryPoints` is protected with no accessor method. So this backwards-compatible PR simply adds an additional method to merge a set of entry points with any which have already been set.

---

I recently found myself in this situation:

- I have two main Vite entry points, `app.css` and `app.js`.
- I also have some additional entry points for custom React components: `component-1.ts`, `component-2.ts` etc.
- My app uses Filament for the backend admin functionality, so I've used `->viteTheme(['app.css', 'app.js'])` to set my entry points in their service provider.
- On pages which require a specific React component, I can add `@vite(['component-2.ts'])` to include them as needed.

However, if `component-2.ts` references assets which are also used by `app.css` (e.g. website logo etc.), **duplicate chunk tags are rendered in the HTML markup**.

With this PR I can let Filament call `withEntryPoints` in its service provider, then later attach any additional components I need to include conditionally, before letting Filament render them once in a single output.

---

There are other ways to solve this, I figured `mergeEntryPoints` was the simplest but am open to any other ideas.

Let me know if any changes are necessary. Thanks! 🙏