### PR TITLE
[11.x] Add Chainable Email Content Builder.

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -8,6 +8,22 @@ use Illuminate\Support\ServiceProvider;
 class MailServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     /**
+     * Boot the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__ . '/resources/views', 'mails');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/resources/views' => $this->app->resourcePath('views/vendor/mail'),
+            ], 'laravel-mail');
+        }
+    }
+
+    /**
      * Register the service provider.
      *
      * @return void
@@ -41,12 +57,6 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerMarkdownRenderer()
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/resources/views' => $this->app->resourcePath('views/vendor/mail'),
-            ], 'laravel-mail');
-        }
-
         $this->app->singleton(Markdown::class, function ($app) {
             $config = $app->make('config');
 

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -14,11 +14,11 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__ . '/resources/views', 'mails');
+        $this->loadViewsFrom(__DIR__.'/resources/views', 'mails');
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/resources/views' => $this->app->resourcePath('views/vendor/mail'),
+                __DIR__.'/resources/views' => $this->app->resourcePath('views/vendor/mail'),
             ], 'laravel-mail');
         }
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1734,10 +1734,10 @@ class Mailable implements MailableContract, Renderable
             $this->view($content->html);
         } elseif ($content->text) {
             $this->text($content->text);
-        } elseif ($content->markdown) {
-            $this->markdown($content->markdown);
         } elseif ($content->htmlString) {
             $this->html($content->htmlString);
+        } elseif ($content->markdown) {
+            $this->markdown($content->markdown);
         }
 
         $this->with($content->with);

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1730,13 +1730,13 @@ class Mailable implements MailableContract, Renderable
 
         if ($content->view) {
             $this->view($content->view);
-        } else if ($content->html) {
+        } elseif ($content->html) {
             $this->view($content->html);
-        } else if ($content->text) {
+        } elseif ($content->text) {
             $this->text($content->text);
-        } else if ($content->markdown) {
+        } elseif ($content->markdown) {
             $this->markdown($content->markdown);
-        } else if ($content->htmlString) {
+        } elseif ($content->htmlString) {
             $this->html($content->htmlString);
         }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1730,27 +1730,17 @@ class Mailable implements MailableContract, Renderable
 
         if ($content->view) {
             $this->view($content->view);
-        }
-
-        if ($content->html) {
+        } else if ($content->html) {
             $this->view($content->html);
-        }
-
-        if ($content->text) {
+        } else if ($content->text) {
             $this->text($content->text);
-        }
-
-        if ($content->markdown) {
+        } else if ($content->markdown) {
             $this->markdown($content->markdown);
-        }
-
-        if ($content->htmlString) {
+        } else if ($content->htmlString) {
             $this->html($content->htmlString);
         }
 
-        foreach ($content->with as $key => $value) {
-            $this->with($key, $value);
-        }
+        $this->with($content->with);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -37,7 +37,7 @@ class Content
      *
      * @var string
      */
