### PR TITLE
[11.x] Handle HtmlString constructed with a null

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -42,7 +42,7 @@ class HtmlString implements Htmlable, Stringable
      */
     public function isEmpty()
     {
-        return $this->html === '';
+        return ($this->html ?? '') === '';
     }
 
     /**
@@ -62,6 +62,6 @@ class HtmlString implements Htmlable, Stringable
      */
     public function __toString()
     {
-        return $this->toHtml();
+        return $this->toHtml() ?? '';
     }
 }

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -39,12 +39,19 @@ class SupportHtmlStringTest extends TestCase
         $str = '<h1>foo</h1>';
         $html = new HtmlString('<h1>foo</h1>');
         $this->assertEquals($str, (string) $html);
+
+        // Check if HtmlString gracefully handles a null value
+        $html = new HtmlString(null);
+        $this->assertIsString((string) $html);
     }
 
     public function testIsEmpty(): void
     {
         // Check if HtmlString correctly identifies an empty string as empty
         $this->assertTrue((new HtmlString(''))->isEmpty());
+
+        // Check if HtmlString identifies a null value as empty
+        $this->assertTrue((new HtmlString(null))->isEmpty());
 
         // HtmlString with whitespace should not be considered as empty
         $this->assertFalse((new HtmlString('   '))->isEmpty());


### PR DESCRIPTION
I managed to construct an `HtmlString` with a `null` value. I realise that inserting a `null` value into an `HtmlString` is pretty bad and I should have sanitized the value properly beforehand.

However, since this is possible, I believe that the `__toString()` and `isEmpty` methods should gracefully handle `null` values. This will prevent a type error exception when getting the string value and correctly reflect that the `HtmlString` is empty.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
