### PR TITLE
[12.x] check database "existence" instead of "count"

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -980,7 +980,7 @@ trait ValidatesAttributes
             $extra = array_merge($extra, $this->currentRule->queryCallbacks());
         }
 
-        return $verifier->getExistence(
+        return ! $verifier->getExistence(
             $table, $column, $value, $id, $idColumn, $extra
         );
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -980,9 +980,9 @@ trait ValidatesAttributes
             $extra = array_merge($extra, $this->currentRule->queryCallbacks());
         }
 
-        return $verifier->getCount(
+        return $verifier->getExistence(
             $table, $column, $value, $id, $idColumn, $extra
-        ) == 0;
+        );
     }
 
     /**

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -33,6 +33,28 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
     }
 
     /**
+     * Check for existence of an object in a collection having the given value.
+     *
+     * @param  string  $collection
+     * @param  string  $column
+     * @param  string  $value
+     * @param  int|null  $excludeId
+     * @param  string|null  $idColumn
+     * @param  array  $extra
+     * @return bool
+     */
+    public function getExistence($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
+    {
+        $query = $this->table($collection)->where($column, '=', $value);
+
+        if (! is_null($excludeId) && $excludeId !== 'NULL') {
+            $query->where($idColumn ?: 'id', '<>', $excludeId);
+        }
+
+        return $this->addConditions($query, $extra)->exists();
+    }
+
+    /**
      * Count the number of objects in a collection having the given value.
      *
      * @param  string  $collection

--- a/src/Illuminate/Validation/PresenceVerifierInterface.php
+++ b/src/Illuminate/Validation/PresenceVerifierInterface.php
@@ -5,6 +5,19 @@ namespace Illuminate\Validation;
 interface PresenceVerifierInterface
 {
     /**
+     * Check for existence of an object in a collection having the given value.
+     *
+     * @param  string  $collection
+     * @param  string  $column
+     * @param  string  $value
+     * @param  int|null  $excludeId
+     * @param  string|null  $idColumn
+     * @param  array  $extra
+     * @return bool
+     */
+    public function getExistence($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = []);
+
+    /**
      * Count the number of objects in a collection having the given value.
      *
      * @param  string  $collection

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -16,6 +16,25 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         m::close();
     }
 
+    public function testBasicExistence()
+    {
+        $verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));
+        $verifier->setConnection('connection');
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(stdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(stdClass::class));
+        $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
+        $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true, 'not' => '!admin'];
+        $builder->shouldReceive('whereNull')->with('foo');
+        $builder->shouldReceive('whereNotNull')->with('bar');
+        $builder->shouldReceive('where')->with('baz', 'taylor');
+        $builder->shouldReceive('where')->with('faz', true);
+        $builder->shouldReceive('where')->with('not', '!=', 'admin');
+        $builder->shouldReceive('exists')->once()->andReturn(true);
+
+        $this->assertTrue($verifier->getExistence('table', 'column', 'value', null, null, $extra));
+    }
+
     public function testBasicCount()
     {
         $verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4019,44 +4019,44 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
+        $mock->shouldReceive('getExistence')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:connection.users']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with('connection');
-        $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
+        $mock->shouldReceive('getExistence')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
+        $mock->shouldReceive('getExistence')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1,id_col']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
+        $mock->shouldReceive('getExistence')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['users' => [['id' => 1, 'email' => 'foo']]], ['users.*.email' => 'Unique:users,email,[users.*.id]']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(1);
+        $mock->shouldReceive('getExistence')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->withArgs(function () {
+        $mock->shouldReceive('getExistence')->once()->withArgs(function () {
             return func_get_args() === ['users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar']];
-        })->andReturn(2);
+        })->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
     }
@@ -4065,11 +4065,12 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
-            '*.email' => 'unique:users', '*.type' => 'exists:user_types',
+            '*.email' => 'unique:users',
+            '*.type' => 'exists:user_types',
         ]);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);
-        $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
+        $mock->shouldReceive('getExistence')->with('users', 'email', 'foo', null, null, [])->andReturn(false);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -4084,7 +4085,7 @@ class ValidationValidatorTest extends TestCase
         ]);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);
-        $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(0);
+        $mock->shouldReceive('getExistence')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(false);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [$closure])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
an "existence" query is consistently more performant than a "count" query on a database, partially due to the fact the "existence" query can stop searching once it finds a single result, while "count" must ALWAYS search the entire table.

by creating a `getExistence()` method on our verifier, we can then use this in our "unique" validation rule for a little performance bump.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
