### PR TITLE
[11.x] Fix fluent syntax for HasManyThrough when combining HasMany followed by HasOne

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -394,7 +394,11 @@ trait HasRelationships
      * @return (
      *     $relationship is string
      *     ? \Illuminate\Database\Eloquent\PendingHasThroughRelationship<\Illuminate\Database\Eloquent\Model, $this>
-     *     : \Illuminate\Database\Eloquent\PendingHasThroughRelationship<TIntermediateModel, $this>
+     *     : (
+     *          $relationship is \Illuminate\Database\Eloquent\Relations\HasMany<TIntermediateModel, $this>
+     *          ? \Illuminate\Database\Eloquent\PendingHasThroughRelationship<TIntermediateModel, $this, \Illuminate\Database\Eloquent\Relations\HasMany<TIntermediateModel, $this>>
+     *          : \Illuminate\Database\Eloquent\PendingHasThroughRelationship<TIntermediateModel, $this, \Illuminate\Database\Eloquent\Relations\HasOne<TIntermediateModel, $this>>
+     *     )
      * )
      */
     public function through($relationship)

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -64,7 +64,7 @@ class PendingHasThroughRelationship
 
         $distantRelation = $callback($this->localRelationship->getRelated());
 
-        if ($distantRelation instanceof HasMany) {
+        if ($distantRelation instanceof HasMany || $this->localRelationship instanceof HasMany) {
             $returnedRelation = $this->rootModel->hasManyThrough(
                 $distantRelation->getRelated()::class,
                 $this->localRelationship->getRelated()::class,

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 /**
  * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
  * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TLocalRelationship of \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TIntermediateModel, TDeclaringModel>
  */
 class PendingHasThroughRelationship
 {
@@ -23,7 +24,7 @@ class PendingHasThroughRelationship
     /**
      * The local relationship.
      *
-     * @var \Illuminate\Database\Eloquent\Relations\HasMany<TIntermediateModel, TDeclaringModel>|\Illuminate\Database\Eloquent\Relations\HasOne<TIntermediateModel, TDeclaringModel>
+     * @var TLocalRelationship
      */
     protected $localRelationship;
 
@@ -31,7 +32,7 @@ class PendingHasThroughRelationship
      * Create a pending has-many-through or has-one-through relationship.
      *
      * @param  TDeclaringModel  $rootModel
-     * @param  \Illuminate\Database\Eloquent\Relations\HasMany<TIntermediateModel, TDeclaringModel>|\Illuminate\Database\Eloquent\Relations\HasOne<TIntermediateModel, TDeclaringModel>  $localRelationship
+     * @param  TLocalRelationship  $localRelationship
      */
     public function __construct($rootModel, $localRelationship)
     {
@@ -50,9 +51,13 @@ class PendingHasThroughRelationship
      *     $callback is string
      *     ? \Illuminate\Database\Eloquent\Relations\HasManyThrough<\Illuminate\Database\Eloquent\Model, TIntermediateModel, TDeclaringModel>|\Illuminate\Database\Eloquent\Relations\HasOneThrough<\Illuminate\Database\Eloquent\Model, TIntermediateModel, TDeclaringModel>
      *     : (
-     *         $callback is callable(TIntermediateModel): \Illuminate\Database\Eloquent\Relations\HasOne<TRelatedModel, TIntermediateModel>
-     *         ? \Illuminate\Database\Eloquent\Relations\HasOneThrough<TRelatedModel, TIntermediateModel, TDeclaringModel>
-     *         : \Illuminate\Database\Eloquent\Relations\HasManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel>
+     *         TLocalRelationship is \Illuminate\Database\Eloquent\Relations\HasMany<TIntermediateModel, TDeclaringModel>
+     *         ? \Illuminate\Database\Eloquent\Relations\HasManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel>
+     *         : (
+     *              $callback is callable(TIntermediateModel): \Illuminate\Database\Eloquent\Relations\HasMany<TRelatedModel, TIntermediateModel>
+     *              ? \Illuminate\Database\Eloquent\Relations\HasManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel>
+     *              : \Illuminate\Database\Eloquent\Relations\HasOneThrough<TRelatedModel, TIntermediateModel, TDeclaringModel>
+     *         )
      *     )
      * )
      */

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -117,6 +117,24 @@ class DatabaseEloquentRelationshipsTest extends TestCase
         $this->assertSame('fluent_projects.p_id', $fluent->getQualifiedLocalKeyName());
         $this->assertSame('environments.pro_id', $fluent->getQualifiedFirstKeyName());
         $this->assertSame('environments.pro_id', $classic->getQualifiedFirstKeyName());
+
+        $fluent = (new FluentProject())->environmentData();
+        $classic = (new ClassicProject())->environmentData();
+
+        $this->assertInstanceOf(HasManyThrough::class, $classic);
+        $this->assertInstanceOf(HasManyThrough::class, $fluent);
+        $this->assertSame('p_id', $classic->getLocalKeyName());
+        $this->assertSame('p_id', $fluent->getLocalKeyName());
+        $this->assertSame('e_id', $classic->getSecondLocalKeyName());
+        $this->assertSame('e_id', $fluent->getSecondLocalKeyName());
+        $this->assertSame('pro_id', $classic->getFirstKeyName());
+        $this->assertSame('pro_id', $fluent->getFirstKeyName());
+        $this->assertSame('env_id', $classic->getForeignKeyName());
+        $this->assertSame('env_id', $fluent->getForeignKeyName());
+        $this->assertSame('classic_projects.p_id', $classic->getQualifiedLocalKeyName());
+        $this->assertSame('fluent_projects.p_id', $fluent->getQualifiedLocalKeyName());
+        $this->assertSame('environments.pro_id', $fluent->getQualifiedFirstKeyName());
+        $this->assertSame('environments.pro_id', $classic->getQualifiedFirstKeyName());
     }
 
     public function testStringyHasThroughApi()
@@ -473,6 +491,18 @@ class ClassicProject extends MockedConnectionModel
             'e_id',
         );
     }
+
+    public function environmentData()
+    {
+        return $this->hasManyThrough(
+            Metadata::class,
+            Environment::class,
+            'pro_id',
+            'env_id',
+            'p_id',
+            'e_id',
+        );
+    }
 }
 
 class FluentProject extends MockedConnectionModel
