### PR TITLE
Change Composer hasPackage to public

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -45,7 +45,7 @@ class Composer
      *
      * @throw \RuntimeException
      */
-    protected function hasPackage($package)
+    public function hasPackage($package)
     {
         $composer = json_decode(file_get_contents($this->findComposerFile()), true);
 


### PR DESCRIPTION
This method is not used in Composer class, and cannot access from outside.
So, I change it's visibility to public.