### PR TITLE
[11.x] Add `waitUntil` method to `Process`

### DIFF
--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -130,4 +130,23 @@ class InvokedProcess implements InvokedProcessContract
             throw new ProcessTimedOutException($e, new ProcessResult($this->process));
         }
     }
+
+    /**
+     * Waits until the callback returns true.
+     *
+     * @param  callable|null  $output
+     * @return \Illuminate\Process\ProcessResult
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
+     */
+    public function waitUntil(?callable $output = null)
+    {
+        try {
+            $this->process->waitUntil($output);
+
+            return new ProcessResult($this->process);
+        } catch (SymfonyTimeoutException $e) {
+            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+        }
+    }
 }

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -132,7 +132,7 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
-     * Waits until the callback returns true.
+     * Wait until the given callback returns true.
      *
      * @param  callable|null  $output
      * @return \Illuminate\Process\ProcessResult


### PR DESCRIPTION
The `waitUntil()` method waits for the long-running process to reach a specific state by continuously checking the output. It keeps waiting until the given anonymous function returns true, allowing developers to respond dynamically to the process's output.