### PR TITLE
[11.x] Refactor and add remaining test cases for the DatabaseFailedJobProviderTest class

### DIFF
--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -214,13 +214,12 @@ class DatabaseFailedJobProviderTest extends TestCase
     protected function createFailedJobsRecord(array $overrides = [])
     {
         return $this->failedJobsTable()
-                ->insert(array_merge([
-                    'connection' => 'database',
-                    'queue' => 'default',
-                    'payload' => json_encode(['uuid' => (string) Str::uuid()]),
-                    'exception' => new Exception('Whoops!'),
-                    'failed_at' => Date::now()->subDays(10),
-                ], $overrides)
-            );
+            ->insert(array_merge([
+                'connection' => 'database',
+                'queue' => 'default',
+                'payload' => json_encode(['uuid' => (string) Str::uuid()]),
+                'exception' => new Exception('Whoops!'),
+                'failed_at' => Date::now()->subDays(10),
+            ], $overrides));
     }
 }

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -25,43 +25,37 @@ class DatabaseFailedJobProviderTest extends TestCase
             ->createProvider();
     }
 
-    public function testGettingAllFaildJobIds()
+    public function testCanGetAllFailedJobIds()
     {
         $this->assertEmpty($this->provider->ids());
 
-        foreach (range(1, 4) as $count) {
-            $this->createFailedJobsRecord();
-        }
+        array_map(fn () => $this->createFailedJobsRecord(), range(1, 4));
 
         $this->assertCount(4, $this->provider->ids());
         $this->assertSame([4, 3, 2, 1], $this->provider->ids());
     }
 
-    public function testGettingAllFailedJobs()
+    public function testCanGetAllFailedJobs()
     {
         $this->assertEmpty($this->provider->all());
 
-        foreach (range(1, 4) as $count) {
-            $this->createFailedJobsRecord();
-        }
+        array_map(fn () => $this->createFailedJobsRecord(), range(1, 4));
 
         $this->assertCount(4, $this->provider->all());
         $this->assertSame(3, $this->provider->all()[1]->id);
         $this->assertSame('default', $this->provider->all()[1]->queue);
     }
 
-    public function testGettingFailedJobsById()
+    public function testCanRetrieveFailedJobsById()
     {
-        foreach (range(1, 2) as $count) {
-            $this->createFailedJobsRecord();
-        }
+        array_map(fn () => $this->createFailedJobsRecord(), range(1, 2));
 
         $this->assertNotNull($this->provider->find(1));
         $this->assertNotNull($this->provider->find(2));
         $this->assertNull($this->provider->find(3));
     }
 
-    public function testRemovingFailedJobs()
+    public function testCanRemoveFailedJobsById()
     {
         $this->createFailedJobsRecord();
 
@@ -71,7 +65,7 @@ class DatabaseFailedJobProviderTest extends TestCase
         $this->assertSame(0, $this->failedJobsTable()->count());
     }
 
-    public function testPruningFailedJobs()
+    public function testCanPruneFailedJobs()
     {
         Carbon::setTestNow(Carbon::createFromDate(2024, 4, 28));
 

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -13,20 +13,22 @@ use RuntimeException;
 
 class DatabaseFailedJobProviderTest extends TestCase
 {
+    protected $db;
+
+    protected $provider;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->createDatabaseWithFailedJobTable()
+            ->createProvider();
+    }
+
     public function testCanFlushFailedJobs()
     {
         Date::setTestNow(Date::now());
 
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-
-        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
-            $table->id();
-            $table->timestamp('failed_at')->useCurrent();
-        });
+        $db = $this->createSimpleDatabaseWithFailedJobTable();
 
         $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
 
@@ -45,123 +47,95 @@ class DatabaseFailedJobProviderTest extends TestCase
 
     public function testCanProperlyLogFailedJob()
     {
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-
-        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
-            $table->id();
-            $table->text('connection');
-            $table->text('queue');
-            $table->longText('payload');
-            $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
-        });
-
         $uuid = Str::uuid();
 
         $exception = new Exception(mb_convert_encoding('ÐÑÙ0E\xE2\x�98\xA0World��7B¹!þÿ', 'ISO-8859-1', 'UTF-8'));
-        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+        $provider = new DatabaseFailedJobProvider($this->db->getDatabaseManager(), 'default', 'failed_jobs');
 
         $provider->log('database', 'default', json_encode(['uuid' => (string) $uuid]), $exception);
 
         $exception = (string) mb_convert_encoding($exception, 'UTF-8');
 
