### PR TITLE
feat(Number): add fraction() method to convert decimals to fractions

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -362,4 +362,36 @@ class Number
             throw new RuntimeException('The "intl" PHP extension is required to use the ['.$method.'] method.');
         }
     }
+    /**
+     * Convert a decimal number to a fraction.
+     *
+     * @param  float  $decimal
+     * @param  int  $precision
+     * @return string
+     */
+    public static function fraction(float $decimal, int $precision = 6)
+    {
+        // Handle edge case for whole numbers
+        if (intval($decimal) == $decimal) {
+            return strval(intval($decimal));
+        }
+
+        // Scale the decimal to an integer fraction with the specified precision
+        $denominator = pow(10, $precision);
+        $numerator = intval(round($decimal * $denominator));
+
+        // Calculate the greatest common divisor
+        $gcd = function($a, $b) use (&$gcd) {
+            return ($b == 0) ? $a : $gcd($b, $a % $b);
+        };
+
+        // Reduce the fraction by dividing by the GCD
+        $divisor = $gcd($numerator, $denominator);
+        $numerator /= $divisor;
+        $denominator /= $divisor;
+
+        // Return the fraction in the form of 'numerator/denominator'
+        return sprintf('%d/%d', $numerator, $denominator);
+    }
+
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -314,4 +314,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    public function testFraction()
+    {
+        $this->assertEquals('3/4', Number::fraction(0.75));
+        $this->assertEquals('333333/1000000', Number::fraction(0.333333, 6));
+        $this->assertEquals('1/2', Number::fraction(0.5));
+        $this->assertEquals('2', Number::fraction(2));
+        $this->assertEquals('7/10', Number::fraction(0.7, 2));
+    }
+
 }


### PR DESCRIPTION
- Introduced a new `fraction()` method that converts decimal numbers to reduced fractional form.
- Supports precision control to handle rounding and accurate conversion of decimal numbers to fractions.
- Handles edge cases for whole numbers by returning the integer directly.
- Added test cases to verify correct behavior for various decimal inputs and precision levels.

```php
echo Number::fraction(0.75); // Output: "3/4"
echo Number::fraction(0.333333, 6); // Output: "333333/1000000"

```
