### PR TITLE
Add the ability to append and prepend middleware priority from the application builder

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -269,6 +269,18 @@ class ApplicationBuilder
             if ($priorities = $middleware->getMiddlewarePriority()) {
                 $kernel->setMiddlewarePriority($priorities);
             }
+
+            if ($priorityAppends = $middleware->getMiddlewarePriorityAppends()) {
+                foreach ($priorityAppends as $middleware => $after) {
+                    $kernel->addToMiddlewarePriorityAfter($after, $middleware);
+                }
+            }
+
+            if ($priorityPrepends = $middleware->getMiddlewarePriorityPrepends()) {
+                foreach ($priorityPrepends as $middleware => $before) {
+                    $kernel->addToMiddlewarePriorityBefore($before, $middleware);
+                }
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -810,7 +810,7 @@ class Middleware
     }
 
     /**
-     * Get the middleware priority to append
+     * Get the middleware priority to append.
      *
      * @return array
      */
@@ -820,7 +820,7 @@ class Middleware
     }
 
     /**
-     * Get the middleware priority to prepend
+     * Get the middleware priority to prepend.
      *
      * @return array
      */

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -146,18 +146,18 @@ class Middleware
     protected $priority = [];
 
     /**
-     * The middleware priority to append.
-     *
-     * @var array
-     */
-    protected $appendPriority = [];
-
-    /**
-     * The middleware priority to prepend.
+     * The middleware to prepend to the middleware priority definition.
      *
      * @var array
      */
     protected $prependPriority = [];
+
+    /**
+     * The middleware to append to the middleware priority definition.
+     *
+     * @var array
+     */
+    protected $appendPriority = [];
 
     /**
      * Prepend middleware to the application's global middleware stack.
@@ -415,20 +415,6 @@ class Middleware
     }
 
     /**
-     * Append middleware to the priority middleware.
-     *
-     * @param  array|string  $after
-     * @param  string  $append
-     * @return $this
-     */
-    public function appendToPriorityList($after, $append)
-    {
-        $this->appendPriority[$append] = $after;
-
-        return $this;
-    }
-
-    /**
      * Prepend middleware to the priority middleware.
      *
      * @param  array|string  $before
@@ -438,6 +424,20 @@ class Middleware
     public function prependToPriorityList($before, $prepend)
     {
         $this->prependPriority[$prepend] = $before;
+
+        return $this;
+    }
+
+    /**
+     * Append middleware to the priority middleware.
+     *
+     * @param  array|string  $after
+     * @param  string  $append
+     * @return $this
+     */
+    public function appendToPriorityList($after, $append)
+    {
+        $this->appendPriority[$append] = $after;
 
         return $this;
     }
@@ -810,22 +810,22 @@ class Middleware
     }
 
     /**
-     * Get the middleware priority to append.
-     *
-     * @return array
-     */
-    public function getMiddlewarePriorityAppends()
-    {
-        return $this->appendPriority;
-    }
-
-    /**
-     * Get the middleware priority to prepend.
+     * Get the middleware to prepend to the middleware priority definition.
      *
      * @return array
      */
     public function getMiddlewarePriorityPrepends()
     {
         return $this->prependPriority;
+    }
+
+    /**
+     * Get the middleware to append to the middleware priority definition.
+     *
+     * @return array
+     */
+    public function getMiddlewarePriorityAppends()
+    {
+        return $this->appendPriority;
     }
 }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -417,13 +417,13 @@ class Middleware
     /**
      * Append middleware to the priority middleware.
      *
-     * @param  array|string  $after
-     * @param  string  $middleware
+     * @param  array|string  $middlewareToPutTheNewMiddlewareAfter
+     * @param  string  $theMiddlewareToAppend
      * @return $this
      */
-    public function appendToPriorityList($after, $middleware)
+    public function appendToPriorityList($middlewareToPutTheNewMiddlewareAfter, $theMiddlewareToAppend)
     {
-        $this->appendPriority[$middleware] = $after;
+        $this->appendPriority[$theMiddlewareToAppend] = $middlewareToPutTheNewMiddlewareAfter;
 
         return $this;
     }
@@ -431,13 +431,13 @@ class Middleware
     /**
      * Prepend middleware to the priority middleware.
      *
-     * @param  array|string  $before
-     * @param  string  $middleware
+     * @param  array|string  $middlewareToPutTheNewMiddlewareBefore
+     * @param  string  $theMiddlewareToPrepend
      * @return $this
      */
