### PR TITLE
Add dd_when Helper to Conditionally Trigger dd()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -507,3 +507,19 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (!function_exists('dd_when')) {
+    /**
+     * Dump and die when a condition is met.
+     *
+     * @param bool $condition
+     * @param  mixed  ...$vars
+     * @return void
+     */
+    function dd_when(bool $condition, mixed ...$vars): void
+    {
+        if ($condition) {
+            dd(...$vars);
+        }
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1229,6 +1229,18 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testDdWhenDoesNotDumpWhenConditionIsFalse()
+    {
+        // Ensure that when the condition is false, dd() does not execute.
+        try {
+            dd_when(false, 'This should not dump');
+        } catch (RuntimeException $e) {
+            $this->fail('dd_when should not have called dd when condition is false.');
+        }
+
+        $this->assertTrue(true); // If no exception, the test passes.
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Propose helper function, `dd_when`, allowing conditional debugging with `dd()`. This function provides a simple way to invoke dd() based on a boolean condition.

Example Usage:
```php
dd_when($user->isAdmin(), $user, 'Only admins can see this debug info');
```

Sample Use case:

Before
```php
foreach($users as $user) {
      if ($user->dontHaveOrder()) {
            dd($user->id);
      }
     ....
}
```

After
```php
foreach($users as $user) {
      dd_when($user->dontHaveOrder(), $user->id);
     ....
}
```