### PR TITLE
fix: EloquentCollection find and unique generics

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -27,7 +27,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  mixed  $key
      * @param  TFindDefault  $default
-     * @return static<TKey, TModel>|TModel|TFindDefault
+     * @return ($key is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? static : TModel|TFindDefault)
      */
     public function find($key, $default = null)
     {
@@ -470,7 +470,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  (callable(TModel, TKey): mixed)|string|null  $key
      * @param  bool  $strict
-     * @return static<int, TModel>
+     * @return static
      */
     public function unique($key = null, $strict = false)
     {
@@ -485,7 +485,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Returns only the models from the collection with the specified keys.
      *
      * @param  array<array-key, mixed>|null  $keys
-     * @return static<int, TModel>
+     * @return static
      */
     public function only($keys)
     {
@@ -502,7 +502,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Returns all models in the collection except the models with specified keys.
      *
      * @param  array<array-key, mixed>|null  $keys
-     * @return static<int, TModel>
+     * @return static
      */
     public function except($keys)
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -5,8 +5,9 @@ use function PHPStan\Testing\assertType;
 $collection = User::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);
 
-assertType('Illuminate\Database\Eloquent\Collection<int, User>|User|null', $collection->find(1));
-assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $collection->find(1, 'string'));
+assertType('User|null', $collection->find(1));
+assertType('string|User', $collection->find(1, 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->find([1]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string']));
@@ -164,6 +165,9 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->ma
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->append('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->append(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->uniqueStrict());
 
 assertType('array<User>', $collection->getDictionary());
 assertType('array<User>', $collection->getDictionary($collection));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

Please see https://github.com/larastan/larastan/issues/1985#issuecomment-2423311706 for context.

This fixes the EloquentCollection `unique` generics to wok with non-generic custom collections. I also made the `find` method more accurate based on the parameter types.

Thanks!
