### PR TITLE
[11.x] Fix `dropColumnIfExists` and `dropForeignIfExists`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1483,9 +1483,7 @@ class Blueprint
      */
     public function vector($column, $dimensions = null)
     {
-        $options = $dimensions ? compact('dimensions') : [];
-
-        return $this->addColumn('vector', $column, $options);
+        return $this->addColumn('vector', $column, compact('dimensions'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -436,15 +436,7 @@ class Blueprint
      */
     public function dropColumnIfExists($columns)
     {
-        $columns = is_array($columns) ? $columns : func_get_args();
-
-        $columns = array_intersect($columns, Schema::getColumnListing($this->getTable()));
-
-        if (empty($columns)) {
-            return new Fluent;
-        }
-
-        return $this->dropColumn($columns);
+        return tap($this->dropColumn($columns))->ifExists();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 
@@ -525,15 +524,7 @@ class Blueprint
      */
     public function dropForeignIfExists($index)
     {
-        if (is_array($index)) {
-            $index = $this->createIndexName('foreign', $index);
-        }
-
-        if (! in_array($index, Schema::getForeignKeys($this->getTable()))) {
-            return new Fluent;
-        }
-
-        return $this->dropIndexCommand('dropForeign', 'foreign', $index);
+        return tap($this->dropForeign($index))->ifExists();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -169,9 +169,10 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string|null
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         throw new RuntimeException('This database driver does not support dropping foreign keys.');
     }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -529,10 +529,15 @@ class MySqlGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileDropColumn(Blueprint $blueprint, Fluent $command)
+    public function compileDropColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if ($command->ifExists) {
+            $command->columns = array_intersect($command->columns, $connection->getSchemaBuilder()->getColumnListing($blueprint->getTable()));
+        }
+
         $columns = $this->prefixArray('drop', $this->wrapArray($command->columns));
 
         return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -530,12 +530,16 @@ class MySqlGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
-     * @return string
+     * @return string|null
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         if ($command->ifExists) {
             $command->columns = array_intersect($command->columns, $connection->getSchemaBuilder()->getColumnListing($blueprint->getTable()));
+
+            if (empty($command->columns)) {
+                return null;
+            }
         }
 
         $columns = $this->prefixArray('drop', $this->wrapArray($command->columns));
@@ -619,7 +623,7 @@ class MySqlGrammar extends Grammar
     {
         if ($command->ifExists &&
             ! in_array($command->index, array_column($connection->getSchemaBuilder()->getForeignKeys($blueprint->getTable()), 'name'))) {
-            return;
+            return null;
         }
 
         $index = $this->wrap($command->index);

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -612,10 +612,16 @@ class MySqlGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string|null
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if ($command->ifExists &&
+            ! in_array($command->index, array_column($connection->getSchemaBuilder()->getForeignKeys($blueprint->getTable()), 'name'))) {
+            return;
+        }
+
         $index = $this->wrap($command->index);
 
         return "alter table {$this->wrapTable($blueprint)} drop foreign key {$index}";

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1143,9 +1143,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeVector(Fluent $column)
     {
-        return isset($column->dimensions) && $column->dimensions !== ''
-            ? "vector({$column->dimensions})"
-            : 'vector';
+        return $column->dimensions ? "vector({$column->dimensions})" : 'vector';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1083,9 +1083,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeVector(Fluent $column)
     {
-        return isset($column->dimensions) && $column->dimensions !== ''
-            ? "vector({$column->dimensions})"
-            : 'vector';
+        return $column->dimensions ? "vector({$column->dimensions})" : 'vector';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -488,7 +488,9 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
-        $columns = $this->prefixArray('drop column', $this->wrapArray($command->columns));
+        $sql = $command->ifExists ? 'drop column if exists' : 'drop column';
+
+        $columns = $this->prefixArray($sql, $this->wrapArray($command->columns));
 
         return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -565,13 +565,16 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        $index = $this->wrap($command->index);
-
-        return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
+        return sprintf('alter table %s drop constraint %s%s',
+            $this->wrapTable($blueprint),
+            $command->ifExists ? 'if exists ' : '',
+            $this->wrap($command->index)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -536,9 +536,10 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return array
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         if (empty($command->columns)) {
             throw new RuntimeException('This database driver does not support dropping foreign keys by name.');

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -468,6 +468,10 @@ class SQLiteGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
+        if ($command->ifExists) {
+            $command->columns = array_intersect($command->columns, $connection->getSchemaBuilder()->getColumnListing($blueprint->getTable()));
+        }
+
         $columns = $this->prefixArray('drop column', $this->wrapArray($command->columns));
 
         return collect($columns)->map(fn ($column) => 'alter table '.$table.' '.$column)->all();

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -470,6 +470,10 @@ class SQLiteGrammar extends Grammar
 
         if ($command->ifExists) {
             $command->columns = array_intersect($command->columns, $connection->getSchemaBuilder()->getColumnListing($blueprint->getTable()));
+
+            if (empty($command->columns)) {
+                return null;
+            }
         }
 
         $columns = $this->prefixArray('drop column', $this->wrapArray($command->columns));

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -400,6 +400,10 @@ class SqlServerGrammar extends Grammar
     {
         if ($command->ifExists) {
             $command->columns = array_intersect($command->columns, $connection->getSchemaBuilder()->getColumnListing($blueprint->getTable()));
+
+            if (empty($command->columns)) {
+                return null;
+            }
         }
 
         $columns = $this->wrapArray($command->columns);
@@ -500,7 +504,7 @@ class SqlServerGrammar extends Grammar
     {
         if ($command->ifExists &&
             ! in_array($command->index, array_column($connection->getSchemaBuilder()->getForeignKeys($blueprint->getTable()), 'name'))) {
-            return;
+            return null;
         }
 
         $index = $this->wrap($command->index);

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -393,10 +393,15 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileDropColumn(Blueprint $blueprint, Fluent $command)
+    public function compileDropColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if ($command->ifExists) {
+            $command->columns = array_intersect($command->columns, $connection->getSchemaBuilder()->getColumnListing($blueprint->getTable()));
+        }
+
         $columns = $this->wrapArray($command->columns);
 
         $dropExistingConstraintsSql = $this->compileDropDefaultConstraint($blueprint, $command).';';

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -493,10 +493,16 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string|null
      */
-    public function compileDropForeign(Blueprint $blueprint, Fluent $command)
+    public function compileDropForeign(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if ($command->ifExists &&
+            ! in_array($command->index, array_column($connection->getSchemaBuilder()->getForeignKeys($blueprint->getTable()), 'name'))) {
+            return;
+        }
+
         $index = $this->wrap($command->index);
 
         return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -249,6 +249,30 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
     }
 
     #[DataProvider('connectionProvider')]
+    public function testDropColumnsIfExists($connection)
+    {
+        $schema = Schema::connection($connection);
+
+        $schema->create('my_schema.table', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('age');
+        });
+
+        $schema->create('table', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('age');
+        });
+
+        $schema->dropColumnsIfExists('my_schema.table', ['name', 'foo']);
+        $schema->dropColumnsIfExists('table', ['age', 'bar']);
+
+        $this->assertSame(['id', 'age'], $schema->getColumnListing('my_schema.table'));
+        $this->assertSame(['id', 'name'], $schema->getColumnListing('table'));
+    }
+
+    #[DataProvider('connectionProvider')]
     public function testIndexes($connection)
     {
         $schema = Schema::connection($connection);

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -864,12 +864,15 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         Schema::create('posts', function (Blueprint $table) {
             $table->foreignId('user_id')->nullable()->index()->constrained();
-            $table->string('user_name')->nullable()->unique();
+            $table->string('user_name')->nullable()->index();
             $table->foreign('user_name')->references('name')->on('users');
             $table->integer('count');
         });
 
-        $this->assertSame([['user_id'], ['user_name']], array_column(Schema::getForeignKeys('posts'), 'columns'));
+        $this->assertEqualsCanonicalizing(
+            [['user_id'], ['user_name']],
+            array_column(Schema::getForeignKeys('posts'), 'columns')
+        );
 
         Schema::table('posts', function (Blueprint $table) {
             $table->dropForeignIfExists(['user_id']);
@@ -892,16 +895,15 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         Schema::create('posts', function (Blueprint $table) {
             $table->foreignId('user_id')->nullable()->index()->constrained();
-            $table->string('user_name')->nullable()->unique();
+            $table->string('user_name')->nullable()->index();
             $table->foreign('user_name')->references('name')->on('users');
             $table->integer('count');
         });
 
-        $this->assertSame(
+        $this->assertEqualsCanonicalizing(
             ['posts_user_id_foreign', 'posts_user_name_foreign'],
             array_column(Schema::getForeignKeys('posts'), 'name')
         );
-
 
         Schema::table('posts', function (Blueprint $table) {
             $table->dropForeignIfExists('posts_user_id_foreign');

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -859,12 +859,12 @@ class SchemaBuilderTest extends DatabaseTestCase
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name')->index();
+            $table->string('name')->unique();
         });
 
         Schema::create('posts', function (Blueprint $table) {
             $table->foreignId('user_id')->nullable()->index()->constrained();
-            $table->string('user_name')->nullable()->index();
+            $table->string('user_name')->nullable()->unique();
             $table->foreign('user_name')->references('name')->on('users');
             $table->integer('count');
         });
@@ -890,12 +890,12 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name')->index();
+            $table->string('name')->unique();
         });
 
         Schema::create('posts', function (Blueprint $table) {
             $table->foreignId('user_id')->nullable()->index()->constrained();
-            $table->string('user_name')->nullable()->index();
+            $table->string('user_name')->nullable()->unique();
             $table->foreign('user_name')->references('name')->on('users');
             $table->integer('count');
         });


### PR DESCRIPTION
This PR does:
* Fixes #53305:
  * Remove direct usage of `Schema` Facade on `Blueprint`, as it ignores builder / migration's connection, checking existence on default connection and dropping on the specified connection.
  * Use native `if exists` statement on PostgreSQL.
  * Fix `dropForeignIfExists()`, could never find the constraint name and was doing nothing!
  * Add integration tests.
* Fixes #53316 
  * Let the column definition know that `dimension` is explicitly `null`.

PS: `Blueprint` doesn't know about the DB connection, it just keeps commands and when `Builder` provides the connection and grammar instances, `Blueprint` converts them to SQL statements (defined on `Schema\Grammar`).