### PR TITLE
feat: Add Dynamic Operator Parameter to Relationship Methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -618,7 +618,7 @@ trait HasRelationships
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, TDeclaringModel>
      */
     protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey,
-                                        $parentKey, $relatedKey, $relationName = null, $operator)
+                                        $parentKey, $relatedKey, $relationName = null, $operator = '=')
     {
         return new BelongsToMany($query, $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName, $operator);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -98,9 +98,10 @@ trait HasRelationships
      * @param  class-string<TRelatedModel>  $related
      * @param  string|null  $foreignKey
      * @param  string|null  $localKey
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<TRelatedModel, $this>
+     * @param  string  $operator
+     * @return \Illuminate\Database\loquent\Relations\HasOne<TRelatedModel, $this>
      */
-    public function hasOne($related, $foreignKey = null, $localKey = null)
+    public function hasOne($related, $foreignKey = null, $localKey = null, $operator = '=')
     {
         $instance = $this->newRelatedInstance($related);
 
@@ -108,7 +109,7 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newHasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+        return $this->newHasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey, $operator);
     }
 
     /**
@@ -121,11 +122,12 @@ trait HasRelationships
      * @param  TDeclaringModel  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\HasOne<TRelatedModel, TDeclaringModel>
      */
-    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
+    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey, $operator)
     {
-        return new HasOne($query, $parent, $foreignKey, $localKey);
+        return new HasOne($query, $parent, $foreignKey, $localKey, $operator);
     }
 
     /**
@@ -230,9 +232,10 @@ trait HasRelationships
      * @param  string|null  $foreignKey
      * @param  string|null  $ownerKey
      * @param  string|null  $relation
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, $this>
      */
-    public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)
+    public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null, $operator = '=')
     {
         // If no relation name was given, we will use this debug backtrace to extract
         // the calling method's name and use that as the relationship name as most
@@ -256,7 +259,7 @@ trait HasRelationships
         $ownerKey = $ownerKey ?: $instance->getKeyName();
 
         return $this->newBelongsTo(
-            $instance->newQuery(), $this, $foreignKey, $ownerKey, $relation
+            $instance->newQuery(), $this, $foreignKey, $ownerKey, $relation, $operator
         );
     }
 
@@ -271,11 +274,12 @@ trait HasRelationships
      * @param  string  $foreignKey
      * @param  string  $ownerKey
      * @param  string  $relation
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, TDeclaringModel>
      */
-    protected function newBelongsTo(Builder $query, Model $child, $foreignKey, $ownerKey, $relation)
+    protected function newBelongsTo(Builder $query, Model $child, $foreignKey, $ownerKey, $relation, $operator)
     {
-        return new BelongsTo($query, $child, $foreignKey, $ownerKey, $relation);
+        return new BelongsTo($query, $child, $foreignKey, $ownerKey, $relation, $operator);
     }
 
     /**
@@ -414,9 +418,10 @@ trait HasRelationships
      * @param  class-string<TRelatedModel>  $related
      * @param  string|null  $foreignKey
      * @param  string|null  $localKey
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\HasMany<TRelatedModel, $this>
      */
-    public function hasMany($related, $foreignKey = null, $localKey = null)
+    public function hasMany($related, $foreignKey = null, $localKey = null, $operator = '=')
     {
         $instance = $this->newRelatedInstance($related);
 
@@ -425,7 +430,7 @@ trait HasRelationships
         $localKey = $localKey ?: $this->getKeyName();
 
         return $this->newHasMany(
-            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey
+            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey, $operator
         );
     }
 
@@ -439,11 +444,12 @@ trait HasRelationships
      * @param  TDeclaringModel  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\HasMany<TRelatedModel, TDeclaringModel>
      */
-    protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
+    protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey, $operator)
     {
-        return new HasMany($query, $parent, $foreignKey, $localKey);
+        return new HasMany($query, $parent, $foreignKey, $localKey, $operator);
     }
 
     /**
@@ -558,10 +564,11 @@ trait HasRelationships
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
      * @param  string|null  $relation
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, $this>
      */
     public function belongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
-                                  $parentKey = null, $relatedKey = null, $relation = null)
+                                  $parentKey = null, $relatedKey = null, $relation = null, $operator = '=')
     {
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
@@ -589,7 +596,7 @@ trait HasRelationships
         return $this->newBelongsToMany(
             $instance->newQuery(), $this, $table, $foreignPivotKey,
             $relatedPivotKey, $parentKey ?: $this->getKeyName(),
-            $relatedKey ?: $instance->getKeyName(), $relation
+            $relatedKey ?: $instance->getKeyName(), $relation, $operator
         );
     }
 
@@ -607,12 +614,13 @@ trait HasRelationships
      * @param  string  $parentKey
      * @param  string  $relatedKey
      * @param  string|null  $relationName
+     * @param  string  $operator
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, TDeclaringModel>
      */
     protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey,
