### PR TITLE
Add Application::removeDeferredServices method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1477,6 +1477,19 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Remove an array of services from the application's deferred services.
+     *
+     * @param  array  $services
+     * @return void
+     */
+    public function removeDeferredServices(array $services)
+    {
+        foreach ($services as $service) {
+            unset($this->deferredServices[$service]);
+        }
+    }
+
+    /**
      * Determine if the given service is a deferred service.
      *
      * @param  string  $service

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1466,6 +1466,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Determine if the given service is a deferred service.
+     *
+     * @param  string  $service
+     * @return bool
+     */
+    public function isDeferredService($service)
+    {
+        return isset($this->deferredServices[$service]);
+    }
+
+    /**
      * Add an array of services to the application's deferred services.
      *
      * @param  array  $services
@@ -1487,17 +1498,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
         foreach ($services as $service) {
             unset($this->deferredServices[$service]);
         }
-    }
-
-    /**
-     * Determine if the given service is a deferred service.
-     *
-     * @param  string  $service
-     * @return bool
-     */
-    public function isDeferredService($service)
-    {
-        return isset($this->deferredServices[$service]);
     }
 
     /**


### PR DESCRIPTION
This PR adds the `Application::removeDeferredServices()` method. The `Application` class already has a series of methods for interacting with deferred services:

- `getDeferredServices()` - Get all deferred services
- `setDeferredServices(array $services)` - Overwrite all deferred services
- `addDeferredServices(array $services)` - Merge an array of services into the current deferred services
- `isDeferredService(string $service)` - Determine if a service is deferred

Currently, if you wanted to remove a service from the deferred service list, you'd have to do something like so:

```php
$deferredServices = $app->getDeferredServices();

unset($deferredServices['auth.password'], $deferredServices['auth.password.broker']);

$app->setDeferredServices($deferredServices);
```

This is real code I currently have in a package. This PR adds what I consider to be a missing method, which replaces the above code with the following:

```php
$app->removeDeferredServices(['auth.password', 'auth.password.broker']);
```

I appreciate that this is an obscure use case, but I figured it's worth a PR for such a simpler method with very little overhead and a tiny footprint.

From my use case, I'm providing a custom binding for `auth.password ` and `auth.password.broker`, which I'm aware will be hit before those deferred services are overridden. This is simply a way to tidy up, and prevent rare edge cases where they end up being loaded after I've overridden.