### PR TITLE
Fix alias test for BeforeResolving method

### DIFF
--- a/tests/Container/ResolvingCallbackTest.php
+++ b/tests/Container/ResolvingCallbackTest.php
@@ -451,8 +451,9 @@ class ResolvingCallbackTest extends TestCase
         // And a contract/implementation stub binding.
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
+        $container->alias(ResolvingContractStub::class, 'resolvingContractStubAlias');
         // When we add a before resolving callback that increment the counter by one.
-        $container->beforeResolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->beforeResolving('resolvingContractStubAlias', function () use (&$callCounter) {
             $callCounter++;
         });
 


### PR DESCRIPTION
In the /framework/src/Illuminate/Container/Container.php file, the beforeResolving method contains:

```php
if (is_string($abstract)) {
    $abstract = $this->getAlias($abstract);
}
```

There was no test written to check if an abstract is an alias, so I modified an existing test to ensure that the alias is resolved.
