### PR TITLE
Added filled($array, $key) method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -321,6 +321,24 @@ class Arr
     }
 
     /**
+     * Check if the key exists in array and is filled
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @return bool
+     */
+    public static function filled($array, $key)
+    {
+        if (! static::has($array, $key)) {
+            return false;
+        }
+
+        $value = static::get($array, $key);
+
+        return ! is_null($value) && trim($value) !== '';
+    }
+
+    /**
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -321,7 +321,7 @@ class Arr
     }
 
     /**
-     * Check if the key exists in array and is filled
+     * Check if the key exists in array and is filled.
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int|null  $key


### PR DESCRIPTION
This method is like $request->filled($key), which returns true if the key exists and filled properly

So in my code I don't do:
```
$value = Arr::get($data, 'field');

return ! is_null($value) && trim($value) !== ''
```

But simply do:
```
return Arr::filled($data, 'field')
```