### PR TITLE
[11.x] Fix exception renderer to display correct view file and error line

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -90,6 +90,18 @@ class Frame
     }
 
     /**
+     * Get the frame's blade file.
+     *
+     * @return string|null
+     */
+    public function blade()
+    {
+        if (isset($this->frame['blade']) && is_file($this->frame['blade'])) {
+            return str_replace($this->basePath.'/', '', $this->frame['blade']);
+        }
+    }
+
+    /**
      * Get the frame's file.
      *
      * @return string

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -90,7 +90,17 @@ class Frame
     }
 
     /**
-     * Get the frame's blade file.
+     * Get the frame's file.
+     *
+     * @return string
+     */
+    public function file()
+    {
+        return str_replace($this->basePath.'/', '', $this->frame['file']);
+    }
+
+    /**
+     * Get the frame's Blade file if applicable.
      *
      * @return string|null
      */
@@ -99,16 +109,6 @@ class Frame
         if (isset($this->frame['blade']) && is_file($this->frame['blade'])) {
             return str_replace($this->basePath.'/', '', $this->frame['blade']);
         }
-    }
-
-    /**
-     * Get the frame's file.
-     *
-     * @return string
-     */
-    public function file()
-    {
-        return str_replace($this->basePath.'/', '', $this->frame['file']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -78,7 +78,7 @@ class Frame
     }
 
     /**
-     * Get the frame's class, if any.
+     * Get the frame's class if applicable.
      *
      * @return string|null
      */

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -90,8 +90,15 @@ class BladeMapper
         $trace = Collection::make($exception->getTrace())
             ->map(function ($frame) {
                 if ($originalPath = $this->findCompiledView((string) Arr::get($frame, 'file', ''))) {
-                    $frame['blade'] = $originalPath;
-                    $frame['line'] = $this->detectLineNumber($frame['file'], $frame['line']);
+                    $originalPathLine = $this->detectLineNumber($originalPath, $frame['line']);
+
+                    if ($originalPathLine !== $frame['line']) {
+                        $frame['file'] = $originalPath;
+                        $frame['line'] = $originalPathLine;
+                    } else {
+                        $frame['blade'] = $originalPath;
+                        $frame['line'] = $this->detectLineNumber($frame['file'], $frame['line']);
+                    }
                 }
 
                 return $frame;

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -90,7 +90,7 @@ class BladeMapper
         $trace = Collection::make($exception->getTrace())
             ->map(function ($frame) {
                 if ($originalPath = $this->findCompiledView((string) Arr::get($frame, 'file', ''))) {
-                    $frame['file'] = $originalPath;
+                    $frame['blade'] = $originalPath;
                     $frame['line'] = $this->detectLineNumber($frame['file'], $frame['line']);
                 }
 

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/editor.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/editor.blade.php
@@ -5,8 +5,7 @@
     >
         <div class="mb-3">
             <div class="text-md text-gray-500 dark:text-gray-400">
-                <div class="mb-2">
-
+                <div>
                     @if (config('app.editor'))
                         <a href="{{ $frame->editorHref() }}" class="text-blue-500 hover:underline">
                             <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span>
@@ -16,6 +15,12 @@
                     @endif
 
                     <span class="font-mono text-xs">:{{ $frame->line() }}</span>
+                </div>
+
+                <div class="mb-2">
+                    @unless(is_null($bladeSourceFile = $frame->blade()))
+                        <span class="font-mono text-xs">View: {{ $bladeSourceFile }}</span>
+                    @endunless
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Before

![CleanShot 2024-11-06 at 10 52 23](https://github.com/user-attachments/assets/20889416-a286-4fdd-b017-a2f550b55687)

### After

![CleanShot 2024-11-06 at 10 47 23](https://github.com/user-attachments/assets/e70d5959-f48f-43a6-8173-2d8b684c30e1)
