### PR TITLE
Fix validation message when there is a parameter with escaped dot "\."

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -410,6 +410,19 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Replace each field parameter dot placeholder with dot.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function replaceDotPlaceholderInParameters(array $parameters)
+    {
+        return array_map(function ($field) {
+            return str_replace($this->dotPlaceholder, '.', $field);
+        }, $parameters);
+    }
+
+    /**
      * Add an after validation callback.
      *
      * @param  callable|array|string  $callback
@@ -932,6 +945,10 @@ class Validator implements ValidatorContract
 
         if (in_array($rule, $this->excludeRules)) {
             return $this->excludeAttribute($attribute);
+        }
+
+        if ($this->dependsOnOtherFields($rule)) {
+            $parameters = $this->replaceDotPlaceholderInParameters($parameters);
         }
 
         $this->messages->add($attribute, $this->makeReplacements(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7074,6 +7074,26 @@ class ValidationValidatorTest extends TestCase
         $this->assertArrayHasKey('foo.bar', $v->validated());
     }
 
+    public function testDotPlaceholdersInParametersAreReplacedIn()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_without' => 'The :attribute field is required when :values is not present.'], 'en');
+
+        // Single parameter
+        $v = new Validator($trans, [], [
+            'name' => 'required_without:user\.name'
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertSame('The name field is required when user.name is not present.', $v->messages()->first());
+
+        // Multiple parameters
+        $v = new Validator($trans, [], [
+            'name' => 'required_without:user\.name,admin\.name'
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertSame('The name field is required when user.name / admin.name is not present.', $v->messages()->first());
+    }
+
     public function testCoveringEmptyKeys()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7081,14 +7081,14 @@ class ValidationValidatorTest extends TestCase
 
         // Single parameter
         $v = new Validator($trans, [], [
-            'name' => 'required_without:user\.name'
+            'name' => 'required_without:user\.name',
         ]);
         $this->assertTrue($v->fails());
         $this->assertSame('The name field is required when user.name is not present.', $v->messages()->first());
 
         // Multiple parameters
         $v = new Validator($trans, [], [
-            'name' => 'required_without:user\.name,admin\.name'
+            'name' => 'required_without:user\.name,admin\.name',
         ]);
         $this->assertTrue($v->fails());
         $this->assertSame('The name field is required when user.name / admin.name is not present.', $v->messages()->first());


### PR DESCRIPTION
When there are parameters with an escaped dot in the validation rule, the error message is weird due to the dotPlaceholder not being replaced in the error message.

For example:
```php
Validator::make([], ['name' => 'required_without:user\.name'])->validate();
```
Would produce an error message like "The name field is required when usery dh uny p t1 o ns i e rfname is not present."

This PR should fix that.