### PR TITLE
add stricter type return to Model::getKey

### DIFF
--- a/src/Illuminate/Contracts/Queue/QueueableEntity.php
+++ b/src/Illuminate/Contracts/Queue/QueueableEntity.php
@@ -6,10 +6,8 @@ interface QueueableEntity
 {
     /**
      * Get the queueable identity for the entity.
-     *
-     * @return mixed
      */
-    public function getQueueableId();
+    public function getQueueableId(): int|string;
 
     /**
      * Get the relationships for the entity.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1985,20 +1985,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
     /**
      * Get the value of the model's primary key.
-     *
-     * @return mixed
      */
-    public function getKey()
+    public function getKey(): int|string
     {
         return $this->getAttribute($this->getKeyName());
     }
 
     /**
      * Get the queueable identity for the entity.
-     *
-     * @return mixed
      */
-    public function getQueueableId()
+    public function getQueueableId(): int|string
     {
         return $this->getKey();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -251,10 +251,8 @@ trait AsPivot
 
     /**
      * Get the queueable identity for the entity.
-     *
-     * @return mixed
      */
-    public function getQueueableId()
+    public function getQueueableId(): int|string
     {
         if (isset($this->attributes[$this->getKeyName()])) {
             return $this->getKey();

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -112,10 +112,8 @@ class MorphPivot extends Pivot
 
     /**
      * Get the queueable identity for the entity.
-     *
-     * @return mixed
      */
-    public function getQueueableId()
+    public function getQueueableId(): int|string
     {
         if (isset($this->attributes[$this->getKeyName()])) {
             return $this->getKey();

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -73,7 +73,7 @@ class DatabaseSoftDeletingTraitStub
         //
     }
 
-    public function getKey()
+    public function getKey(): int
     {
         return 1;
     }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -109,7 +109,7 @@ class QueueSyncQueueTest extends TestCase
 
 class SyncQueueTestEntity implements QueueableEntity
 {
-    public function getQueueableId()
+    public function getQueueableId(): int
     {
         return 1;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Specify that `getKey` can only returns a `int` or a `string` as I don't think it's supported to have something else as primary key.
The aim is to improve type hinting when this method is used.

I didn't used the PHPDoc: it's suggested in https://laravel.com/docs/11.x/contributions#phpdoc to use native types in signature but most the methods on that class uses PHPDoc so I'm not sure about it.