### PR TITLE
[11.x] Introduce whenWhere methods in query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1774,6 +1774,44 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a whenWhere to the query.
+     *
+     * @param mixed $condition
+     * @param string $column
+     * @param string|null $operator
+     * @param mixed|null $value
+     * @param string $boolean
+     * @return $this
+    */
+    public function whenWhere($condition, string $column, $operator = null, $value = null, string $boolean = 'and')
+    {
+        if(!$condition) {
+            return $this;
+        }
+
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+
+        return $this->where($column, $operator, $value, $boolean);
+    }
+
+    /**
+     * Add a or whenWhere to the query.
+     *
+     * @param mixed $condition The condition to check
+     * @param string $column The column to filter
+     * @param string|null $operator The comparison operator
+     * @param mixed|null $value The value to compare against
+     * @param string
+     * @return $this
+     */
+    public function orWhenWhere($condition, string $column, $operator = null, $value = null)
+    {
+        return $this->whenWhere($condition, $column, $operator, $value, 'or');
+    }
+
+    /**
      * Add a nested where statement to the query.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1789,20 +1789,16 @@ class Builder implements BuilderContract
             return $this;
         }
 
-        [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
-        );
-
         return $this->where($column, $operator, $value, $boolean);
     }
 
     /**
      * Add a or whenWhere to the query.
      *
-     * @param mixed $condition The condition to check
-     * @param string $column The column to filter
-     * @param string|null $operator The comparison operator
-     * @param mixed|null $value The value to compare against
+     * @param mixed $condition
+     * @param string $column
+     * @param string|null $operator
+     * @param mixed|null $value
      * @param string
      * @return $this
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1776,16 +1776,16 @@ class Builder implements BuilderContract
     /**
      * Add a whenWhere to the query.
      *
-     * @param mixed $condition
-     * @param string $column
-     * @param string|null $operator
-     * @param mixed|null $value
-     * @param string $boolean
+     * @param  mixed  $condition
+     * @param  string  $column
+     * @param  string|null  $operator
+     * @param  mixed|null  $value
+     * @param  string  $boolean
      * @return $this
-    */
-    public function whenWhere($condition, string $column, $operator = null, $value = null, string $boolean = 'and')
+     */
+    public function whenWhere($condition, $column, $operator = null, $value = null, string $boolean = 'and')
     {
-        if(!$condition) {
+        if (! $condition) {
             return $this;
         }
 
@@ -1795,14 +1795,13 @@ class Builder implements BuilderContract
     /**
      * Add a or whenWhere to the query.
      *
-     * @param mixed $condition
-     * @param string $column
-     * @param string|null $operator
-     * @param mixed|null $value
-     * @param string
+     * @param  mixed  $condition
+     * @param  string  $column
+     * @param  string|null  $operator
+     * @param  mixed|null  $value
      * @return $this
      */
-    public function orWhenWhere($condition, string $column, $operator = null, $value = null)
+    public function orWhenWhere($condition, $column, $operator = null, $value = null)
     {
         return $this->whenWhere($condition, $column, $operator, $value, 'or');
     }

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -600,13 +600,13 @@ class QueryBuilderTest extends DatabaseTestCase
 
     public function testWhenWhere()
     {
-        $this->assertSame(1, DB::table('posts')->whenWhere(true,'id', 1)->count());
-        $this->assertSame(2, DB::table('posts')->whenWhere(false,'id', 1)->count());
+        $this->assertSame(1, DB::table('posts')->whenWhere(true, 'id', 1)->count());
+        $this->assertSame(2, DB::table('posts')->whenWhere(false, 'id', 1)->count());
     }
     public function testOrWhenWhere()
     {
-        $this->assertSame(1, DB::table('posts')->whenWhere(true,'id', 1)->count());
-        $this->assertSame(2, DB::table('posts')->whenWhere(false,'id', 1)->count());
+        $this->assertSame(1, DB::table('posts')->whenWhere(true, 'id', 1)->count());
+        $this->assertSame(2, DB::table('posts')->whenWhere(false, 'id', 1)->count());
     }
     public function testPluck()
     {

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -603,11 +603,13 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whenWhere(true, 'id', 1)->count());
         $this->assertSame(2, DB::table('posts')->whenWhere(false, 'id', 1)->count());
     }
+
     public function testOrWhenWhere()
     {
         $this->assertSame(1, DB::table('posts')->whenWhere(true, 'id', 1)->count());
         $this->assertSame(2, DB::table('posts')->whenWhere(false, 'id', 1)->count());
     }
+
     public function testPluck()
     {
         // Test SELECT override, since pluck will take the first column.

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -598,6 +598,16 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertCount(3, DB::getQueryLog());
     }
 
+    public function testWhenWhere()
+    {
+        $this->assertSame(1, DB::table('posts')->whenWhere(true,'id', 1)->count());
+        $this->assertSame(2, DB::table('posts')->whenWhere(false,'id', 1)->count());
+    }
+    public function testOrWhenWhere()
+    {
+        $this->assertSame(1, DB::table('posts')->whenWhere(true,'id', 1)->count());
+        $this->assertSame(2, DB::table('posts')->whenWhere(false,'id', 1)->count());
+    }
     public function testPluck()
     {
         // Test SELECT override, since pluck will take the first column.


### PR DESCRIPTION
**Introduction of whenWhere function to Laravel Query Builder**

_Usage Examples_


```
$users = User::query()
            ->whenWhere($request->active, 'is_active', true)
            ->whenWhere($request->role, 'role', $request->role)
            ->get();

```

instead of


```
 $users = User::query()
            ->when($request->active, function($query) {
                $query->where('is_active', true);
            })
            ->when($request->role, function($query, $role) {
                $query->where('role', $role);
            })
            ->get();

```