### PR TITLE
Update docblock to correctly reflect return value of Model::delete()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1401,7 +1401,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Delete the model from the database.
      *
-     * @return bool|null
+     * @return bool
      *
      * @throws \LogicException
      */


### PR DESCRIPTION
The delete() method does not return null so I fixed the PHPDoc - this helps developers get a clear understanding of the actual return type.
