### PR TITLE
[12.x] force `Eloquent\Collection::partition` to return a base `Collection`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -629,6 +629,19 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Partition the collection into two arrays using the given callback or key.
+     *
+     * @param  (callable(TModel, TKey): bool)|TModel|string  $key
+     * @param  TModel|string|null  $operator
+     * @param  TModel|null  $value
+     * @return \Illuminate\Support\Collection<int<0, 1>, static<TKey, TModel>>
+     */
+    public function partition($key, $operator = null, $value = null)
+    {
+        return parent::partition($key, $operator, $value)->toBase();
+    }
+
+    /**
      * Get an array with the values of a given key.
      *
      * @param  string|array<array-key, string>|null  $value

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -499,6 +499,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($a->zip(['a', 'b'], ['c', 'd'])));
         $this->assertEquals(BaseCollection::class, get_class($a->countBy('foo')));
         $this->assertEquals(BaseCollection::class, get_class($b->flip()));
+        $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', '=', 'bar')));
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()


### PR DESCRIPTION
the way `partition` currently works is it returns an `Eloquent\Collection` of `Eloquent\Collection`s, which is technically not allowed by the generic type hints defined by the class, and also doesn't really make any logical sense for how someone would want to use this.

It also causes issues in the IDE because based on the type hints it assumes ALL values of an `Eloquent\Collection` are of type `Eloquent\Model`, which is not the case for the `partition` method.

what we really want is a `Support\Collection` of `Eloquent\Collection`s. we can accomplish this by first calling the `parent::partition` method to get our (illegal) result of `Eloquent\Collection<int, Eloquent\Collection>`, and then converting it to a base collection to end up with the desired `Support\Collection<int, Eloquent\Collection>`.

```php
//get users
$users = User::all();

//partition by age
$partition = $users->partition(fn ($user) => $user->age > 18);

//before change
dump($partition::class);    // Illuminate\Database\Eloquent\Collection
dump($partition[0]::class); // Illuminate\Database\Eloquent\Collection
dump($partition[1]::class); // Illuminate\Database\Eloquent\Collection

//after change
dump($partition::class);    // Illuminate\Support\Collection
dump($partition[0]::class); // Illuminate\Database\Eloquent\Collection
dump($partition[1]::class); // Illuminate\Database\Eloquent\Collection
```

someone please double check my generic return type docblock. I'm relatively new to them, but I think this should be correct and fix the issues.

#53298 #53283

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
