### PR TITLE
[11.x] Allow the authorize method to accept Backed Enums directly

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Auth\Access;
 
+use BackedEnum;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Support\Str;
 
@@ -49,6 +50,10 @@ trait AuthorizesRequests
      */
     protected function parseAbilityAndArguments($ability, $arguments)
     {
+        if ($ability instanceof BackedEnum) {
+            $ability = $ability->value;
+        }
+
         if (is_string($ability) && ! str_contains($ability, '\\')) {
             return [$ability, $arguments];
         }

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Foundation\Auth\Access;
 
-use BackedEnum;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Support\Str;
+
+use function Illuminate\Support\enum_value;
 
 trait AuthorizesRequests
 {
@@ -50,9 +51,7 @@ trait AuthorizesRequests
      */
     protected function parseAbilityAndArguments($ability, $arguments)
     {
-        if ($ability instanceof BackedEnum) {
-            $ability = $ability->value;
-        }
+        $ability = enum_value($ability);
 
         if (is_string($ability) && ! str_contains($ability, '\\')) {
             return [$ability, $arguments];

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -35,6 +35,24 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait']);
     }
 
+    public function testAcceptsBackedEnumAsAbility()
+    {
+        unset($_SERVER['_test.authorizes.trait.enum']);
+
+        $gate = $this->getBasicGate();
+
+        $gate->define('baz', function () {
+            $_SERVER['_test.authorizes.trait.enum'] = true;
+
+            return true;
+        });
+
+        $response = (new FoundationTestAuthorizeTraitClass)->authorize(TestAbility::BAZ);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($_SERVER['_test.authorizes.trait.enum']);
+    }
+
     public function testExceptionIsThrownIfGateCheckFails()
     {
         $this->expectException(AuthorizationException::class);
@@ -162,4 +180,9 @@ class FoundationTestAuthorizeTraitClass
     {
         $this->authorize($object);
     }
+}
+
+enum TestAbility: string
+{
+    case BAZ = 'baz';
 }


### PR DESCRIPTION
This PR improves the `authorize` method by allowing it to accept Backed Enums directly as the ability parameter.

In most of the applications I am working in, we are using BackedEnums for permissions:

```php
enum DashboardPermission: string
{
    case VIEW = 'dashboard.view';
}
```

Currently, when performing authorization checks using the authorize method, developers need to explicitly access the value of the enum:

```php
    public function index(): Response
    {
        $this->authorize(DashboardPermission::VIEW->value);

        //
    }
```

This PR modifies the authorize method to accept Backed Enums directly, so there is no need anymore to access the value property manually. With this change, the authorization check could now be:

```php
    public function index(): Response
    {
        $this->authorize(DashboardPermission::VIEW);

        //
    }
```

**Testing:**
A test has been added to FoundationAuthorizesRequestsTraitTest to cover the new behavior.