### PR TITLE
Introduce support for popping items from a stackable context item

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -290,6 +290,23 @@ class Repository
     }
 
     /**
+     * Pop the latest value from the key's stack.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public function pop($key)
+    {
+        if (! $this->isStackable($key) || !count($this->data[$key])) {
+            throw new RuntimeException("Unable to pop value from context stack for key [{$key}].");
+        }
+
+        return array_pop($this->data[$key]);
+    }
+
+    /**
      * Push the given hidden values onto the key's stack.
      *
      * @param  string  $key
@@ -310,6 +327,23 @@ class Repository
         ];
 
         return $this;
+    }
+
+    /**
+     * Pop the latest hidden value from the key's stack.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public function popHidden($key)
+    {
+        if (! $this->isHiddenStackable($key) || !count($this->hidden[$key])) {
+            throw new RuntimeException("Unable to pop value from hidden context stack for key [{$key}].");
+        }
+
+        return array_pop($this->hidden[$key]);
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -299,7 +299,7 @@ class Repository
      */
     public function pop($key)
     {
-        if (! $this->isStackable($key) || !count($this->data[$key])) {
+        if (! $this->isStackable($key) || ! count($this->data[$key])) {
             throw new RuntimeException("Unable to pop value from context stack for key [{$key}].");
         }
 
@@ -339,7 +339,7 @@ class Repository
      */
     public function popHidden($key)
     {
-        if (! $this->isHiddenStackable($key) || !count($this->hidden[$key])) {
+        if (! $this->isHiddenStackable($key) || ! count($this->hidden[$key])) {
             throw new RuntimeException("Unable to pop value from hidden context stack for key [{$key}].");
         }
 

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -195,6 +195,64 @@ class ContextTest extends TestCase
         Context::push('breadcrumbs', 'bar');
     }
 
+    public function test_it_can_pop_from_list()
+    {
+        Context::push('breadcrumbs', 'foo', 'bar');
+
+        $this->assertSame('bar', Context::pop('breadcrumbs'));
+        $this->assertSame('foo', Context::pop('breadcrumbs'));
+        $this->assertSame([], Context::get('breadcrumbs'));
+    }
+
+    public function test_throws_when_popping_from_empty_list()
+    {
+        Context::push('breadcrumbs', 'bar');
+        Context::pop('breadcrumbs');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to pop value from context stack for key [breadcrumbs].');
+
+        Context::pop('breadcrumbs');
+    }
+
+    public function test_throws_when_popping_from_non_list_array()
+    {
+        Context::add('breadcrumbs', ['foo' => 'bar']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to pop value from context stack for key [breadcrumbs].');
+        Context::pop('breadcrumbs');
+    }
+
+    public function test_it_can_pop_from_hidden_list()
+    {
+        Context::pushHidden('breadcrumbs', 'foo', 'bar');
+
+        $this->assertSame('bar', Context::popHidden('breadcrumbs'));
+        $this->assertSame('foo', Context::popHidden('breadcrumbs'));
+        $this->assertSame([], Context::getHidden('breadcrumbs'));
+    }
+
+    public function test_throws_when_popping_from_empty_hidden_list()
+    {
+        Context::pushHidden('breadcrumbs', 'bar');
+        Context::popHidden('breadcrumbs');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to pop value from hidden context stack for key [breadcrumbs].');
+
+        Context::popHidden('breadcrumbs');
+    }
+
+    public function test_throws_when_popping_from_hidden_non_list_array()
+    {
+        Context::addHidden('breadcrumbs', ['foo' => 'bar']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to pop value from hidden context stack for key [breadcrumbs].');
+        Context::popHidden('breadcrumbs');
+    }
+
     public function test_it_can_check_if_context_has_been_set()
     {
         Context::add('foo', 'bar');


### PR DESCRIPTION
This PR introduces the ability to pop items from a stackable context item.

Use case is primarily in business transactions where you might have a need to provide context in a nested way.