### PR TITLE
[11.x] Cache token repository

### DIFF
--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -24,7 +24,8 @@ class CacheTokenRepository implements TokenRepositoryInterface
         protected string $hashKey,
         protected int $expires = 3600,
         protected int $throttle = 60
-    ) {}
+    ) {
+    }
 
     /**
      * Create a new token.

--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -19,11 +19,11 @@ class CacheTokenRepository implements TokenRepositoryInterface
      * Create a new token repository instance.
      */
     public function __construct(
-        protected Repository     $cache,
+        protected Repository $cache,
         protected HasherContract $hasher,
-        protected string         $hashKey,
-        protected int            $expires = 3600,
-        protected int            $throttle = 60
+        protected string $hashKey,
+        protected int $expires = 3600,
+        protected int $throttle = 60
     ) {}
 
     /**
@@ -120,6 +120,5 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function deleteExpired()
     {
-        return;
     }
 }

--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Illuminate\Auth\Passwords;
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+class CacheTokenRepository implements TokenRepositoryInterface
+{
+    /**
+     * The Hasher implementation.
+     */
+    protected HasherContract $hasher;
+
+    /**
+     * The hashing key.
+     */
+    protected string $hashKey;
+
+    /**
+     * The number of seconds a token should last.
+     */
+    protected int|float $expires;
+
+    /**
+     * Minimum number of seconds before re-redefining the token.
+     */
+    protected int $throttle;
+
+    /**
+     * @var \Illuminate\Cache\Repository
+     */
+    private Repository $cache;
+
+    /**
+     * Create a new token repository instance.
+     *
+     * @param  \Illuminate\Cache\Repository  $cache
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
+     * @param  string  $hashKey
+     * @param  int  $expires
+     * @param  int  $throttle
+     */
+    public function __construct(
+        Repository     $cache,
+        HasherContract $hasher,
+        string         $hashKey,
+        int            $expires = 60,
+        int            $throttle = 60
+    ) {
+        $this->cache = $cache;
+        $this->hasher = $hasher;
+        $this->hashKey = $hashKey;
+        $this->expires = $expires * 60;
+        $this->throttle = $throttle;
+    }
+
+    /**
+     * Create a new token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return string
+     */
+    public function create(CanResetPasswordContract $user)
+    {
+        $email = $user->getEmailForPasswordReset();
+
+        $this->cache->forget($email);
+
+        $token = hash_hmac('sha256', Str::random(40), $this->hashKey);
+
+        $this->cache->put($email, [$token, Carbon::now()], $this->expires);
+
+        return $token;
+    }
+
+    /**
+     * Determine if a token record exists and is valid.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $token
+     * @return bool
+     */
+    public function exists(CanResetPasswordContract $user, #[\SensitiveParameter] $token)
+    {
+        [$record, $createdAt] = $this->cache->get($user->getEmailForPasswordReset());
+
+        return $record
+            && ! $this->tokenExpired($createdAt)
+            && $this->hasher->check($token, $record);
+    }
+
+    /**
+     * Determine if the token has expired.
+     *
+     * @param  string  $createdAt
+     * @return bool
+     */
+    protected function tokenExpired($createdAt)
+    {
+        return Carbon::parse($createdAt)->addSeconds($this->expires)->isPast();
+    }
+
+    /**
+     * Determine if the given user recently created a password reset token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return bool
+     */
+    public function recentlyCreatedToken(CanResetPasswordContract $user)
+    {
+        [$record, $createdAt] = $this->cache->get($user->getEmailForPasswordReset());
+
+        return $record && $this->tokenRecentlyCreated($createdAt);
+    }
+
+    /**
+     * Determine if the token was recently created.
+     *
+     * @param  string  $createdAt
+     * @return bool
+     */
+    protected function tokenRecentlyCreated($createdAt)
+    {
+        if ($this->throttle <= 0) {
+            return false;
+        }
+
+        return Carbon::parse($createdAt)->addSeconds(
+            $this->throttle
+        )->isFuture();
+    }
+
+    /**
+     * Delete a token record.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    public function delete(CanResetPasswordContract $user)
+    {
+        $this->cache->forget($user->getEmailForPasswordReset());
+    }
+
+    /**
+     * Delete expired tokens.
+     *
+     * @return void
+     */
+    public function deleteExpired()
+    {
+        return;
+    }
+}

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -93,7 +93,7 @@ class PasswordBrokerManager implements FactoryContract
                 $this->app['cache']->store($config['store'] ?? null),
                 $this->app['hash'],
                 $key,
-                $config['expire'],
+                ($config['expire'] ?? 60) * 60,
                 $config['throttle'] ?? 0
             );
         }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -88,7 +88,7 @@ class PasswordBrokerManager implements FactoryContract
             $key = base64_decode(substr($key, 7));
         }
 
-        if ($config['driver'] === 'cache') {
+        if (isset($config['driver']) && $config['driver'] === 'cache') {
             return new CacheTokenRepository(
                 $this->app['cache']->store($config['store'] ?? null),
                 $this->app['hash'],

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -88,10 +88,18 @@ class PasswordBrokerManager implements FactoryContract
             $key = base64_decode(substr($key, 7));
         }
 
-        $connection = $config['connection'] ?? null;
+        if ($config['driver'] === 'cache') {
+            return new CacheTokenRepository(
+                $this->app['cache']->store($config['store'] ?? null),
+                $this->app['hash'],
+                $key,
+                $config['expire'],
+                $config['throttle'] ?? 0
+            );
+        }
 
         return new DatabaseTokenRepository(
-            $this->app['db']->connection($connection),
+            $this->app['db']->connection($config['connection'] ?? null),
             $this->app['hash'],
             $config['table'],
             $key,


### PR DESCRIPTION
Password reset tokens are a relatively short lived entity. Currently our only framework option is for them to be stored in the database.  This is an okay option, but it's slightly annoying because it's another table to maintain, and makes it more difficult for Laravel to make desired adjustment if they require a schema change.

This PR proposes a new `CacheTokenRepository` which will allow the password reset tokens to be handled via cache. IMO cache is a perfect storage medium because it can be more ephemeral, just like the password reset tokens.

To enable this new `CacheTokenRepository`, adjust your `config/auth.php` like so:

```php
'passwords' => [

    //new cache driver
    'customers' => [
        'driver'   => 'cache',
        'store'    => 'passwords',
        'provider' => 'customers',
        'expire'   => 60,
        'throttle' => 60,
    ],

   //default old database driver
    'users'     => [
        'provider' => 'users',
        'table'    =>'password_reset_tokens',
        'expire'   => 60,
        'throttle' => 60,
    ],
],
```

The `driver` key will activate the new "cache" driver.  The `store` key is optional, although I would recommend creating a dedicated cache store for your password resets to prevent flushing your password resets when refreshing your normal cache.  The `expire` and `throttle` key behave as before.

If your application has multiple "providers" that all use `email` as their identifier, you also get the added benefit of being able to place them on separate cache stores, thus avoiding an unlikely but possible collision.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
