### PR TITLE
[11.x] middleware support for specific method in resource routes

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -161,7 +161,7 @@ class PendingResourceRegistration
     }
 
     /**
-     * Specify middleware that should be added to the specific resource routes.
+     * Specify middleware that should be added to the specified resource routes.
      *
      * @param  array|string  $methods
      * @param  array|string  $middleware

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -165,7 +165,6 @@ class PendingResourceRegistration
      *
      * @param  array|string  $methods
      * @param  array|string  $middleware
-     *
      * @return $this
      */
     public function middlewareFor($methods, $middleware)

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -161,6 +161,26 @@ class PendingResourceRegistration
     }
 
     /**
+     * Specify middleware that should be added to the specific resource routes.
+     *
+     * @param  array|string  $methods
+     * @param  array|string  $middleware
+     *
+     * @return $this
+     */
+    public function middlewareFor($methods, $middleware)
+    {
+        $methods = Arr::wrap($methods);
+        $middleware = Arr::wrap($middleware);
+
+        foreach ($methods as $method) {
+            $this->options['middleware_for'][$method] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Specify middleware that should be removed from the resource routes.
      *
      * @param  array|string  $middleware

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -211,6 +211,25 @@ class PendingResourceRegistration
     }
 
     /**
+     * Specify middleware that should be removed from the specified resource routes.
+     *
+     * @param  array|string  $methods
+     * @param  array|string  $middleware
+     * @return $this
+     */
+    public function withoutMiddlewareFor($methods, $middleware)
+    {
+        $methods = Arr::wrap($methods);
+        $middleware = Arr::wrap($middleware);
+
+        foreach ($methods as $method) {
+            $this->options['excluded_middleware_for'][$method] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Add "where" constraints to the resource routes.
      *
      * @param  mixed  $wheres

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -157,6 +157,15 @@ class PendingResourceRegistration
 
         $this->options['middleware'] = $middleware;
 
+        if (isset($this->options['middleware_for'])) {
+            foreach ($this->options['middleware_for'] as $method => $value) {
+                $this->options['middleware_for'][$method] = Router::uniqueMiddleware(array_merge(
+                    Arr::wrap($value),
+                    $middleware
+                ));
+            }
+        }
+
         return $this;
     }
 
@@ -171,6 +180,13 @@ class PendingResourceRegistration
     {
         $methods = Arr::wrap($methods);
         $middleware = Arr::wrap($middleware);
+
+        if (isset($this->options['middleware'])) {
+            $middleware = Router::uniqueMiddleware(array_merge(
+                $this->options['middleware'],
+                $middleware
+            ));
+        }
 
         foreach ($methods as $method) {
             $this->options['middleware_for'][$method] = $middleware;

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -185,7 +185,7 @@ class PendingSingletonResourceRegistration
     }
 
     /**
-     * Specify middleware that should be added to the specific resource routes.
+     * Specify middleware that should be added to the specified resource routes.
      *
      * @param  array|string  $methods
      * @param  array|string  $middleware

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -185,6 +185,26 @@ class PendingSingletonResourceRegistration
     }
 
     /**
+     * Specify middleware that should be added to the specific resource routes.
+     *
+     * @param  array|string  $methods
+     * @param  array|string  $middleware
+     *
+     * @return $this
+     */
+    public function middlewareFor($methods, $middleware)
+    {
+        $methods = Arr::wrap($methods);
+        $middleware = Arr::wrap($middleware);
+
+        foreach ($methods as $method) {
+            $this->options['middleware_for'][$method] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Specify middleware that should be removed from the resource routes.
      *
      * @param  array|string  $middleware

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -189,7 +189,6 @@ class PendingSingletonResourceRegistration
      *
      * @param  array|string  $methods
      * @param  array|string  $middleware
-     *
      * @return $this
      */
     public function middlewareFor($methods, $middleware)

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -181,6 +181,15 @@ class PendingSingletonResourceRegistration
 
         $this->options['middleware'] = $middleware;
 
+        if (isset($this->options['middleware_for'])) {
+            foreach ($this->options['middleware_for'] as $method => $value) {
+                $this->options['middleware_for'][$method] = Router::uniqueMiddleware(array_merge(
+                    Arr::wrap($value),
+                    $middleware
+                ));
+            }
+        }
+
         return $this;
     }
 
@@ -195,6 +204,13 @@ class PendingSingletonResourceRegistration
     {
         $methods = Arr::wrap($methods);
         $middleware = Arr::wrap($middleware);
+
+        if (isset($this->options['middleware'])) {
+            $middleware = Router::uniqueMiddleware(array_merge(
+                $this->options['middleware'],
+                $middleware
+            ));
+        }
 
         foreach ($methods as $method) {
             $this->options['middleware_for'][$method] = $middleware;

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -235,6 +235,25 @@ class PendingSingletonResourceRegistration
     }
 
     /**
+     * Specify middleware that should be removed from the specified resource routes.
+     *
+     * @param  array|string  $methods
+     * @param  array|string  $middleware
+     * @return $this
+     */
+    public function withoutMiddlewareFor($methods, $middleware)
+    {
+        $methods = Arr::wrap($methods);
+        $middleware = Arr::wrap($middleware);
+
+        foreach ($methods as $method) {
+            $this->options['excluded_middleware_for'][$method] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Add "where" constraints to the resource routes.
      *
      * @param  mixed  $wheres

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -104,8 +104,14 @@ class ResourceRegistrar
         $resourceMethods = $this->getResourceMethods($defaults, $options);
 
         foreach ($resourceMethods as $m) {
+            $optionsForMethod = $options;
+            if (isset($optionsForMethod['middleware_for'][$m])) {
+                $optionsForMethod['middleware'] ??= [];
+                $optionsForMethod['middleware'] = [...$optionsForMethod['middleware_for'][$m], ...$optionsForMethod['middleware']];
+            }
+
             $route = $this->{'addResource'.ucfirst($m)}(
-                $name, $base, $controller, $options
+                $name, $base, $controller, $optionsForMethod
             );
 
             if (isset($options['bindingFields'])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -165,8 +165,15 @@ class ResourceRegistrar
         $resourceMethods = $this->getResourceMethods($defaults, $options);
 
         foreach ($resourceMethods as $m) {
+            $optionsForMethod = $options;
+
+            if (isset($options['middleware_for'][$m])) {
+                $optionsForMethod['middleware'] ??= [];
+                $optionsForMethod['middleware'] = [...$optionsForMethod['middleware_for'][$m], ...$optionsForMethod['middleware']];
+            }
+
             $route = $this->{'addSingleton'.ucfirst($m)}(
-                $name, $controller, $options
+                $name, $controller, $optionsForMethod
             );
 
             if (isset($options['bindingFields'])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -105,9 +105,9 @@ class ResourceRegistrar
 
         foreach ($resourceMethods as $m) {
             $optionsForMethod = $options;
+
             if (isset($optionsForMethod['middleware_for'][$m])) {
-                $optionsForMethod['middleware'] ??= [];
-                $optionsForMethod['middleware'] = [...$optionsForMethod['middleware_for'][$m], ...$optionsForMethod['middleware']];
+                $optionsForMethod['middleware'] = $optionsForMethod['middleware_for'][$m];
             }
 
             $route = $this->{'addResource'.ucfirst($m)}(
@@ -167,9 +167,8 @@ class ResourceRegistrar
         foreach ($resourceMethods as $m) {
             $optionsForMethod = $options;
 
-            if (isset($options['middleware_for'][$m])) {
-                $optionsForMethod['middleware'] ??= [];
-                $optionsForMethod['middleware'] = [...$optionsForMethod['middleware_for'][$m], ...$optionsForMethod['middleware']];
+            if (isset($optionsForMethod['middleware_for'][$m])) {
+                $optionsForMethod['middleware'] = $optionsForMethod['middleware_for'][$m];
             }
 
             $route = $this->{'addSingleton'.ucfirst($m)}(

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -110,6 +110,13 @@ class ResourceRegistrar
                 $optionsForMethod['middleware'] = $optionsForMethod['middleware_for'][$m];
             }
 
+            if (isset($optionsForMethod['excluded_middleware_for'][$m])) {
+                $optionsForMethod['excluded_middleware'] = Router::uniqueMiddleware(array_merge(
+                    $optionsForMethod['excluded_middleware'] ?? [],
+                    $optionsForMethod['excluded_middleware_for'][$m]
+                ));
+            }
+
             $route = $this->{'addResource'.ucfirst($m)}(
                 $name, $base, $controller, $optionsForMethod
             );
@@ -169,6 +176,13 @@ class ResourceRegistrar
 
             if (isset($optionsForMethod['middleware_for'][$m])) {
                 $optionsForMethod['middleware'] = $optionsForMethod['middleware_for'][$m];
+            }
+
+            if (isset($optionsForMethod['excluded_middleware_for'][$m])) {
+                $optionsForMethod['excluded_middleware'] = Router::uniqueMiddleware(array_merge(
+                    $optionsForMethod['excluded_middleware'] ?? [],
+                    $optionsForMethod['excluded_middleware_for'][$m]
+                ));
             }
 
             $route = $this->{'addSingleton'.ucfirst($m)}(

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -844,6 +844,22 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
+    public function testCanSetMiddlewareForSpecificMethodsOnRegisteredResource()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
+                     ->middlewareFor(['create', 'store'], 'one')
+                     ->middlewareFor(['edit'],['one', 'two']);
+
+        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(),[RouteRegistrarMiddlewareStub::class]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(),['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(),['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(),[]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(),['one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(),[]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(),[]);
+    }
+
     public function testResourceWithoutMiddlewareRegistration()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -851,13 +851,13 @@ class RouteRegistrarTest extends TestCase
                      ->middlewareFor(['create', 'store'], 'one')
                      ->middlewareFor(['edit'],['one', 'two']);
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(),[RouteRegistrarMiddlewareStub::class]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(),['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(),['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(),[]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(),['one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(),[]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(),[]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), []);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), []);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), []);
     }
 
     public function testResourceWithoutMiddlewareRegistration()
@@ -1352,6 +1352,23 @@ class RouteRegistrarTest extends TestCase
         $this->assertCount(1, $this->router->getRoutes());
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
+    }
+
+    public function testCanSetMiddlewareForSpecificMethodsOnRegisteredSingletonResource()
+    {
+        $this->router->singleton('users', RouteRegistrarControllerStub::class)
+                    ->creatable()
+                    ->destroyable()
+                    ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
+                    ->middlewareFor(['create', 'store'], 'one')
+                    ->middlewareFor(['edit'],['one', 'two']);
+
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), []);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), []);
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -849,7 +849,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
                      ->middlewareFor(['create', 'store'], 'one')
-                     ->middlewareFor(['edit'],['one', 'two']);
+                     ->middlewareFor(['edit'], ['one', 'two']);
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class]);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one']);
@@ -1361,7 +1361,7 @@ class RouteRegistrarTest extends TestCase
                     ->destroyable()
                     ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
                     ->middlewareFor(['create', 'store'], 'one')
-                    ->middlewareFor(['edit'],['one', 'two']);
+                    ->middlewareFor(['edit'], ['one', 'two']);
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one']);

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -844,20 +844,35 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
-    public function testCanSetMiddlewareForSpecificMethodsOnRegisteredResource()
+    public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
-                     ->middlewareFor(['create', 'store'], 'one')
-                     ->middlewareFor(['edit'], ['one', 'two']);
+                    ->middleware('default')
+                    ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
+                    ->middlewareFor(['create', 'store'], 'one')
+                    ->middlewareFor(['edit'], ['one', 'two']);
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), []);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), []);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), []);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), ['default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['default', 'one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
+                ->middlewareFor(['create', 'store'], 'one')
+                ->middlewareFor(['edit'], ['one', 'two'])
+                ->middleware('default');
+
+        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), ['default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two', 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
     }
 
     public function testResourceWithoutMiddlewareRegistration()
@@ -1354,21 +1369,37 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
     }
 
-    public function testCanSetMiddlewareForSpecificMethodsOnRegisteredSingletonResource()
+    public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredSingletonResource()
     {
         $this->router->singleton('users', RouteRegistrarControllerStub::class)
                     ->creatable()
                     ->destroyable()
+                    ->middleware('default')
                     ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
                     ->middlewareFor(['create', 'store'], 'one')
                     ->middlewareFor(['edit'], ['one', 'two']);
 
-        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class]);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two']);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), []);
-        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), []);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['default', 'one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+
+        $this->router->singleton('users', RouteRegistrarControllerStub::class)
+                ->creatable()
+                ->destroyable()
+                ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
+                ->middlewareFor(['create', 'store'], 'one')
+                ->middlewareFor(['edit'], ['one', 'two'])
+                ->middleware('default');
+
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two', 'default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -887,6 +887,23 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
     }
 
+    public function testCanSetExcludedMiddlewareForSpecifiedMethodsOnRegisteredResource()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                    ->withoutMiddleware('one')
+                    ->withoutMiddlewareFor('index', 'two')
+                    ->withoutMiddlewareFor(['create', 'store'], 'three')
+                    ->withoutMiddlewareFor(['edit'], ['four', 'five']);
+
+        $this->assertEquals($this->router->getRoutes()->getByName('users.index')->excludedMiddleware(), ['one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->excludedMiddleware(), ['one', 'three']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->excludedMiddleware(), ['one', 'three']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->excludedMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->excludedMiddleware(), ['one', 'four', 'five']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->excludedMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->excludedMiddleware(), ['one']);
+    }
+
     public function testResourceWithMiddlewareAsStringable()
     {
         $one = new class implements Stringable
@@ -1400,6 +1417,24 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->gatherMiddleware(), ['one', 'two', 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.update')->gatherMiddleware(), ['default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
+    }
+
+    public function testCanSetExcludedMiddlewareForSpecifiedMethodsOnRegisteredSingletonResource()
+    {
+        $this->router->singleton('users', RouteRegistrarControllerStub::class)
+                    ->creatable()
+                    ->destroyable()
+                    ->withoutMiddleware('one')
+                    ->withoutMiddlewareFor('show', 'two')
+                    ->withoutMiddlewareFor(['create', 'store'], 'three')
+                    ->withoutMiddlewareFor(['edit'], ['four', 'five']);
+
+        $this->assertEquals($this->router->getRoutes()->getByName('users.create')->excludedMiddleware(), ['one', 'three']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.store')->excludedMiddleware(), ['one', 'three']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.show')->excludedMiddleware(), ['one', 'two']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.edit')->excludedMiddleware(), ['one', 'four', 'five']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.update')->excludedMiddleware(), ['one']);
+        $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->excludedMiddleware(), ['one']);
     }
 
     /**


### PR DESCRIPTION
**Enhancement: Middleware Assignment for Resource & Singleton Routes**

This pull request enables assigning middleware to specific resourceful methods on resource and singleton routes within the Laravel framework. Key changes include new method 'middlewareFor` for method-specific middleware assignment and updates to resource registration logic to support these configurations.

Motivation: While most developers prefer using routes for defining middleware, this particular case necessitates defining it at the controller level. Alternatively, we could extract all routes into separate routes. Addressing this challenge will streamline our approach.

Examples after merging:

```php
Route::resource('users', UserController::class)->middlewareFor('show', 'auth');
Route::apiResource('users', UserController::class)->middlewareFor(['show', 'update'], 'auth');
Route::resource('users', UserController::class)
    ->middlewareFor('show', 'auth')
    ->middlewareFor('update', 'auth');
Route::apiResource('users', UserController::class)
    ->middlewareFor(['show', 'update'], ['auth', 'verified']);

Route::singleton('users', UserController::class)->middlewareFor('show', 'auth');
Route::apiSingleton('users', UserController::class)->middlewareFor(['show', 'update'], 'auth');
Route::singleton('users', UserController::class)
    ->middlewareFor('show', 'auth')
    ->middlewareFor('update', 'auth');
Route::apiSingleton('users', UserController::class)
    ->middlewareFor(['show', 'update'], ['auth', 'verified']);
```

~~I'm up for `withoutMiddlewareFor` if it's in demand.~~ added `withoutMiddlewareFor`.

```php
Route::middleware('auth', 'verified', 'other')->group(function () {
    Route::resource('users', UsersController::class)->withoutMiddlewareFor(['create', 'store'], 'verified')
        ->withoutMiddlewareFor('index', ['auth', 'verified'])
        ->withoutMiddlewareFor('destroy', 'other');

    Route::singleton('user', UserController::class)->withoutMiddlewareFor('show', ['auth', 'verified'])
        ->withoutMiddlewareFor(['create', 'store'], 'verified')
        ->withoutMiddlewareFor('destroy', 'other');
});
```