-                                        $parentKey, $relatedKey, $relationName = null)
+                                        $parentKey, $relatedKey, $relationName = null, $operator)
     {
-        return new BelongsToMany($query, $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName);
+        return new BelongsToMany($query, $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName, $operator);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -69,7 +69,7 @@ class BelongsTo extends Relation
      * @param  string  $operator
      * @return void
      */
-    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName, $operator)
+    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName, $operator = '=')
     {
         $this->ownerKey = $ownerKey;
         $this->relationName = $relationName;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -52,6 +52,13 @@ class BelongsTo extends Relation
     protected $relationName;
 
     /**
+     * The operator of the relationship.
+     *
+     * @var string
+     */
+    protected $operator;
+
+    /**
      * Create a new belongs to relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
@@ -59,13 +66,15 @@ class BelongsTo extends Relation
      * @param  string  $foreignKey
      * @param  string  $ownerKey
      * @param  string  $relationName
+     * @param  string  $operator
      * @return void
      */
-    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName)
+    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName, $operator)
     {
         $this->ownerKey = $ownerKey;
         $this->relationName = $relationName;
         $this->foreignKey = $foreignKey;
+        $this->operator = $operator;
 
         // In the underlying base relationship class, this variable is referred to as
         // the "parent" since most relationships are not inversed. But, since this
@@ -98,7 +107,7 @@ class BelongsTo extends Relation
             // of the related models matching on the foreign key that's on a parent.
             $table = $this->related->getTable();
 
-            $this->query->where($table.'.'.$this->ownerKey, '=', $this->getForeignKeyFrom($this->child));
+            $this->query->where($table.'.'.$this->ownerKey, $this->operator, $this->getForeignKeyFrom($this->child));
         }
     }
 
@@ -240,7 +249,7 @@ class BelongsTo extends Relation
         }
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedForeignKeyName(), '=', $query->qualifyColumn($this->ownerKey)
+            $this->getQualifiedForeignKeyName(), $this->operator, $query->qualifyColumn($this->ownerKey)
         );
     }
 
@@ -261,7 +270,7 @@ class BelongsTo extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->whereColumn(
-            $hash.'.'.$this->ownerKey, '=', $this->getQualifiedForeignKeyName()
+            $hash.'.'.$this->ownerKey, $this->operator, $this->getQualifiedForeignKeyName()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -132,6 +132,13 @@ class BelongsToMany extends Relation
     protected $using;
 
     /**
+     * The operator for the relationship.
+     *
+     * @var string
+     */
+    protected $operator;
+
+    /**
      * The name of the accessor to use for the "pivot" relationship.
      *
      * @var string
@@ -149,16 +156,18 @@ class BelongsToMany extends Relation
      * @param  string  $parentKey
      * @param  string  $relatedKey
      * @param  string|null  $relationName
+     * @param  string  $operator
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null)
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $operator)
     {
         $this->parentKey = $parentKey;
         $this->relatedKey = $relatedKey;
         $this->relationName = $relationName;
         $this->relatedPivotKey = $relatedPivotKey;
         $this->foreignPivotKey = $foreignPivotKey;
+        $this->operator = $operator;
         $this->table = $this->resolveTableName($table);
 
         parent::__construct($query, $parent);
@@ -219,7 +228,7 @@ class BelongsToMany extends Relation
         $query->join(
             $this->table,
             $this->getQualifiedRelatedKeyName(),
-            '=',
+            $this->operator,
             $this->getQualifiedRelatedPivotKeyName()
         );
 
@@ -234,7 +243,7 @@ class BelongsToMany extends Relation
     protected function addWhereConstraints()
     {
         $this->query->where(
-            $this->getQualifiedForeignPivotKeyName(), '=', $this->parent->{$this->parentKey}
+            $this->getQualifiedForeignPivotKeyName(), $this->operator, $this->parent->{$this->parentKey}
         );
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -160,7 +160,7 @@ class BelongsToMany extends Relation
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $operator)
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $operator = '=')
     {
         $this->parentKey = $parentKey;
         $this->relatedKey = $relatedKey;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -51,7 +51,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $operator
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey, $operator)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey, $operator = '=')
     {
         $this->localKey = $localKey;
         $this->foreignKey = $foreignKey;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -35,18 +35,27 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
+     * The operator of relationship.
+     *
+     * @var string
+     */
+    protected $operator;
+
+    /**
      * Create a new has one or many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
      * @param  TDeclaringModel  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  string  $operator
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey, $operator)
     {
         $this->localKey = $localKey;
         $this->foreignKey = $foreignKey;
+        $this->operator = $operator;
 
         parent::__construct($query, $parent);
     }
@@ -92,7 +101,7 @@ abstract class HasOneOrMany extends Relation
         if (static::$constraints) {
             $query = $this->getRelationQuery();
 
-            $query->where($this->foreignKey, '=', $this->getParentKey());
+            $query->where($this->foreignKey, $this->operator, $this->getParentKey());
 
             $query->whereNotNull($this->foreignKey);
         }
@@ -475,7 +484,7 @@ abstract class HasOneOrMany extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->select($columns)->whereColumn(
-            $this->getQualifiedParentKeyName(), '=', $hash.'.'.$this->getForeignKeyName()
+            $this->getQualifiedParentKeyName(), $this->operator, $hash.'.'.$this->getForeignKeyName()
         );
     }
 


### PR DESCRIPTION
### Overview
This pull request introduces a new dynamic operator parameter to the Eloquent relationship methods: `hasMany`, `hasOne`, `belongsToMany`, and `belongsTo`. This enhancement allows developers to specify operators (e.g., `>`, `<`, `=`, `!=`) when querying relationships, providing greater flexibility and control over the data retrieved.

### Changes Made
- Modified the signature of the relationship methods to include an optional operator parameter.
- Updated the query logic to handle the specified operator, enabling dynamic comparisons based on the provided value.
  
### Example Usage
Here's an example of how to use the new operator parameter in a `hasMany` relationship:

```php
public function comments()
{
    return $this->hasMany(Comment::class, 'foreign_key', 'local_key', '>');
}
