### PR TITLE
Fix code for invalid locale for number class. if provided locale is not valid throws exception.

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
+use ResourceBundle;
 use RuntimeException;
 
 class Number
@@ -24,6 +25,21 @@ class Number
      */
     protected static $currency = 'USD';
 
+
+    /**
+     * @param string $locale
+     * @return void
+     * @throws \Exception
+     */
+    public static function validateLocale(string $locale): void
+    {
+        $availableLocales = ResourceBundle::getLocales('');
+
+        if ( ! in_array($locale, $availableLocales, true)){
+            throw new \Exception("Locale is invalid");
+        }
+    }
+
     /**
      * Format the given number according to the current locale.
      *
@@ -32,10 +48,13 @@ class Number
      * @param  int|null  $maxPrecision
      * @param  string|null  $locale
      * @return string|false
+     * @throws \Exception
      */
     public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        static::validateLocale($locale);
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Number;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class SupportNumberTest extends TestCase
 {
@@ -314,4 +315,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    /**
+     * Test invalid locale input in format method.
+     */
+    public function testInvalidLocale()
+    {
+        $this->expectException(\Exception::class);
+        Number::format(1234.56, locale: 'invalid-locale');
+    }
+
 }


### PR DESCRIPTION
Fix code for invalid locale for number class. if provided locale is not valid throws exception. 

**Existing behaviour:**  If locale is invalid, falback en is used. 
**Updated behaviour:** if locale is invalid throws an exception as **Locale is invalid**. 

Note: A test is also added. 