### PR TITLE
Fix typo in Translator code comment

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -118,7 +118,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $locale = $locale ?: $this->locale;
 
         // We should temporarily disable the handling of missing translation keys
-        // while perfroming the existence check. After the check, we will turn
+        // while performing the existence check. After the check, we will turn
         // the missing translation keys handling back to its original value.
         $handleMissingTranslationKeys = $this->handleMissingTranslationKeys;
 


### PR DESCRIPTION
Fixes `perfroming` => `performing`