### PR TITLE
Add a method to obtain a regex that reflects default password require…

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -380,4 +380,37 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
 
         return false;
     }
+
+    /**
+     * Get a regex representing the minimum password requirements.
+     *
+     * @return string
+     */
+    public function regex()
+    {
+        $regex = '^';
+
+        if ($this->letters) {
+            $regex .= '(?=.*[a-zA-Z])';
+        }
+
+        if ($this->mixedCase) {
+            $regex .= '(?=.*[a-z])(?=.*[A-Z])';
+        }
+
+        if ($this->numbers) {
+            $regex .= '(?=.*\d)';
+        }
+
+        if ($this->symbols) {
+            $regex .= '(?=.*\d)(?=.*[^a-zA-Z\d\s])';
+        }
+
+        $regex .= '.';
+
+        $limit = "$this->min," . ($this->max ?? '');
+        $regex .= '{'.$limit.'}$';
+
+        return $regex;
+    }
 }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -339,6 +339,33 @@ class ValidationPasswordRuleTest extends TestCase
         ]);
     }
 
+    public function testRegex()
+    {
+        $letters = '(?=.*[a-zA-Z])';
+        $mixedCase = '(?=.*[a-z])(?=.*[A-Z])';
+        $numbers = '(?=.*\d)';
+        $symbols = '(?=.*\d)(?=.*[^a-zA-Z\d\s])';
+
+        $passwords = [
+            [Password::min(2), "^.{2,}\$"],
+            [Password::min(3)->max(5), "^.{3,5}\$"],
+            [Password::min(4)->letters(), "^$letters.{4,}\$"],
+            [Password::min(5)->max(7)->mixedCase(), "^$mixedCase.{5,7}\$"],
+            [Password::min(6)->numbers(), "^$numbers.{6,}\$"],
+            [Password::min(7)->symbols(), "^$symbols.{7,}\$"],
+            [Password::min(8)->mixedCase()->symbols(), "^$mixedCase$symbols.{8,}\$"],
+            [Password::min(9)->symbols()->mixedCase(), "^$mixedCase$symbols.{9,}\$"],
+            [Password::min(8)->symbols()->max(9)->mixedCase(), "^$mixedCase$symbols.{8,9}\$"],
+            [Password::min(7)->symbols()->mixedCase(), "^$mixedCase$symbols.{7,}\$"],
+            [Password::min(6)->mixedCase()->symbols()->max(10)->numbers(), "^$mixedCase$numbers$symbols.{6,10}\$"],
+        ];
+
+        foreach ($passwords as $password) {
+            Password::defaults(fn () => $password[0]);
+            $this->assertSame(Password::default()->regex(), $password[1]);
+        }
+    }
+
     protected function passes($rule, $values)
     {
         $this->assertValidationRules($rule, $values, true, []);


### PR DESCRIPTION
I've been using something similar to this in projects and thought I'd see if it was deemed helpful to anyone else.

This PR doesn't change any existing functionality, but adds a `regex()` method to the `Illuminate/Validation/Rules/Password` class. It builds and returns a regular expression based on the password requirements that are set.

One of the main places I've used it so far is in factories and tests. Because I always increase the password requirements by default (i.e. ensure mixed case, numbers and symbols), I have to change the default password of "password" in my User factory and, in other packages such as Jetstream, lots of tests. The idea is to use something like `fake()->regexify(Password::default()->regex())` instead (which I may submit a PR for in the relevant places should this end up being merged) so that factories/tests worked regardless of changes to your password strength.

I also find it a handy shortcut to pass through to the front-end when native validation isn't an option for me, where I want the regex in Javascript.