### PR TITLE
[11.x] Support Optional Dimensions for `vector` Column Type

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1456,12 +1456,14 @@ class Blueprint
      * Create a new vector column on the table.
      *
      * @param  string  $column
-     * @param  int  $dimensions
+     * @param  int|null  $dimensions  The number of dimensions for the vector, or null if unspecified.
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
     public function vector($column, $dimensions)
     {
-        return $this->addColumn('vector', $column, compact('dimensions'));
+        $options = $dimensions ? compact('dimensions') : [];
+
+        return $this->addColumn('vector', $column, $options);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1456,10 +1456,10 @@ class Blueprint
      * Create a new vector column on the table.
      *
      * @param  string  $column
-     * @param  int|null  $dimensions  The number of dimensions for the vector, or null if unspecified.
+     * @param  int|null  $dimensions
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function vector($column, $dimensions)
+    public function vector($column, $dimensions = null)
     {
         $options = $dimensions ? compact('dimensions') : [];
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1128,7 +1128,9 @@ class MySqlGrammar extends Grammar
      */
     protected function typeVector(Fluent $column)
     {
-        return "vector($column->dimensions)";
+        return isset($column->dimensions) && $column->dimensions !== ''
+            ? "vector({$column->dimensions})"
+            : 'vector';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1078,7 +1078,9 @@ class PostgresGrammar extends Grammar
      */
     protected function typeVector(Fluent $column)
     {
-        return "vector($column->dimensions)";
+        return isset($column->dimensions) && $column->dimensions !== ''
+            ? "vector({$column->dimensions})"
+            : 'vector';
     }
 
     /**


### PR DESCRIPTION
The `vector` method to support adding a new vector column without specifying dimensions. The changes include:

- Modified the `vector` method to handle cases where the `$dimensions` parameter is not provided or is null.
- Ensures that the code gracefully defaults to an empty options array when dimensions are not defined, allowing for flexibility when creating vector columns.

These changes provide more flexibility in defining vector columns, making the dimensions parameter truly optional.
