### PR TITLE
[11.x] Added `dropColumnsIfExists`, `dropColumnIfExists` and `dropForeignIfExists`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 
@@ -423,6 +424,26 @@ class Blueprint
     public function dropColumn($columns)
     {
         $columns = is_array($columns) ? $columns : func_get_args();
+
+        return $this->addCommand('dropColumn', compact('columns'));
+    }
+
+    /**
+     * Indicate that the given columns should be dropped if exists.
+     *
+     * @param  array|mixed  $columns
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropColumnIfExists($columns)
+    {
+        $current = Schema::getColumnListing($this->getTable());
+
+        $columns = is_array($columns) ? $columns : func_get_args();
+        $columns = array_filter($columns, fn ($column) => in_array($column, $current));
+
+        if (empty($columns)) {
+            return new Fluent();
+        }
 
         return $this->addCommand('dropColumn', compact('columns'));
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -445,7 +445,7 @@ class Blueprint
             return new Fluent();
         }
 
-        return $this->addCommand('dropColumn', compact('columns'));
+        return $this->dropColumn($columns);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -437,6 +437,7 @@ class Blueprint
     public function dropColumnIfExists($columns)
     {
         $columns = is_array($columns) ? $columns : func_get_args();
+
         $columns = array_intersect($columns, Schema::getColumnListing($this->getTable()));
 
         if (empty($columns)) {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -436,10 +436,8 @@ class Blueprint
      */
     public function dropColumnIfExists($columns)
     {
-        $current = Schema::getColumnListing($this->getTable());
-
         $columns = is_array($columns) ? $columns : func_get_args();
-        $columns = array_filter($columns, fn ($column) => in_array($column, $current));
+        $columns = array_intersect($columns, Schema::getColumnListing($this->getTable()));
 
         if (empty($columns)) {
             return new Fluent();

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -525,7 +525,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the given foreign key should be dropped.
+     * Indicate that the given foreign key should be dropped if exists.
      *
      * @param  string|array  $index
      * @return \Illuminate\Support\Fluent

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -525,6 +525,25 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given foreign key should be dropped.
+     *
+     * @param  string|array  $index
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropForeignIfExists($index)
+    {
+        if (is_array($index)) {
+            $index = $this->createIndexName('foreign', $index);
+        }
+
+        if (! in_array($index, Schema::getForeignKeys($this->getTable()))) {
+            return new Fluent();
+        }
+
+        return $this->dropIndexCommand('dropForeign', 'foreign', $index);
+    }
+
+    /**
      * Indicate that the given column and foreign key should be dropped.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -429,7 +429,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the given columns should be dropped if exists.
+     * Indicate that the given columns should be dropped if they exist.
      *
      * @param  array|mixed  $columns
      * @return \Illuminate\Support\Fluent
@@ -526,7 +526,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the given foreign key should be dropped if exists.
+     * Indicate that the given foreign key should be dropped if it exists.
      *
      * @param  string|array  $index
      * @return \Illuminate\Support\Fluent

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -441,7 +441,7 @@ class Blueprint
         $columns = array_intersect($columns, Schema::getColumnListing($this->getTable()));
 
         if (empty($columns)) {
-            return new Fluent();
+            return new Fluent;
         }
 
         return $this->dropColumn($columns);
@@ -538,7 +538,7 @@ class Blueprint
         }
 
         if (! in_array($index, Schema::getForeignKeys($this->getTable()))) {
-            return new Fluent();
+            return new Fluent;
         }
 
         return $this->dropIndexCommand('dropForeign', 'foreign', $index);

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -463,7 +463,7 @@ class Builder
     }
 
     /**
-     * Drop columns from a table schema if exists.
+     * Drop columns from a table schema if they exist.
      *
      * @param  string  $table
      * @param  string|array  $columns

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -463,6 +463,20 @@ class Builder
     }
 
     /**
+     * Drop columns from a table schema if exists.
+     *
+     * @param  string  $table
+     * @param  string|array  $columns
+     * @return void
+     */
+    public function dropColumnsIfExists($table, $columns)
+    {
+        $this->table($table, function (Blueprint $blueprint) use ($columns) {
+            $blueprint->dropColumnIfExists($columns);
+        });
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void


### PR DESCRIPTION
This PR introduces the `dropColumnsIfExists` method in `Builder` and `dropColumnIfExists` / `dropForeignIfExists` in `Blueprint`.

These methods add a convenient way to safely drop columns from a table if they exist, preventing errors when the specified columns are absent.

While I am not entirely sure how to approach creating tests for this functionality, I have tested it extensively in my code with different migration scenarios. For example, I've tested it with columns that are present and others that are not, and in every case, no errors were thrown.

Here’s how the new methods can be used in migrations:

```php
Schema::table('assignment', function (Blueprint $table) {
    $table->dropColumnIfExists('model');
    $table->dropColumnIfExists('text', 'remote_id');
});

Schema::table('bot', function (Blueprint $table) {
    $table->dropColumnIfExists('icebr');
    $table->dropColumnIfExists('text');
});

Schema::table('grade', function (Blueprint $table) {
    $table->dropColumnIfExists('submission');
    $table->dropForeignIfExists(['tutor_id']);
    $table->dropColumnIfExists('tutor_id');
    $table->dropColumnIfExists('response');
});
```

Our team uses a shared database across multiple applications, which requires us to frequently modify the database schema. The `dropColumnIfExists` functionality is essential for our workflow as it ensures that migrations run smoothly without being interrupted by missing columns. This enhancement could also be beneficial to others who work in environments where Laravel does not have complete control over the database schema, providing a more resilient and error-proof migration process.

Any feedback would be welcome.

Thanks!