### PR TITLE
[11.x] Pick up existing views and markdowns when creating mails

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -88,6 +88,10 @@ class MailMakeCommand extends GeneratorCommand
             str_replace('.', '/', $this->getView()).'.blade.php'
         );
 
+        if ($this->files->exists($path)) {
+            return $this->components->info(sprintf('%s [%s] has been picked up.', 'View', $path));
+        }
+
         $this->files->ensureDirectoryExists(dirname($path));
 
         $stub = str_replace(

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -71,7 +71,7 @@ class MailMakeCommand extends GeneratorCommand
         );
 
         if ($this->files->exists($path)) {
-            return $this->components->info(sprintf('%s [%s] has been picked up.', 'Markdown view', $path));
+            return $this->components->error(sprintf('%s [%s] already exists.', 'Markdown view', $path));
         }
 
         $this->files->ensureDirectoryExists(dirname($path));
@@ -93,7 +93,7 @@ class MailMakeCommand extends GeneratorCommand
         );
 
         if ($this->files->exists($path)) {
-            return $this->components->info(sprintf('%s [%s] has been picked up.', 'View', $path));
+            return $this->components->error(sprintf('%s [%s] already exists.', 'View', $path));
         }
 
         $this->files->ensureDirectoryExists(dirname($path));

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -70,6 +70,10 @@ class MailMakeCommand extends GeneratorCommand
             str_replace('.', '/', $this->getView()).'.blade.php'
         );
 
+        if ($this->files->exists($path)) {
+            return $this->components->info(sprintf('%s [%s] has been picked up.', 'Markdown view', $path));
+        }
+
         $this->files->ensureDirectoryExists(dirname($path));
 
         $this->files->put($path, file_get_contents(__DIR__.'/stubs/markdown.stub'));

--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -47,6 +47,31 @@ class MailMakeCommandTest extends TestCase
         ], 'resources/views/foo-mail.blade.php');
     }
 
+    public function testExistingMarkdownsWillBePickedUp()
+    {
+        $this->app['files']
+            ->put(
+                $this->app->basePath('resources/views/existing-markdown.blade.php'),
+                '<x-mail::message>My existing markdown</x-mail::message>'
+            );
+        $this->artisan('make:mail', ['name' => 'FooMail', '--markdown' => 'existing-markdown'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Mail;',
+            'use Illuminate\Mail\Mailable;',
+            'class FooMail extends Mailable',
+            'return new Content(',
+            "markdown: 'existing-markdown',",
+        ], 'app/Mail/FooMail.php');
+
+        $this->assertFileContains([
+            '<x-mail::message>',
+            'My existing markdown',
+            '</x-mail::message>',
+        ], 'resources/views/existing-markdown.blade.php');
+    }
+
     public function testItCanGenerateMailFileWithViewOption()
     {
         $this->artisan('make:mail', ['name' => 'FooMail', '--view' => 'foo-mail'])
@@ -63,7 +88,7 @@ class MailMakeCommandTest extends TestCase
         $this->assertFilenameExists('resources/views/foo-mail.blade.php');
     }
 
-    public function testMailTemplateWillBePickedUp()
+    public function testMailTemplatesWillBePickedUp()
     {
         $this->app['files']
             ->put(

--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -63,6 +63,30 @@ class MailMakeCommandTest extends TestCase
         $this->assertFilenameExists('resources/views/foo-mail.blade.php');
     }
 
+    public function testMailTemplateWillBePickedUp()
+    {
+        $this->app['files']
+            ->put(
+                $this->app->basePath('resources/views/existing-template.blade.php'),
+                '<div>My existing template</div>'
+            );
+        $this->artisan('make:mail', ['name' => 'FooMail', '--view' => 'existing-template'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Mail;',
+            'use Illuminate\Mail\Mailable;',
+            'class FooMail extends Mailable',
+            'return new Content(',
+            "view: 'existing-template',",
+        ], 'app/Mail/FooMail.php');
+
+        $this->assertFilenameExists('resources/views/existing-template.blade.php');
+        $this->assertFileContains([
+            '<div>My existing template</div>',
+        ], 'resources/views/existing-template.blade.php');
+    }
+
     public function testItCanGenerateMailFileWithTest()
     {
         $this->artisan('make:mail', ['name' => 'FooMail', '--test' => true])

--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -47,14 +47,16 @@ class MailMakeCommandTest extends TestCase
         ], 'resources/views/foo-mail.blade.php');
     }
 
