### PR TITLE
[11.x] Add `URL::forceHttps()` to enforce HTTPS scheme for URLs

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -729,6 +729,19 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Force the use of the HTTPS scheme for all generated URLs.
+     *
+     * @param  bool  $force
+     * @return void
+     */
+    public function forceHttps($force = true)
+    {
+        if ($force) {
+            $this->forceScheme('https');
+        }
+    }
+
+    /**
      * Set the forced root URL.
      *
      * @param  string|null  $root

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -30,6 +30,7 @@ namespace Illuminate\Support\Facades;
  * @method static void defaults(array $defaults)
  * @method static array getDefaultParameters()
  * @method static void forceScheme(string|null $scheme)
+ * @method static void forceHttps(bool $force = true)
  * @method static void forceRootUrl(string|null $root)
  * @method static \Illuminate\Routing\UrlGenerator formatHostUsing(\Closure $callback)
  * @method static \Illuminate\Routing\UrlGenerator formatPathUsing(\Closure $callback)

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -716,6 +716,20 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.bar.com/foo', $url->route('plain'));
     }
 
+    public function testForceHttps()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $url->forceHttps();
+        $route = new Route(['GET'], '/foo', ['as' => 'plain']);
+        $routes->add($route);
+
+        $this->assertSame('https://www.foo.com/foo', $url->route('plain'));
+    }
+
     public function testPrevious()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
This PR introduces the `URL::forceHttps()` method, which simplifies enforcing the HTTPS scheme for URLs without requiring the scheme name.

A useful use case is to enforce HTTPS only in the production environment. You can achieve this with the following code:
```php
URL::forceHttps(
    $this->app->isProduction()
);
```
