### PR TITLE
[Feature] Add support for casting pure enums to integers instead of strings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -42,8 +42,6 @@ use ReflectionNamedType;
 use RuntimeException;
 use ValueError;
 
-use function Illuminate\Support\enum_value;
-
 trait HasAttributes
 {
     /**


### PR DESCRIPTION
## [Feature] Add support for casting pure enums to integers instead of strings

This PR modifies the default behavior of storing pure enum values as strings to storing them as integers. The motivation behind this change is that, in most cases I use enums as casts I use integer backed enums —which typically requires maintaining specific value for each enum case— because int columns are more effiecent in storing and indexing, and don't care what is the value of each enum. This PR takes care of giving each case a unique value and it was inspired by implicit enum values in C++.

### Cons
1. Changing the order of the enum cases will give you wrong results as the value of each case is determined by order of the case in the array returned from ```Enum::cases()``` method which also depends on the order of the cases in the enum.

#### Changes Made
- Updated the `getStorableEnumValue` method in the `HasAttributes` trait to return an integer instead of a string.
- Modified the `getEnumCaseFromValue` method in the `HasAttributes` trait to interpret enum values as integers or strings for old values.

#### Compatibility
This change is expected to be backward-compatible, If you can think of a scenario where this might introduce a breaking change, please let me know.

#### Tests
- Tests have not yet been added, but I plan to add them to cover the new behavior.

#### Example

Here’s an example to illustrate the change:

##### Before:
Using a pure enum cast in the model:
```php
enum Status {
    case Pending;
    case Approved;
}
// This would store the case name in the db as a string "Pending".
$model->update(['status' => Status::Pending]);
```

##### After:
With this PR, using the same pure enum cast will store integer values instead:
```php
// This would store case integer index in Status::cases() array which is 0, (where `PENDING` maps to 0, `APPROVED` to 1, and so on)
$model->update(['status' => Status::Pending]);
```

### Notes
1. I opted for using the implementation of enum_value() helper method instead of using the method it self because this helper is used throughout the project and I don't know whether this change will cause errors or not.

This change makes it easier to use pure enums in the casts without needing to define explicit integer-backed values for each case.