### PR TITLE
[11.x] Ensure datetime cache durations account for script execution time

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -624,7 +624,9 @@ class Repository implements ArrayAccess, CacheContract
         $duration = $this->parseDateInterval($ttl);
 
         if ($duration instanceof DateTimeInterface) {
-            $duration = Carbon::now()->diffInSeconds($duration, false);
+            $duration = (int) ceil(
+                Carbon::now()->diffInMilliseconds($duration, false) / 1000
+            );
         }
 
         return (int) ($duration > 0 ? $duration : 0);

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\TestCase;
 
@@ -234,5 +236,22 @@ class RepositoryTest extends TestCase
         $this->assertFalse($cache->getFilesystem()->exists($cache->path('count')));
         $this->assertFalse($cache->getFilesystem()->exists($cache->path('illuminate:cache:flexible:created:count')));
         $this->assertTrue($cache->missing('illuminate:cache:flexible:created:count'));
+    }
+
+    public function testItRoundsDateTimeValuesToAccountForTimePassedDuringScriptExecution()
+    {
+        // do not freeze time as this test depends on time progressing duration execution.
+        $cache = Cache::driver('array');
+        $events = [];
+        Event::listen(function (KeyWritten $event) use (&$events) {
+            $events[] = $event;
+        });
+
+        $result = $cache->put('foo', 'bar', now()->addSecond());
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $events);
+        $this->assertSame('foo', $events[0]->key);
+        $this->assertSame(1, $events[0]->seconds);
     }
 }


### PR DESCRIPTION
This PR addresses a rounding bug when datetime or intervals are used with the cache.

```php
Cache::put($key, $value, now()->addSecond());
```

Surprisingly, this will not put the value into the cache. It will instead call `Cache::forget` under the hood.

This is because by the time we do a diff between `now()` and `$ttl = now()->addSecond()` some time has passed during PHP execution, even if only microseconds. That means the diff is ~0.999 seconds, which we cast to an `int` resulting in `0`.

This also impacts date time intervals, because we convert those to datetime instances.

I have a gut feeling this also impacts other parts of the framework where we pull the seconds off a datetime, such as the queue system. Also anything that uses `InteractsWithTime` may also be impacted. Some of those values are likely off by a second. I haven't investigated this to confirm, though.