### PR TITLE
[11.x] Allow query builders to be passed to database rules

### DIFF
--- a/src/Illuminate/Contracts/Validation/RequiresPreviousRule.php
+++ b/src/Illuminate/Contracts/Validation/RequiresPreviousRule.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface RequiresPreviousRule
+{
+}

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\ArrayRule;
@@ -10,6 +11,7 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\ExistsUsingBuilder;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
@@ -17,6 +19,7 @@ use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\UniqueUsingBuilder;
 
 class Rule
 {
@@ -85,25 +88,29 @@ class Rule
     /**
      * Get a unique constraint builder instance.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Builder  $table
      * @param  string  $column
-     * @return \Illuminate\Validation\Rules\Unique
+     * @return ($table is string ? \Illuminate\Validation\Rules\Unique : \Illuminate\Validation\Rules\UniqueUsingBuilder)
      */
     public static function unique($table, $column = 'NULL')
     {
-        return new Unique($table, $column);
+        return $table instanceof Builder
+            ? new UniqueUsingBuilder($table, $column)
+            : new Unique($table, $column);
     }
 
     /**
      * Get an exists constraint builder instance.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Builder  $table
      * @param  string  $column
-     * @return \Illuminate\Validation\Rules\Exists
+     * @return ($table is string ? \Illuminate\Validation\Rules\Exists : \Illuminate\Validation\Rules\ExistsUsingBuilder)
      */
     public static function exists($table, $column = 'NULL')
     {
-        return new Exists($table, $column);
+        return $table instanceof Builder
+            ? new ExistsUsingBuilder($table, $column)
+            : new Exists($table, $column);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ExistsUsingBuilder.php
+++ b/src/Illuminate/Validation/Rules/ExistsUsingBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Contracts\Validation\RequiresPreviousRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Validation\Validator;
+
+class ExistsUsingBuilder implements ValidationRule, ValidatorAwareRule, RequiresPreviousRule
+{
+    /**
+     * The current validator.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected Validator $validator;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Builder  $query
+     * @param  string  $column
+     *
+     * @retun void
+     */
+    public function __construct(
+        protected Builder $query,
+        protected string $column,
+    ) {
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $column = $this->column === 'NULL'
+            ? $this->query->qualifyColumn($this->validator->guessColumnForQuery($attribute))
+            : $this->query->qualifyColumn($this->column);
+
+        if (is_array($value)) {
+            $expectedCount = count(array_unique($value));
+
+            if (
+                $expectedCount > 0
+                && $this->query->clone()->whereIn($column, $value)->distinct()->count($column) < $expectedCount
+            ) {
+                $fail('validation.exists')->translate();
+            }
+        } elseif ($this->query->clone()->where($column, $value)->doesntExist()) {
+            $fail('validation.exists')->translate();
+        }
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator(Validator $validator): self
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/Rules/UniqueUsingBuilder.php
+++ b/src/Illuminate/Validation/Rules/UniqueUsingBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Contracts\Validation\RequiresPreviousRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Validation\Validator;
+
+class UniqueUsingBuilder implements ValidationRule, ValidatorAwareRule, RequiresPreviousRule
+{
+    /**
+     * The current validator.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected Validator $validator;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Builder  $query
+     * @param  string  $column
+     *
+     * @retun void
+     */
+    public function __construct(
+        protected Builder $query,
+        protected string $column,
+    ) {
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $column = $this->column === 'NULL'
+            ? $this->query->qualifyColumn($this->validator->guessColumnForQuery($attribute))
+            : $this->query->qualifyColumn($this->column);
+
+        if ($this->query->clone()->where($column, $value)->exists()) {
+            $fail('validation.unique')->translate();
+        }
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator(Validator $validator): self
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+}

--- a/tests/Validation/ValidationExistsUsingBuilderRuleTest.php
+++ b/tests/Validation/ValidationExistsUsingBuilderRuleTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\ExistsUsingBuilder;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class ValidationExistsUsingBuilderRuleTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    #[TestWith(['id'])]
+    #[TestWith(['NULL'])]
+    public function testItChoosesValidRecordsUsingWhereNotInRule(string $column): void
+    {
+        $rule = new ExistsUsingBuilder(UserForExistsRule::query()->whereNotIn('type', ['foo', 'bar']), $column);
+
+        UserForExistsRule::query()->create(['id' => '1', 'type' => 'foo']);
+        UserForExistsRule::query()->create(['id' => '2', 'type' => 'bar']);
+        UserForExistsRule::query()->create(['id' => '3', 'type' => 'baz']);
+        UserForExistsRule::query()->create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 4, 4]]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testItDoesNotQueryDatabaseWhenPreviousRuleFailed(): void
+    {
+        $rule = new ExistsUsingBuilder(UserForExistsRule::query(), 'id');
+
+        DB::enableQueryLog();
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => ['uuid', $rule]]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    public function testItDoesNotQueryDatabaseForEmptyArrays(): void
+    {
+        $rule = new ExistsUsingBuilder(UserForExistsRule::query(), 'id');
+
+        DB::enableQueryLog();
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => [$rule]]);
+
+        $v->setData(['id' => []]);
+        $this->assertTrue($v->passes());
+
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    protected function createSchema(): void
+    {
+        $this->schema('default')->create('users', function ($table) {
+            $table->unsignedInteger('id');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return $this->getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get connection resolver.
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected function getConnectionResolver()
+    {
+        return Eloquent::getConnectionResolver();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema('default')->drop('users');
+    }
+
+    public function getIlluminateArrayTranslator()
+    {
+        return new Translator(
+            new ArrayLoader, 'en'
+        );
+    }
+}
+
+/**
+ * Eloquent Models.
+ */
+class UserForExistsRule extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/Validation/ValidationUniqueUsingBuilderRuleTest.php
+++ b/tests/Validation/ValidationUniqueUsingBuilderRuleTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\UniqueUsingBuilder;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class ValidationUniqueUsingBuilderRuleTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    #[TestWith(['id'])]
+    #[TestWith(['NULL'])]
+    public function testItChoosesUniqueRecordsUsingWhereNotInRule(string $column): void
+    {
+        $rule = new UniqueUsingBuilder(UserForUniqueRule::query()->whereNotIn('type', ['foo', 'bar']), $column);
+
+        UserForUniqueRule::query()->create(['id' => '1', 'type' => 'foo']);
+        UserForUniqueRule::query()->create(['id' => '2', 'type' => 'bar']);
+        UserForUniqueRule::query()->create(['id' => '3', 'type' => 'baz']);
+        UserForUniqueRule::query()->create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+
+        $v->setData(['id' => 1]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testItDoesNotQueryDatabaseWhenPreviousRuleFailed(): void
+    {
+        $rule = new UniqueUsingBuilder(UserForUniqueRule::query(), 'id');
+
+        DB::enableQueryLog();
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => ['uuid', $rule]]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    protected function createSchema(): void
+    {
+        $this->schema('default')->create('users', function ($table) {
+            $table->unsignedInteger('id');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return $this->getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get connection resolver.
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected function getConnectionResolver()
+    {
+        return Eloquent::getConnectionResolver();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema('default')->drop('users');
+    }
+
+    public function getIlluminateArrayTranslator()
+    {
+        return new Translator(
+            new ArrayLoader, 'en'
+        );
+    }
+}
+
+/**
+ * Eloquent Models.
+ */
+class UserForUniqueRule extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/types/Validation/Rule.php
+++ b/types/Validation/Rule.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\ExistsUsingBuilder;
+use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\UniqueUsingBuilder;
+
+use function PHPStan\Testing\assertType;
+
+/** @var \Illuminate\Database\Query\Builder $builder */
+assertType(Unique::class, Rule::unique('table', 'id'));
+assertType(UniqueUsingBuilder::class, Rule::unique($builder, 'id'));
+
+assertType(Exists::class, Rule::exists('table', 'id'));
+assertType(ExistsUsingBuilder::class, Rule::exists($builder, 'id'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I liked the idea of #52505, but since it seems to be stale, I decided to give it my own shot.

This PR allows you to pass any builder instance to `Rule::unique` and `Rule::exists`.

**Exists:**
Before:
```php
['uuid' => ['uuid', Rule::exists('posts')->where('user_id', $this->user()->id)->where('active', 1)]],
```

After:
```php
['uuid' => ['uuid', Rule::exists($this->user()->posts()->where('active', 1))]],
```


**Unique:**
Before:
```php
'email' => ['email', Rule::unique('users')->ignore($user)],
```

After:
```php
'email' => ['email', Rule::unique(User::query()->whereKeyNot($user)),
```