### PR TITLE
fix: allows policy result in after check callbacks as mentioned in docs

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -591,7 +591,7 @@ class Gate implements GateContract
 
             $afterResult = $after($user, $ability, $result, $arguments);
 
-            $result ??= $afterResult;
+            $result = $afterResult !== null ? (bool) $afterResult : $result;
         }
 
         return $result;


### PR DESCRIPTION
As mentioned in the docs, we can override results after the checks has been passed in after callback checks.

https://laravel.com/docs/11.x/authorization#intercepting-gate-checks

Scenario:
- in my project I want to first check if user is allowed to access some api or not, and that is all resolved by default using sanctum.
- now in after check, I want to fire up extra sql queries to make sure initial checks are passed.