### PR TITLE
[11.X] Postgres Aurora failover - DetectsLostConnections

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -79,6 +79,7 @@ trait DetectsLostConnections
             'Channel connection is closed',
             'Connection lost',
             'Broken pipe',
+            'SQLSTATE[25006]: Read only sql transaction: 7',
         ]);
     }
 }


### PR DESCRIPTION
We recently experienced a Postgres Aurora failover on production and noticed that our queue workers didn't restart. We are using read and write endpoints for the database connection in `database.php` and when Aurora fails over, the writer connection becomes a reader, but Laravel is trying to perform writes on it.

The exception message we are getting:
- `SQLSTATE[25006]: Read only sql transaction: 7`

By adding this exception to the list lost connection in `DetectsLostConnections.php`, Laravel should reconnect to the right connection.