### PR TITLE
[11.x] Added `useCascadeTruncate` method for `PostgresGrammar`

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -39,7 +39,7 @@ class PostgresGrammar extends Grammar
     ];
 
     /**
-     * Whether to use the cascade option for truncating.
+     * Indicates if the cascade option should be used when truncating.
      *
      * @var bool
      */
@@ -816,7 +816,7 @@ class PostgresGrammar extends Grammar
      * @param  bool  $value
      * @return void
      */
-    public static function useCascadeTruncate(bool $value = true)
+    public static function cascadeOnTrucate(bool $value = true)
     {
         static::$cascadeTruncate = $value;
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -39,6 +39,13 @@ class PostgresGrammar extends Grammar
     ];
 
     /**
+     * Whether to use the cascade option for truncating.
+     *
+     * @var bool
+     */
+    protected static $cascadeTruncate = true;
+
+    /**
      * Compile a basic where clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -653,7 +660,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return ['truncate '.$this->wrapTable($query->from).' restart identity cascade' => []];
+        return ['truncate '.$this->wrapTable($query->from).' restart identity'.(static::$cascadeTruncate ? ' cascade' : '') => []];
     }
 
     /**
@@ -801,5 +808,16 @@ class PostgresGrammar extends Grammar
         static::$customOperators = array_values(
             array_merge(static::$customOperators, array_filter(array_filter($operators, 'is_string')))
         );
+    }
+
+    /**
+     * Enable or disable the "cascade" option when compiling the truncate statement.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function useCascadeTruncate(bool $value = true)
+    {
+        static::$cascadeTruncate = $value;
     }
 }

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -59,13 +59,13 @@ class DatabasePostgresQueryGrammarTest extends TestCase
             'truncate "users" restart identity cascade' => [],
         ], $postgres->compileTruncate($builder));
 
-        PostgresGrammar::useCascadeTruncate(false);
+        PostgresGrammar::cascadeOnTrucate(false);
 
         $this->assertEquals([
             'truncate "users" restart identity' => [],
         ], $postgres->compileTruncate($builder));
 
-        PostgresGrammar::useCascadeTruncate();
+        PostgresGrammar::cascadeOnTrucate();
 
         $this->assertEquals([
             'truncate "users" restart identity cascade' => [],

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -46,5 +47,28 @@ class DatabasePostgresQueryGrammarTest extends TestCase
         $this->assertNotContains('', $operators);
         $this->assertNotContains(1, $operators);
         $this->assertSame(array_unique($operators), $operators);
+    }
+
+    public function testCompileTruncate()
+    {
+        $postgres = new PostgresGrammar;
+        $builder = m::mock(Builder::class);
+        $builder->from = 'users';
+
+        $this->assertEquals([
+            'truncate "users" restart identity cascade' => [],
+        ], $postgres->compileTruncate($builder));
+
+        PostgresGrammar::useCascadeTruncate(false);
+
+        $this->assertEquals([
+            'truncate "users" restart identity' => [],
+        ], $postgres->compileTruncate($builder));
+
+        PostgresGrammar::useCascadeTruncate();
+
+        $this->assertEquals([
+            'truncate "users" restart identity cascade' => [],
+        ], $postgres->compileTruncate($builder));
     }
 }


### PR DESCRIPTION

In the current version of **Laravel**, the `cascade` option is used for the `truncate` in **Postgres**. However, this behavior is not expected by many developers (issue #35157) as **Postgres** by default uses the `restrict` option
for `truncate` (https://www.postgresql.org/docs/current/sql-truncate.html#id-1.9.3.181.6).

For **Laravel** 11.x, it is proposed to add a new `useCascadeTruncate` method in the `PostgresGrammar`, allowing developers to disable the cascade behavior. This provides more control over how the `truncate` operation behaves in **Postgres**.

By default, the `cascade` behavior remains enabled in version 11.x to avoid *BC*.

**Future Plans**:

For versions 12.x or 13.x, we may consider changing the default behavior to disable the `cascade` option for `truncate`.
The upgrade notes will state that this behavior can be easily restored using the `PostgresGrammar::useCascadeTruncate()` method.