### PR TITLE
[11.x] Allow using `castAsJson()` on non default db connection during test

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -231,9 +231,10 @@ trait InteractsWithDatabase
      * Cast a JSON string to a database compatible type.
      *
      * @param  array|object|string  $value
+     * @param  string|null  $collection
      * @return \Illuminate\Contracts\Database\Query\Expression
      */
-    public function castAsJson($value)
+    public function castAsJson($value, $connection = null)
     {
         if ($value instanceof Jsonable) {
             $value = $value->toJson();
@@ -241,10 +242,12 @@ trait InteractsWithDatabase
             $value = json_encode($value);
         }
 
-        $value = DB::connection()->getPdo()->quote($value);
+        $db = DB::connection($connection);
 
-        return DB::raw(
-            DB::connection()->getQueryGrammar()->compileJsonValueCast($value)
+        $value = $db->getPdo()->quote($value);
+
+        return $db->raw(
+            $db->getQueryGrammar()->compileJsonValueCast($value)
         );
     }
 

--- a/tests/Testing/Concerns/InteractsWithDatabaseTest.php
+++ b/tests/Testing/Concerns/InteractsWithDatabaseTest.php
@@ -149,15 +149,15 @@ class InteractsWithDatabaseTest extends TestCase
 
         $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
 
+        $connection->shouldReceive('raw')->andReturnUsing(function ($value) {
+            return new Expression($value);
+        });
+
         $connection->shouldReceive('getPdo->quote')->andReturnUsing(function ($value) {
             return "'".$value."'";
         });
 
-        DB::shouldReceive('connection')->andReturn($connection);
-
-        DB::shouldReceive('raw')->andReturnUsing(function ($value) {
-            return new Expression($value);
-        });
+        DB::shouldReceive('connection')->with(null)->andReturn($connection);
 
         $instance = new class
         {


### PR DESCRIPTION


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
