### PR TITLE
[11.x] Skip the number of connections transacting while testing to run callbacks

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -13,9 +13,11 @@ trait DatabaseTransactions
     {
         $database = $this->app->make('db');
 
-        $this->app->instance('db.transactions', $transactionsManager = new DatabaseTransactionsManager);
+        $connections = $this->connectionsToTransact();
 
-        foreach ($this->connectionsToTransact() as $name) {
+        $this->app->instance('db.transactions', $transactionsManager = new DatabaseTransactionsManager($connections));
+
+        foreach ($connections as $name) {
             $connection = $database->connection($name);
             $connection->setTransactionManager($transactionsManager);
             $dispatcher = $connection->getEventDispatcher();

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
@@ -7,12 +7,15 @@ use Illuminate\Database\DatabaseTransactionsManager as BaseManager;
 class DatabaseTransactionsManager extends BaseManager
 {
     /**
-     * A list with the names of connections transacting on tests to be skiped and run the callbacks correctly.
+     * The names of the connections transacting during tests.
      */
     protected array $connectionsTransacting;
 
     /**
-     * @param  array  $connectionsTransacting  The name of the connections transacting on tests (to skip for callbacks).
+     * Create a new database transaction manager instance.
+     *
+     * @param  array  $connectionsTransacting
+     * @return void
      */
     public function __construct(array $connectionsTransacting)
     {

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
@@ -7,6 +7,21 @@ use Illuminate\Database\DatabaseTransactionsManager as BaseManager;
 class DatabaseTransactionsManager extends BaseManager
 {
     /**
+     * Number of connections transacting on tests to be skiped and run the callbacks correctly.
+     */
+    protected int $connectionsTransacting = 1;
+
+    /**
+     * @param  int  $connectionsTransacting  Number of root connections transacting on tests (to skip for callbacks).
+     */
+    public function __construct(int $connectionsTransacting = 1)
+    {
+        parent::__construct();
+
+        $this->connectionsTransacting = $connectionsTransacting;
+    }
+
+    /**
      * Register a transaction callback.
      *
      * @param  callable  $callback
@@ -31,7 +46,7 @@ class DatabaseTransactionsManager extends BaseManager
      */
     public function callbackApplicableTransactions()
     {
-        return $this->pendingTransactions->skip(1)->values();
+        return $this->pendingTransactions->skip($this->connectionsTransacting)->values();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
@@ -7,14 +7,14 @@ use Illuminate\Database\DatabaseTransactionsManager as BaseManager;
 class DatabaseTransactionsManager extends BaseManager
 {
     /**
-     * Number of connections transacting on tests to be skiped and run the callbacks correctly.
+     * A list with the names of connections transacting on tests to be skiped and run the callbacks correctly.
      */
-    protected int $connectionsTransacting = 1;
+    protected array $connectionsTransacting;
 
     /**
-     * @param  int  $connectionsTransacting  Number of root connections transacting on tests (to skip for callbacks).
+     * @param  array  $connectionsTransacting  The name of the connections transacting on tests (to skip for callbacks).
      */
-    public function __construct(int $connectionsTransacting = 1)
+    public function __construct(array $connectionsTransacting)
     {
         parent::__construct();
 
@@ -46,7 +46,7 @@ class DatabaseTransactionsManager extends BaseManager
      */
     public function callbackApplicableTransactions()
     {
-        return $this->pendingTransactions->skip($this->connectionsTransacting)->values();
+        return $this->pendingTransactions->skip(count($this->connectionsTransacting))->values();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -84,7 +84,7 @@ trait RefreshDatabase
 
         $connections = $this->connectionsToTransact();
 
-        $this->app->instance('db.transactions', $transactionsManager = new DatabaseTransactionsManager(count($connections)));
+        $this->app->instance('db.transactions', $transactionsManager = new DatabaseTransactionsManager($connections));
 
         foreach ($connections as $name) {
             $connection = $database->connection($name);

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -82,9 +82,11 @@ trait RefreshDatabase
     {
         $database = $this->app->make('db');
 
-        $this->app->instance('db.transactions', $transactionsManager = new DatabaseTransactionsManager);
+        $connections = $this->connectionsToTransact();
 
-        foreach ($this->connectionsToTransact() as $name) {
+        $this->app->instance('db.transactions', $transactionsManager = new DatabaseTransactionsManager(count($connections)));
+
+        foreach ($connections as $name) {
             $connection = $database->connection($name);
 
             $connection->setTransactionManager($transactionsManager);

--- a/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
+++ b/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
@@ -9,8 +9,8 @@ class DatabaseTransactionsManagerTest extends TestCase
 {
     public function testItExecutesCallbacksImmediatelyIfThereIsOnlyOneTransaction()
     {
-        $testObject = new TestingDatabaseTransactionsManagerTestObject();
-        $manager = new DatabaseTransactionsManager;
+        $testObject = new TestingDatabaseTransactionsManagerTestObject;
+        $manager = new DatabaseTransactionsManager([null]);
 
         $manager->begin('foo', 1);
 
@@ -22,7 +22,7 @@ class DatabaseTransactionsManagerTest extends TestCase
 
     public function testItIgnoresTheBaseTransactionForCallbackApplicableTransactions()
     {
-        $manager = new DatabaseTransactionsManager;
+        $manager = new DatabaseTransactionsManager([null]);
 
         $manager->begin('foo', 1);
         $manager->begin('foo', 2);
@@ -33,7 +33,7 @@ class DatabaseTransactionsManagerTest extends TestCase
 
     public function testCommittingDoesNotRemoveTheBasePendingTransaction()
     {
-        $manager = new DatabaseTransactionsManager;
+        $manager = new DatabaseTransactionsManager([null]);
 
         $manager->begin('foo', 1);
 
@@ -50,8 +50,8 @@ class DatabaseTransactionsManagerTest extends TestCase
 
     public function testItExecutesCallbacksForTheSecondTransaction()
     {
-        $testObject = new TestingDatabaseTransactionsManagerTestObject();
-        $manager = new DatabaseTransactionsManager;
+        $testObject = new TestingDatabaseTransactionsManagerTestObject;
+        $manager = new DatabaseTransactionsManager([null]);
         $manager->begin('foo', 1);
         $manager->begin('foo', 2);
 
@@ -67,17 +67,28 @@ class DatabaseTransactionsManagerTest extends TestCase
 
     public function testItExecutesTransactionCallbacksAtLevelOne()
     {
-        $manager = new DatabaseTransactionsManager;
+        $manager = new DatabaseTransactionsManager([null]);
 
         $this->assertFalse($manager->afterCommitCallbacksShouldBeExecuted(0));
         $this->assertTrue($manager->afterCommitCallbacksShouldBeExecuted(1));
         $this->assertFalse($manager->afterCommitCallbacksShouldBeExecuted(2));
+    }
+
+    public function testSkipsTheNumberOfConnectionsTransacting()
+    {
+        $manager = new DatabaseTransactionsManager([null]);
+
+        $manager->begin('foo', 1);
+        $manager->begin('foo', 2);
+
+        $this->assertCount(1, $manager->callbackApplicableTransactions());
     }
 }
 
 class TestingDatabaseTransactionsManagerTestObject
 {
     public $ran = false;
+
     public $runs = 0;
 
     public function handle()

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
@@ -2,28 +2,17 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Orchestra\Testbench\Attributes\WithConfig;
+
 use function Orchestra\Testbench\artisan;
 
+#[WithConfig('database.connections.second', ['driver' => 'sqlite', 'database' => ':memory:', 'foreign_key_constraints' => false])]
 class EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest extends EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest
 {
     /** {@inheritDoc} */
     protected function connectionsToTransact()
     {
         return [null, 'second'];
-    }
-
-    /** {@inheritDoc} */
-    protected function defineEnvironment($app)
-    {
-        parent::defineEnvironment($app);
-
-        $app->make('config')->set([
-            'database.connections.second' => [
-                'driver' => 'sqlite',
-                'database' => ':memory:',
-                'foreign_key_constraints' => false,
-            ],
-        ]);
     }
 
     /** {@inheritDoc} */

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
@@ -19,8 +19,8 @@ class EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnection
         });
 
         parent::setUp();
-
     }
+
     /** {@inheritDoc} */
     protected function connectionsToTransact()
     {

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use function Orchestra\Testbench\artisan;
+
+class EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest extends EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest
+{
+    /** {@inheritDoc} */
+    protected function connectionsToTransact()
+    {
+        return [null, 'second'];
+    }
+
+    /** {@inheritDoc} */
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app->make('config')->set([
+            'database.connections.second' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'foreign_key_constraints' => false,
+            ],
+        ]);
+    }
+
+    /** {@inheritDoc} */
+    protected function afterRefreshingDatabase()
+    {
+        artisan($this, 'migrate', ['--database' => 'second']);
+    }
+}

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest.php
@@ -10,6 +10,18 @@ use function Orchestra\Testbench\artisan;
 class EloquentTransactionWithAfterCommitUsingRefreshDatabaseOnMultipleConnectionsTest extends EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest
 {
     /** {@inheritDoc} */
+    protected function setUp(): void
+    {
+        $this->afterApplicationCreated(function () {
+            $this->markTestSkippedWhen(
+                $this->usesSqliteInMemoryDatabaseConnection(), 'Skipped when default database is configured to use In-Memory SQLite Database'
+            );
+        });
+
+        parent::setUp();
+
+    }
+    /** {@inheritDoc} */
     protected function connectionsToTransact()
     {
         return [null, 'second'];

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest.php
@@ -17,6 +17,7 @@ class EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest extends TestCas
      */
     protected $driver;
 
+    /** {@inheritDoc} */
     protected function setUp(): void
     {
         $this->beforeApplicationDestroyed(function () {
@@ -28,7 +29,8 @@ class EloquentTransactionWithAfterCommitUsingRefreshDatabaseTest extends TestCas
         parent::setUp();
     }
 
-    protected function getEnvironmentSetUp($app)
+    /** {@inheritDoc} */
+    protected function defineEnvironment($app)
     {
         $connection = $app['config']->get('database.default');
 


### PR DESCRIPTION
### Changed

- Skip the number of connections transacting on tests to run callbacks correctly

---

The testing DatabaseTransactionsManager was hardcoding the number of
connections to skip as 1. In a multi-db context, it must skip the same
number of connections transacting defined on the tests.

related PRs: https://github.com/laravel/framework/pull/48523
resolves https://github.com/laravel/framework/discussions/53334
