### PR TITLE
[11.x] Make `lang:publish` command respects existing translation directory

### DIFF
--- a/src/Illuminate/Foundation/Console/LangPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/LangPublishCommand.php
@@ -32,8 +32,11 @@ class LangPublishCommand extends Command
      */
     public function handle()
     {
-        if (! is_dir($langPath = $this->laravel->resourcePath('lang/en'))
-            && ! is_dir($langPath = $this->laravel->basePath('lang/en'))) {
+        $langPath = is_dir($this->laravel->resourcePath('lang'))
+            ? $this->laravel->resourcePath('lang/en')
+            : $this->laravel->basePath('lang/en');
+
+        if (! is_dir($langPath)) {
             (new Filesystem)->makeDirectory($langPath, recursive: true);
         }
 

--- a/src/Illuminate/Foundation/Console/LangPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/LangPublishCommand.php
@@ -32,7 +32,8 @@ class LangPublishCommand extends Command
      */
     public function handle()
     {
-        if (! is_dir($langPath = $this->laravel->basePath('lang/en'))) {
+        if (! is_dir($langPath = $this->laravel->resourcePath('lang/en'))
+            && ! is_dir($langPath = $this->laravel->basePath('lang/en'))) {
             (new Filesystem)->makeDirectory($langPath, recursive: true);
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As noted in #51432, some packages still publish translation files to the `resources/lang` directory, while the `lang:publish` command places them in the `/lang` directory, even when a `resources/lang` directory already exists. This inconsistency can be confusing, as translations won't work unless they are manually moved from `/lang` to `/resources/lang`.

This PR updates the `lang:publish` command to first check for an existing `resources/lang` directory. If found, translations will be published there; otherwise, they will default to the `/lang` directory.