### PR TITLE
[11.x] Introduce `HasUniqueStringIds`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -10,7 +10,7 @@ trait HasUlids
     use HasUniqueStringIds;
 
     /**
-     * Generate a new ULID for the model.
+     * Generate a new unique key for the model.
      *
      * @return string
      */
@@ -20,12 +20,12 @@ trait HasUlids
     }
 
     /**
-     * Determine if value is a valid ULID.
+     * Determine if given key is valid.
      *
      * @param  mixed  $value
      * @return bool
      */
-    protected function isValidKey($value): bool
+    protected function isValidUniqueId($value): bool
     {
         return Str::isUlid($value);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -7,25 +7,7 @@ use Illuminate\Support\Str;
 
 trait HasUlids
 {
-    /**
-     * Initialize the trait.
-     *
-     * @return void
-     */
-    public function initializeHasUlids()
-    {
-        $this->usesUniqueIds = true;
-    }
-
-    /**
-     * Get the columns that should receive a unique identifier.
-     *
-     * @return array
-     */
-    public function uniqueIds()
-    {
-        return [$this->getKeyName()];
-    }
+    use HasUniqueStringIds;
 
     /**
      * Generate a new ULID for the model.
@@ -38,53 +20,13 @@ trait HasUlids
     }
 
     /**
-     * Retrieve the model for a bound value.
+     * Determine if value is a valid ULID.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $query
      * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Contracts\Database\Eloquent\Builder
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function resolveRouteBindingQuery($query, $value, $field = null)
-    {
-        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        return parent::resolveRouteBindingQuery($query, $value, $field);
-    }
-
-    /**
-     * Get the auto-incrementing key type.
-     *
-     * @return string
-     */
-    public function getKeyType()
-    {
-        if (in_array($this->getKeyName(), $this->uniqueIds())) {
-            return 'string';
-        }
-
-        return $this->keyType;
-    }
-
-    /**
-     * Get the value indicating whether the IDs are incrementing.
-     *
      * @return bool
      */
-    public function getIncrementing()
+    protected function isValidKey($value): bool
     {
-        if (in_array($this->getKeyName(), $this->uniqueIds())) {
-            return false;
-        }
-
-        return $this->incrementing;
+        return Str::isUlid($value);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
+
+trait HasUniqueStringIds
+{
+    /**
+     * Generate a new key for the Model.
+     *
+     * @return mixed
+     */
+    abstract public function newUniqueId();
+
+    /**
+     * Determine if key is valid for Model.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    abstract protected function isValidKey($value): bool;
+
+    /**
+     * Initialize the trait.
+     *
+     * @return void
+     */
+    public function initializeHasUniqueStringIds()
+    {
+        $this->usesUniqueIds = true;
+    }
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array
+     */
+    public function uniqueIds()
+    {
+        return [$this->getKeyName()];
+    }
+
+
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $query
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Contracts\Database\Eloquent\Builder
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function resolveRouteBindingQuery($query, $value, $field = null)
+    {
+        if ($field && in_array($field, $this->uniqueIds()) && ! $this->isValidKey($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        }
+
+        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! $this->isValidKey($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        }
+
+        return parent::resolveRouteBindingQuery($query, $value, $field);
+    }
+
+    /**
+     * Get the auto-incrementing key type.
+     *
+     * @return string
+     */
+    public function getKeyType()
+    {
+        if (in_array($this->getKeyName(), $this->uniqueIds())) {
+            return 'string';
+        }
+
+        return $this->keyType;
+    }
+
+    /**
+     * Get the value indicating whether the IDs are incrementing.
+     *
+     * @return bool
+     */
+    public function getIncrementing()
+    {
+        if (in_array($this->getKeyName(), $this->uniqueIds())) {
+            return false;
+        }
+
+        return $this->incrementing;
+    }
+
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -8,19 +8,19 @@ use Illuminate\Support\Str;
 trait HasUniqueStringIds
 {
     /**
-     * Generate a new key for the Model.
+     * Generate a new unique key for the model.
      *
      * @return mixed
      */
     abstract public function newUniqueId();
 
     /**
-     * Determine if key is valid for Model.
+     * Determine if given key is valid.
      *
      * @param  mixed  $value
      * @return bool
      */
-    abstract protected function isValidKey($value): bool;
+    abstract protected function isValidUniqueId($value): bool;
 
     /**
      * Initialize the trait.
@@ -55,11 +55,11 @@ trait HasUniqueStringIds
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        if ($field && in_array($field, $this->uniqueIds()) && ! $this->isValidKey($value)) {
+        if ($field && in_array($field, $this->uniqueIds()) && ! $this->isValidUniqueId($value)) {
             throw (new ModelNotFoundException)->setModel(get_class($this), $value);
         }
 
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! $this->isValidKey($value)) {
+        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! $this->isValidUniqueId($value)) {
             throw (new ModelNotFoundException)->setModel(get_class($this), $value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -7,25 +7,7 @@ use Illuminate\Support\Str;
 
 trait HasUuids
 {
-    /**
-     * Initialize the trait.
-     *
-     * @return void
-     */
-    public function initializeHasUuids()
-    {
-        $this->usesUniqueIds = true;
-    }
-
-    /**
-     * Get the columns that should receive a unique identifier.
-     *
-     * @return array
-     */
-    public function uniqueIds()
-    {
-        return [$this->getKeyName()];
-    }
+    use HasUniqueStringIds;
 
     /**
      * Generate a new UUID for the model.
@@ -38,53 +20,13 @@ trait HasUuids
     }
 
     /**
-     * Retrieve the model for a bound value.
+     * Determine if value is a valid UUID.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $query
      * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Contracts\Database\Eloquent\Builder
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function resolveRouteBindingQuery($query, $value, $field = null)
-    {
-        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        return parent::resolveRouteBindingQuery($query, $value, $field);
-    }
-
-    /**
-     * Get the auto-incrementing key type.
-     *
-     * @return string
-     */
-    public function getKeyType()
-    {
-        if (in_array($this->getKeyName(), $this->uniqueIds())) {
-            return 'string';
-        }
-
-        return $this->keyType;
-    }
-
-    /**
-     * Get the value indicating whether the IDs are incrementing.
-     *
      * @return bool
      */
-    public function getIncrementing()
+    protected function isValidKey($value): bool
     {
-        if (in_array($this->getKeyName(), $this->uniqueIds())) {
-            return false;
-        }
-
-        return $this->incrementing;
+        return Str::isUuid($value);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -10,7 +10,7 @@ trait HasUuids
     use HasUniqueStringIds;
 
     /**
-     * Generate a new UUID for the model.
+     * Generate a new unique key for the model.
      *
      * @return string
      */
@@ -20,12 +20,12 @@ trait HasUuids
     }
 
     /**
-     * Determine if value is a valid UUID.
+     * Determine if given key is valid.
      *
      * @param  mixed  $value
      * @return bool
      */
-    protected function isValidKey($value): bool
+    protected function isValidUniqueId($value): bool
     {
         return Str::isUuid($value);
     }


### PR DESCRIPTION
At work, we have a custom unique identifier type that we are using in place of UUIDs. (They are kind of like Amazon's ARNs).

I wanted to be able to use these as route keys, which works fine if I do something like this:

```php
trait HasTwrnsTrait
{
    use HasUuids;

    public function newUniqueId(): string
    {
        return (string) Twrn::new();
    }

    public function resolveRouteBindingQuery($query, $value, $field = null)
    {
        if ($field && in_array($field, $this->uniqueIds()) && ! Twrn::isValid($value)) {
            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
        }

        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Twrn::isValid($value)) {
            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
        }

        return parent::resolveRouteBindingQuery($query, $value, $field);
    }
}
```

This seemed a little bit cumbersome to have to duplicate the `resolveRouteBindingQuery()` logic only to change `Str::isUuid()`. Additionally, it's a maintenance burden.

The goal with this change is to make a more generalized trait which can be extended to make building custom string unique keys/routing by those custom implementations. As a bonus, this also consolidates the code between HasUlids and HasUuids.

With this change I can create a quick trait like this.

```php
trait HasTwrnsTrait
{
    use HasUniqueStringIds;

    public function newUniqueId()
    {
        return (string) Twrn::new();
    }
  
    protected function isValidUniqueId($value): bool
    {
        return Twrn::isValid($value);
    }
}
```