### PR TITLE
Fix: APP_KEY is not replaced during `key:generate` command because of missing double quotes

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -118,8 +118,8 @@ class KeyGenerateCommand extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escaped = preg_quote($this->laravel['config']['app.key'], '/');
 
-        return "/^APP_KEY{$escaped}/m";
+        return "/^APP_KEY=(\"|)?{$escaped}\\1$/m";
     }
 }


### PR DESCRIPTION
### **Issue:**
When `.env` APP_KEY value is wrapped in double quotes, `php artisan key:generate` will throw an error saying `"Unable to set application key. No APP_KEY variable was found in the .env file."` 

The preg_replace pattern used during replace will not find the APP_KEY= string  correctly because double quotes are missing .

### **.env ✅**
This works currently.
```
APP_KEY=base64:some-key
```

### **.env  ❌**
This won't work because of the double quotes.
```
APP_KEY="base64:some-key"
```

### **Fix:**
This fix applied to handle both cases for `APP_KEY` in `.env`:
1. `APP_KEY="base64:some-key"`
2. `APP_KEY=base64:some-key`