### PR TITLE
add support for BackedEnums to session

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use ArgumentCountError;
 use ArrayAccess;
+use BackedEnum;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
@@ -27,7 +28,7 @@ class Arr
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
      * @param  array  $array
-     * @param  string|int|float  $key
+     * @param  string|\BackedEnum|int|float  $key
      * @param  mixed  $value
      * @return array
      */
@@ -144,7 +145,7 @@ class Arr
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array
-     * @param  array|string|int|float  $keys
+     * @param  array|string|\BackedEnum|int|float  $keys
      * @return array
      */
     public static function except($array, $keys)
@@ -158,11 +159,13 @@ class Arr
      * Determine if the given key exists in the provided array.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int|float  $key
+     * @param  string|\BackedEnum|int|float  $key
      * @return bool
      */
     public static function exists($array, $key)
     {
+        $key = $key instanceof BackedEnum ? $key->value : $key;
+
         if ($array instanceof Enumerable) {
             return $array->has($key);
         }
@@ -280,12 +283,14 @@ class Arr
      * Remove one or many array items from a given array using "dot" notation.
      *
      * @param  array  $array
-     * @param  array|string|int|float  $keys
+     * @param  array|string|\BackedEnum|int|float  $keys
      * @return void
      */
     public static function forget(&$array, $keys)
     {
         $original = &$array;
+
+        $keys = $keys instanceof BackedEnum ? $keys->value : $keys;
 
         $keys = (array) $keys;
 
@@ -294,6 +299,8 @@ class Arr
         }
 
         foreach ($keys as $key) {
+            $key = $key instanceof BackedEnum ? $key->value : $key;
+
             // if the exact key exists in the top-level, remove it
             if (static::exists($array, $key)) {
                 unset($array[$key]);
@@ -324,7 +331,7 @@ class Arr
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
+     * @param  string|\BackedEnum|int|null  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -337,6 +344,8 @@ class Arr
         if (is_null($key)) {
             return $array;
         }
+
+        $key = $key instanceof BackedEnum ? $key->value : $key;
 
         if (static::exists($array, $key)) {
             return $array[$key];
@@ -361,11 +370,13 @@ class Arr
      * Check if an item or items exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
+     * @param  string|\BackedEnum|array  $keys
      * @return bool
      */
     public static function has($array, $keys)
     {
+        $keys = $keys instanceof BackedEnum ? $keys->value : $keys;
+
         $keys = (array) $keys;
 
         if (! $array || $keys === []) {
@@ -373,6 +384,8 @@ class Arr
         }
 
         foreach ($keys as $key) {
+            $key = $key instanceof BackedEnum ? $key->value : $key;
+
             $subKeyArray = $array;
 
             if (static::exists($array, $key)) {
@@ -395,7 +408,7 @@ class Arr
      * Determine if any of the keys exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
+     * @param  string|\BackedEnum|array  $keys
      * @return bool
      */
     public static function hasAny($array, $keys)
@@ -403,6 +416,8 @@ class Arr
         if (is_null($keys)) {
             return false;
         }
+
+        $keys = $keys instanceof BackedEnum ? $keys->value : $keys;
 
         $keys = (array) $keys;
 
@@ -504,11 +519,13 @@ class Arr
      * Get a subset of the items from the given array.
      *
      * @param  array  $array
-     * @param  array|string  $keys
+     * @param  array|string|\BackedEnum  $keys
      * @return array
      */
     public static function only($array, $keys)
     {
+        $keys = $keys instanceof BackedEnum ? $keys->value : $keys;
+
         return array_intersect_key($array, array_flip((array) $keys));
     }
 
@@ -516,17 +533,21 @@ class Arr
      * Select an array of values from an array.
      *
      * @param  array  $array
-     * @param  array|string  $keys
+     * @param  array|string|\BackedEnum  $keys
      * @return array
      */
     public static function select($array, $keys)
     {
+        $keys = $keys instanceof BackedEnum ? $keys->value : $keys;
+
         $keys = static::wrap($keys);
 
         return static::map($array, function ($item) use ($keys) {
             $result = [];
 
             foreach ($keys as $key) {
+                $key = $key instanceof BackedEnum ? $key->value : $key;
+
                 if (Arr::accessible($item) && Arr::exists($item, $key)) {
                     $result[$key] = $item[$key];
                 } elseif (is_object($item) && isset($item->{$key})) {
@@ -543,7 +564,7 @@ class Arr
      *
      * @param  iterable  $array
      * @param  string|array|int|null  $value
-     * @param  string|array|null  $key
+     * @param  string|\BackedEnum|array|null  $key
      * @return array
      */
     public static function pluck($array, $value, $key = null)
@@ -553,6 +574,8 @@ class Arr
         [$value, $key] = static::explodePluckParameters($value, $key);
 
         foreach ($array as $item) {
+            $value = $value instanceof BackedEnum ? $value->value : $value;
+
             $itemValue = data_get($item, $value);
 
             // If the key is "null", we will just append the value to the array and keep
@@ -578,12 +601,14 @@ class Arr
      * Explode the "value" and "key" arguments passed to "pluck".
      *
      * @param  string|array  $value
-     * @param  string|array|null  $key
+     * @param  string|\BackedEnum|array|null  $key
      * @return array
      */
     protected static function explodePluckParameters($value, $key)
     {
         $value = is_string($value) ? explode('.', $value) : $value;
+
+        $key = $key instanceof BackedEnum ? $key->value : $key;
 
         $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
 
@@ -681,7 +706,7 @@ class Arr
      * Get a value from the array, and remove it.
      *
      * @param  array  $array
-     * @param  string|int  $key
+     * @param  string|\BackedEnum|int  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -758,7 +783,7 @@ class Arr
      * If no key is given to the method, the entire array will be replaced.
      *
      * @param  array  $array
-     * @param  string|int|null  $key
+     * @param  string|\BackedEnum|int|null  $key
      * @param  mixed  $value
      * @return array
      */
@@ -767,6 +792,8 @@ class Arr
         if (is_null($key)) {
             return $array = $value;
         }
+
+        $key = $key instanceof BackedEnum ? $key->value : $key;
 
         $keys = explode('.', $key);
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
@@ -259,12 +260,14 @@ class Store implements Session
     /**
      * Checks if a key exists.
      *
-     * @param  string|array  $key
+     * @param  string|\BackedEnum|array  $key
      * @return bool
      */
     public function exists($key)
     {
         $placeholder = new stdClass;
+
+        $key = $key instanceof BackedEnum ? $key->value : $key;
 
         return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) use ($placeholder) {
             return $this->get($key, $placeholder) === $placeholder;
@@ -274,7 +277,7 @@ class Store implements Session
     /**
      * Determine if the given key is missing from the session data.
      *
-     * @param  string|array  $key
+     * @param  string|\BackedEnum|array  $key
      * @return bool
      */
     public function missing($key)
@@ -285,11 +288,13 @@ class Store implements Session
     /**
      * Determine if a key is present and not null.
      *
-     * @param  string|array  $key
+     * @param  string|\BackedEnum|array  $key
      * @return bool
      */
     public function has($key)
     {
+        $key = $key instanceof BackedEnum ? $key->value : $key;
+
         return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) {
             return is_null($this->get($key));
         });
@@ -298,11 +303,13 @@ class Store implements Session
     /**
      * Determine if any of the given keys are present and not null.
      *
-     * @param  string|array  $key
+     * @param  string|\BackedEnum|array  $key
      * @return bool
      */
     public function hasAny($key)
     {
+        $key = $key instanceof BackedEnum ? $key->value : $key;
+
         return collect(is_array($key) ? $key : func_get_args())->filter(function ($key) {
             return ! is_null($this->get($key));
         })->count() >= 1;
@@ -311,19 +318,21 @@ class Store implements Session
     /**
      * Get an item from the session.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
     {
+        $key = $key instanceof BackedEnum ? $key->value : $key;
+
         return Arr::get($this->attributes, $key, $default);
     }
 
     /**
      * Get the value of a given key and then forget it.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -335,7 +344,7 @@ class Store implements Session
     /**
      * Determine if the session contains old input.
      *
-     * @param  string|null  $key
+     * @param  string|\BackedEnum|null  $key
      * @return bool
      */
     public function hasOldInput($key = null)
@@ -348,7 +357,7 @@ class Store implements Session
     /**
      * Get the requested item from the flashed input array.
      *
-     * @param  string|null  $key
+     * @param  string|\BackedEnum|null  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -371,12 +380,14 @@ class Store implements Session
     /**
      * Put a key / value pair or array of key / value pairs in the session.
      *
-     * @param  string|array  $key
+     * @param  string|\BackedEnum|array  $key
      * @param  mixed  $value
      * @return void
      */
     public function put($key, $value = null)
     {
+        $key = $key instanceof BackedEnum ? $key->value : $key;
+
         if (! is_array($key)) {
             $key = [$key => $value];
         }
@@ -389,7 +400,7 @@ class Store implements Session
     /**
      * Get an item from the session, or store the default value.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -407,7 +418,7 @@ class Store implements Session
     /**
      * Push a value onto a session array.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  mixed  $value
      * @return void
      */
@@ -423,7 +434,7 @@ class Store implements Session
     /**
      * Increment the value of an item in the session.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  int  $amount
      * @return mixed
      */
@@ -437,7 +448,7 @@ class Store implements Session
     /**
      * Decrement the value of an item in the session.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  int  $amount
      * @return int
      */
@@ -449,11 +460,11 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  mixed  $value
      * @return void
      */
-    public function flash(string $key, $value = true)
+    public function flash($key, $value = true)
     {
         $this->put($key, $value);
 
@@ -465,7 +476,7 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session for immediate use.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @param  mixed  $value
      * @return void
      */
@@ -539,7 +550,7 @@ class Store implements Session
     /**
      * Remove an item from the session, returning its value.
      *
-     * @param  string  $key
+     * @param  string|\BackedEnum  $key
      * @return mixed
      */
     public function remove($key)
@@ -550,7 +561,7 @@ class Store implements Session
     /**
      * Remove one or many items from the session.
      *
-     * @param  string|array  $keys
+     * @param  string|\BackedEnum|array  $keys
      * @return void
      */
     public function forget($keys)

--- a/tests/Support/Fixtures/StringBackedEnum.php
+++ b/tests/Support/Fixtures/StringBackedEnum.php
@@ -6,4 +6,5 @@ enum StringBackedEnum: string
 {
     case ADMIN_LABEL = 'I am \'admin\'';
     case HELLO_WORLD = 'Hello world';
+    case ARRAY_KEY = 'arrayKey';
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -37,7 +37,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
 
         $this->assertEquals(['surname' => 'Mövsümov'], Arr::add([], 'surname', 'Mövsümov'));
-        $this->assertEquals([StringBackedEnum::ARRAY_KEY->value => 'foo'], Arr::add([], StringBackedEnum::ARRAY_KEY, 'foo'));
+        $this->assertEquals([StringBackedEnum::ARRAY_KEY->value => 'enum'], Arr::add([], StringBackedEnum::ARRAY_KEY, 'enum'));
         $this->assertEquals(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
         $this->assertEquals([1 => 'hAz'], Arr::add([], 1, 'hAz'));
         $this->assertEquals([1 => [1 => 'hAz']], Arr::add([], 1.1, 'hAz'));
@@ -434,8 +434,8 @@ class SupportArrTest extends TestCase
         $array = ['products.desk' => ['price' => 100]];
         $this->assertEquals(['price' => 100], Arr::get($array, 'products.desk'));
 
-        $array = ['products.desk' => ['price' => 100], StringBackedEnum::ARRAY_KEY->value => 'foo'];
-        $this->assertEquals('foo', Arr::get($array, StringBackedEnum::ARRAY_KEY));
+        $array = ['products.desk' => ['price' => 100], StringBackedEnum::ARRAY_KEY->value => 'enum'];
+        $this->assertEquals('enum', Arr::get($array, StringBackedEnum::ARRAY_KEY));
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         $value = Arr::get($array, 'products.desk');
@@ -527,7 +527,7 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has($array, 'products.foo'));
         $this->assertFalse(Arr::has($array, 'products.desk.foo'));
 
-        $array = ['foo' => null, 'bar' => ['baz' => null], StringBackedEnum::ARRAY_KEY->value => 'something-else'];
+        $array = ['foo' => null, 'bar' => ['baz' => null], StringBackedEnum::ARRAY_KEY->value => 'enum'];
         $this->assertTrue(Arr::has($array, 'foo'));
         $this->assertTrue(Arr::has($array, 'bar.baz'));
         $this->assertTrue(Arr::has($array, StringBackedEnum::ARRAY_KEY));
@@ -582,7 +582,7 @@ class SupportArrTest extends TestCase
 
     public function testHasAnyMethod()
     {
-        $array = ['name' => 'Taylor', 'age' => '', 'city' => null, StringBackedEnum::ARRAY_KEY->value => 'foo'];
+        $array = ['name' => 'Taylor', 'age' => '', 'city' => null, StringBackedEnum::ARRAY_KEY->value => 'enum'];
         $this->assertTrue(Arr::hasAny($array, 'name'));
         $this->assertTrue(Arr::hasAny($array, 'age'));
         $this->assertTrue(Arr::hasAny($array, 'city'));
@@ -643,7 +643,7 @@ class SupportArrTest extends TestCase
 
     public function testOnly()
     {
-        $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10, StringBackedEnum::ARRAY_KEY->value => 'foo'];
+        $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10, StringBackedEnum::ARRAY_KEY->value => 'enum'];
         $array = Arr::only($array, ['name', 'price']);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
@@ -658,7 +658,7 @@ class SupportArrTest extends TestCase
                         '#foo', '#bar',
                     ],
                 ],
-                StringBackedEnum::ARRAY_KEY->value => 'foo',
+                StringBackedEnum::ARRAY_KEY->value => 'enum1',
             ],
             'post-2' => [
                 'comments' => [
@@ -666,7 +666,7 @@ class SupportArrTest extends TestCase
                         '#baz',
                     ],
                 ],
-                StringBackedEnum::ARRAY_KEY->value => 'bar',
+                StringBackedEnum::ARRAY_KEY->value => 'enum2',
             ],
         ];
 
@@ -686,7 +686,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([['#foo', '#bar'], ['#baz']], Arr::pluck($data, 'comments.tags'));
         $this->assertEquals([null, null], Arr::pluck($data, 'foo'));
         $this->assertEquals([null, null], Arr::pluck($data, 'foo.bar'));
-        $this->assertEquals(['foo', 'bar'], Arr::pluck($data, StringBackedEnum::ARRAY_KEY));
+        $this->assertEquals(['enum1', 'enum2'], Arr::pluck($data, StringBackedEnum::ARRAY_KEY));
 
         $array = [
             ['developer' => ['name' => 'Taylor']],
@@ -880,9 +880,9 @@ class SupportArrTest extends TestCase
         $this->assertSame('Desk', $name);
         $this->assertSame(['price' => 100], $array);
 
-        $array = ['name' => 'Desk', StringBackedEnum::ARRAY_KEY->value => 'foo', 'price' => 100];
+        $array = ['name' => 'Desk', StringBackedEnum::ARRAY_KEY->value => 'enum', 'price' => 100];
         $name = Arr::pull($array, StringBackedEnum::ARRAY_KEY);
-        $this->assertSame('foo', $name);
+        $this->assertSame('enum', $name);
         $this->assertSame(['name' => 'Desk', 'price' => 100], $array);
 
         // Only works on first level keys
@@ -1003,8 +1003,8 @@ class SupportArrTest extends TestCase
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::set($array, 'products.desk.price', 200);
         $this->assertEquals(['products' => ['desk' => ['price' => 200]]], $array);
-        Arr::set($array, StringBackedEnum::ARRAY_KEY, 'foo');
-        $this->assertEquals(['products' => ['desk' => ['price' => 200]], StringBackedEnum::ARRAY_KEY->value => 'foo'], $array);
+        Arr::set($array, StringBackedEnum::ARRAY_KEY, 'enum');
+        $this->assertEquals(['products' => ['desk' => ['price' => 200]], StringBackedEnum::ARRAY_KEY->value => 'enum'], $array);
 
         // No key is given
         $array = ['products' => ['desk' => ['price' => 100]]];
@@ -1311,7 +1311,7 @@ class SupportArrTest extends TestCase
         Arr::forget($array, []);
         $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
 
-        $array = ['products' => ['desk' => ['price' => 100]], StringBackedEnum::ARRAY_KEY->value => 'foo'];
+        $array = ['products' => ['desk' => ['price' => 100]], StringBackedEnum::ARRAY_KEY->value => 'enum'];
         Arr::forget($array, StringBackedEnum::ARRAY_KEY);
         $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
 
@@ -1503,13 +1503,13 @@ class SupportArrTest extends TestCase
                 'name' => 'Taylor',
                 'role' => 'Developer',
                 'age' => 1,
-                StringBackedEnum::ARRAY_KEY->value => 'foo',
+                StringBackedEnum::ARRAY_KEY->value => 'enum1',
             ],
             [
                 'name' => 'Abigail',
                 'role' => 'Infrastructure',
                 'age' => 2,
-                StringBackedEnum::ARRAY_KEY->value => 'bar',
+                StringBackedEnum::ARRAY_KEY->value => 'enum2',
             ],
         ];
 
@@ -1536,11 +1536,11 @@ class SupportArrTest extends TestCase
         $this->assertEquals([
             [
                 'role' => 'Developer',
-                StringBackedEnum::ARRAY_KEY->value => 'foo',
+                StringBackedEnum::ARRAY_KEY->value => 'enum1',
             ],
             [
                 'role' => 'Infrastructure',
-                StringBackedEnum::ARRAY_KEY->value => 'bar',
+                StringBackedEnum::ARRAY_KEY->value => 'enum2',
             ],
         ], Arr::select($array, ['role', StringBackedEnum::ARRAY_KEY]));
     }


### PR DESCRIPTION
Similar to https://github.com/laravel/framework/pull/52677, https://github.com/laravel/framework/pull/52679, and https://github.com/laravel/framework/pull/52792, using enums improves code readability, maintainability and reduces the hassle of using string values within the code itself.

This adds BackedEnum support to the session methods:

```php
session()->put(RememberMeEnum::SESSION_KEY, true);
session()->forget(RememberMeEnum::SESSION_KEY, true);
```

This PR is backward compatible, with one minor(?) change to the `flash()` method: https://github.com/laravel/framework/pull/53235/files#r1806848088

This depends on https://github.com/laravel/framework/pull/53234 being merged first.