### PR TITLE
Add detailed error handling in non-production environments for verifyUserCanAccessChannel method

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -119,13 +119,21 @@ abstract class Broadcaster implements BroadcasterContract
             $result = $handler($this->retrieveUser($request, $channel), ...$parameters);
 
             if ($result === false) {
-                throw new AccessDeniedHttpException;
+                if (App::environment('production')) {
+                    throw new AccessDeniedHttpException;
+                } else {
+                    throw new AccessDeniedHttpException('User does not have access to this channel.');
+                }
             } elseif ($result) {
                 return $this->validAuthenticationResponse($request, $result);
             }
         }
 
-        throw new AccessDeniedHttpException;
+        if (App::environment('production')) {
+            throw new AccessDeniedHttpException;
+        } else {
+            throw new AccessDeniedHttpException('No matching pattern found or user authentication failed.');
+        }
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
+use Illuminate\Support\Facades\App;
 use ReflectionClass;
 use ReflectionFunction;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;


### PR DESCRIPTION
**Summary:**
This PR modifies the `verifyUserCanAccessChannel` method to provide more informative error messages when the application is not in production, helping with debugging during development. In production environments, the method continues to return generic error responses for security reasons.

**Changes:**
- Introduced an environment check using `App::environment('production')` to differentiate between production and non-production environments.
- In non-production environments, detailed error messages are thrown, explaining why the access was denied.
- In production environments, the generic `AccessDeniedHttpException` is maintained for security.

**Why:**
This change improves the debugging experience by providing more context in non-production environments, while maintaining secure error handling in production.