### PR TITLE
Added new Arr::notAccessible($value) function. Tests are added.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -24,6 +24,17 @@ class Arr
     }
 
     /**
+     * Determine whether the given value is array accessible.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function notAccessible($value)
+    {
+        return ! self::accessible(value: $value);
+    }
+
+    /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -24,7 +24,7 @@ class Arr
     }
 
     /**
-     * Determine whether the given value is array accessible.
+     * Determine whether the given value is not array accessible.
      *
      * @param  mixed  $value
      * @return bool

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -30,6 +30,24 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::accessible(static fn () => null));
     }
 
+    public function testNotAccessible(): void
+    {
+        $this->assertFalse(Arr::notAccessible([]));
+        $this->assertFalse(Arr::notAccessible([1, 2]));
+        $this->assertFalse(Arr::notAccessible(['a' => 1, 'b' => 2]));
+        $this->assertFalse(Arr::notAccessible(new Collection));
+
+        $this->assertTrue(Arr::notAccessible(null));
+        $this->assertTrue(Arr::notAccessible('abc'));
+        $this->assertTrue(Arr::notAccessible(new stdClass));
+        $this->assertTrue(Arr::notAccessible((object) ['a' => 1, 'b' => 2]));
+        $this->assertTrue(Arr::notAccessible(123));
+        $this->assertTrue(Arr::notAccessible(12.34));
+        $this->assertTrue(Arr::notAccessible(true));
+        $this->assertTrue(Arr::notAccessible(new \DateTime));
+        $this->assertTrue(Arr::notAccessible(static fn () => null));
+    }
+
     public function testAdd()
     {
         $array = Arr::add(['name' => 'Desk'], 'price', 100);


### PR DESCRIPTION
### Summary:
This pull request introduces a new static method `Arr::notAccessible()` to the Arr utility class, along with a comprehensive set of unit tests to verify its functionality. This method checks whether a given value is not accessible as an array.

### Key Changes:
New Method: `Arr::notAccessible($value)`

This method is a simple inverse of the existing `Arr::accessible($value)` method. It returns true if the value is not accessible as an array and false if it is.
The method helps to simplify the logic when checking non-array-accessible types, enhancing code readability.

### Unit Tests:

Added a suite of tests for the `Arr::notAccessible()` method.
Tests cover various data types to ensure that the method behaves correctly in different scenarios, including arrays, collections, objects, primitives, and anonymous functions.

### No Breaking Changes
This addition does not alter any existing functionality