### PR TITLE
Add generics to `Arr::wrap()` to better understand the return type

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -941,7 +941,8 @@ class Arr
      * If the given value is not an array and not null, wrap it in one.
      *
      * @template T
-     * @param T|array|null $value
+     *
+     * @param  T|array|null  $value
      * @return ($value is array ? T : ($value is null ? array<never, never> : array{0: T}))
      */
     public static function wrap($value)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -940,8 +940,9 @@ class Arr
     /**
      * If the given value is not an array and not null, wrap it in one.
      *
-     * @param  mixed  $value
-     * @return array
+     * @template T
+     * @param T|array|null $value
+     * @return ($value is array ? T : ($value is null ? array<never, never> : array{0: T}))
      */
     public static function wrap($value)
     {


### PR DESCRIPTION
This PR adds the following generics to the `Illuminate\Support\Arr::wrap()` method:

```php
     * @template T
     *
     * @param  T|array|null  $value
     * @return ($value is array ? T : ($value is null ? array<never, never> : array{0: T}))
```

These annotations allow IDEs and tools like PHPStan or Psalm to more accurately infer the return type based on the input.

**Example Usage**

```php
$fruit = Arr::wrap('apple'); 
// Returns ['apple']
// Type: array{0: string}

Arr::wrap(['apple', 'banana']);
// Returns: ['apple', 'banana']
// Type: array<string>

Arr::wrap(null);
// Returns: []
// Type: array<never>
```

value -> [value] is inferred:

![image](https://github.com/user-attachments/assets/7d1152c8-aa79-4147-9a03-badf92dfe6d4)

null -> [] is inferred:

![image](https://github.com/user-attachments/assets/85b4f610-1107-4ab8-be96-98d56f010ca5)

[value] -> [value] is inferred:

![image](https://github.com/user-attachments/assets/00379105-61fd-4d7e-80fb-c704c62adb0e)

Open to suggestions or improvements.