### PR TITLE
Changed the instance resolution in service container when exists simple bind with an explicit instance

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -793,7 +793,7 @@ class Container implements ArrayAccess, ContainerContract
 
         $concrete = $this->getContextualConcrete($abstract);
 
-        $needsContextualBuild = ! empty($parameters) || ! is_null($concrete);
+        $needsContextualBuild = ! is_null($concrete);
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -255,6 +255,19 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Determine if a given type has a bind and specific instance,
+     * this should be because after define the bind, it has set a instance.
+     *
+     * @param  string  $abstract
+     * @return bool
+     */
+    public function hasBindWithInstance($abstract)
+    {
+        return isset($this->bindings[$abstract]) &&
+               isset($this->instances[$abstract]);
+    }
+
+    /**
      * Determine if a given string is an alias.
      *
      * @param  string  $name
@@ -793,12 +806,12 @@ class Container implements ArrayAccess, ContainerContract
 
         $concrete = $this->getContextualConcrete($abstract);
 
-        $needsContextualBuild = ! is_null($concrete);
+        $needsContextualBuild = ! is_null($concrete) || ! empty($parameters);
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
         // so the developer can keep using the same objects instance every time.
-        if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
+        if ((isset($this->instances[$abstract]) && ! $needsContextualBuild) || $this->hasBindWithInstance($abstract)) {
             return $this->instances[$abstract];
         }
 


### PR DESCRIPTION
The change is used to solve the problem of instances resolution of a app->make(MyService::class, ['param' => 'foo']) call with parameters. Before the change, if you replace a call that is resolved with the callback of the app()->bind() method with an instance provided by the app()->instance() method for the same abstract key, if after doing the "overwriting" of the abstract key instance you call the app->make(MyService::class) method to get an instance of the service without parameters, it will be resolved with the instance provided in the app()->instance() method, but if you make the call to make() with parameters like app->make(MyService::class, ['param' => 'foo']) it will be resolved with the callback provided in the app()->bind() method, so I think the abstract key is not "overwritten" correctly. 

With the change, the "overwriting" of the instance provided in the instance() method when make() is called with parameters is now properly resolved. Before the change it was only possible to force an instance to be "overwritten" by the instant() method if the call of the make() method did not come with additional parameters.

This allows mocking for service container elements binded with parameters.

Benefit example:

```php
// For my application I need to define a bind of my service in the service container.

app()->bind(MyService::class, function (Application $app, array $params): MyService {
  return new MyService($params['payload']);
});

// -----------------------------------------------------------------------------------------------

/*
 *  Somewhere in my application I eventually make a call to get an instance of the service.
 *  I could also directly use the app(MyService::class, ['payload' => 'Hello']) call. 
 */

app()->make(MyService::class, ['payload' => 'Hello']);

// -----------------------------------------------------------------------------------------------

/*
 *  To mock the service, I instantiate a mock object and invoke the instance method of the service container 
 *  to forcibly substitute the resolution of my service so that when the service container is called, 
 *  my mock object is returned. This is necessary in a testing context.
 */

$mockInstance = Mockery::mock(MyService::class, function (MockInterface $mock) {
	$mock
	  ->shouldReceive('getMyData')
	  ->andReturn('Forzed return');
  })->makePartial();

app()->instance(
  MyService::class,
  $mockInstance
);

// -----------------------------------------------------------------------------------------------

/*
 *  If I make a call in my code like this to resolve an instance of the service, before the change
 *  proposed by this pull request, it was resolved with the callback of the bind method 
 *  and ignored my overwrite of my mock object added by the instance() method
 */
app()->make(MyService::class, ['payload' => 'Hello']);

// Before the change to make this work I could only make the call without parameters like this.

app()->make(MyService::class);

/*
 *  Both calls can now be used with or without additional parameters in the make() 
 *  and both will resolve to the instance provided in the instance() method instead of 
 *  resolving a new instance by calling the bind() method again.
 */
```

