### PR TITLE
Fix reversed logic in version comparison

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -460,7 +460,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        if (version_compare($connection->getServerVersion(), '3.35', '>=')) {
+        if (version_compare($connection->getServerVersion(), '3.35', '<')) {
             // Handled on table alteration...
 
             return null;

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -460,7 +460,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        if (version_compare($connection->getServerVersion(), '3.35', '<')) {
+        if (version_compare($connection->getServerVersion(), '3.35', '>=')) {
             // Handled on table alteration...
 
             return null;

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -36,7 +36,7 @@ class SQLiteGrammar extends Grammar
     {
         $alterCommands = ['change', 'primary', 'dropPrimary', 'foreign', 'dropForeign'];
 
-        if (version_compare($connection->getServerVersion(), '3.35', '<')) {
+        if (version_compare($connection->getServerVersion(), '3.35', '>=')) {
             $alterCommands[] = 'dropColumn';
         }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -995,7 +995,13 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
             $table->dropColumn('name');
         });
 
-        $this->assertEquals(['alter table "users" drop column "name"'], $blueprint->toSql($this->getConnection(), $this->getGrammar()));
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getSchemaBuilder->getColumns')->andReturn([ ['name' => 'foo', 'type' => 'varchar(255)'] ]);
+        $connection->shouldReceive('getSchemaBuilder->getForeignKeys')->andReturn([]);
+        $connection->shouldReceive('getSchemaBuilder->getIndexes')->andReturn([]);
+        $connection->shouldReceive('scalar')->andReturn('');
+
+        $this->assertEquals(['alter table "users" drop column "name"'], $blueprint->toSql($connection, $this->getGrammar()));
     }
 
     protected function getConnection()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -254,6 +254,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $blueprint = clone $base;
         $connection->shouldReceive('getServerVersion')->andReturn('3.35');
+        $connection->shouldReceive('getSchemaBuilder->getColumns')->andReturn([ ['name' => 'foo', 'type' => 'varchar(255)' ] ]);
+
         $this->assertEquals(['alter table "users" drop column "foo"'], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;


### PR DESCRIPTION
The intended use was to verify if the server's SQLite version was greather than or equal to 3.35, version at which `dropColumn` support was added to SQLite.