### PR TITLE
[11.x] Update `console.stub` to make new commands lazy by default

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -3,7 +3,9 @@
 namespace {{ namespace }};
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: '{{ command }}')]
 class {{ class }} extends Command
 {
     /**


### PR DESCRIPTION
The `AsCommand` attribute was introduced quite some time ago (March 2024) in most or even all framework Artisan commands. For some examples, see:

- https://github.com/laravel/framework/pull/50617
- https://github.com/laravel/jetstream/pull/1455
- https://github.com/laravel/sanctum/pull/502

So I guess it's time that this is also added to `console.stub` to motivate everyone to make commands lazy by default when using `php artisan make:command`.

Short explanation of what this magic `AsCommand` attribute does:

> Applying the attribute allows us to not instantiate a command when running a different command.