### PR TITLE
Encrypter - Add ability to check if payload is encrypted

### DIFF
--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -12,6 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static string getKey()
  * @method static array getAllKeys()
  * @method static array getPreviousKeys()
+ * @method static bool isEncrypted(string $payload)
  * @method static \Illuminate\Encryption\Encrypter previousKeys(array $keys)
  *
  * @see \Illuminate\Encryption\Encrypter


### PR DESCRIPTION
Sometimes, I need to check if a text is already encrypted. This is mainly when:
- I try to encrypt it, to avoid double encryption
- When I attempt to decrypt it. If a string is already decrypted, it will throw an exception
- ... (there are likely more cases where checking if a string is encrypted makes sense too)

So, I’ve added a new function: `isEncrypted()`. This allows us to easily check if a string is encrypted before proceeding with the next steps in the code.

I’m PRing because I think this would be useful. Take these examples - [here](https://laracasts.com/discuss/channels/laravel/check-if-text-is-encrypted-before-running-encryptdecrypttext) or [here](https://www.webdevelopmentscripts.com/95-solved-how-to-check-if-string-is-already-encrypted-in-laravel) or [here](https://stackoverflow.com/questions/48045490/laravel-encrypted-data-check). Users are looking for a solution, but using try-catch isn’t really effective. You might catch an actual error instead of checking if the value is already encrypted.

If you think this is a valuable contribution, feel free to edit the function to improve it or fix any flaws you find.