### PR TITLE
replace mixed by array-key as getKey return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1986,7 +1986,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the value of the model's primary key.
      *
-     * @return array-key
+     * @return null|array-key
      */
     public function getKey()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1986,7 +1986,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the value of the model's primary key.
      *
-     * @return null|array-key
+     * @return array-key|null
      */
     public function getKey()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1986,7 +1986,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the value of the model's primary key.
      *
-     * @return mixed
+     * @return array-key
      */
     public function getKey()
     {


### PR DESCRIPTION
Specify that `Model::getKey` can only returns a `array-key` as I don't think it's supported to have something else as primary key.

The aim is to improve type hinting and static analysis when this method is used.