### PR TITLE
Add ability to disable controller middleware

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -269,6 +269,10 @@ class ApplicationBuilder
             if ($priorities = $middleware->getMiddlewarePriority()) {
                 $kernel->setMiddlewarePriority($priorities);
             }
+
+            if ($middleware->shouldDisableControllerMiddleware()) {
+                $kernel->getRouter()->disableControllerMiddleware();
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -146,7 +146,7 @@ class Middleware
     protected $priority = [];
 
     /**
-     * Whether to disable controller middleware
+     * Whether to disable controller middleware.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -146,6 +146,13 @@ class Middleware
     protected $priority = [];
 
     /**
+     * Whether to disable controller middleware
+     *
+     * @var bool
+     */
+    protected $disableControllerMiddleware = false;
+
+    /**
      * Prepend middleware to the application's global middleware stack.
      *
      * @param  array|string  $middleware
@@ -765,5 +772,39 @@ class Middleware
     public function getMiddlewarePriority()
     {
         return $this->priority;
+    }
+
+    /**
+     * Disable controller middleware.
+     *
+     * @return $this
+     */
+    public function withoutControllerMiddleware()
+    {
+        $this->disableControllerMiddleware = true;
+
+        return $this;
+    }
+
+    /**
+     * Disable controller middleware.
+     *
+     * @return $this
+     */
+    public function withControllerMiddleware()
+    {
+        $this->disableControllerMiddleware = false;
+
+        return $this;
+    }
+
+    /**
+     * Whether controller middleware should be disabled.
+     *
+     * @return bool
+     */
+    public function shouldDisableControllerMiddleware()
+    {
+        return $this->disableControllerMiddleware;
     }
 }

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -699,4 +699,14 @@ class Kernel implements KernelContract
 
         return $this;
     }
+
+    /**
+     * Get the router.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
 }

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -18,6 +18,36 @@ use Traversable;
 abstract class AbstractRouteCollection implements Countable, IteratorAggregate, RouteCollectionInterface
 {
     /**
+     * The router instance used by the route.
+     *
+     * @var \Illuminate\Routing\Router
+     */
+    protected $router;
+
+    /**
+     * Get the router instance.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
+
+    /**
+     * Set the router instance on the route.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return $this
+     */
+    public function setRouter(Router $router)
+    {
+        $this->router = $router;
+
+        return $this;
+    }
+
+    /**
      * Handle the matched route.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -99,9 +129,9 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     protected function getRouteForMethods($request, array $methods)
     {
         if ($request->isMethod('OPTIONS')) {
-            return (new Route('OPTIONS', $request->path(), function () use ($methods) {
+            return $this->getRouter()->newRoute('OPTIONS', $request->path(), function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
-            }))->bind($request);
+            })->bind($request);
         }
 
         $this->requestMethodNotAllowed($request, $methods, $request->method());

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -303,19 +303,6 @@ class CompiledRouteCollection extends AbstractRouteCollection
     }
 
     /**
-     * Set the router instance on the route.
-     *
-     * @param  \Illuminate\Routing\Router  $router
-     * @return $this
-     */
-    public function setRouter(Router $router)
-    {
-        $this->router = $router;
-
-        return $this;
-    }
-
-    /**
      * Set the container instance on the route.
      *
      * @param  \Illuminate\Container\Container  $container

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1103,7 +1103,7 @@ class Route
      */
     public function controllerMiddleware()
     {
-        if (! $this->isControllerAction()) {
+        if ($this->router->shouldSkipControllerMiddleware() || ! $this->isControllerAction()) {
             return [];
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -154,6 +154,8 @@ class Router implements BindingRegistrar, RegistrarContract
         $this->events = $events;
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
+
+        $this->routes->setRouter($this);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -101,6 +101,13 @@ class Router implements BindingRegistrar, RegistrarContract
     public $middlewarePriority = [];
 
     /**
+     * Whether to disable controller middleware
+     *
+     * @var bool
+     */
+    protected $disableControllerMiddleware = false;
+
+    /**
      * The registered route value binders.
      *
      * @var array
@@ -1502,5 +1509,39 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         return (new RouteRegistrar($this))->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);
+    }
+
+    /**
+     * Skip the gathering of controller middleware.
+     *
+     * @return $this
+     */
+    public function skipControllerMiddleware()
+    {
+        $this->disableControllerMiddleware = true;
+
+        return $this;
+    }
+
+    /**
+     * Allow the gathering of controller middleware.
+     *
+     * @return $this
+     */
+    public function allowControllerMiddleware()
+    {
+        $this->disableControllerMiddleware = false;
+
+        return $this;
+    }
+
+    /**
+     * Whether the router should gather controller middleware.
+     *
+     * @return bool
+     */
+    public function shouldSkipControllerMiddleware()
+    {
+        return $this->disableControllerMiddleware;
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -101,7 +101,7 @@ class Router implements BindingRegistrar, RegistrarContract
     public $middlewarePriority = [];
 
     /**
-     * Whether to disable controller middleware
+     * Whether to disable controller middleware.
      *
      * @var bool
      */

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -314,6 +314,26 @@ class RoutingRouteTest extends TestCase
         );
     }
 
+    public function testControllerMiddlewareCanBeSkipped()
+    {
+        $router = $this->getRouter();
+        $router->skipControllerMiddleware();
+        $router->get('foo/bar', [
+            'uses' => RouteTestClosureMiddlewareController::class.'@index',
+            'middleware' => 'foo',
+        ]);
+        $router->aliasMiddleware('foo', function ($request, $next) {
+            $request['foo-middleware'] = 'foo-middleware';
+
+            return $next($request);
+        });
+
+        $this->assertSame(
+            'index',
+            $router->dispatch(Request::create('foo/bar', 'GET'))->getContent()
+        );
+    }
+
     public function testFluentRouting()
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
This PR adds the ability to disable the collection of controller middleware.

The main reason behind this is to prevent the controller's constructor from being run before the route is being processed. Primarily for dependency-injection purposes.

This implementation is non-invasive and comes in two parts.

## Middleware Config/Builder

When building the application controller, middleware can be disabled for the entire application.

```php
    ->withMiddleware(function (Middleware $middleware) {
        $middleware->withoutControllerMiddleware();
    });
```

It can also be re-enabled.

```php
    ->withMiddleware(function (Middleware $middleware) {
        $middleware->withControllerMiddleware();
    });
```

> [!NOTE]
> As a side effect of this, the default HTTP Kernel implementation now has a `Kernel::getRouter()` method that serves as a getter for `Kernel::$router`.

## Router

You can also disable or enable controller middleware directly on the router.

```php
app('router')->skipControllerMiddleware();
```

And re-enable.

```php
app('router')->allowControllerMiddleware();
```

## Side Effect/Possible Bug-fix

Some tests failed the first time around, and I discovered it's because the `OPTIONS` routes that are automatically created are created without access to the router. This means that `Route::$router` is `null`, which doesn't seem to be allowed by its docblock.

To fix this, I moved `CompiledRouteCollection::setRouter()` to `AbstractRouteCollection`, and had the `RouteCollection` class call `$this->router->newRoute()` instead of manually creating a new instance of `Route`.

I suspect this was a side effect bug that hadn't been caught yet, as it's quite obscure,