-        $this->assertSame(1, $db->getConnection()->table('failed_jobs')->count());
-        $this->assertSame($exception, $db->getConnection()->table('failed_jobs')->first()->exception);
+        $this->assertSame(1, $this->failedJobsTable()->count());
+        $this->assertSame($exception, $this->failedJobsTable()->first()->exception);
     }
 
     public function testJobsCanBeCounted()
     {
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
-            $table->id();
-            $table->text('connection');
-            $table->text('queue');
-            $table->longText('payload');
-            $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
-        });
-        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+        $this->assertSame(0, $this->provider->count());
 
-        $this->assertSame(0, $provider->count());
+        $this->provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $this->provider->count());
 
-        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(1, $provider->count());
-
-        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('another-connection', 'another-queue', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(3, $provider->count());
+        $this->provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('another-connection', 'another-queue', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(3, $this->provider->count());
     }
 
     public function testJobsCanBeCountedByConnection()
     {
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
-            $table->id();
-            $table->text('connection');
-            $table->text('queue');
-            $table->longText('payload');
-            $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
-        });
-        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+        $this->provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-2', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $this->provider->count('connection-1'));
+        $this->assertSame(1, $this->provider->count('connection-2'));
 
-        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(1, $provider->count('connection-1'));
-        $this->assertSame(1, $provider->count('connection-2'));
-
-        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(2, $provider->count('connection-1'));
-        $this->assertSame(1, $provider->count('connection-2'));
+        $this->provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $this->provider->count('connection-1'));
+        $this->assertSame(1, $this->provider->count('connection-2'));
     }
 
     public function testJobsCanBeCountedByQueue()
     {
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
-            $table->id();
-            $table->text('connection');
-            $table->text('queue');
-            $table->longText('payload');
-            $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
-        });
-        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+        $this->provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('database', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $this->provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
 
-        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('database', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(1, $provider->count(queue: 'queue-1'));
-        $this->assertSame(1, $provider->count(queue: 'queue-2'));
-
-        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(2, $provider->count(queue: 'queue-1'));
-        $this->assertSame(1, $provider->count(queue: 'queue-2'));
+        $this->provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $this->provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
     }
 
     public function testJobsCanBeCountedByQueueAndConnection()
+    {
+        $this->provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-2', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+
+        $this->assertSame(2, $this->provider->count('connection-1', 'queue-99'));
+        $this->assertSame(1, $this->provider->count('connection-2', 'queue-99'));
+        $this->assertSame(1, $this->provider->count('connection-1', 'queue-1'));
+        $this->assertSame(2, $this->provider->count('connection-2', 'queue-1'));
+    }
+
+    protected function createSimpleDatabaseWithFailedJobTable()
     {
         $db = new DB;
         $db->addConnection([
             'driver' => 'sqlite',
             'database' => ':memory:',
         ]);
+
         $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('failed_at')->useCurrent();
+        });
+
+        return $db;
+    }
+
+    protected function createDatabaseWithFailedJobTable()
+    {
+        $this->db = new DB;
+        $this->db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $this->db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
             $table->id();
             $table->text('connection');
             $table->text('queue');
@@ -169,17 +143,19 @@ class DatabaseFailedJobProviderTest extends TestCase
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
         });
-        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
 
-        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertSame(2, $provider->count('connection-1', 'queue-99'));
-        $this->assertSame(1, $provider->count('connection-2', 'queue-99'));
-        $this->assertSame(1, $provider->count('connection-1', 'queue-1'));
-        $this->assertSame(2, $provider->count('connection-2', 'queue-1'));
+        return $this;
+    }
+
+    protected function createProvider(string $database = 'default', string $table = 'failed_jobs')
+    {
+        $this->provider = new DatabaseFailedJobProvider($this->db->getDatabaseManager(), $database, $table);
+
+        return $this;
+    }
+
+    protected function failedJobsTable()
+    {
+        return $this->db->getConnection()->table('failed_jobs');
     }
 }


### PR DESCRIPTION
This PR is very similar to #53408, I would like to refactor and add test cases for remaining methods of the `Illuminate\Queue\Failed\DatabaseFailedJobProvider` class.

This includes:
- Extract the following code snippets to new methods:
   - creating a database instance
   - creating a provider instance
   - inserting records to the `failed_jobs` table
- Create test cases for the following methods:
   - `ids`
   - `all`
   - `find`
   - `forget`
   - `prune`