@@ -480,6 +510,11 @@ class FluentProject extends MockedConnectionModel
     public function deployments()
     {
         return $this->through($this->environments())->has(fn (Environment $env) => $env->deployments());
+    }
+
+    public function environmentData()
+    {
+        return $this->through($this->environments())->has(fn (Environment $env) => $env->metadata());
     }
 
     public function environments()
@@ -494,6 +529,16 @@ class Environment extends MockedConnectionModel
     {
         return $this->hasMany(Deployment::class, 'env_id', 'e_id');
     }
+
+    public function metadata()
+    {
+        return $this->hasOne(MetaData::class, 'env_id', 'e_id');
+    }
+}
+
+class MetaData extends MockedConnectionModel
+{
+    //
 }
 
 class Deployment extends MockedConnectionModel

--- a/types/Database/Eloquent/Relations.php
+++ b/types/Database/Eloquent/Relations.php
@@ -169,6 +169,12 @@ class User extends Model
         return $this->hasOne(Mechanic::class);
     }
 
+    /** @return HasMany<Mechanic, $this> */
+    public function mechanics(): HasMany
+    {
+        return $this->hasMany(Mechanic::class);
+    }
+
     /** @return HasOneThrough<Car, Mechanic, $this> */
     public function car(): HasOneThrough
     {
@@ -187,7 +193,7 @@ class User extends Model
 
         $through = $this->through($this->mechanic());
         assertType(
-            'Illuminate\Database\Eloquent\PendingHasThroughRelationship<Illuminate\Types\Relations\Mechanic, $this(Illuminate\Types\Relations\User)>',
+            'Illuminate\Database\Eloquent\PendingHasThroughRelationship<Illuminate\Types\Relations\Mechanic, $this(Illuminate\Types\Relations\User), Illuminate\Database\Eloquent\Relations\HasOne<Illuminate\Types\Relations\Mechanic, $this(Illuminate\Types\Relations\User)>>',
             $through,
         );
         assertType(
@@ -200,6 +206,27 @@ class User extends Model
         );
 
         return $hasOneThrough;
+    }
+
+    /** @return HasManyThrough<Car, Mechanic, $this> */
+    public function cars(): HasManyThrough
+    {
+        $through = $this->through($this->mechanics());
+        assertType(
+            'Illuminate\Database\Eloquent\PendingHasThroughRelationship<Illuminate\Types\Relations\Mechanic, $this(Illuminate\Types\Relations\User), Illuminate\Database\Eloquent\Relations\HasMany<Illuminate\Types\Relations\Mechanic, $this(Illuminate\Types\Relations\User)>>',
+            $through,
+        );
+        $hasManyThrough = $through->has(function ($mechanic) {
+            assertType('Illuminate\Types\Relations\Mechanic', $mechanic);
+
+            return $mechanic->car();
+        });
+        assertType(
+            'Illuminate\Database\Eloquent\Relations\HasManyThrough<Illuminate\Types\Relations\Car, Illuminate\Types\Relations\Mechanic, $this(Illuminate\Types\Relations\User)>',
+            $hasManyThrough,
+        );
+
+        return $hasManyThrough;
     }
 
     /** @return HasManyThrough<Part, Mechanic, $this> */


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In #45894 'fluent' syntax for has-many-through and has-one-through relations was added. When combining has-one and has-many, one has 4 options:
1. `HasOne` followed by `HasOne` => `HasOneThrough`
1. `HasOne` followed by `HasMany` => `HasManyThrough`
1. `HasMany` followed by `HasMany` => `HasManyThrough`
1. `HasMany` followed by `HasOne` => `HasManyThrough`

All of these options work fine when using the 'classic' relation definitions. However, the 4th option does not work with the new 'fluent' syntax, as ending with a `HasOne` makes it incorrectly infer the type of the 'full' relation to be `HasOneThrough` rather than `HasManyThrough`.

This PR aims to fix this discrepancy between 'classic' and 'fluent' syntax, by fixing the latter to also allow the 4th option. This is illustrated by adding tests in the first commit that will fail without the fix.

Open issue: the inferred typing on the `has` method will still incorrectly report `HasOneThrough` with current changeset.