### PR TITLE
[11.x] Add getConnection() Method to Factory Class for Retrieving Database Connection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -740,6 +740,16 @@ abstract class Factory
     }
 
     /**
+     * Get the database connection that is used to generate models.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
      * Create a new instance of the factory builder with the given mutated properties.
      *
      * @param  array  $arguments

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -742,7 +742,7 @@ abstract class Factory
     /**
      * Get the database connection that is used to generate models.
      *
-     * @return \Illuminate\Database\Connection
+     * @return string
      */
     public function getConnection()
     {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -729,6 +729,16 @@ abstract class Factory
     }
 
     /**
+     * Get the name of the database connection that is used to generate models.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return $this->connection;
+    }
+
+    /**
      * Specify the database connection that should be used to generate models.
      *
      * @param  string  $connection
@@ -737,16 +747,6 @@ abstract class Factory
     public function connection(string $connection)
     {
         return $this->newInstance(['connection' => $connection]);
-    }
-
-    /**
-     * Get the database connection that is used to generate models.
-     *
-     * @return string
-     */
-    public function getConnection()
-    {
-        return $this->connection;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -820,6 +820,13 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestUser::count());
     }
 
+    public function test_getter_for_connection_used_to_create_a_model()
+    {
+        $factory = FactoryTestUserFactory::new()->connection('custom-connection');
+
+        $this->assertSame('custom-connection', $factory->getConnection());
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -820,13 +820,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestUser::count());
     }
 
-    public function test_getter_for_connection_used_to_create_a_model()
-    {
-        $factory = FactoryTestUserFactory::new()->connection('custom-connection');
-
-        $this->assertSame('custom-connection', $factory->getConnection());
-    }
-
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
**Context:** I’m proposing a small but useful addition to the `Illuminate\Database\Eloquent\Factories\Factory` class by introducing a `getConnection()` method. This method allows developers to retrieve the database connection used by a factory when generating models.

**Problem:** Currently, there’s no easy way to access the database connection associated with a factory. In certain scenarios, especially when working with factories in testing environments on multi-database setups, having access to this connection would be valuable. This change makes it easier to inspect and work with the connection, especially when debugging or ensuring models are generated with the correct database connection.

**Solution:** I have added the following method to the Factory class:
```php
/**
 * Get the database connection that is used to generate models.
 *
 * @return string
 */
public function getConnection()
{
    return $this->connection;
}
```

This method will simply return the connection that was set when the factory instance was created.

**Tests:** I have added a test case that verifies the behavior of the new `getConnection()` method. The test sets a custom connection on the factory and ensures that the getter retrieves the correct connection:
```php
public function test_get_connection_used_to_create_a_model()
{
    $factory = FactoryTestUserFactory::new()->connection('custom-connection');

    $this->assertSame('custom-connection', $factory->getConnection());
}
```

I believe this small enhancement could be beneficial for those working with Laravel factories in environments where multiple database connections are used, as it provides a simple way to inspect and work with connections at the factory level.

Thank you for your consideration, and I’m happy to discuss any feedback or make any adjustments as needed.