### PR TITLE
Add `$bind` parameter to `Blade::directive`

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -939,17 +939,18 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $name
      * @param  callable  $handler
+     * @param  bool  $bind
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function directive($name, callable $handler)
+    public function directive($name, callable $handler, bool $bind = false)
     {
         if (! preg_match('/^\w+(?:::\w+)?$/x', $name)) {
             throw new InvalidArgumentException("The directive name [{$name}] is not valid. Directive names must only contain alphanumeric characters and underscores.");
         }
 
-        $this->customDirectives[$name] = $handler;
+        $this->customDirectives[$name] = $bind ? $handler->bindTo($this, BladeCompiler::class) : $handler;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -935,6 +935,20 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Register a handler for custom directives, binding the handler to the compiler.
+     *
+     * @param  string  $name
+     * @param  callable  $handler
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function bindDirective($name, callable $handler)
+    {
+        $this->directive($name, $handler, bind: true);
+    }
+
+    /**
      * Register a handler for custom directives.
      *
      * @param  string  $name


### PR DESCRIPTION
_I submitted the same PR a few days ago, but it was closed with an unrelated response and wasn’t properly reviewed. I was advised by your colleagues to resubmit it and be clearer. my previous PR #53222_ 

# Description
Let's say we want to have a custom `@extends` directive:
```
// ▪ I have to repeat this everywhere
@extends('templates.MY_TEMPLATE_NAME.layouts.app')

// ▪ Custom Directive
// Automatically detects the current template name and prepends it
@template_extends('layouts.app')
```
Currently, this is impossible without modifying files in the `./vendor` directory. My changes would be lost if I upgraded Laravel.

## Solution
_`$this->footer` is a protected property in `BladeCompiler::class` which is used inside `CompilesLayouts::compileExtends()`_
https://github.com/laravel/framework/blob/4b5ce19b3bbe1d317585d4b98da66fbb6e7357af/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php#L26

#### Default Behavior of the Blade::directive without the `$bind` param
```php
// Inside AppServiceProvider::boot()
Blade::directive('template_extends', function () {
    // ...
    
    // ❌ Fails
    // $this refers to AppServerProvider
    $this->footer[] = $echo;
    
});
```

### 🟢 Setting the `$bind` param to `true`
_We can create advanced directives now_
```php
// Inside AppServiceProvider::boot()
Blade::directive('template_extends', function () {
    // ...
    
    // ✅ Works
    // $this refers to BladeCompiler
    $this->footer[] = $echo;
 
},           true         );
```