### PR TITLE
Allow for custom Postgres operators to be added

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -23,7 +23,7 @@ class PostgresGrammar extends Grammar
     ];
 
     /**
-     * The grammar specific custom operators.
+     * The Postgres grammar specific custom operators.
      *
      * @var array
      */
@@ -781,34 +781,25 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Get the grammar specific operators.
+     * Get the Postgres grammar specific operators.
      *
      * @return array
      */
     public function getOperators()
     {
-        return array_values(
-            array_unique(
-                array_merge(parent::getOperators(), static::$customOperators)
-            )
-        );
+        return array_values(array_unique(array_merge(parent::getOperators(), static::$customOperators)));
     }
 
     /**
-     * Set any grammar specific custom operators.
+     * Set any Postgres grammar specific custom operators.
      *
-     * @param  array|mixed  $operators
+     * @param  array  $operators
      * @return void
      */
-    public static function customOperators($operators)
+    public static function customOperators(array $operators)
     {
-        $operators = array_filter(array_filter(
-            is_array($operators) ? $operators : func_get_args(),
-            'is_string'
-        ));
-
         static::$customOperators = array_values(
-            array_merge(static::$customOperators, $operators)
+            array_merge(static::$customOperators, array_filter(array_filter($operators, 'is_string')))
         );
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -23,6 +23,13 @@ class PostgresGrammar extends Grammar
     ];
 
     /**
+     * The grammar specific custom operators.
+     *
+     * @var array
+     */
+    protected static $customOperators = [];
+
+    /**
      * The grammar specific bitwise operators.
      *
      * @var array
@@ -771,5 +778,37 @@ class PostgresGrammar extends Grammar
         }
 
         return $query;
+    }
+
+    /**
+     * Get the grammar specific operators.
+     *
+     * @return array
+     */
+    public function getOperators()
+    {
+        return array_values(
+            array_unique(
+                array_merge(parent::getOperators(), static::$customOperators)
+            )
+        );
+    }
+
+    /**
+     * Set any grammar specific custom operators.
+     *
+     * @param  array|mixed  $operators
+     * @return void
+     */
+    public static function customOperators($operators)
+    {
+        $operators = array_filter(array_filter(
+            is_array($operators) ? $operators : func_get_args(),
+            'is_string'
+        ));
+
+        static::$customOperators = array_values(
+            array_merge(static::$customOperators, $operators)
+        );
     }
 }

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -31,7 +31,7 @@ class DatabasePostgresQueryGrammarTest extends TestCase
 
     public function testCustomOperators()
     {
-        PostgresGrammar::customOperators('@@@', '@>', '');
+        PostgresGrammar::customOperators(['@@@', '@>', '']);
         PostgresGrammar::customOperators(['@@>', 1]);
 
         $connection = m::mock(Connection::class);

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -28,4 +28,23 @@ class DatabasePostgresQueryGrammarTest extends TestCase
 
         $this->assertSame('select * from "users" where \'{}\' ? \'Hello\\\'\\\'World?\' AND "email" = \'foo\'', $query);
     }
+
+    public function testCustomOperators()
+    {
+        PostgresGrammar::customOperators('@@@', '@>', '');
+        PostgresGrammar::customOperators(['@@>', 1]);
+
+        $connection = m::mock(Connection::class);
+        $grammar = new PostgresGrammar;
+        $grammar->setConnection($connection);
+
+        $operators = $grammar->getOperators();
+
+        $this->assertIsList($operators);
+        $this->assertContains('@@@', $operators);
+        $this->assertContains('@@>', $operators);
+        $this->assertNotContains('', $operators);
+        $this->assertNotContains(1, $operators);
+        $this->assertSame(array_unique($operators), $operators);
+    }
 }


### PR DESCRIPTION
In Postgres custom operators can be defined. Currently there is no way, tho, to add these to the grammar. This PR addresses this issue.

For my particular use-case, I am maintaining a [package](https://github.com/ShabuShabu/laravel-paradedb-search/issues/3) that integrates the `pg_search` extension by ParadeDB into Laravel. This extension comes with a custom `@@@` operator that allows for full-text search. Up until recently, using this operator had some drawbacks and there was another way to integrate the extension, which I initially used for my integration. The use of this operator has been greatly improved in the latest version, tho, and the alternative way has therefore been deprecated. 

I have added a static `PostgresGrammar::customOperators()` method that can be called in service providers to add any needed operators. I looked into adding this to some of the other grammars as well, but couldn't find much information, tbh, so I asked @tpetry about this and apparently Postgres is the only database that allows custom operators.