### PR TITLE
[11.x] Refactor: return Command::FAILURE

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -38,7 +38,7 @@ class RefreshCommand extends Command
     {
         if ($this->isProhibited() ||
             ! $this->confirmToProceed()) {
-            return 1;
+            return Command::FAILURE;
         }
 
         // Next we'll gather some of the options so that we can have the right options

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\Migrations\Migrator;
@@ -56,7 +57,7 @@ class ResetCommand extends BaseCommand
     {
         if ($this->isProhibited() ||
             ! $this->confirmToProceed()) {
-            return 1;
+            return Command::FAILURE;
         }
 
         return $this->migrator->usingConnection($this->option('database'), function () {


### PR DESCRIPTION
Replace return 1 with Command::FAILURE to standardize with other commands
