### PR TITLE
Fix code for invalid locale for number class. if provided locale is not valid throws exception

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,7 +25,6 @@ class Number
      */
     protected static $currency = 'USD';
 
-
     /**
      * @param  string  $locale
      * @return string

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -28,16 +28,18 @@ class Number
 
     /**
      * @param string $locale
-     * @return void
+     * @return string
      * @throws \Exception
      */
-    public static function validateLocale(string $locale): void
+    public static function validateLocale(string $locale): string
     {
         $availableLocales = ResourceBundle::getLocales('');
 
         if ( ! in_array($locale, $availableLocales, true)){
             throw new \Exception("Locale is invalid");
         }
+
+        return $locale;
     }
 
     /**
@@ -54,7 +56,7 @@ class Number
     {
         static::ensureIntlExtensionIsInstalled();
 
-        static::validateLocale($locale);
+        $locale = $locale ? static::validateLocale($locale) : null;
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -29,7 +29,7 @@ class Number
     /**
      * @param string $locale
      * @return string
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public static function validateLocale(string $locale): string
     {
@@ -50,7 +50,7 @@ class Number
      * @param  int|null  $maxPrecision
      * @param  string|null  $locale
      * @return string|false
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
+use ResourceBundle;
 use RuntimeException;
 
 class Number
@@ -24,6 +25,21 @@ class Number
      */
     protected static $currency = 'USD';
 
+
+    /**
+     * @param string $locale
+     * @return void
+     * @throws \Exception
+     */
+    public static function validateLocale(string $locale): void
+    {
+        $availableLocales = ResourceBundle::getLocales('');
+
+        if ( ! in_array($locale, $availableLocales, true)){
+            throw new \Exception("Locale is invalid");
+        }
+    }
+
     /**
      * Format the given number according to the current locale.
      *
@@ -32,10 +48,13 @@ class Number
      * @param  int|null  $maxPrecision
      * @param  string|null  $locale
      * @return string|false
+     * @throws \Exception
      */
     public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        static::validateLocale($locale);
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -36,7 +36,7 @@ class Number
         $availableLocales = ResourceBundle::getLocales('');
 
         if ( ! in_array($locale, $availableLocales, true)){
-            throw new \Exception("Locale is invalid");
+            throw new \InvalidArgumentException("Locale [$locale] is invalid");
         }
 
         return $locale;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -27,15 +27,16 @@ class Number
 
 
     /**
-     * @param string $locale
+     * @param  string  $locale
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateLocale(string $locale): string
     {
         $availableLocales = ResourceBundle::getLocales('');
 
-        if ( ! in_array($locale, $availableLocales, true)){
+        if (! in_array($locale, $availableLocales, true)) {
             throw new \InvalidArgumentException("Locale [$locale] is invalid");
         }
 
@@ -50,6 +51,7 @@ class Number
      * @param  int|null  $maxPrecision
      * @param  string|null  $locale
      * @return string|false
+     *
      * @throws \InvalidArgumentException
      */
     public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -324,5 +324,4 @@ class SupportNumberTest extends TestCase
         $this->expectExceptionMessage('Locale [invalid-locale] is invalid');
         Number::format(1234.56, locale: 'invalid-locale');
     }
-
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -321,7 +321,7 @@ class SupportNumberTest extends TestCase
      */
     public function testInvalidLocale()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(\InvalidArgumentException::class);
         Number::format(1234.56, locale: 'invalid-locale');
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Number;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
-use TypeError;
 
 class SupportNumberTest extends TestCase
 {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Number;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class SupportNumberTest extends TestCase
 {
@@ -314,4 +315,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    /**
+     * Test invalid locale input in format method.
+     */
+    public function testInvalidLocale()
+    {
+        $this->expectException(\Exception::class);
+        Number::format(1234.56, locale: 'invalid-locale');
+    }
+
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -322,6 +322,7 @@ class SupportNumberTest extends TestCase
     public function testInvalidLocale()
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Locale [invalid-locale] is invalid");
         Number::format(1234.56, locale: 'invalid-locale');
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -321,7 +321,7 @@ class SupportNumberTest extends TestCase
     public function testInvalidLocale()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Locale [invalid-locale] is invalid");
+        $this->expectExceptionMessage('Locale [invalid-locale] is invalid');
         Number::format(1234.56, locale: 'invalid-locale');
     }
 


### PR DESCRIPTION
Fix code for invalid locale for number class. if provided locale is not valid throws exception.

**Existing behaviour:** If locale is invalid, falback en is used.
**Updated behaviour:** if locale is invalid throws an exception as Locale is invalid.

**Note:** A test is also added.