### PR TITLE
BelongsToMany improvement: Filtering Queries Via Intermediate Table Columns in a Callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -157,27 +157,28 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the pivot relation with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\BelongsToMany<*, *, *>|string  $relation
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
+     * @param  string  $boolean
      * @return $this
      */
-    public function whereHasPivot($relation, Closure $callback, $operator = '>=', $count = 1)
+    public function whereHasPivot($relation, Closure $callback, $operator = '>=', $count = 1, $boolean = 'and')
     {
-        return $this->whereHas($relation,
+        return $this->has($relation, $operator, $count, $boolean,
             function (Builder $builder) use ($callback, $relation) {
-                $relation = $this->getRelation($relation);
 
-                if ($relation instanceof BelongsToMany) {
-                    call_user_func($callback, $relation->setQuery($builder->getQuery()));
+            $relation = is_string($relation) ? $this->getRelation($relation) : $relation;
 
-                    return $builder;
-                }
+            if ($relation instanceof BelongsToMany) {
+                call_user_func($callback, $relation->setQuery($builder->getQuery()));
 
-                throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
-            }, $operator, $count
-        );
+                return $builder;
+            }
+
+            throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
+        });
     }
 
     /**
@@ -214,7 +215,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the pivot relation with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\BelongsToMany<*, *, *>|string  $relation
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
@@ -222,19 +223,7 @@ trait QueriesRelationships
      */
     public function orWhereHasPivot($relation, Closure $callback, $operator = '>=', $count = 1): static
     {
-        return $this->orWhereHas($relation,
-            function (Builder $builder) use ($callback, $relation) {
-                $relation = $this->getRelation($relation);
-
-                if ($relation instanceof BelongsToMany) {
-                    call_user_func($callback, $relation->setQuery($builder->getQuery()));
-
-                    return $builder;
-                }
-
-                throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
-            }, $operator, $count
-        );
+        return $this->whereHasPivot($relation, $callback, $operator, $count, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -168,7 +168,8 @@ trait QueriesRelationships
     {
         return $this->has($relation, $operator, $count, $boolean,
             function (Builder $builder) use ($callback, $relation) {
-                $relation = is_string($relation) ? $this->getRelation($relation) : $relation;
+                // As we modify given relation, will use its clone
+                $relation = is_string($relation) ? $this->getRelationWithoutConstraints($relation) : clone $relation;
 
                 if ($relation instanceof BelongsToMany) {
                     call_user_func($callback, $relation->setQuery($builder->getQuery()));

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -168,17 +168,16 @@ trait QueriesRelationships
     {
         return $this->has($relation, $operator, $count, $boolean,
             function (Builder $builder) use ($callback, $relation) {
+                $relation = is_string($relation) ? $this->getRelation($relation) : $relation;
 
-            $relation = is_string($relation) ? $this->getRelation($relation) : $relation;
+                if ($relation instanceof BelongsToMany) {
+                    call_user_func($callback, $relation->setQuery($builder->getQuery()));
 
-            if ($relation instanceof BelongsToMany) {
-                call_user_func($callback, $relation->setQuery($builder->getQuery()));
+                    return $builder;
+                }
 
-                return $builder;
-            }
-
-            throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
-        });
+                throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
+            });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -161,7 +161,6 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     *
      * @return $this
      */
     public function whereHasPivot($relation, Closure $callback, $operator = '>=', $count = 1)
@@ -172,10 +171,11 @@ trait QueriesRelationships
 
                 if ($relation instanceof BelongsToMany) {
                     call_user_func($callback, $relation->setQuery($builder->getQuery()));
+
                     return $builder;
                 }
 
-                throw new InvalidArgumentException("Only BelongsToMany relations are applicable.");
+                throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
             }, $operator, $count
         );
     }
@@ -228,10 +228,11 @@ trait QueriesRelationships
 
                 if ($relation instanceof BelongsToMany) {
                     call_user_func($callback, $relation->setQuery($builder->getQuery()));
+
                     return $builder;
                 }
 
-                throw new InvalidArgumentException("Only BelongsToMany relations are applicable.");
+                throw new InvalidArgumentException('Only BelongsToMany relations are applicable.');
             }, $operator, $count
         );
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1359,11 +1359,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'rab'],
         ]);
 
-        $relationTag = $post->tags()->whereHasPivot($tag->posts(),
+        $relation = $tag->posts();
+        $originalQuery = $relation->getQuery();
+
+        $relationTag = $post->tags()->whereHasPivot($relation,
             fn (BelongsToMany $builder) => $builder->wherePivot('flag', 'foo')
         )->first();
 
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+        $this->assertEquals($originalQuery, $relation->getQuery());
     }
 
     public function testWhereHasPivotForwardCall()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1326,19 +1326,19 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         ]);
 
         $relationTag = $post->tags()->whereHasPivot('posts',
-            fn(BelongsToMany $builder) => $builder->wherePivot('flag', 'foo')
+            fn (BelongsToMany $builder) => $builder->wherePivot('flag', 'foo')
         )->first();
 
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
 
         $relationTag = $post->tags()->whereHasPivot('posts',
-            fn(BelongsToMany $builder) => $builder->wherePivotIn('flag', ['bar', 'rab'])
+            fn (BelongsToMany $builder) => $builder->wherePivotIn('flag', ['bar', 'rab'])
         )->first();
 
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
 
         $relationTag = $post->tags()->whereHasPivot('posts',
-            fn(BelongsToMany $builder) => $builder->wherePivotNull('flag')
+            fn (BelongsToMany $builder) => $builder->wherePivotNull('flag')
         )->first();
 
         $this->assertNull($relationTag);
