### PR TITLE
added whenEmpty, unlessEmpty, whenIsset, unlessIsset methods in Build…

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4437,4 +4437,68 @@ class Builder implements BuilderContract
 
         static::throwBadMethodCallException($method);
     }
+
+    /**
+     * Apply the callback if the given "value" is empty.
+     *
+     * @template TWhenParameter
+     * @template TWhenReturnType
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function whenEmpty($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        return $this->when(empty($value), $callback, $default);
+    }
+
+    /**
+     * Apply the callback if the given "value" is not empty.
+     *
+     * @template TWhenParameter
+     * @template TWhenReturnType
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function unlessEmpty($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        return $this->unless(empty($value), $callback, $default);
+    }
+
+    /**
+     * Apply the callback if the given "value" is set.
+     *
+     * @template TWhenParameter
+     * @template TWhenReturnType
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function whenIsset($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        return $this->when(isset($value), $callback, $default);
+    }
+
+    /**
+     * Apply the callback if the given "value" is not set.
+     *
+     * @template TWhenParameter
+     * @template TWhenReturnType
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function unlessIsset($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        return $this->unless(isset($value), $callback, $default);
+    }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6830,6 +6830,182 @@ SQL;
         $this->assertSame('select * from "users" where "email" = \'foo\'', $builder->toRawSql());
     }
 
+    public function testWhenEmptyCallback()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->whenEmpty([], $callback)->where('email', '=', 'foo');;
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->whenEmpty(['email' => 'foo'], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testWhenEmptyCallbackWithDefault()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $default = function ($query, $condition) {
+            $this->assertFalse($condition);
+
+            $query->where('email', '=', 'foo');
+        };
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->whenEmpty([], $callback, $default);
+        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->whenEmpty(['email' => 'foo'], $callback, $default);
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testUnlessEmptyCallback()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertFalse($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->unlessEmpty(['email' => 'foo'], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->unlessEmpty([], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testUnlessEmptyCallbackWithDefault()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertFalse($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $default = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('email', '=', 'foo');
+        };
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->unlessEmpty(['email' => 'foo'], $callback, $default);
+        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->unlessEmpty([], $callback, $default);
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testWhenIssetCallback()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $builder = $this->getBuilder();
+        $array = ['email' => 'foo'];
+        $builder->select('*')->from('users')->whenIsset($array['email'], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $array = ['email' => null];
+        $builder->select('*')->from('users')->whenIsset($array['email'], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testWhenIssetCallbackWithDefault()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $default = function ($query, $condition) {
+            $this->assertFalse($condition);
+
+            $query->where('email', '=', 'foo');
+        };
+
+        $builder = $this->getBuilder();
+        $array = ['email' => 'foo'];
+        $builder->select('*')->from('users')->whenIsset($array['email'], $callback, $default);
+        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $array = ['email' => null];
+        $builder->select('*')->from('users')->whenIsset($array['email'], $callback, $default);
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testUnlessIssetCallback()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertFalse($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $builder = $this->getBuilder();
+        $array = ['email' => 'foo'];
+        $builder->select('*')->from('users')->unlessIsset($array['email'], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $array = ['email' => null];
+        $builder->select('*')->from('users')->unlessIsset($array['email'], $callback)->where('email', '=', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+    }
+
+    public function testUnlessIssetCallbackWithDefault()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertFalse($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $default = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('email', '=', 'foo');
+        };
+
+        $builder = $this->getBuilder();
+        $array = ['email' => 'foo'];
+        $builder->select('*')->from('users')->unlessIsset($array['email'], $callback, $default);
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $array = ['email' => null];
+        $builder->select('*')->from('users')->unlessIsset($array['email'], $callback, $default);
+        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6840,7 +6840,7 @@ SQL;
 
         $builder = $this->getBuilder();
 
-        $builder->select('*')->from('users')->whenEmpty([], $callback)->where('email', '=', 'foo');;
+        $builder->select('*')->from('users')->whenEmpty([], $callback)->where('email', '=', 'foo');
         $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
…er.php

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Added the methods whenIsset, unlessIsset, whenEmpty, and unlessEmpty in Builder.php. I often find myself using the when method in the query builder, and I noticed that most of the time I use $query->when(isset($filters['email']), $callback) or $query->when(!empty($filters['email']), $callback). So, I thought it would be useful to have methods that directly perform these checks, similar to what exists for Collections.