### PR TITLE
Fix eager loading when primary key is float

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -31,6 +31,10 @@ trait InteractsWithDictionary
             throw new InvalidArgumentException('Model attribute value is an object but does not have a __toString method.');
         }
 
+        if (is_float($attribute)) {
+            return (string)$attribute;
+        }
+
         return $attribute;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -32,7 +32,7 @@ trait InteractsWithDictionary
         }
 
         if (is_float($attribute)) {
-            return (string)$attribute;
+            return (string) $attribute;
         }
 
         return $attribute;


### PR DESCRIPTION
When the primary key is a float (not my decision 😉), eager loading returns incorrect values. The dictionary is built with the key as it is.

And because array keys can't be floats, it groups them by their integer values.

```php
$array = [
    1.1 => '1.1',
    1.2 => '1.1',
];

// result -> [1 => 1.1]
```

My solution is to convert the floats to string.