### PR TITLE
[11.x] Use PHP 8.4 array helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -204,6 +204,12 @@ class Arr
             return value($default);
         }
 
+        if (function_exists('array_find_key')) {
+            $key = array_find_key($array, $callback);
+
+            return $key !== null ? $array[$key] : value($default);
+        }
+
         foreach ($array as $key => $value) {
             if ($callback($value, $key)) {
                 return $value;

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -175,6 +175,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if (func_num_args() === 1) {
             if ($this->useAsCallable($key)) {
+                if (function_exists('array_any')) {
+                    return array_any($this->items, $key);
+                }
+
                 $placeholder = new stdClass;
 
                 return $this->first($key, $placeholder) !== $placeholder;
@@ -573,6 +577,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $keys = is_array($key) ? $key : func_get_args();
 
+        if (function_exists('array_all')) {
+            return array_all($keys, fn ($key) => array_key_exists($key, $this->items));
+        }
+
         foreach ($keys as $value) {
             if (! array_key_exists($value, $this->items)) {
                 return false;
@@ -595,6 +603,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         $keys = is_array($key) ? $key : func_get_args();
+
+        if (function_exists('array_any')) {
+            return array_any($keys, fn ($key) => array_key_exists($key, $this->items));
+        }
 
         foreach ($keys as $value) {
             if ($this->has($value)) {
@@ -1152,6 +1164,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if (! $this->useAsCallable($value)) {
             return array_search($value, $this->items, $strict);
+        }
+
+        if (function_exists('array_find_key')) {
+            return array_find_key($this->items, $value) ?? false;
         }
 
         foreach ($this->items as $key => $item) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PHP 8.4 introduces new array search functions for finding items matching criteria or determining if any/all of them pass. See also https://php.watch/versions/8.4/array_find-array_find_key-array_any-array_all.

This PR introduces these helpers in the `Arr` and `Collection` classes to use 'modern' logic for the case where these functions are available. If in the future the minimal PHP version is 8.4, this will allow for further simplification by removing the old logic altogether.

Requires #52633 to be merged or to be merged into #52633.