@@ -1346,21 +1346,21 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testWhereHasPivotForwardCall()
     {
-        $tag = Tag::create(['id' => 1, 'name' => Str::random()])->fresh();
-        $post = Post::create(['id' => 2, 'title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()])->fresh();
+        $post = Post::create(['title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'foo'],
         ]);
 
         $relationTag = $post->tags()->whereHasPivot('posts',
-            fn(BelongsToMany $builder) => $builder->whereKey(2)
+            fn (BelongsToMany $builder) => $builder->whereKey($post->getKey())
         )->first();
 
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
 
         $relationTag = $post->tags()->whereHasPivot('posts',
-            fn(BelongsToMany $builder) => $builder->whereKey(1)
+            fn (BelongsToMany $builder) => $builder->whereKey($post->getKey() + 1)
         )->first();
 
         $this->assertNull($relationTag);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1322,6 +1322,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'foo'],
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'rab'],
         ]);
 
         $relationTag = $post->tags()->whereHasPivot('posts',
@@ -1329,22 +1330,40 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         )->first();
 
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+
+        $relationTag = $post->tags()->whereHasPivot('posts',
+            fn(BelongsToMany $builder) => $builder->wherePivotIn('flag', ['bar', 'rab'])
+        )->first();
+
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+
+        $relationTag = $post->tags()->whereHasPivot('posts',
+            fn(BelongsToMany $builder) => $builder->wherePivotNull('flag')
+        )->first();
+
+        $this->assertNull($relationTag);
     }
 
     public function testWhereHasPivotForwardCall()
     {
-        $tag = Tag::create(['name' => Str::random()])->fresh();
-        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['id' => 1, 'name' => Str::random()])->fresh();
+        $post = Post::create(['id' => 2, 'title' => Str::random()]);
 
         DB::table('posts_tags')->insert([
             ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'foo'],
         ]);
 
         $relationTag = $post->tags()->whereHasPivot('posts',
-            fn(BelongsToMany $builder) => $builder->whereKey($tag->getKey())
+            fn(BelongsToMany $builder) => $builder->whereKey(2)
         )->first();
 
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+
+        $relationTag = $post->tags()->whereHasPivot('posts',
+            fn(BelongsToMany $builder) => $builder->whereKey(1)
+        )->first();
+
+        $this->assertNull($relationTag);
     }
 }
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -3,10 +3,14 @@
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Post;
+use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag;
 
 class EloquentBelongsToTest extends DatabaseTestCase
 {
@@ -126,6 +130,15 @@ class EloquentBelongsToTest extends DatabaseTestCase
 
         $this->assertFalse($child->parent()->is($parent));
         $this->assertTrue($child->parent()->isNot($parent));
+    }
+
+    public function testWhereHasPivotWrongType()
+    {
+        $user = User::first();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $user->whereHasPivot('parent', fn(BelongsToMany $pivot) => $pivot)->first();
     }
 }
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -5,12 +5,9 @@ namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Post;
-use Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag;
 
 class EloquentBelongsToTest extends DatabaseTestCase
 {
@@ -138,7 +135,7 @@ class EloquentBelongsToTest extends DatabaseTestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        $user->whereHasPivot('parent', fn(BelongsToMany $pivot) => $pivot)->first();
+        $user->whereHasPivot('parent', fn (BelongsToMany $pivot) => $pivot)->first();
     }
 }
 


### PR DESCRIPTION
For now, the only documented way to filter queries via Intermediate table columns — is to apply it while [defining relations](https://laravel.com/docs/10.x/eloquent-relationships#filtering-queries-via-intermediate-table-columns).

But sometimes we need more flexibility.

For example — `Users` belongs to many `Organization` with `roles` (role of user in organization) in pivot. `Users` has `roles` too (role of user in application). So, we have _ambiguous column name_.

`users` table

|Column | Type|
|-- | --|
|id |  |
|roles | json, array|

`employees` pivot table

|Column | Type|
|-- | --|
|user_id |  |
|organization_id |  |
|roles | json, array|

Define relation in `User` model:

```php
class User extends Model {
  public function organizations(): BelongsToMany
  {
    return $this->belongsToMany(Organization::class, 'employees')->withPivot('roles');
  }
}
```

**Now, how to query users, who play some roles?**

Of course, we may define some additional relations:

```php
class User extends Model {
  public function organizationManagers(): BelongsToMany
  {
    // I wish I could use wherePivotJsonContains() method
    return $this->organizations()->wherePivot('roles', 'like', '%manager%');
  }
}
```

And use it:

```php
User::query()->whereHas('organizationManagers');
```

It builds such query:

```sql
select * from `users` where exists 
  (select * from `organizations` inner join `employees` 
    on `organizations`.`id` = `employees`.`organization_id` 
    where `users`.`id` = `employees`.`user_id` and `employees`.`roles` like ?
  )
```

**But what if we have too many possible roles and its combinations? We doomed to define so many relations in User model.**

We could try to filter query in a callback:

```php
User::query()->whereHas('organizations', function(Builder $builder) {
  $builder->where('employees.roles', 'like', '%manager%');
});
```

_Not good. We should explicitly point to pivot table._

**This PR brings a solution.** It provides new `Builder` method `whereHasPivot`. This method doing exactly the same as `whereHas`, but it calls callback with `BelongsToMany` relationship. 

```php
User::query()->whereHasPivot('organizations', function(BelongsToMany $builder) {
  $builder->wherePivot('roles', 'like', '%manager%');
  // Or
  $builder->whereJsonContains($builder->qualifyPivotColumn('roles'), 'manager');
});
```

Of course, `BelongsToMany` forwards calls to its parent query.

```php
User::query()->whereHasPivot('organizations', function(BelongsToMany $builder) {
  $builder->whereKey('123');
});
```

`whereHasPivot` method works only with `BelongsToMany` relations, thrownig an exception if it is not.

Tests included.