### PR TITLE
[11.x] Refactor: check for contextual attribute before getting parameter class name

### DIFF
--- a/src/Illuminate/Routing/ResolvesRouteDependencies.php
+++ b/src/Illuminate/Routing/ResolvesRouteDependencies.php
@@ -75,11 +75,11 @@ trait ResolvesRouteDependencies
      */
     protected function transformDependency(ReflectionParameter $parameter, $parameters, $skippableValue)
     {
-        $className = Reflector::getParameterClassName($parameter);
-
         if ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
             return $this->container->resolveFromAttribute($attribute);
         }
+
+        $className = Reflector::getParameterClassName($parameter);
 
         // If the parameter has a type-hinted class, we will check to see if it is already in
         // the list of parameters. If it is we will just skip it as it is probably a model


### PR DESCRIPTION
The class name of the parameter is not used if the parameter has a contextual attribute, so getting the class name is unnecessary.