### PR TITLE
[12.x] Add Number::spelloutOrdinal() and format validation message to ordinal

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -91,6 +91,24 @@ class Number
     }
 
     /**
+     * Convert the given number to spelled out ordinal form.
+     *
+     * @param  int|float  $number
+     * @param  string|null  $locale
+     * @return string
+     */
+    public static function spelloutOrdinal(int|float $number, ?string $locale = null)
+    {
+        static::ensureIntlExtensionIsInstalled();
+
+        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
+
+        $formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, "%spellout-ordinal");
+
+        return $formatter->format($number);
+    }
+
+    /**
      * Convert the given number to its percentage equivalent.
      *
      * @param  int|float  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -103,7 +103,7 @@ class Number
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
 
-        $formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, "%spellout-ordinal");
+        $formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, '%spellout-ordinal');
 
         return $formatter->format($number);
     }

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -427,7 +427,7 @@ trait FormatsMessages
      */
     protected function numberToIndexOrPositionWord(int $value)
     {
-        return match($value) {
+        return match ($value) {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10 => Number::spelloutOrdinal($value, 'en'),
             default => 'other',
         };

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation\Concerns;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -426,18 +427,10 @@ trait FormatsMessages
      */
     protected function numberToIndexOrPositionWord(int $value)
     {
-        return [
-            1 => 'first',
-            2 => 'second',
-            3 => 'third',
-            4 => 'fourth',
-            5 => 'fifth',
-            6 => 'sixth',
-            7 => 'seventh',
-            8 => 'eighth',
-            9 => 'ninth',
-            10 => 'tenth',
-        ][(int) $value] ?? 'other';
+        return match($value) {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10 => Number::spelloutOrdinal($value, 'en'),
+            default => 'other',
+        };
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -106,6 +106,13 @@ class SupportNumberTest extends TestCase
         $this->assertSame('3rd', Number::ordinal(3));
     }
 
+    public function testSpelloutOrdinal()
+    {
+        $this->assertSame('first', Number::spelloutOrdinal(1));
+        $this->assertSame('second', Number::spelloutOrdinal(2));
+        $this->assertSame('third', Number::spelloutOrdinal(3));
+    }
+
     #[RequiresPhpExtension('intl')]
     public function testToPercent()
     {


### PR DESCRIPTION
* `Number::ordinal(1) // 1st`
* 🆕 `Number::spelloutOrdinal() // first`