### PR TITLE
Add whereEmpty and whereNotEmpty methods to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1354,6 +1354,7 @@ class Builder implements BuilderContract
         return $this;
     }
 
+
     /**
      * Add an "or where null" clause to the query.
      *
@@ -1375,6 +1376,59 @@ class Builder implements BuilderContract
     public function whereNotNull($columns, $boolean = 'and')
     {
         return $this->whereNull($columns, $boolean, true);
+    }
+
+    /**
+     * Add a "where empty" clause to the query.
+     *
+     * @param  string|array  $columns
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereEmpty($columns, $boolean = 'and', $not = false)
+    {
+        $type = 'Empty';
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'not');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where empty" clause to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereEmpty($columns)
+    {
+        return $this->whereEmpty($columns, 'or');
+    }
+
+    /**
+     * Add a "where not empty" clause to the query.
+     *
+     * @param  string|array  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotEmpty($columns, $boolean = 'and')
+    {
+        return $this->whereEmpty($columns, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not empty" clause to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereNotEmpty($columns)
+    {
+        return $this->whereNotEmpty($columns, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -407,6 +407,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where empty" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereEmpty(Builder $query, $where)
+    {
+        $column = $this->wrap($where['column']);
+
+        if ($where['not']) {
+            return '('.$column.' is not null and '.$column." != '')";
+        }
+
+        return '('.$column.' is null or '.$column." = '')";
+    }
+
+    /**
      * Compile a "where not null" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6516,6 +6516,35 @@ SQL;
 
         $this->assertSame('select * from "users" where "email" = \'foo\'', $builder->toRawSql());
     }
+    public function testWhereEmpty()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereEmpty('name');
+        $this->assertSame('select * from "users" where ("name" is null or "name" = \'\')', $builder->toSql());
+    }
+
+    public function testOrWhereEmpty()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereEmpty('name');
+        $this->assertSame('select * from "users" where "id" = ? or ("name" is null or "name" = \'\')', $builder->toSql());
+        $this->assertEquals([1], $builder->getBindings());
+    }
+
+    public function testWhereNotEmpty()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotEmpty('name');
+        $this->assertSame('select * from "users" where ("name" is not null and "name" != \'\')', $builder->toSql());
+    }
+
+    public function testOrWhereNotEmpty()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotEmpty('name');
+        $this->assertSame('select * from "users" where "id" = ? or ("name" is not null and "name" != \'\')', $builder->toSql());
+        $this->assertEquals([1], $builder->getBindings());
+    }
 
     protected function getConnection()
     {


### PR DESCRIPTION
This PR introduces new methods to the Query Builder to check if a column is empty (null or an empty string):

   - `whereEmpty()`
   - `orWhereEmpty()`
   - `whereNotEmpty()`
   - `orWhereNotEmpty()`

   These methods provide a convenient way to check for both null and empty string values in a single condition, improving query readability and reducing the need for multiple where clauses.

   Example usage:

   ```php
   $users = User::whereEmpty('name')
               ->get();

   $users = DB::table('users')
               ->where('id', 1)
               ->orWhereNotEmpty('email')
               ->get();
   ```

   Changes made:
   1. Added new methods to the Query\Builder class
   2. Updated the Grammar class to handle the new 'Empty' type
   3. Added test cases to ensure proper functionality

   These additions aim to simplify common query patterns and improve the overall developer experience when working with the Laravel Query Builder.