### PR TITLE
[11.x] Automatically open files when generated via make commands

### DIFF
--- a/src/Illuminate/Console/Events/FileGenerated.php
+++ b/src/Illuminate/Console/Events/FileGenerated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+class FileGenerated
+{
+    /**
+     * The path of the generated file.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+}

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\Events\FileGenerated;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -191,6 +192,8 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         }
 
         $this->components->info(sprintf('%s [%s] created successfully.', $info, $path));
+
+        $this->laravel['events']->dispatch(new FileGenerated($path));
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Console\Events\FileGenerated;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Composer;
@@ -112,6 +113,8 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         $file = $this->creator->create(
             $name, $this->getMigrationPath(), $table, $create
         );
+
+        $this->laravel['events']->dispatch(new FileGenerated($file));
 
         $this->components->info(sprintf('Migration [%s] created successfully.', $file));
     }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -114,6 +114,10 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
             $name, $this->getMigrationPath(), $table, $create
         );
 
+        if (windows_os()) {
+            $file = str_replace('/', '\\', $file);
+        }
+
         $this->laravel['events']->dispatch(new FileGenerated($file));
 
         $this->components->info(sprintf('Migration [%s] created successfully.', $file));

--- a/src/Illuminate/Foundation/Console/Editor.php
+++ b/src/Illuminate/Foundation/Console/Editor.php
@@ -22,7 +22,7 @@ class Editor
      */
     public function __construct(
         #[Config('app.editor')] ?string $editor
-    ){
+    ) {
         $this->editor = $editor;
     }
 
@@ -34,7 +34,7 @@ class Editor
      */
     public function open(string $path)
     {
-        if(!$this->editor){
+        if (! $this->editor) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/Editor.php
+++ b/src/Illuminate/Foundation/Console/Editor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Support\Facades\Process;
+
+class Editor
+{
+    /**
+     * The editor command.
+     *
+     * @var string|null
+     */
+    public ?string $editor;
+
+    /**
+     * Create a new Editor instance.
+     *
+     * @param  string|null  $editor
+     * @return void
+     */
+    public function __construct(
+        #[Config('app.editor')] ?string $editor
+    ){
+        $this->editor = $editor;
+    }
+
+    /**
+     * Open the given path in the editor.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function open(string $path)
+    {
+        if(!$this->editor){
+            return;
+        }
+
+        Process::run([$this->editor, $path]);
+    }
+}

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -129,7 +129,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
             ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
         $events->shouldReceive('dispatch')
-            ->withArgs(function($event) {
+            ->withArgs(function ($event) {
                 return $event instanceof FileGenerated
                     && $event->path === __DIR__.DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR.'2021_04_23_110457_create_foo.php';
             })

--- a/tests/Integration/Console/GeneratorCommandTest.php
+++ b/tests/Integration/Console/GeneratorCommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Console;
 
+use Illuminate\Console\Events\FileGenerated;
+use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -64,5 +66,19 @@ class GeneratorCommandTest extends TestCase
         yield ['ARRAY'];
         yield ['__class__'];
         yield ['__CLASS__'];
+    }
+
+    public function testItDispatchedFileGeneratedEvent()
+    {
+        Event::fake();
+
+        $this->artisan('make:command', ['name' => 'FooCommand'])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('app/Console/Commands/FooCommand.php');
+
+        Event::assertDispatched(function (FileGenerated $event) {
+            return $event->path === base_path('app'.DIRECTORY_SEPARATOR.'Console'.DIRECTORY_SEPARATOR.'Commands'.DIRECTORY_SEPARATOR.'FooCommand.php');
+        });
     }
 }

--- a/tests/Integration/Foundation/Console/EditorTest.php
+++ b/tests/Integration/Foundation/Console/EditorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Foundation\Console\Editor;
+use Illuminate\Process\Factory;
+use Illuminate\Support\Facades\Process;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class EditorTest extends TestCase
+{
+    public function testEditorRunsNothingWhenBinaryIsNotGiven()
+    {
+        $editor = new Editor(null);
+
+        Process::fake();
+
+        $editor->open('path/to/file');
+
+        Process::assertNothingRan();
+    }
+
+    public function testEditorRunsBinary()
+    {
+        $editor = new Editor( 'my-ide');
+
+        Process::fake();
+
+        $editor->open('path/to/file');
+
+        Process::assertRan(function($process) {
+            return $process->command == ['my-ide', 'path/to/file'];
+        });
+    }
+}

--- a/tests/Integration/Foundation/Console/EditorTest.php
+++ b/tests/Integration/Foundation/Console/EditorTest.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
 use Illuminate\Foundation\Console\Editor;
-use Illuminate\Process\Factory;
 use Illuminate\Support\Facades\Process;
-use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class EditorTest extends TestCase
@@ -23,13 +21,13 @@ class EditorTest extends TestCase
 
     public function testEditorRunsBinary()
     {
-        $editor = new Editor( 'my-ide');
+        $editor = new Editor('my-ide');
 
         Process::fake();
 
         $editor->open('path/to/file');
 
-        Process::assertRan(function($process) {
+        Process::assertRan(function ($process) {
             return $process->command == ['my-ide', 'path/to/file'];
         });
     }


### PR DESCRIPTION
[Capture vidéo du 19-10-2024 17:53:01.webm](https://github.com/user-attachments/assets/563c31b4-afd2-461a-89a3-9d758043ab98)

[Capture vidéo du 19-10-2024 17:55:26.webm](https://github.com/user-attachments/assets/b7ca71a5-df98-4c95-8868-bdbdd477f0ee)

# Why

I'm lazy. And I guess I'm not the only one here. I feel like 99% of the time, when files are created via `make:...`commands, the developer wants to open and edit them in their IDE. Having to open them manually is a waste of time and energy  :laughing:  

Seriously, I think it could improve a lot the DX. We have a similar solution in our company and developers like it a lot. 

# What

I chose to dispatch an event when the file is generated and a listener will wait for it and run a process which will open configured editor. This architecture will make easier for packages to leverage this feature as they will just have to dispatch an event (if they do not already extend `GeneratorCommand`).

Every file is opened when a command creates several files.

The editor must be configured by the developer. I used `app.editor` but I'm not sure if this is the best place for that. 

The listener is registered only when the app is running in console but I'm not against going more restrictive allowing only local environment if there are security concerns.

I chose not to open the files generated by `make:cache-table`, `make:notifications-table`, ... as I feel there is no need for the developer to edit them most of the time.

A PR was opened on laravel/laravel to add `editor` config key : https://github.com/laravel/laravel/pull/6477
Another one was opened on the documentation : https://github.com/laravel/docs/pull/9977

# Next steps

I tested this feature only on my Ubuntu with PHPStorm and VS Code. Some feedback would be highly appreciated on different OS and with other IDEs (I'll admit, maybe a bit scared about Windows :sweat_smile: )

I'm totally opened to feedback on the code if it can be improved.

# How to try

Add my fork's repository in your `composer.json`

```json
{
  // ..
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/bastien-phi/framework"
    }
  ]
}
```

Change version of the framework in `composer.json`

```
"laravel/framework": "dev-make-open as 11.28.1",
```

Update : 
```bash
composer update laravel/framework -w
```

Add your editor in `config/app.php` : 
```php
return [
    // ...
    'editor' => 'phpstorm', // executable of your IDE
];
```
Provide feedback !