### PR TITLE
[11.x] Update `tap` dockblock for better IDE autocompletion 

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -369,7 +369,7 @@ if (! function_exists('tap')) {
      *
      * @param  TValue  $value
      * @param  (callable(TValue): mixed)|null  $callback
-     * @return ($callback is null ? \Illuminate\Support\HigherOrderTapProxy : TValue)
+     * @return TValue|\Illuminate\Support\HigherOrderTapProxy<TValue>
      */
     function tap($value, $callback = null)
     {


### PR DESCRIPTION
This PR enhances the type annotations for the `tap` helper function to improve IDE autocompletion and type inference. By introducing a union return type that covers both TValue and HigherOrderTapProxy<TValue>, this change allows IDEs to accurately infer the return type of tap in all usage scenarios.

![image](https://github.com/user-attachments/assets/82e06ba8-7299-44dd-9748-2f8d4fe1ed43)
