### PR TITLE
[11.x] Allow adding attributes to Vite html tags

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -419,7 +419,7 @@ class Vite implements Htmlable
                         $this->assetPath("{$buildDirectory}/{$css}"),
                         $partialManifest->first(),
                         $manifest,
-                        $attributes
+                        []
                     ));
                 }
             }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -53,11 +53,22 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $result = app(Vite::class)(['resources/css/app.css' => ['media' => 'all'], 'resources/js/app.js' => ['async']]);
+        $result = app(Vite::class)([
+            'resources/css/app.css' => ['media' => 'all'],
+            'resources/js/app.js' => ['async'],
+            'resources/js/app-with-shared-css.js' => ['data-attribute' => 'only-on-js'],
+        ]);
 
-        $this->assertStringEndsWith(
-            '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" media="all" />'
-            .'<script type="module" src="https://example.com/build/assets/app.versioned.js" async></script>',
+        $this->assertSame(
+            '<link rel="preload" as="style" href="https://example.com/build/assets/app.versioned.css" />'
+            .'<link rel="preload" as="style" href="https://example.com/build/assets/shared-css.versioned.css" />'
+            .'<link rel="modulepreload" href="https://example.com/build/assets/app.versioned.js" />'
+            .'<link rel="modulepreload" href="https://example.com/build/assets/app-with-shared-css.versioned.js" />'
+            .'<link rel="modulepreload" href="https://example.com/build/assets/someFile.versioned.js" />'
+            .'<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" media="all" />'
+            .'<link rel="stylesheet" href="https://example.com/build/assets/shared-css.versioned.css" />'
+            .'<script type="module" src="https://example.com/build/assets/app.versioned.js" async></script>'
+            .'<script type="module" src="https://example.com/build/assets/app-with-shared-css.versioned.js" data-attribute="only-on-js"></script>',
             $result->toHtml()
         );
     }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -49,6 +49,19 @@ class FoundationViteTest extends TestCase
         );
     }
 
+    public function testViteWithCustomAttributes()
+    {
+        $this->makeViteManifest();
+
+        $result = app(Vite::class)(['resources/css/app.css' => ['media' => 'all'], 'resources/js/app.js' => ['async']]);
+
+        $this->assertStringEndsWith(
+            '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" media="all" />'
+            .'<script type="module" src="https://example.com/build/assets/app.versioned.js" async></script>',
+            $result->toHtml()
+        );
+    }
+
     public function testViteWithCssImport()
     {
         $this->makeViteManifest();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using the Blade `@vite` helper, it currently is very hard to add additional attributes to the created (script) elements. This PR introduces syntax to allow adding attributes to script and/or style tags, by passing them in the shape
```php
['/asset/path' => ['attribute' => 'value', 'attribute-without-value']]
```

A use-case would be adding the `async` attribute to a created `script` element or `media` attribute to stylesheets, although there are probably more. 

Current ways of achieving this are for example (see also https://github.com/laravel/framework/pull/53429#issuecomment-2463476435 and https://laravel.com/docs/11.x/vite#arbitrary-attributes):
```blade
{{
    Vite::withEntryPoints(['resources/js/app.js'])
        ->useScriptTagAttributes(fn (string $source) => $source === 'resources/js/app.js' ? ['async' => true] : []);
}}
```

or:
```blade
    @php
        $scriptPath = 'resources/js/foo.ts';
        \Illuminate\Support\Facades\Vite::useScriptTagAttributes(fn (string $source) => $source === $scriptPath ? ['async' => true] : []);
    @endphp
    @vite($scriptPath)
```

See also https://github.com/laravel/framework/discussions/52032.