### PR TITLE
Add laravel default exception blade files to view:cache

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -244,6 +244,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
         }
 
         $this->loadViewsFrom(__DIR__.'/../resources/exceptions/renderer', 'laravel-exceptions-renderer');
+        $this->loadViewsFrom(__DIR__.'/../Exceptions/views', 'laravel-exceptions');
 
         $this->app->singleton(Renderer::class, function (Application $app) {
             $errorRenderer = new HtmlErrorRenderer(

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -240,7 +240,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     protected function registerExceptionRenderer()
     {
         $this->loadViewsFrom(__DIR__.'/../Exceptions/views', 'laravel-exceptions');
-        
+
         if (! $this->app->hasDebugModeEnabled()) {
             return;
         }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -246,7 +246,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
         }
 
         $this->loadViewsFrom(__DIR__.'/../resources/exceptions/renderer', 'laravel-exceptions-renderer');
-        
 
         $this->app->singleton(Renderer::class, function (Application $app) {
             $errorRenderer = new HtmlErrorRenderer(

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -239,12 +239,14 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     protected function registerExceptionRenderer()
     {
+        $this->loadViewsFrom(__DIR__.'/../Exceptions/views', 'laravel-exceptions');
+        
         if (! $this->app->hasDebugModeEnabled()) {
             return;
         }
 
         $this->loadViewsFrom(__DIR__.'/../resources/exceptions/renderer', 'laravel-exceptions-renderer');
-        $this->loadViewsFrom(__DIR__.'/../Exceptions/views', 'laravel-exceptions');
+        
 
         $this->app->singleton(Renderer::class, function (Application $app) {
             $errorRenderer = new HtmlErrorRenderer(


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Fixes #53336 

This PR adds the path of the default exception blade views to the view:cache command
