### PR TITLE
[11.x] Add ability to dynamically build mailers on-demand using `Mail::build`

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -120,8 +120,28 @@ class MailManager implements FactoryContract
         // Once we have created the mailer instance we will set a container instance
         // on the mailer. This allows us to resolve mailer classes via containers
         // for maximum testability on said classes instead of passing Closures.
+        $mailer = $this->build(['name' => $name, ...$config]);
+
+        // Next we will set all of the global addresses on this mailer, which allows
+        // for easy unification of all "from" addresses as well as easy debugging
+        // of sent messages since these will be sent to a single email address.
+        foreach (['from', 'reply_to', 'to', 'return_path'] as $type) {
+            $this->setGlobalAddress($mailer, $config, $type);
+        }
+
+        return $mailer;
+    }
+
+    /**
+     * Build a new mailer instance.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Mail\Mailer
+     */
+    public function build($config)
+    {
         $mailer = new Mailer(
-            $name,
+            $config['name'],
             $this->app['view'],
             $this->createSymfonyTransport($config),
             $this->app['events']
@@ -129,13 +149,6 @@ class MailManager implements FactoryContract
 
         if ($this->app->bound('queue')) {
             $mailer->setQueue($this->app['queue']);
-        }
-
-        // Next we will set all of the global addresses on this mailer, which allows
-        // for easy unification of all "from" addresses as well as easy debugging
-        // of sent messages since these will be sent to a single email address.
-        foreach (['from', 'reply_to', 'to', 'return_path'] as $type) {
-            $this->setGlobalAddress($mailer, $config, $type);
         }
 
         return $mailer;

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -141,7 +141,7 @@ class MailManager implements FactoryContract
     public function build($config)
     {
         $mailer = new Mailer(
-            $config['name'],
+            $config['name'] ?? 'ondemand',
             $this->app['view'],
             $this->createSymfonyTransport($config),
             $this->app['events']

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
 /**
  * @method static \Illuminate\Contracts\Mail\Mailer mailer(string|null $name = null)
  * @method static \Illuminate\Mail\Mailer driver(string|null $driver = null)
+ * @method static \Illuminate\Mail\Mailer build(array $config)
  * @method static \Symfony\Component\Mailer\Transport\TransportInterface createSymfonyTransport(array $config)
  * @method static string getDefaultDriver()
  * @method static void setDefaultDriver(string $name)

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -43,6 +43,28 @@ class MailManagerTest extends TestCase
         $this->assertSame(5876, $transport->getStream()->getPort());
     }
 
+    public function testBuild()
+    {
+        $config = [
+            'transport' => 'smtp',
+            'host' => '127.0.0.2',
+            'port' => 5876,
+            'encryption' => 'tls',
+            'username' => 'usr',
+            'password' => 'pwd',
+            'timeout' => 5,
+        ];
+
+        $mailer = $this->app['mail.manager']->build($config);
+        $transport = $mailer->getSymfonyTransport();
+
+        $this->assertInstanceOf(EsmtpTransport::class, $transport);
+        $this->assertSame('usr', $transport->getUsername());
+        $this->assertSame('pwd', $transport->getPassword());
+        $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
+        $this->assertSame(5876, $transport->getStream()->getPort());
+    }
+
     public static function emptyTransportConfigDataProvider()
     {
         return [


### PR DESCRIPTION
### Description

This PR adds the ability to build on-demand mailers using `Mail::build($config)`.

This allows developers to create mailers based on a given configuration instead of being hard-coded in the config files.

This is really useful for circumstances where you may have mail configurations that are stored in your database, or another repository.

We currently have a way to build on-demand Storage disks using [`Storage::build`](https://laravel.com/docs/11.x/filesystem#on-demand-disks), so I kept the same API.

### Usage

```php
use Illuminate\Support\Facades\Mail;

$mailer = Mail::build([
    'transport' => 'smtp',
    'host' => '127.0.0.1',
    'port' => 587,
    'encryption' => 'tls',
    'username' => 'usr',
    'password' => 'pwd',
    'timeout' => 5,
]);

$mailer->send($mailable);
```

Let me know your thoughts! No hard feelings on closure. Thanks so much for your time :heart: 