### PR TITLE
[12.x] Optimize + simplify blade foreach loops

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -35,11 +35,11 @@ trait CompilesLoops
 
         $iteration = trim($matches[2]);
 
-        $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
+        $commenceLoop = "\$__env->addLoop({$iteratee})";
 
-        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getLastLoop();';
+        $assignLoop = '$loop = $__env->getLastLoop();';
 
-        return "<?php {$empty} = true; {$initLoop} foreach(\$__currentLoopData as {$iteration}): {$iterateLoop} {$empty} = false; ?>";
+        return "<?php {$empty} = true; foreach({$commenceLoop} as {$iteration}): {$assignLoop} {$empty} = false; ?>";
     }
 
     /**
@@ -56,7 +56,7 @@ trait CompilesLoops
 
         $empty = '$__empty_'.$this->forElseCounter--;
 
-        return "<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); if ({$empty}): ?>";
+        return "<?php \$__env->incrementLoopIndices(); endforeach; \$loop = \$__env->popLoop(); if ({$empty}): ?>";
     }
 
     /**
@@ -110,11 +110,11 @@ trait CompilesLoops
 
         $iteration = trim($matches[2]);
 
-        $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
+        $commenceLoop = "\$__env->addLoop({$iteratee})";
 
-        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getLastLoop();';
+        $assignLoop = '$loop = $__env->getLastLoop();';
 
-        return "<?php {$initLoop} foreach(\$__currentLoopData as {$iteration}): {$iterateLoop} ?>";
+        return "<?php foreach({$commenceLoop} as {$iteration}): {$assignLoop} ?>";
     }
 
     /**
@@ -168,7 +168,7 @@ trait CompilesLoops
      */
     protected function compileEndforeach()
     {
-        return '<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        return '<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>';
     }
 
     /**

--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -26,11 +26,11 @@ class BladeEscapedTest extends AbstractBladeTestCase
     @@endforeach
 @endforeach';
         $compiled = '
-<?php $__currentLoopData = $cols; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $col): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+<?php foreach($__env->addLoop($cols) as $col): $loop = $__env->getLastLoop(); ?>
     @foreach($issues as $issue_45915)
         👋 سلام 👋
     @endforeach
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>';
         $this->assertSame($compiled, $this->compiler->compileString($template));
     }
 }

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -12,9 +12,9 @@ class BladeForeachStatementsTest extends AbstractBladeTestCase
         $string = '@foreach ($this->getUsers() as $user)
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php foreach($__env->addLoop($this->getUsers()) as $user): $loop = $__env->getLastLoop(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -23,9 +23,9 @@ test
         $string = '@foreach ($this->getUsers() AS $user)
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php foreach($__env->addLoop($this->getUsers()) as $user): $loop = $__env->getLastLoop(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -37,12 +37,12 @@ bar,
 ] as $label)
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = [
+        $expected = '<?php foreach($__env->addLoop([
 foo,
 bar,
-]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $label): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+]) as $label): $loop = $__env->getLastLoop(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -54,43 +54,44 @@ user info
 tag info
 @endforeach
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php foreach($__env->addLoop($this->getUsers()) as $user): $loop = $__env->getLastLoop(); ?>
 user info
-<?php $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+<?php foreach($__env->addLoop($user->tags) as $tag): $loop = $__env->getLastLoop(); ?>
 tag info
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testLoopContentHolderIsExtractedFromForeachStatements()
     {
         $string = '@foreach ($some_uSers1 as $user)';
-        $expected = '<?php $__currentLoopData = $some_uSers1; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php foreach($__env->addLoop($some_uSers1) as $user): $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach ($users->get() as $user)';
-        $expected = '<?php $__currentLoopData = $users->get(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php foreach($__env->addLoop($users->get()) as $user): $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (range(1, 4) as $user)';
-        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php foreach($__env->addLoop(range(1, 4)) as $user): $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (   $users as $user)';
-        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php foreach($__env->addLoop($users) as $user): $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach ($tasks as $task)';
-        $expected = '<?php $__currentLoopData = $tasks; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $task): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php foreach($__env->addLoop($tasks) as $task): $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "@foreach(resolve('App\\\\DataProviders\\\\'.\$provider)->data() as \$key => \$value)
     <input {{ \$foo ? 'bar': 'baz' }}>
 @endforeach";
-        $expected = "<?php \$__currentLoopData = resolve('App\\\\DataProviders\\\\'.\$provider)->data(); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$key => \$value): \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); ?>
+
+        $expected = "<?php foreach(\$__env->addLoop(resolve('App\\\\DataProviders\\\\'.\$provider)->data()) as \$key => \$value): \$loop = \$__env->getLastLoop(); ?>
     <input <?php echo e(\$foo ? 'bar': 'baz'); ?>>
-<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); ?>";
+<?php \$__env->incrementLoopIndices(); endforeach; \$loop = \$__env->popLoop(); ?>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -14,9 +14,9 @@ breeze
 @empty
 empty
 @endforelse';
-        $expected = '<?php $__empty_1 = true; $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+        $expected = '<?php $__empty_1 = true; foreach($__env->addLoop($this->getUsers()) as $user): $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
 breeze
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); if ($__empty_1): ?>
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
@@ -29,9 +29,9 @@ breeze
 @empty
 empty
 @endforelse';
-        $expected = '<?php $__empty_1 = true; $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+        $expected = '<?php $__empty_1 = true; foreach($__env->addLoop($this->getUsers()) as $user): $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
 breeze
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); if ($__empty_1): ?>
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
@@ -47,12 +47,12 @@ breeze
 @empty
 empty
 @endforelse';
-        $expected = '<?php $__empty_1 = true; $__currentLoopData = [
+        $expected = '<?php $__empty_1 = true; foreach($__env->addLoop([
 foo,
 bar,
-]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $label): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+]) as $label): $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
 breeze
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); if ($__empty_1): ?>
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
@@ -69,13 +69,13 @@ tag empty
 @empty
 empty
 @endforelse';
-        $expected = '<?php $__empty_1 = true; $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
-<?php $__empty_2 = true; $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_2 = false; ?>
+        $expected = '<?php $__empty_1 = true; foreach($__env->addLoop($this->getUsers()) as $user): $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+<?php $__empty_2 = true; foreach($__env->addLoop($user->tags) as $tag): $loop = $__env->getLastLoop(); $__empty_2 = false; ?>
 breeze
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_2): ?>
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); if ($__empty_2): ?>
 tag empty
 <?php endif; ?>
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); if ($__empty_1): ?>
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -917,14 +917,14 @@ class ViewFactoryTest extends TestCase
         $factory->addLoop([1, 2, 3]);
 
         $expectedLoop = [
-            'iteration' => 0,
+            'iteration' => 1,
             'index' => 0,
-            'remaining' => 3,
+            'remaining' => 2,
             'count' => 3,
             'first' => true,
             'last' => false,
-            'odd' => false,
-            'even' => true,
+            'odd' => true,
+            'even' => false,
             'depth' => 1,
             'parent' => null,
         ];
@@ -934,17 +934,18 @@ class ViewFactoryTest extends TestCase
         $factory->addLoop([1, 2, 3, 4]);
 
         $secondExpectedLoop = [
-            'iteration' => 0,
+            'iteration' => 1,
             'index' => 0,
-            'remaining' => 4,
+            'remaining' => 3,
             'count' => 4,
             'first' => true,
             'last' => false,
-            'odd' => false,
-            'even' => true,
+            'odd' => true,
+            'even' => false,
             'depth' => 2,
             'parent' => (object) $expectedLoop,
         ];
+
         $this->assertEquals([$expectedLoop, $secondExpectedLoop], $factory->getLoopStack());
 
         $factory->popLoop();
@@ -980,14 +981,14 @@ class ViewFactoryTest extends TestCase
         $factory->addLoop('');
 
         $expectedLoop = [
-            'iteration' => 0,
+            'iteration' => 1,
             'index' => 0,
             'remaining' => null,
             'count' => null,
             'first' => true,
             'last' => null,
-            'odd' => false,
-            'even' => true,
+            'odd' => true,
+            'even' => false,
             'depth' => 1,
             'parent' => null,
         ];
@@ -1004,14 +1005,14 @@ class ViewFactoryTest extends TestCase
         }));
 
         $expectedLoop = [
-            'iteration' => 0,
+            'iteration' => 1,
             'index' => 0,
             'remaining' => null,
             'count' => null,
             'first' => true,
             'last' => null,
-            'odd' => false,
-            'even' => true,
+            'odd' => true,
+            'even' => false,
             'depth' => 1,
             'parent' => null,
         ];
@@ -1024,8 +1025,6 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
 
         $factory->addLoop([1, 2, 3, 4]);
-
-        $factory->incrementLoopIndices();
 
         $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
         $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
@@ -1050,8 +1049,6 @@ class ViewFactoryTest extends TestCase
 
         $factory->incrementLoopIndices();
 
-        $factory->incrementLoopIndices();
-
         $this->assertTrue($factory->getLoopStack()[0]['last']);
     }
 
@@ -1060,8 +1057,6 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
 
         $factory->addLoop('');
-
-        $factory->incrementLoopIndices();
 
         $factory->incrementLoopIndices();
 


### PR DESCRIPTION
The compilation of `@foreach` blade directives in `<=11.x` results in pretty verbose code to make the `$loop` variable work. This PR greatly simplifies that output while improving the general logic of the `$loop` variable.

This changes the output of a compiled blade file from:
```php
<ul>
<?php $__currentLoopData = [1, 2]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $outer): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
    <li>i: <?php echo e($outer); ?>
        <ul>
            <?php $__currentLoopData = [1, 2, 3]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $inner): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
                <li>j: <?php echo e($inner); ?></li>
            <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
        </ul>
    </li>
<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
</ul>
<?php /**PATH C:\...\loops.blade.php ENDPATH**/ ?>
```

To:
```php
<ul>
<?php foreach($__env->addLoop([1, 2]) as $outer): $loop = $__env->getLastLoop(); ?>
    <li>i: <?php echo e($outer); ?>
        <ul>
            <?php foreach($__env->addLoop([1, 2, 3]) as $inner): $loop = $__env->getLastLoop(); ?>
                <li>j: <?php echo e($inner); ?></li>
            <?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>
        </ul>
    </li>
<?php $__env->incrementLoopIndices(); endforeach; $loop = $__env->popLoop(); ?>
</ul>
<?php /**PATH C:\...\loops.blade.php ENDPATH**/ ?>
```

Noteworthy changes:
- The `$__currentLoopData` variable no longer exists
- `$__env->addLoop()` now returns the input data, so it can be used instantly within the `foreach` struct
- `$__env->popLoop()` now returns the new loop variable immediately
- The `$__env->incrementLoopIndices()` is now moved to the end of each iteration, since the initial `$loop` variable assignment (the `$loop = $__env->getLastLoop();`) will now contain correct data from the start (the previous implementation created an incomplete placeholder which had to be incremented in order to be correct). The new implementation should have no behavioral change whatsoever.
- The changes in the tests correspond to the fact that the initial loop variable is now correct.

Here is a simple blade test script to check the output of the loop variables (even though it is also covered by the tests):
- https://gist.github.com/bert-w/b818cddfba8f02a2f271181373217120

I have submitted this to the master branch because **this change requires a recompilation of all views** (so a `php artisan view:clear` would be required).