### PR TITLE
[12.x] Let MassAssignmentExceptions support multiple unfillable attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -3,8 +3,60 @@
 namespace Illuminate\Database\Eloquent;
 
 use RuntimeException;
+use Throwable;
 
 class MassAssignmentException extends RuntimeException
 {
-    //
+    /**
+     * The affected key.
+     *
+     * @var string
+     */
+    private string $key;
+
+    /**
+     * The affected Eloquent model class.
+     *
+     * @var string
+     */
+    private string $class;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  string  $key
+     * @param  string  $class
+     * @param  int  $code
+     * @param  \Throwable|null  $previous
+     *
+     */
+    public function __construct(string $key, string $class, int $code = 0, ?Throwable $previous = null)
+    {
+        $this->key = $key;
+        $this->class = $class;
+
+        $message = "Add [{$key}] to fillable property to allow mass assignment on [{$class}].";
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Get the affected key.
+     *
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Get the affected Eloquent model class.
+     *
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent;
 
 use RuntimeException;
-use Throwable;
 
 class MassAssignmentException extends RuntimeException
 {
@@ -12,36 +11,35 @@ class MassAssignmentException extends RuntimeException
      *
      * @var array
      */
-    private array $keys;
+    protected array $keys;
 
     /**
      * The affected Eloquent model class.
      *
      * @var string
      */
-    private string $class;
+    protected string $class;
 
     /**
      * Create a new exception instance.
      *
      * @param  array|string  $keys
      * @param  object  $model
-     * @param  int  $code
-     * @param  \Throwable|null  $previous
-     * @return void
+     * @return static
      */
-    public function __construct(array|string $keys, object $model, int $code = 0, ?Throwable $previous = null)
+    public static function make(array|string $keys, object $model): static
     {
-        $keysCollection = collect($keys)->unique()->sort()->values();
-        $this->keys = $keysCollection->all();
-        $this->class = get_class($model);
+        $properties = collect($keys)->unique()->sort()->values();
 
-        $message = sprintf(
+        $instance = new static;
+        $instance->keys = $properties->all();
+        $instance->class = $model::class;
+        $instance->message = sprintf(
             "Add [%s] to fillable property to allow mass assignment on [%s].",
-            $keysCollection->implode(', '), $this->class
+            $properties->implode(', '), $model::class
         );
 
-        parent::__construct($message, $code, $previous);
+        return $instance;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -25,20 +25,20 @@ class MassAssignmentException extends RuntimeException
      * Create a new exception instance.
      *
      * @param  array|string  $keys
-     * @param  string  $class
+     * @param  object  $model
      * @param  int  $code
      * @param  \Throwable|null  $previous
      * @return void
      */
-    public function __construct(array|string $keys, string $class, int $code = 0, ?Throwable $previous = null)
+    public function __construct(array|string $keys, object $model, int $code = 0, ?Throwable $previous = null)
     {
         $keysCollection = collect($keys)->unique()->sort()->values();
         $this->keys = $keysCollection->all();
-        $this->class = $class;
+        $this->class = get_class($model);
 
         $message = sprintf(
             "Add [%s] to fillable property to allow mass assignment on [%s].",
-            $keysCollection->implode(', '), $class
+            $keysCollection->implode(', '), $this->class
         );
 
         parent::__construct($message, $code, $previous);

--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -8,11 +8,11 @@ use Throwable;
 class MassAssignmentException extends RuntimeException
 {
     /**
-     * The affected key.
+     * The affected keys.
      *
-     * @var string
+     * @var array
      */
-    private string $key;
+    private array $keys;
 
     /**
      * The affected Eloquent model class.
@@ -24,30 +24,34 @@ class MassAssignmentException extends RuntimeException
     /**
      * Create a new exception instance.
      *
-     * @param  string  $key
+     * @param  array|string  $keys
      * @param  string  $class
      * @param  int  $code
      * @param  \Throwable|null  $previous
-     *
+     * @return void
      */
-    public function __construct(string $key, string $class, int $code = 0, ?Throwable $previous = null)
+    public function __construct(array|string $keys, string $class, int $code = 0, ?Throwable $previous = null)
     {
-        $this->key = $key;
+        $keysCollection = collect($keys)->unique()->sort()->values();
+        $this->keys = $keysCollection->all();
         $this->class = $class;
 
-        $message = "Add [{$key}] to fillable property to allow mass assignment on [{$class}].";
+        $message = sprintf(
+            "Add [%s] to fillable property to allow mass assignment on [%s].",
+            $keysCollection->implode(', '), $class
+        );
 
         parent::__construct($message, $code, $previous);
     }
 
     /**
-     * Get the affected key.
+     * Get the affected keys.
      *
-     * @return string
+     * @return array
      */
-    public function getKey(): string
+    public function getKeys(): array
     {
-        return $this->key;
+        return $this->keys;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -35,7 +35,7 @@ class MassAssignmentException extends RuntimeException
         $instance->keys = $properties->all();
         $instance->class = $model::class;
         $instance->message = sprintf(
-            "Add [%s] to fillable property to allow mass assignment on [%s].",
+            'Add [%s] to fillable property to allow mass assignment on [%s].',
             $properties->implode(', '), $model::class
         );
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -540,10 +540,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 if (isset(static::$discardedAttributeViolationCallback)) {
                     call_user_func(static::$discardedAttributeViolationCallback, $this, [$key]);
                 } else {
-                    throw new MassAssignmentException(sprintf(
-                        'Add [%s] to fillable property to allow mass assignment on [%s].',
-                        $key, get_class($this)
-                    ));
+                    throw new MassAssignmentException($key, get_class($this));
                 }
             }
         }
@@ -555,11 +552,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             if (isset(static::$discardedAttributeViolationCallback)) {
                 call_user_func(static::$discardedAttributeViolationCallback, $this, $keys);
             } else {
-                throw new MassAssignmentException(sprintf(
-                    'Add fillable property [%s] to allow mass assignment on [%s].',
-                    implode(', ', $keys),
-                    get_class($this)
-                ));
+                throw new MassAssignmentException(implode(', ', $keys), get_class($this));
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -559,7 +559,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         if (count($guarded) > 0) {
-            throw new MassAssignmentException($guarded, get_class($this));
+            throw new MassAssignmentException($guarded, $this);
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -559,7 +559,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         if (count($guarded) > 0) {
-            throw new MassAssignmentException($guarded, $this);
+            throw MassAssignmentException::make($guarded, $this);
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -530,6 +530,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $fillable = $this->fillableFromArray($attributes);
 
+        $guarded = [];
+
         foreach ($fillable as $key => $value) {
             // The developers may choose to place some attributes in the "fillable" array
             // which means only those attributes may be set through mass assignment to
@@ -540,7 +542,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 if (isset(static::$discardedAttributeViolationCallback)) {
                     call_user_func(static::$discardedAttributeViolationCallback, $this, [$key]);
                 } else {
-                    throw new MassAssignmentException($key, get_class($this));
+                    $guarded[] = $key;
                 }
             }
         }
@@ -552,8 +554,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             if (isset(static::$discardedAttributeViolationCallback)) {
                 call_user_func(static::$discardedAttributeViolationCallback, $this, $keys);
             } else {
-                throw new MassAssignmentException(implode(', ', $keys), get_class($this));
+                $guarded = array_merge($guarded, $keys);
             }
+        }
+
+        if (count($guarded) > 0) {
+            throw new MassAssignmentException($guarded, get_class($this));
         }
 
         return $this;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1599,13 +1599,14 @@ class DatabaseEloquentModelTest extends TestCase
 
         Model::preventSilentlyDiscardingAttributes();
 
-        $exception = new MassAssignmentException(['Foo', 'Bar'], EloquentModelStub::class);
+        $model = new EloquentModelStub;
+
+        $exception = new MassAssignmentException(['Foo', 'Bar'], $model);
         $this->assertSame(['Bar', 'Foo'], $exception->getKeys());
         $this->assertSame(EloquentModelStub::class, $exception->getClass());
         $this->assertSame('Add [Bar, Foo] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
         $this->expectExceptionObject($exception);
 
-        $model = new EloquentModelStub;
         $model->guard(['name', 'age']);
         $model->fill(['Foo' => 'bar', 'Bar' => 'baz']);
 
@@ -1653,14 +1654,14 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testGlobalGuarded(): void
     {
-        $exception = new MassAssignmentException(['name', 'age', 'votes'], EloquentModelStub::class);
+        $model = new EloquentModelStub;
+
+        $exception = new MassAssignmentException(['name', 'age', 'votes'], $model);
         $this->assertSame(['age', 'name', 'votes'], $exception->getKeys());
         $this->assertSame(EloquentModelStub::class, $exception->getClass());
         $this->assertSame('Add [age, name, votes] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
         $this->expectExceptionObject($exception);
 
-
-        $model = new EloquentModelStub;
         $model->guard(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'votes' => 'baz']);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -10,7 +10,6 @@ use Foo\Bar\EloquentModelNamespacedStub;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
@@ -41,7 +40,6 @@ use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
@@ -1601,15 +1599,15 @@ class DatabaseEloquentModelTest extends TestCase
 
         Model::preventSilentlyDiscardingAttributes();
 
-        $exception = new MassAssignmentException('Foo', EloquentModelStub::class);
-        $this->assertSame('Foo', $exception->getKey());
+        $exception = new MassAssignmentException(['Foo', 'Bar'], EloquentModelStub::class);
+        $this->assertSame(['Bar', 'Foo'], $exception->getKeys());
         $this->assertSame(EloquentModelStub::class, $exception->getClass());
-        $this->assertSame('Add [Foo] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
+        $this->assertSame('Add [Bar, Foo] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
         $this->expectExceptionObject($exception);
 
         $model = new EloquentModelStub;
         $model->guard(['name', 'age']);
-        $model->fill(['Foo' => 'bar']);
+        $model->fill(['Foo' => 'bar', 'Bar' => 'baz']);
 
         Model::preventSilentlyDiscardingAttributes(false);
     }
@@ -1655,10 +1653,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testGlobalGuarded(): void
     {
-        $exception = new MassAssignmentException('name', EloquentModelStub::class);
-        $this->assertSame('name', $exception->getKey());
+        $exception = new MassAssignmentException(['name', 'age', 'votes'], EloquentModelStub::class);
+        $this->assertSame(['age', 'name', 'votes'], $exception->getKeys());
         $this->assertSame(EloquentModelStub::class, $exception->getClass());
-        $this->assertSame('Add [name] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
+        $this->assertSame('Add [age, name, votes] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
         $this->expectExceptionObject($exception);
 
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1601,7 +1601,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model = new EloquentModelStub;
 
-        $exception = new MassAssignmentException(['Foo', 'Bar'], $model);
+        $exception = MassAssignmentException::make(['Foo', 'Bar'], $model);
         $this->assertSame(['Bar', 'Foo'], $exception->getKeys());
         $this->assertSame(EloquentModelStub::class, $exception->getClass());
         $this->assertSame('Add [Bar, Foo] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());
@@ -1656,7 +1656,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
 
-        $exception = new MassAssignmentException(['name', 'age', 'votes'], $model);
+        $exception = MassAssignmentException::make(['name', 'age', 'votes'], $model);
         $this->assertSame(['age', 'name', 'votes'], $exception->getKeys());
         $this->assertSame(EloquentModelStub::class, $exception->getClass());
         $this->assertSame('Add [age, name, votes] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].', $exception->getMessage());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR aims is to update the way MassAssignmentException works.

- [x] Let MassAssignmentException support multiple guarded attributes
- [x] Let MassAssignmentException support one or many attributes
- [x] Let MassAssignmentException support passing the impacted model instead of the class name.
