### PR TITLE
[11.x] Refactor `NotIn` rule to extend `In` rule

### DIFF
--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,12 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Contracts\Support\Arrayable;
-use Stringable;
-
-use function Illuminate\Support\enum_value;
-
-class NotIn implements Stringable
+class NotIn extends In
 {
     /**
      * The name of the rule.
@@ -15,42 +10,4 @@ class NotIn implements Stringable
      * @var string
      */
     protected $rule = 'not_in';
-
-    /**
-     * The accepted values.
-     *
-     * @var array
-     */
-    protected $values;
-
-    /**
-     * Create a new "not in" rule instance.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
-     * @return void
-     */
-    public function __construct($values)
-    {
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        $this->values = is_array($values) ? $values : func_get_args();
-    }
-
-    /**
-     * Convert the rule to a validation string.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $values = array_map(function ($value) {
-            $value = enum_value($value);
-
-            return '"'.str_replace('"', '""', $value).'"';
-        }, $this->values);
-
-        return $this->rule.':'.implode(',', $values);
-    }
 }


### PR DESCRIPTION
This PR refactors the `NotIn` validation rule to extend the existing `In` rule. By doing so, it leverages the shared logic from the `In` rule, while only overriding the `$rule` property to set it to `not_in`. This reduces code duplication and maintains consistency between the two validation rules.
