### PR TITLE
[11.x] Provide an error message for PostTooLargeException

### DIFF
--- a/src/Illuminate/Http/Middleware/ValidatePostSize.php
+++ b/src/Illuminate/Http/Middleware/ValidatePostSize.php
@@ -21,7 +21,7 @@ class ValidatePostSize
         $max = $this->getPostMaxSize();
 
         if ($max > 0 && $request->server('CONTENT_LENGTH') > $max) {
-            throw new PostTooLargeException;
+            throw new PostTooLargeException('The POST data is too large.');
         }
 
         return $next($request);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -46,7 +46,6 @@ use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Subscription;
 use LogicException;
-use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class ResourceTest extends TestCase
@@ -1503,12 +1502,15 @@ class ResourceTest extends TestCase
 
     public function testPostTooLargeException()
     {
+        $request = new Request(server: ['CONTENT_LENGTH' => '4']);
+        $post = new ValidatePostSize;
+        $post->handle($request, fn () => null);
+
         $this->expectException(PostTooLargeException::class);
 
-        $request = m::mock(Request::class, ['server' => ['CONTENT_LENGTH' => '2147483640']]);
+        $request = new Request(server: ['CONTENT_LENGTH' => '2147483640']);
         $post = new ValidatePostSize;
-        $post->handle($request, function () {
-        });
+        $post->handle($request, fn () => null);
     }
 
     public function testLeadingMergeKeyedValueIsMergedCorrectlyWhenFirstValueIsMissing()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1507,6 +1507,7 @@ class ResourceTest extends TestCase
         $post->handle($request, fn () => null);
 
         $this->expectException(PostTooLargeException::class);
+        $this->expectExceptionMessage('The POST data is too large.');
 
         $request = new Request(server: ['CONTENT_LENGTH' => '2147483640']);
         $post = new ValidatePostSize;


### PR DESCRIPTION
The `ValidatePostSize` middleware ensures the POST is under the allowed size set in `php.ini`.

However the exception message is empty

```json
{
   "message": ""
}
```

This PR adds a message.

