### PR TITLE
[11.x] Add withoutDefer and withDefer testing helpers

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Closure;
 use Illuminate\Foundation\Mix;
 use Illuminate\Foundation\Vite;
+use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\HtmlString;
 use Mockery;
@@ -24,6 +25,13 @@ trait InteractsWithContainer
      * @var \Illuminate\Foundation\Mix|null
      */
     protected $originalMix;
+
+    /**
+     * The original deferred callbacks collection.
+     *
+     * @var \Illuminate\Support\Defer\DeferredCallbackCollection|null
+     */
+    protected $originalDeferredCallbacksCollection;
 
     /**
      * Register an instance of an object in the container.
@@ -230,6 +238,40 @@ trait InteractsWithContainer
     {
         if ($this->originalMix) {
             $this->app->instance(Mix::class, $this->originalMix);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute deferred functions immediately.
+     *
+     * @return $this
+     */
+    protected function withoutDefer()
+    {
+        if ($this->originalDeferredCallbacksCollection == null) {
+            $this->originalDeferredCallbacksCollection = $this->app->make(DeferredCallbackCollection::class);
+        }
+
+        $this->swap(DeferredCallbackCollection::class, new class extends DeferredCallbackCollection
+        {
+            public function offsetSet(mixed $offset, mixed $value): void
+            {
+                $value();
+            }
+        });
+    }
+
+    /**
+     * Restore deferred functions.
+     *
+     * @return $this
+     */
+    protected function withDefer()
+    {
+        if ($this->originalDeferredCallbacksCollection) {
+            $this->app->instance(DeferredCallbackCollection::class, $this->originalDeferredCallbacksCollection);
         }
 
         return $this;

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
 use Illuminate\Foundation\Mix;
 use Illuminate\Foundation\Vite;
+use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Orchestra\Testbench\TestCase;
 use stdClass;
 
@@ -71,6 +72,26 @@ class InteractsWithContainerTest extends TestCase
 
         $this->assertSame($handler, resolve(Mix::class));
         $this->assertSame($this, $instance);
+    }
+
+    public function testWithoutDefer()
+    {
+        $called = [];
+        defer(function () use (&$called) {
+            $called[] = 1;
+        });
+        $this->assertSame([], $called);
+
+        $this->withoutDefer();
+        defer(function () use (&$called) {
+            $called[] = 2;
+        });
+        $this->assertSame([2], $called);
+
+        $this->withDefer();
+        $this->assertSame([2], $called);
+        $this->app[DeferredCallbackCollection::class]->invoke();
+        $this->assertSame([2, 1], $called);
     }
 
     public function testForgetMock()


### PR DESCRIPTION
Adds the ability to have deferred functions execute immediately within a test.

This is useful when you are working with unit tests that cover and assert against deferred function outcomes, as deferred functions are only invoked at the end of the request lifecycle.

```php
User::create(/* ... */);

$this->assertAgainstSomeDeferredOutcome(); // will not work
```

```php
$this->withoutDefer();

User::create(/* ... */);

$this->assertAgainstSomeDeferredOutcome(); // will now work
```