### PR TITLE
Added testResolvedInstances method to ContainerTest

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -474,6 +474,17 @@ class ContainerTest extends TestCase
         $this->assertTrue($container->resolved('foo'));
     }
 
+    public function testResolvedInstances()
+    {
+        $container = new Container;
+        $container->instance('ConcreteStub', function () {
+            //
+        });
+        $container->make('ConcreteStub');
+
+        $this->assertTrue($container->resolved('ConcreteStub'));
+    }
+
     public function testGetAlias()
     {
         $container = new Container;


### PR DESCRIPTION
Hi, I’ve written a test that ensures an instance is created, and when resolved is called, it returns true.

Currently, we don't have a test to ensure that the resolved method returns true if an instance exists.

```php
public function resolved($abstract)
{
    if ($this->isAlias($abstract)) {
        $abstract = $this->getAlias($abstract);
    }

    return isset($this->resolved[$abstract]) ||
           isset($this->instance[$abstract]);
}
```

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Container/Container.php#L234

If I remove ```isset($this->instances[$abstract])``` and run the tests, all tests pass successfully. So, I wrote a test for it. :)

Let me know if you'd like any further adjustments or explanations!