### PR TITLE
Allow the Batch and Chain onQueue method to accept Backed Enums

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
 use Throwable;
 
+use function Illuminate\Support\enum_value;
+
 class PendingBatch
 {
     use Conditionable;
@@ -261,12 +263,12 @@ class PendingBatch
     /**
      * Specify the queue that the batched jobs should run on.
      *
-     * @param  string  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
-    public function onQueue(string $queue)
+    public function onQueue($queue)
     {
-        $this->options['queue'] = $queue;
+        $this->options['queue'] = enum_value($queue);
 
         return $this;
     }

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -5,6 +5,8 @@ namespace Illuminate\Events;
 use Closure;
 use Laravel\SerializableClosure\SerializableClosure;
 
+use function Illuminate\Support\enum_value;
+
 class QueuedClosure
 {
     /**
@@ -69,12 +71,12 @@ class QueuedClosure
     /**
      * Set the desired queue for the job.
      *
-     * @param  string|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)
     {
-        $this->queue = $queue;
+        $this->queue = enum_value($queue);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -8,6 +8,8 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
 
+use function Illuminate\Support\enum_value;
+
 class PendingChain
 {
     use Conditionable;
@@ -83,12 +85,12 @@ class PendingChain
     /**
      * Set the desired queue for the job.
      *
-     * @param  string|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)
     {
-        $this->queue = $queue;
+        $this->queue = enum_value($queue);
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -465,7 +465,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Queue a new mail message for sending.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
-     * @param  string|null  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @return mixed
      *
      * @throws \InvalidArgumentException
@@ -486,7 +486,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Queue a new mail message for sending on the given queue.
      *
-     * @param  string  $queue
+     * @param  \BackedEnum|string|null  $queue
      * @param  \Illuminate\Contracts\Mail\Mailable  $view
      * @return mixed
      */


### PR DESCRIPTION
Continuing the journey of better enums support in L11 ...

This PR improves the `PendingChain` and `PendingBatch`'s `onQueue` method to accept Backed Enums directly as the queue parameter.

Before:

```php
Bus::chain($jobs)
    ->onQueue(QueueName::long->value)->dispatch();
```

With this PR, you can now pass the Backed Enum directly:

```php
Bus::chain($jobs)
    ->onQueue(QueueName::long)->dispatch();
```