-    public function testExistingMarkdownsWillBePickedUp()
+    public function testErrorsAreDisplayedWhenMarkdownsAlreadyExist()
     {
+        $existingMarkdownPath = 'resources/views/existing-markdown.blade.php';
         $this->app['files']
             ->put(
-                $this->app->basePath('resources/views/existing-markdown.blade.php'),
+                $this->app->basePath($existingMarkdownPath),
                 '<x-mail::message>My existing markdown</x-mail::message>'
             );
         $this->artisan('make:mail', ['name' => 'FooMail', '--markdown' => 'existing-markdown'])
+            ->expectsOutputToContain('already exists.')
             ->assertExitCode(0);
 
         $this->assertFileContains([
@@ -64,12 +66,11 @@ class MailMakeCommandTest extends TestCase
             'return new Content(',
             "markdown: 'existing-markdown',",
         ], 'app/Mail/FooMail.php');
-
         $this->assertFileContains([
             '<x-mail::message>',
             'My existing markdown',
             '</x-mail::message>',
-        ], 'resources/views/existing-markdown.blade.php');
+        ], $existingMarkdownPath);
     }
 
     public function testItCanGenerateMailFileWithViewOption()
@@ -88,14 +89,16 @@ class MailMakeCommandTest extends TestCase
         $this->assertFilenameExists('resources/views/foo-mail.blade.php');
     }
 
-    public function testMailTemplatesWillBePickedUp()
+    public function testErrorsWillBeDisplayedWhenViewsAlreadyExist()
     {
+        $existingViewPath = 'resources/views/existing-template.blade.php';
         $this->app['files']
             ->put(
-                $this->app->basePath('resources/views/existing-template.blade.php'),
+                $this->app->basePath($existingViewPath),
                 '<div>My existing template</div>'
             );
         $this->artisan('make:mail', ['name' => 'FooMail', '--view' => 'existing-template'])
+            ->expectsOutputToContain('already exists.')
             ->assertExitCode(0);
 
         $this->assertFileContains([
@@ -105,11 +108,10 @@ class MailMakeCommandTest extends TestCase
             'return new Content(',
             "view: 'existing-template',",
         ], 'app/Mail/FooMail.php');
-
-        $this->assertFilenameExists('resources/views/existing-template.blade.php');
+        $this->assertFilenameExists($existingViewPath);
         $this->assertFileContains([
             '<div>My existing template</div>',
-        ], 'resources/views/existing-template.blade.php');
+        ], $existingViewPath);
     }
 
     public function testItCanGenerateMailFileWithTest()

--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -47,7 +47,7 @@ class MailMakeCommandTest extends TestCase
         ], 'resources/views/foo-mail.blade.php');
     }
 
-    public function testErrorsAreDisplayedWhenMarkdownsAlreadyExist()
+    public function testErrorsWillBeDisplayedWhenMarkdownsAlreadyExist()
     {
         $existingMarkdownPath = 'resources/views/existing-markdown.blade.php';
         $this->app['files']


### PR DESCRIPTION
I spend a whole afternoon designing an email template named `resources/views/customers/welcome.blade.php`.

Then I run the command `php artisan make:mail --view=customers.welcome`.

And my completed template has been replaced with the stub file.

This is not exactly ideal, and it is easy to fix. People might have existing templates to use, or design them first. If blade files are already present, it would be great if they are picked up.

To be consistent, I do the same with markdowns.