### PR TITLE
[11.x] Fix `trans_choice()` when translation replacement include `|` separator

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -200,7 +200,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     public function choice($key, $number, array $replace = [], $locale = null)
     {
         $line = $this->get(
-            $key, $replace, $locale = $this->localeForChoice($key, $locale)
+            $key, [], $locale = $this->localeForChoice($key, $locale)
         );
 
         // If the given "number" is actually an array or countable we will simply count the

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Translation;
 
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TranslatorTest extends TestCase
 {
@@ -14,6 +15,7 @@ class TranslatorTest extends TestCase
      */
     protected function defineEnvironment($app)
     {
+        $app['translator']->addNamespace('tests', __DIR__.'/lang');
         $app['translator']->addJsonPath(__DIR__.'/lang');
 
         parent::defineEnvironment($app);
@@ -95,5 +97,43 @@ class TranslatorTest extends TestCase
         $this->assertSame('ht', $_SERVER['__missing_translation_key_locale']);
 
         $this->app['translator']->handleMissingKeysUsing(null);
+    }
+
+    #[DataProvider('greetingChoiceDataProvider')]
+    public function testItCanHandleChoice(int $count, string $expected, ?string $locale = null)
+    {
+        if (! is_null($locale)) {
+            $this->app->setLocale($locale);
+        }
+
+        $name = 'Taylor';
+
+        $this->assertSame(
+            strtr($expected, [':name' => $name, ':count' => $count]),
+            $this->app['translator']->choice('tests::app.greeting', $count, ['name' => $name])
+        );
+    }
+
+    #[DataProvider('greetingChoiceDataProvider')]
+    public function testItCanHandleChoiceWithChoiceSeparatorInReplaceString(int $count, string $expected, ?string $locale = null)
+    {
+        if (! is_null($locale)) {
+            $this->app->setLocale($locale);
+        }
+
+        $name = 'Taylor | Laravel';
+
+        $this->assertSame(
+            strtr($expected, [':name' => $name, ':count' => $count]),
+            $this->app['translator']->choice('tests::app.greeting', $count, ['name' => $name])
+        );
+    }
+
+    public static function greetingChoiceDataProvider()
+    {
+        yield [0, 'Hello :name'];
+        yield [3, 'Hello :name, you have 3 unread messages'];
+        yield [0, 'Bonjour :name', 'fr'];
+        yield [3, 'Bonjour :name, vous avez :count messages non lus', 'fr'];
     }
 }

--- a/tests/Integration/Translation/lang/en/app.php
+++ b/tests/Integration/Translation/lang/en/app.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-   'greeting' => '{0} Hello :name|[1,*] Hello :name, you have :count unread messages'
+    'greeting' => '{0} Hello :name|[1,*] Hello :name, you have :count unread messages',
 ];

--- a/tests/Integration/Translation/lang/en/app.php
+++ b/tests/Integration/Translation/lang/en/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+   'greeting' => '{0} Hello :name|[1,*] Hello :name, you have :count unread messages'
+];

--- a/tests/Integration/Translation/lang/fr/app.php
+++ b/tests/Integration/Translation/lang/fr/app.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-   'greeting' => '{0} Bonjour :name|[1,*] Bonjour :name, vous avez :count messages non lus',
+    'greeting' => '{0} Bonjour :name|[1,*] Bonjour :name, vous avez :count messages non lus',
 ];

--- a/tests/Integration/Translation/lang/fr/app.php
+++ b/tests/Integration/Translation/lang/fr/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+   'greeting' => '{0} Bonjour :name|[1,*] Bonjour :name, vous avez :count messages non lus',
+];

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -126,7 +126,7 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyLoadsAndRetrievesItemForAnInt()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
         $t->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
@@ -137,7 +137,7 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyLoadsAndRetrievesItemForAFloat()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
         $t->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 1.2, 'en')->andReturn('choiced');
@@ -148,7 +148,7 @@ class TranslationTranslatorTest extends TestCase
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
         $t->expects($this->exactly(2))->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
@@ -164,7 +164,7 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'hasForLocale'])->setConstructorArgs([$this->getLoader(), 'cs'])->getMock();
         $t->setFallback('en');
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
         $t->expects($this->once())->method('hasForLocale')->with($this->equalTo('foo'), $this->equalTo('cs'))->willReturn(false);
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');


### PR DESCRIPTION
fixes #53289

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
