### PR TITLE
Add ability to provide custom token repository creation logic

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -63,7 +63,7 @@ class PasswordBrokerManager implements FactoryContract
      * @param  \Closure  $callback
      * @return $this
      */
-    public function provider($name, Closure $callback)
+    public function repository($name, Closure $callback)
     {
         $this->customRepositoryCreators[$name] = $callback;
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -104,14 +104,16 @@ class PasswordBrokerManager implements FactoryContract
      */
     protected function createTokenRepository(array $config)
     {
-        // This is here so that we can default for the 'driver' database,
-        // as that's the default implementation.
-        if (isset($config['driver']) && $config['driver'] !== 'database') {
-            if (! isset($this->customRepositoryCreators[$config['driver']])) {
-                throw new InvalidArgumentException("Password reset token repository [{$config['driver']}] is not defined");
+        if (isset($config['driver'])) {
+            if (isset($this->customRepositoryCreators[$config['driver']])) {
+                return $this->customRepositoryCreators[$config['driver']]($this->app, $config);
             }
 
-            return $this->customRepositoryCreators[$config['driver']]($this->app, $config);
+            // If there's no custom provider for the driver, but the driver is
+            // 'database', use the default implementation.
+            if ($config['driver'] !== 'database') {
+                throw new InvalidArgumentException("Password reset token repository [{$config['driver']}] is not defined");
+            }
         }
 
         $key = $this->app['config']['app.key'];


### PR DESCRIPTION
This PR adds the ability to create custom token repositories for the password broker.

Custom creators are registered with the `PasswordBrokerManager`:

```php
app('auth.password')->repository('redis', function ($app, $config) {
    return new RedisTokenRepository($config);
});
```

And provided in the config using the `driver` value:

```php
[
  'passwords' => [
      'users' => [
          'provider' => 'users',
          'driver' => 'redis',
          'connection' => 'redis',
          'expire' => 60,
          'throttle' => 60,
      ],
  ],
```

If the `driver` config value is missing, or equal to `database`, the default implementation is used.

> [!NOTE]
> I'm unsure how you want this to be tested, as this part of the codebase doesn't appear to be tested at all, instead, all the elements it interacts with are mocked and dealt with directly.