### PR TITLE
[11.x]  Introduce `Support\Url` and `Support\UrlQueryParameters` classes for easier URL handling

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Url;
 use InvalidArgumentException;
 use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
 use League\Flysystem\FilesystemOperator;
@@ -790,12 +791,12 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function replaceBaseUrl($uri, $url)
     {
-        $parsed = parse_url($url);
+        $parsed = Url::parse($url);
 
         return $uri
-            ->withScheme($parsed['scheme'])
-            ->withHost($parsed['host'])
-            ->withPort($parsed['port'] ?? null);
+            ->withScheme($parsed->scheme)
+            ->withHost($parsed->host)
+            ->withPort($parsed->port);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
+use Illuminate\Support\Url;
 
 class SetRequestForConsole
 {
@@ -17,14 +18,14 @@ class SetRequestForConsole
     {
         $uri = $app->make('config')->get('app.url', 'http://localhost');
 
-        $components = parse_url($uri);
+        $components = Url::parse($uri);
 
         $server = $_SERVER;
 
-        if (isset($components['path'])) {
+        if ($components->path) {
             $server = array_merge($server, [
-                'SCRIPT_FILENAME' => $components['path'],
-                'SCRIPT_NAME' => $components['path'],
+                'SCRIPT_FILENAME' => $components->path,
+                'SCRIPT_NAME' => $components->path,
             ]);
         }
 

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Url implements Arrayable
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        public $scheme = null,
+        public $host = null,
+        public $port = null,
+        public $user = null,
+        public $pass = null,
+        public $path = null,
+        public $query = null,
+        public $fragment = null,
+    ) {}
+
+    /**
+     * Parse a URL string into a URL object.
+     *
+     * @param  string  $url
+     *
+     * @return static
+     */
+    public static function parse($url)
+    {
+        $components = parse_url($url) ?? [];
+
+        return new static(
+            $components['scheme'] ?? null,
+            $components['host'] ?? null,
+            $components['port'] ?? null,
+            $components['user'] ?? null,
+            $components['pass'] ?? null,
+            $components['path'] ?? null,
+            $components['query'] ?? null,
+            $components['fragment'] ?? null,
+        );
+    }
+
+    /**
+     * Get the URL query parameters.
+     *
+     * @return \Illuminate\Support\UrlQueryParameters
+     */
+    public function query()
+    {
+        return UrlQueryParameters::parse($this->query);
+    }
+
+    /**
+     * Convert the URL object to an array.
+     *
+     * @return array<string, string|null>
+     */
+    public function toArray()
+    {
+        return [
+            'scheme' => $this->scheme,
+            'host' => $this->host,
+            'port' => $this->port,
+            'user' => $this->user,
+            'pass' => $this->pass,
+            'path' => $this->path,
+            'query' => $this->query,
+            'fragment' => $this->fragment,
+        ];
+    }
+}

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -10,14 +10,14 @@ class Url implements Arrayable
      * Constructor.
      */
     public function __construct(
-        public $scheme = null,
-        public $host = null,
-        public $port = null,
-        public $user = null,
-        public $pass = null,
-        public $path = null,
-        public $query = null,
-        public $fragment = null,
+        public ?string $scheme = null,
+        public ?string $host = null,
+        public ?string $port = null,
+        public ?string $user = null,
+        public ?string $pass = null,
+        public ?string $path = null,
+        public ?string $query = null,
+        public ?string $fragment = null,
     ) {
     }
 
@@ -27,7 +27,7 @@ class Url implements Arrayable
      * @param  string  $url
      * @return static
      */
-    public static function parse($url)
+    public static function parse(string $url): static
     {
         $components = parse_url($url) ?? [];
 
@@ -48,7 +48,7 @@ class Url implements Arrayable
      *
      * @return \Illuminate\Support\UrlQueryParameters
      */
-    public function query()
+    public function query(): UrlQueryParameters
     {
         return UrlQueryParameters::parse($this->query);
     }
@@ -58,7 +58,7 @@ class Url implements Arrayable
      *
      * @return array<string, string|null>
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'scheme' => $this->scheme,

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support;
 
-use Stringable;
 use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
 
 class Url implements Arrayable, Stringable
 {
@@ -83,13 +83,13 @@ class Url implements Arrayable, Stringable
         $url = '';
 
         if ($this->scheme) {
-            $url .= $this->scheme . ':';
+            $url .= $this->scheme.':';
         }
 
         $url .= '//';
 
         if ($this->user) {
-            $url .= $this->user . ($this->pass ? ':' . $this->pass : '') . '@';
+            $url .= $this->user.($this->pass ? ':'.$this->pass : '').'@';
         }
 
         if ($this->host) {
@@ -97,7 +97,7 @@ class Url implements Arrayable, Stringable
         }
 
         if ($this->port) {
-            $url .= ':' . $this->port;
+            $url .= ':'.$this->port;
         }
 
         if ($this->path) {
@@ -105,11 +105,11 @@ class Url implements Arrayable, Stringable
         }
 
         if ($this->query) {
-            $url .= '?' . $this->query;
+            $url .= '?'.$this->query;
         }
 
         if ($this->fragment) {
-            $url .= '#' . $this->fragment;
+            $url .= '#'.$this->fragment;
         }
 
         return $url;

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -15,6 +15,7 @@ class Url implements Arrayable, Stringable
         public ?string $host = null,
         public ?int $port = null,
         public ?string $user = null,
+        #[\SensitiveParameter]
         public ?string $pass = null,
         public ?string $path = null,
         public ?UrlQueryParameters $query = null,

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -13,13 +13,14 @@ class Url implements Arrayable, Stringable
     public function __construct(
         public ?string $scheme = null,
         public ?string $host = null,
-        public ?string $port = null,
+        public ?int $port = null,
         public ?string $user = null,
         public ?string $pass = null,
         public ?string $path = null,
-        public ?string $query = null,
+        public ?UrlQueryParameters $query = null,
         public ?string $fragment = null,
     ) {
+        $this->query ??= new UrlQueryParameters;
     }
 
     /**
@@ -30,28 +31,23 @@ class Url implements Arrayable, Stringable
      */
     public static function parse(string $url): static
     {
-        $components = parse_url($url) ?? [];
+        $components = parse_url($url) ?: [];
 
-        return new static(
-            $components['scheme'] ?? null,
-            $components['host'] ?? null,
-            $components['port'] ?? null,
-            $components['user'] ?? null,
-            $components['pass'] ?? null,
-            $components['path'] ?? null,
-            $components['query'] ?? null,
-            $components['fragment'] ?? null,
-        );
+        if (isset($components['query'])) {
+            $components['query'] = static::query($components['query']);
+        }
+
+        return new static(...$components);
     }
 
     /**
-     * Get the URL query parameters.
+     * Parse URL query parameters.
      *
      * @return \Illuminate\Support\UrlQueryParameters
      */
-    public function query(): UrlQueryParameters
+    protected static function query(?string $query): UrlQueryParameters
     {
-        return UrlQueryParameters::parse($this->query);
+        return UrlQueryParameters::parse($query);
     }
 
     /**
@@ -68,7 +64,7 @@ class Url implements Arrayable, Stringable
             'user' => $this->user,
             'pass' => $this->pass,
             'path' => $this->path,
-            'query' => $this->query,
+            'query' => (string) $this->query,
             'fragment' => $this->fragment,
         ];
     }

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Support;
 
+use Stringable;
 use Illuminate\Contracts\Support\Arrayable;
 
-class Url implements Arrayable
+class Url implements Arrayable, Stringable
 {
     /**
      * Constructor.
@@ -70,5 +71,47 @@ class Url implements Arrayable
             'query' => $this->query,
             'fragment' => $this->fragment,
         ];
+    }
+
+    /**
+     * Convert the URL object to a string.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        $url = '';
+
+        if ($this->scheme) {
+            $url .= $this->scheme . ':';
+        }
+
+        $url .= '//';
+
+        if ($this->user) {
+            $url .= $this->user . ($this->pass ? ':' . $this->pass : '') . '@';
+        }
+
+        if ($this->host) {
+            $url .= $this->host;
+        }
+
+        if ($this->port) {
+            $url .= ':' . $this->port;
+        }
+
+        if ($this->path) {
+            $url .= $this->path;
+        }
+
+        if ($this->query) {
+            $url .= '?' . $this->query;
+        }
+
+        if ($this->fragment) {
+            $url .= '#' . $this->fragment;
+        }
+
+        return $url;
     }
 }

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
+use RuntimeException;
 use Stringable;
 
 class Url implements Arrayable, Stringable
@@ -31,7 +32,11 @@ class Url implements Arrayable, Stringable
      */
     public static function parse(string $url): static
     {
-        $components = parse_url($url) ?: [];
+        $components = parse_url($url);
+
+        if ($components === false) {
+            throw new RuntimeException("Invalid URL [$url].");
+        }
 
         if (isset($components['query'])) {
             $components['query'] = static::query($components['query']);

--- a/src/Illuminate/Support/Url.php
+++ b/src/Illuminate/Support/Url.php
@@ -18,13 +18,13 @@ class Url implements Arrayable
         public $path = null,
         public $query = null,
         public $fragment = null,
-    ) {}
+    ) {
+    }
 
     /**
      * Parse a URL string into a URL object.
      *
      * @param  string  $url
-     *
      * @return static
      */
     public static function parse($url)

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Support;
+use Illuminate\Contracts\Support\Arrayable;
+
+class UrlQueryParameters implements Arrayable
+{
+    /**
+     * Constructor.
+     *
+     * @param  array  $parameters
+     * @return void
+     */
+    public function __construct(
+        protected array $parameters = []
+    ) {
+    }
+
+    /**
+     * Parse a query string.
+     *
+     * @param  string|null  $query
+     *
+     * @return static
+     */
+    public static function parse($query)
+    {
+        if (is_null($query)) {
+            return new static;
+        }
+
+        parse_str(
+            Str::of(urldecode($query))
+                ->replaceStart('?', '')
+                ->toString(),
+            $params
+        );
+
+        return new static($params);
+    }
+
+    /**
+     * Get a parameter value.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return $this->parameters[$key] ?? $default;
+    }
+
+    /**
+     * Check if a parameter exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return isset($this->parameters[$key]);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray()
+    {
+        return $this->parameters;
+    }
+}
+

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -80,12 +80,6 @@ class UrlQueryParameters implements Arrayable, Stringable
      */
     public function __toString(): string
     {
-        $parameters = [];
-
-        foreach ($this->parameters as $key => $value) {
-            $parameters[] = $key.'='.$value;
-        }
-
-        return implode('&', $parameters);
+        return http_build_query($this->parameters);
     }
 }

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -33,7 +33,7 @@ class UrlQueryParameters implements Arrayable, ArrayAccess, Stringable
 
         parse_str(
             Str::of($query)
-                ->replaceStart('?', '')
+                ->chopStart('?')
                 ->toString(),
             $parameters
         );

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support;
 
-use Stringable;
 use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
 
 class UrlQueryParameters implements Arrayable, Stringable
 {

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Support;
 
-use Stringable;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
 
 class UrlQueryParameters implements Arrayable, ArrayAccess, Stringable
 {

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Support;
 
+use Stringable;
 use Illuminate\Contracts\Support\Arrayable;
 
-class UrlQueryParameters implements Arrayable
+class UrlQueryParameters implements Arrayable, Stringable
 {
     /**
      * Constructor.
@@ -70,5 +71,21 @@ class UrlQueryParameters implements Arrayable
     public function toArray(): array
     {
         return $this->parameters;
+    }
+
+    /**
+     * Convert the query parameters to a string.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        $parameters = [];
+
+        foreach ($this->parameters as $key => $value) {
+            $parameters[] = $key.'='.$value;
+        }
+
+        return implode('&', $parameters);
     }
 }

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Support;
+
 use Illuminate\Contracts\Support\Arrayable;
 
 class UrlQueryParameters implements Arrayable
@@ -71,4 +72,3 @@ class UrlQueryParameters implements Arrayable
         return $this->parameters;
     }
 }
-

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -20,7 +20,6 @@ class UrlQueryParameters implements Arrayable
      * Parse a query string.
      *
      * @param  string|null  $query
-     *
      * @return static
      */
     public static function parse($query)

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -31,7 +31,7 @@ class UrlQueryParameters implements Arrayable, Stringable
         }
 
         parse_str(
-            Str::of(urldecode($query))
+            Str::of($query)
                 ->replaceStart('?', '')
                 ->toString(),
             $params

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -80,6 +80,6 @@ class UrlQueryParameters implements Arrayable, Stringable
      */
     public function __toString(): string
     {
-        return http_build_query($this->parameters);
+        return Arr::query($this->parameters);
     }
 }

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -2,15 +2,16 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Stringable;
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
 
-class UrlQueryParameters implements Arrayable, Stringable
+class UrlQueryParameters implements Arrayable, ArrayAccess, Stringable
 {
     /**
      * Constructor.
      *
-     * @param  array  $parameters
+     * @param  array<string, string>  $parameters
      * @return void
      */
     public function __construct(
@@ -34,10 +35,10 @@ class UrlQueryParameters implements Arrayable, Stringable
             Str::of($query)
                 ->replaceStart('?', '')
                 ->toString(),
-            $params
+            $parameters
         );
 
-        return new static($params);
+        return new static($parameters);
     }
 
     /**
@@ -53,6 +54,45 @@ class UrlQueryParameters implements Arrayable, Stringable
     }
 
     /**
+     * Set a parameter value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function set(string $key, string $value): static
+    {
+        $this->parameters[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Remove a parameter.
+     *
+     * @param  string  $key
+     * @return $this
+     */
+    public function forget(string $key): static
+    {
+        unset($this->parameters[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Clear all parameters.
+     *
+     * @return $this
+     */
+    public function clear(): static
+    {
+        $this->parameters = [];
+
+        return $this;
+    }
+
+    /**
      * Check if a parameter exists.
      *
      * @param  string  $key
@@ -64,13 +104,33 @@ class UrlQueryParameters implements Arrayable, Stringable
     }
 
     /**
-     * Get the instance as an array.
+     * Get all parameters.
      *
      * @return array<string, mixed>
      */
-    public function toArray(): array
+    public function all(): array
     {
         return $this->parameters;
+    }
+
+    /**
+     * Determine if the parameters are empty.
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->parameters);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return $this->all();
     }
 
     /**
@@ -81,5 +141,50 @@ class UrlQueryParameters implements Arrayable, Stringable
     public function __toString(): string
     {
         return Arr::query($this->parameters);
+    }
+
+    /**
+     * Determine if a parameter exists.
+     *
+     * @param  mixed  $offset
+     * @return bool
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->parameters[$offset]);
+    }
+
+    /**
+     * Get a parameter value.
+     *
+     * @param  mixed  $offset
+     * @return mixed
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->parameters[$offset];
+    }
+
+    /**
+     * Set a parameter value.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->parameters[$offset] = $value;
+    }
+
+    /**
+     * Remove a parameter.
+     *
+     * @param  mixed  $offset
+     * @return void
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->parameters[$offset]);
     }
 }

--- a/src/Illuminate/Support/UrlQueryParameters.php
+++ b/src/Illuminate/Support/UrlQueryParameters.php
@@ -23,7 +23,7 @@ class UrlQueryParameters implements Arrayable
      * @param  string|null  $query
      * @return static
      */
-    public static function parse($query)
+    public static function parse(?string $query): static
     {
         if (is_null($query)) {
             return new static;
@@ -46,7 +46,7 @@ class UrlQueryParameters implements Arrayable
      * @param  mixed  $default
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         return $this->parameters[$key] ?? $default;
     }
@@ -57,7 +57,7 @@ class UrlQueryParameters implements Arrayable
      * @param  string  $key
      * @return bool
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         return isset($this->parameters[$key]);
     }
@@ -67,7 +67,7 @@ class UrlQueryParameters implements Arrayable
      *
      * @return array<string, mixed>
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->parameters;
     }

--- a/tests/Support/UrlQueryParametersTest.php
+++ b/tests/Support/UrlQueryParametersTest.php
@@ -34,10 +34,10 @@ class UrlQueryParametersTest extends TestCase
 
     public function testParseWithEncodedCharacters()
     {
-        $params = UrlQueryParameters::parse('foo=bar%20baz');
+        $params = UrlQueryParameters::parse('test=1%2B2');
 
         $this->assertInstanceOf(UrlQueryParameters::class, $params);
-        $this->assertSame('bar baz', $params->get('foo'));
+        $this->assertSame('1+2', $params->get('test'));
     }
 
     public function testGet()

--- a/tests/Support/UrlQueryParametersTest.php
+++ b/tests/Support/UrlQueryParametersTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\UrlQueryParameters;
+use PHPUnit\Framework\TestCase;
 
 class UrlQueryParametersTest extends TestCase
 {
@@ -61,7 +61,7 @@ class UrlQueryParametersTest extends TestCase
     {
         $params = new UrlQueryParameters([
             'foo' => 'bar',
-            'baz' => 'qux'
+            'baz' => 'qux',
         ]);
 
         $this->assertSame([

--- a/tests/Support/UrlQueryParametersTest.php
+++ b/tests/Support/UrlQueryParametersTest.php
@@ -69,4 +69,14 @@ class UrlQueryParametersTest extends TestCase
             'baz' => 'qux',
         ], $params->toArray());
     }
+
+    public function testToString()
+    {
+        $params = new UrlQueryParameters([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+
+        $this->assertSame('foo=bar&baz=qux', (string) $params);
+    }
 }

--- a/tests/Support/UrlQueryParametersTest.php
+++ b/tests/Support/UrlQueryParametersTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\UrlQueryParameters;
+
+class UrlQueryParametersTest extends TestCase
+{
+    public function testParse()
+    {
+        $params = UrlQueryParameters::parse('foo=bar&baz=qux');
+
+        $this->assertInstanceOf(UrlQueryParameters::class, $params);
+        $this->assertSame('bar', $params->get('foo'));
+        $this->assertSame('qux', $params->get('baz'));
+    }
+
+    public function testParseWithEmptyString()
+    {
+        $params = UrlQueryParameters::parse('');
+
+        $this->assertInstanceOf(UrlQueryParameters::class, $params);
+        $this->assertEmpty($params->toArray());
+    }
+
+    public function testParseWithNull()
+    {
+        $params = UrlQueryParameters::parse(null);
+
+        $this->assertInstanceOf(UrlQueryParameters::class, $params);
+        $this->assertEmpty($params->toArray());
+    }
+
+    public function testParseWithEncodedCharacters()
+    {
+        $params = UrlQueryParameters::parse('foo=bar%20baz');
+
+        $this->assertInstanceOf(UrlQueryParameters::class, $params);
+        $this->assertSame('bar baz', $params->get('foo'));
+    }
+
+    public function testGet()
+    {
+        $params = new UrlQueryParameters(['foo' => 'bar']);
+
+        $this->assertSame('bar', $params->get('foo'));
+        $this->assertNull($params->get('baz'));
+        $this->assertSame('default', $params->get('baz', 'default'));
+    }
+
+    public function testHas()
+    {
+        $params = new UrlQueryParameters(['foo' => 'bar']);
+
+        $this->assertTrue($params->has('foo'));
+        $this->assertFalse($params->has('baz'));
+    }
+
+    public function testToArray()
+    {
+        $params = new UrlQueryParameters([
+            'foo' => 'bar',
+            'baz' => 'qux'
+        ]);
+
+        $this->assertSame([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ], $params->toArray());
+    }
+}

--- a/tests/Support/UrlQueryParametersTest.php
+++ b/tests/Support/UrlQueryParametersTest.php
@@ -49,12 +49,80 @@ class UrlQueryParametersTest extends TestCase
         $this->assertSame('default', $params->get('baz', 'default'));
     }
 
+    public function testSet()
+    {
+        $params = new UrlQueryParameters(['foo' => 'bar']);
+
+        $params->set('baz', 'qux');
+
+        $this->assertSame('qux', $params->get('baz'));
+    }
+
+    public function testForget()
+    {
+        $params = new UrlQueryParameters(['foo' => 'bar']);
+
+        $params->forget('foo');
+
+        $this->assertNull($params->get('foo'));
+    }
+
+    public function testClear()
+    {
+        $params = new UrlQueryParameters(['foo' => 'bar']);
+
+        $params->clear();
+
+        $this->assertEmpty($params->toArray());
+    }
+
     public function testHas()
     {
         $params = new UrlQueryParameters(['foo' => 'bar']);
 
         $this->assertTrue($params->has('foo'));
         $this->assertFalse($params->has('baz'));
+    }
+
+    public function testAll()
+    {
+        $params = new UrlQueryParameters([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+
+        $this->assertSame([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ], $params->all());
+    }
+
+    public function testIsEmpty()
+    {
+        $params = new UrlQueryParameters;
+
+        $this->assertTrue($params->isEmpty());
+
+        $params = new UrlQueryParameters(['foo' => 'bar']);
+
+        $this->assertFalse($params->isEmpty());
+    }
+
+    public function testArrayAccess()
+    {
+        $params = new UrlQueryParameters([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+
+        $this->assertSame('bar', $params['foo']);
+        $this->assertSame('qux', $params['baz']);
+
+        $this->assertFalse(isset($params['zax']));
+
+        $params['zax'] = 'baz';
+
+        $this->assertSame('baz', $params['zax']);
     }
 
     public function testToArray()

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Url;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\UrlQueryParameters;
+use PHPUnit\Framework\TestCase;
 
 class UrlTest extends TestCase
 {

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -14,11 +14,11 @@ class UrlTest extends TestCase
 
         $this->assertSame('https', $url->scheme);
         $this->assertSame('example.com', $url->host);
-        $this->assertSame('8080', $url->port);
+        $this->assertSame(8080, $url->port);
         $this->assertSame('user', $url->user);
         $this->assertSame('pass', $url->pass);
         $this->assertSame('/path/to/resource', $url->path);
-        $this->assertSame('foo=bar&baz=qux', $url->query);
+        $this->assertSame('foo=bar&baz=qux', (string) $url->query);
         $this->assertSame('fragment', $url->fragment);
     }
 
@@ -40,9 +40,17 @@ class UrlTest extends TestCase
     {
         $url = Url::parse('https://example.com?foo=bar&baz=qux');
 
-        $this->assertInstanceOf(UrlQueryParameters::class, $url->query());
-        $this->assertSame('bar', $url->query()->get('foo'));
-        $this->assertSame('qux', $url->query()->get('baz'));
+        $this->assertInstanceOf(UrlQueryParameters::class, $url->query);
+
+        $this->assertSame('bar', $url->query->get('foo'));
+        $this->assertSame('qux', $url->query->get('baz'));
+        $this->assertSame(['foo' => 'bar', 'baz' => 'qux'], $url->query->all());
+
+        $url->query->forget('foo');
+        $url->query->set('baz', 'zax');
+
+        $this->assertSame('zax', $url->query->get('baz'));
+        $this->assertSame('baz=zax', (string) $url->query);
     }
 
     public function testToArray()
@@ -52,7 +60,7 @@ class UrlTest extends TestCase
         $this->assertSame([
             'scheme' => 'https',
             'host' => 'example.com',
-            'port' => '8080',
+            'port' => 8080,
             'user' => 'user',
             'pass' => 'pass',
             'path' => '/path/to/resource',
@@ -68,6 +76,6 @@ class UrlTest extends TestCase
         $url = Url::parse($rawUrl);
 
         $this->assertSame($rawUrl, (string) $url);
-        $this->assertSame('foo=bar&baz=qux', (string) $url->query());
+        $this->assertSame('foo=bar&baz=qux', (string) $url->query);
     }
 }

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -32,7 +32,7 @@ class UrlTest extends TestCase
         $this->assertNull($url->user);
         $this->assertNull($url->pass);
         $this->assertSame('/path/to/resource', $url->path);
-        $this->assertNull($url->query);
+        $this->assertInstanceOf(UrlQueryParameters::class, $url->query);
         $this->assertNull($url->fragment);
     }
 

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -14,7 +14,7 @@ class UrlTest extends TestCase
 
         $this->assertSame('https', $url->scheme);
         $this->assertSame('example.com', $url->host);
-        $this->assertSame(8080, $url->port);
+        $this->assertSame('8080', $url->port);
         $this->assertSame('user', $url->user);
         $this->assertSame('pass', $url->pass);
         $this->assertSame('/path/to/resource', $url->path);
@@ -52,7 +52,7 @@ class UrlTest extends TestCase
         $this->assertSame([
             'scheme' => 'https',
             'host' => 'example.com',
-            'port' => 8080,
+            'port' => '8080',
             'user' => 'user',
             'pass' => 'pass',
             'path' => '/path/to/resource',

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -60,4 +60,14 @@ class UrlTest extends TestCase
             'fragment' => 'fragment',
         ], $url->toArray());
     }
+
+    public function testToString()
+    {
+        $rawUrl = 'https://user:pass@example.com:8080/path/to/resource?foo=bar&baz=qux#fragment';
+
+        $url = Url::parse($rawUrl);
+
+        $this->assertSame($rawUrl, (string) $url);
+        $this->assertSame('foo=bar&baz=qux', (string) $url->query());
+    }
 }

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Url;
 use Illuminate\Support\UrlQueryParameters;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class UrlTest extends TestCase
 {
@@ -20,6 +21,16 @@ class UrlTest extends TestCase
         $this->assertSame('/path/to/resource', $url->path);
         $this->assertSame('foo=bar&baz=qux', (string) $url->query);
         $this->assertSame('fragment', $url->fragment);
+    }
+
+    public function testParseFailsWithMalformedUrl()
+    {
+        $url = '///**/foobar/**///';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Invalid URL [$url].");
+
+        Url::parse($url);
     }
 
     public function testParseWithMissingComponents()

--- a/tests/Support/UrlTest.php
+++ b/tests/Support/UrlTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Url;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\UrlQueryParameters;
+
+class UrlTest extends TestCase
+{
+    public function testParse()
+    {
+        $url = Url::parse('https://user:pass@example.com:8080/path/to/resource?foo=bar&baz=qux#fragment');
+
+        $this->assertSame('https', $url->scheme);
+        $this->assertSame('example.com', $url->host);
+        $this->assertSame(8080, $url->port);
+        $this->assertSame('user', $url->user);
+        $this->assertSame('pass', $url->pass);
+        $this->assertSame('/path/to/resource', $url->path);
+        $this->assertSame('foo=bar&baz=qux', $url->query);
+        $this->assertSame('fragment', $url->fragment);
+    }
+
+    public function testParseWithMissingComponents()
+    {
+        $url = Url::parse('/path/to/resource');
+
+        $this->assertNull($url->scheme);
+        $this->assertNull($url->host);
+        $this->assertNull($url->port);
+        $this->assertNull($url->user);
+        $this->assertNull($url->pass);
+        $this->assertSame('/path/to/resource', $url->path);
+        $this->assertNull($url->query);
+        $this->assertNull($url->fragment);
+    }
+
+    public function testQuery()
+    {
+        $url = Url::parse('https://example.com?foo=bar&baz=qux');
+
+        $this->assertInstanceOf(UrlQueryParameters::class, $url->query());
+        $this->assertSame('bar', $url->query()->get('foo'));
+        $this->assertSame('qux', $url->query()->get('baz'));
+    }
+
+    public function testToArray()
+    {
+        $url = Url::parse('https://user:pass@example.com:8080/path/to/resource?foo=bar&baz=qux#fragment');
+
+        $this->assertSame([
+            'scheme' => 'https',
+            'host' => 'example.com',
+            'port' => 8080,
+            'user' => 'user',
+            'pass' => 'pass',
+            'path' => '/path/to/resource',
+            'query' => 'foo=bar&baz=qux',
+            'fragment' => 'fragment',
+        ], $url->toArray());
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces two new classes in the `Support` namespace to provide a more convenient way to work with URLs with an object-oriented representation using PHP's native `parse_url` and `parse_str` functions:

- `Illuminate\Support\Url`
- `Illuminate\Support\UrlQueryParameters`

I copy these same classes over from project to project as I usually end up needing them. I figured others may find these classes a more (IDE) friendly replacement to the existing `parse_url` and `parse_str` functions.

### Example

```php
use Illuminate\Support\Url;

// Parse a URL string
$url = Url::parse('https://example.com/path/to/resource?foo=bar&baz=qux');

// Access URL components
$scheme = $url->scheme; // 'https'
$host = $url->host; // 'example.com'
$path = $url->path; // '/path/to/resource'

// Work with query parameters
$queryParams = $url->query; // UrlQueryParameters
$foo = $queryParams->get('foo'); // 'bar'
$baz = $queryParams->get('baz'); // 'qux'
$default = $queryParams->get('bar', 'default'); // 'default'

// Check if a query parameter exists
$hasBar = $queryParams->has('bar'); // true

// Set a query parameter
$queryParams->set('foo', 'baz');

// Convert to array
$urlArray = $url->toArray(); // ['foo' => 'bar', 'baz' => 'qux']
```

Let me know your thoughts! 👍  No hard feelings on closure ❤️ 