### PR TITLE
[11.x] Provide different Blade templates for html and text `MailMessage` notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -125,7 +125,7 @@ class MailChannel
     protected function buildMarkdownText($message)
     {
         return fn ($data) => $this->markdownRenderer($message)->renderText(
-            $message->markdown, array_merge($data, $message->data()),
+            $message->markdownText ?? $message->markdown, array_merge($data, $message->data()),
         );
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -36,6 +36,14 @@ class MailMessage extends SimpleMessage implements Renderable
     public $markdown = 'notifications::email';
 
     /**
+     * The Markdown template to render the plain text version.
+     * If not set, the `markdown` property will be used.
+     *
+     * @var string|null
+     */
+    public $markdownText = null;
+
+    /**
      * The current theme being used when generating emails.
      *
      * @var string|null
@@ -157,6 +165,19 @@ class MailMessage extends SimpleMessage implements Renderable
         $this->viewData = $data;
 
         $this->view = null;
+
+        return $this;
+    }
+
+    /**
+     * Set the Markdown template for the plain text version.
+     *
+     * @param  string  $textView
+     * @return $this
+     */
+    public function markdownText($textView)
+    {
+        $this->markdownText = $textView;
 
         return $this;
     }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -20,6 +20,32 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame('notifications::foo', $message->markdown);
     }
 
+    public function testMarkdown()
+    {
+        $message = new MailMessage;
+
+        $this->assertSame('notifications::email', $message->markdown);
+        $this->assertSame([], $message->viewData);
+
+        $message->markdown('notifications::foo', ['foo' => 'bar']);
+
+        $this->assertSame('notifications::foo', $message->markdown);
+        $this->assertSame(['foo' => 'bar'], $message->viewData);
+        $this->assertNull($message->view);
+    }
+
+    public function testMarkdownText()
+    {
+        $message = new MailMessage;
+
+        $this->assertNull($message->markdownText);
+
+        $message->markdownText('notifications::foo');
+
+        $this->assertSame('notifications::foo', $message->markdownText);
+        $this->assertSame([], $message->viewData);
+    }
+
     public function testHtmlAndPlainView()
     {
         $message = new MailMessage;


### PR DESCRIPTION
Since Laravel v10.38 (see my PR #49407) we can easily send out notifications as plain text emails, using the `MailMessage::text()` helper method. But if we send out Markdown rendered HTML messages using `MailMessage`, there is currently no way to provide different Blade templates for the HTML and plain text variant of the email.

Problem: [`MailChannel::buildView()`](https://github.com/laravel/framework/blob/5a9886c8f88be09543143862a18a7624e7ff577c/src/Illuminate/Notifications/Channels/MailChannel.php#L94-L104) uses the same view template for both HTML and text rendering:

```php
    protected function buildView($message)
    {
        if ($message->view) {
            return $message->view;
        }

        return [
            'html' => $this->buildMarkdownHtml($message),
            'text' => $this->buildMarkdownText($message),
        ];
    }
```

Both `MailMessage::text()` and `MailMessage::markdown()` are mutually exclusive, overriding each other. So if you try to set `->markdown('emails.invoice', $data)->text('emails.invoice-text', $data)` the email would get rendered as plaintext only. And if you call it the other way round `->text('emails.invoice-text', $data)->markdown('emails.invoice', $data)`, the text template assignment would get overridden by the `invoice.blade.php` Markdown template, getting rendered both as HTML and text variants.

In some occasions we just need to provide different Blade templates to get a "clean" `text/plain` version of the email.

I currently don't see a clean way to make the `text()` and `markdown()` setters play nicely together and it would probably be a BC break if we'd try so.

This PR adds a simple `MailMessage::markdownText()` method which can be used in addition to `MailMessage::markdown()` to provide another template for the text variant.

Usage in a [`Notification`](https://laravel.com/docs/11.x/notifications#generating-the-message) is then simple as that:

```php
    public function toMail(object $notifiable): MailMessage
    {
        return (new MailMessage)
            // ...
            ->markdown('emails.invoice', ['foo' => 'bar'])
            ->markdownText('emails.invoice-text');
    }
```