-    public $markdown = 'mails::email';
+    public $markdown;
 
     /**
      * The pre-rendered HTML of the message.
@@ -67,7 +67,7 @@ class Content
         $this->view = $view;
         $this->html = $html;
         $this->text = $text;
-        $this->markdown ??= $markdown;
+        $this->markdown = $markdown ?? 'mails::email';
         $this->with = array_merge(['outroLines' => [], 'introLines' => []], $with);
         $this->htmlString = $htmlString;
     }

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -277,7 +277,7 @@ class Content
         return $this->with([
             'actionText' => $text,
             'actionUrl' => $url,
-            'color' => $color,
+            'actionColor' => $color,
             'displayableActionUrl' => str_replace(['mailto:', 'tel:'], '', $url),
         ]);
     }

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -55,6 +55,15 @@ class Content
 
     /**
      * Create a new content definition.
+     *
+     * @param  string|null  $view
+     * @param  string|null  $html
+     * @param  string|null  $text
+     * @param  string|null  $markdown
+     * @param  array  $with
+     * @param  string|null  $htmlString
+     *
+     * @named-arguments-supported
      */
     public function __construct(
         ?string $view = null,

--- a/src/Illuminate/Mail/resources/views/email.blade.php
+++ b/src/Illuminate/Mail/resources/views/email.blade.php
@@ -12,7 +12,7 @@
 
 {{-- Action Button --}}
 @isset($actionText)
-<x-mail::button :url="$actionUrl" :color="$color">
+<x-mail::button :url="$actionUrl" :color="$actionColor">
 {{ $actionText }}
 </x-mail::button>
 @endisset

--- a/src/Illuminate/Mail/resources/views/email.blade.php
+++ b/src/Illuminate/Mail/resources/views/email.blade.php
@@ -1,0 +1,46 @@
+<x-mail::message>
+{{-- Greeting --}}
+@if (! empty($greeting))
+# {{ $greeting }}
+@endif
+
+{{-- Intro Lines --}}
+@foreach ($introLines as $line)
+{{ $line }}
+
+@endforeach
+
+{{-- Action Button --}}
+@isset($actionText)
+<x-mail::button :url="$actionUrl" :color="$color">
+{{ $actionText }}
+</x-mail::button>
+@endisset
+
+{{-- Outro Lines --}}
+@foreach ($outroLines as $line)
+{{ $line }}
+
+@endforeach
+
+{{-- Salutation --}}
+@if (! empty($salutation))
+{{ $salutation }}
+@else
+@lang('Regards,')<br>
+{{ config('app.name') }}
+@endif
+
+{{-- Subcopy --}}
+@isset($actionText)
+<x-slot:subcopy>
+@lang(
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
+    'into your web browser:',
+    [
+        'actionText' => $actionText,
+    ]
+) <span class="break-all">[{{ $displayableActionUrl }}]({{ $actionUrl }})</span>
+</x-slot:subcopy>
+@endisset
+</x-mail::message>

--- a/tests/Integration/Mail/MarkdownEmailWithoutCustomViewTest.php
+++ b/tests/Integration/Mail/MarkdownEmailWithoutCustomViewTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Mail;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Support\Facades\Mail;
+use Orchestra\Testbench\TestCase;
+
+class MarkdownEmailWithoutCustomViewTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('mail.driver', 'array');
+    }
+
+    public function testDefaultMarkdownEmailContainsExpectedContent()
+    {
+        $mailable = new DefaultMarkdownMailable;
+
+        $mailable
+            ->assertHasSubject('Subject from Mailable')
+            ->assertSeeInText('Hello, world!')
+            ->assertSeeInHtml('Welcome to your new Laravel application.')
+            ->assertSeeInHtml('My basic content')
+            ->assertSeeInHtml('Sincerely, Laravel');
+    }
+
+    public function testDefaultMarkdownEmailIsSentAndContainsText()
+    {
+        Mail::to('michael@mail.com')->send($mailable = new DefaultMarkdownMailable);
+
+        $mailable
+            ->assertSeeInText('Welcome to your new Laravel application.')
+            ->assertSeeInHtml('Welcome to your new Laravel application.');
+
+        $email = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage()->toString();
+
+        $this->assertStringContainsString('Welcome to your new Laravel application.', $email);
+    }
+
+    public function testEmailRecipientAndSubject()
+    {
+        Mail::to('michael@mail.com')->send(new DefaultMarkdownMailable);
+
+        $email = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage()->toString();
+
+        $this->assertStringContainsString('To: michael@mail.com', $email);
+        $this->assertStringContainsString('Subject: Subject from Mailable', $email);
+    }
+}
+
+class DefaultMarkdownMailable extends Mailable
+{
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Subject from Mailable',
+        );
+    }
+
+    public function content(): Content
+    {
+        return (new Content)
+            ->greeting('Hello, world!')
+            ->line('Welcome to your new Laravel application.')
+            ->line('My basic content')
+            ->salutation('Sincerely, Laravel');
+    }
+}

--- a/tests/Integration/Mail/MarkdownEmailWithoutCustomViewTest.php
+++ b/tests/Integration/Mail/MarkdownEmailWithoutCustomViewTest.php
@@ -6,15 +6,12 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Support\Facades\Mail;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
+#[WithConfig('mail.driver', 'array')]
 class MarkdownEmailWithoutCustomViewTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('mail.driver', 'array');
-    }
-
     public function testDefaultMarkdownEmailContainsExpectedContent()
     {
         $mailable = new DefaultMarkdownMailable;

--- a/tests/Mail/MailableAlternativeSyntaxTest.php
+++ b/tests/Mail/MailableAlternativeSyntaxTest.php
@@ -34,7 +34,11 @@ class MailableAlternativeSyntaxTest extends TestCase
         $method->invoke($mailable);
 
         $this->assertEquals('test-view', $mailable->view);
-        $this->assertEquals(['test-data-key' => 'test-data-value'], $mailable->viewData);
+        $this->assertEquals([
+            'test-data-key' => 'test-data-value',
+            'outroLines' => [],
+            'introLines' => [],
+        ], $mailable->viewData);
         $this->assertEquals(2, count($mailable->to));
         $this->assertEquals(1, count($mailable->cc));
         $this->assertEquals(1, count($mailable->bcc));


### PR DESCRIPTION
**Overview:**
This PR introduces a new feature allowing developers to create email content in Laravel without the need for setting up a separate view or markdown file. Instead, it enables email creation directly in PHP using a chainable syntax.

**Example Usage:**
The following example demonstrates the streamlined syntax:
```php
public function content(): Content
{
    return (new Content)
        ->greeting('Hello, world!')
        ->line('Welcome to your new Laravel application.')
        ->line('My basic content')
        ->salutation('Sincerely, Laravel');
}
```

**Benefits:**
- **Ease of Use:** Allows for rapid development of emails without needing additional view files.
- **Flexibility:** Enables developers to quickly add greetings, multiple content lines, and salutations in a straightforward, readable format.
- **Reduced Boilerplate:** Ideal for applications where simple notification emails are sufficient, reducing the need to manage extra files.