-    public function prependToPriorityList($before, $middleware)
+    public function prependToPriorityList($middlewareToPutTheNewMiddlewareBefore, $theMiddlewareToPrepend)
     {
-        $this->prependPriority[$middleware] = $before;
+        $this->prependPriority[$theMiddlewareToPrepend] = $middlewareToPutTheNewMiddlewareBefore;
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -146,6 +146,20 @@ class Middleware
     protected $priority = [];
 
     /**
+     * The middleware priority to append.
+     *
+     * @var array
+     */
+    protected $appendPriority = [];
+
+    /**
+     * The middleware priority to prepend.
+     *
+     * @var array
+     */
+    protected $prependPriority = [];
+
+    /**
      * Prepend middleware to the application's global middleware stack.
      *
      * @param  array|string  $middleware
@@ -396,6 +410,34 @@ class Middleware
     public function priority(array $priority)
     {
         $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Append middleware to the priority middleware.
+     *
+     * @param  string  $middleware
+     * @param  array|string  $after
+     * @return $this
+     */
+    public function appendPriority($middleware, $after = null)
+    {
+        $this->appendPriority[$middleware] = $after;
+
+        return $this;
+    }
+
+    /**
+     * Prepend middleware to the priority middleware.
+     *
+     * @param  string  $middleware
+     * @param  array|string  $before
+     * @return $this
+     */
+    public function prependPriority($middleware, $before = null)
+    {
+        $this->prependPriority[$middleware] = $before;
 
         return $this;
     }
@@ -765,5 +807,25 @@ class Middleware
     public function getMiddlewarePriority()
     {
         return $this->priority;
+    }
+
+    /**
+     * Get the middleware priority to append
+     *
+     * @return array
+     */
+    public function getMiddlewarePriorityAppends()
+    {
+        return $this->appendPriority;
+    }
+
+    /**
+     * Get the middleware priority to prepend
+     *
+     * @return array
+     */
+    public function getMiddlewarePriorityPrepends()
+    {
+        return $this->prependPriority;
     }
 }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -417,11 +417,11 @@ class Middleware
     /**
      * Append middleware to the priority middleware.
      *
-     * @param  string  $middleware
      * @param  array|string  $after
+     * @param  string  $middleware
      * @return $this
      */
-    public function appendPriority($middleware, $after = null)
+    public function appendToPriorityList($after, $middleware)
     {
         $this->appendPriority[$middleware] = $after;
 
@@ -431,11 +431,11 @@ class Middleware
     /**
      * Prepend middleware to the priority middleware.
      *
-     * @param  string  $middleware
      * @param  array|string  $before
+     * @param  string  $middleware
      * @return $this
      */
-    public function prependPriority($middleware, $before = null)
+    public function prependToPriorityList($before, $middleware)
     {
         $this->prependPriority[$middleware] = $before;
 

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -417,13 +417,13 @@ class Middleware
     /**
      * Append middleware to the priority middleware.
      *
-     * @param  array|string  $middlewareToPutTheNewMiddlewareAfter
-     * @param  string  $theMiddlewareToAppend
+     * @param  array|string  $after
+     * @param  string  $append
      * @return $this
      */
-    public function appendToPriorityList($middlewareToPutTheNewMiddlewareAfter, $theMiddlewareToAppend)
+    public function appendToPriorityList($after, $append)
     {
-        $this->appendPriority[$theMiddlewareToAppend] = $middlewareToPutTheNewMiddlewareAfter;
+        $this->appendPriority[$append] = $after;
 
         return $this;
     }
@@ -431,13 +431,13 @@ class Middleware
     /**
      * Prepend middleware to the priority middleware.
      *
-     * @param  array|string  $middlewareToPutTheNewMiddlewareBefore
-     * @param  string  $theMiddlewareToPrepend
+     * @param  array|string  $before
+     * @param  string  $prepend
      * @return $this
      */
-    public function prependToPriorityList($middlewareToPutTheNewMiddlewareBefore, $theMiddlewareToPrepend)
+    public function prependToPriorityList($before, $prepend)
     {
-        $this->prependPriority[$theMiddlewareToPrepend] = $middlewareToPutTheNewMiddlewareBefore;
+        $this->prependPriority[$prepend] = $before;
 
         return $this;
     }


### PR DESCRIPTION
This is a follow-up PR for #52897 that adds two methods to the application builder, allowing for easy access to the add middleware after/before methods on the kernel.

Using the examples from the previous PR, the methods would be accessible like so:

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )
    ->withMiddleware(function (Middleware $middleware) {
        $middleware->appendToPriorityList(
		    [
		        \Illuminate\Cookie\Middleware\EncryptCookies::class,
		        \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
		    ],
		    \Illuminate\Routing\Middleware\ValidateSignature::class
		);

		$middleware->prependToPriorityList(
		    [
		        \Illuminate\Cookie\Middleware\EncryptCookies::class,
		        \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
		    ],
		    \Illuminate\Routing\Middleware\ValidateSignature::class
		);
    })
    ->withExceptions(function (Exceptions $exceptions) {
        //
    })->create();
```

They map as follows:

 - `Middleware::appendToPriorityList()` -> `Kernel::addToMiddlewarePriorityAfter()`
 - `Middleware::prependToPriorityList()` -> `Kernel::addToMiddlewarePriorityBefore()`