### PR TITLE
[11.x] create Laravel internal components

### DIFF
--- a/src/Illuminate/View/Components/CsrfField.php
+++ b/src/Illuminate/View/Components/CsrfField.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class CsrfField extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        protected string $name = '_token',
+    ) {}
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('laravel::csrf-field')
+            ->with([
+                'name'  => $this->name,
+                'value' => csrf_token(),
+            ]);
+    }
+}

--- a/src/Illuminate/View/Components/CsrfField.php
+++ b/src/Illuminate/View/Components/CsrfField.php
@@ -13,7 +13,8 @@ class CsrfField extends Component
      */
     public function __construct(
         protected string $name = '_token',
-    ) {}
+    ) {
+    }
 
     /**
      * Get the view / contents that represent the component.
@@ -22,7 +23,7 @@ class CsrfField extends Component
     {
         return view('laravel::csrf-field')
             ->with([
-                'name'  => $this->name,
+                'name' => $this->name,
                 'value' => csrf_token(),
             ]);
     }

--- a/src/Illuminate/View/Components/MethodField.php
+++ b/src/Illuminate/View/Components/MethodField.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class MethodField extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        protected string $value,
+        protected string $name = '_method',
+    ) {}
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('laravel::method-field')
+            ->with([
+                'name'  => $this->name,
+                'value' => $this->value,
+            ]);
+    }
+}

--- a/src/Illuminate/View/Components/MethodField.php
+++ b/src/Illuminate/View/Components/MethodField.php
@@ -14,7 +14,8 @@ class MethodField extends Component
     public function __construct(
         protected string $value,
         protected string $name = '_method',
-    ) {}
+    ) {
+    }
 
     /**
      * Get the view / contents that represent the component.
@@ -23,7 +24,7 @@ class MethodField extends Component
     {
         return view('laravel::method-field')
             ->with([
-                'name'  => $this->name,
+                'name' => $this->name,
                 'value' => $this->value,
             ]);
     }

--- a/src/Illuminate/View/Components/views/csrf-field.blade.php
+++ b/src/Illuminate/View/Components/views/csrf-field.blade.php
@@ -1,0 +1,7 @@
+<input
+    type="hidden"
+    name="{{ $name }}"
+    value="{{ $value }}"
+    autocomplete="off"
+    {{ $attributes }}
+/>

--- a/src/Illuminate/View/Components/views/method-field.blade.php
+++ b/src/Illuminate/View/Components/views/method-field.blade.php
@@ -1,0 +1,6 @@
+<input
+    type="hidden"
+    name="{{ $name }}"
+    value="{{ $value }}"
+    {{ $attributes }}
+/>

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View;
 
 use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
@@ -23,6 +24,7 @@ class ViewServiceProvider extends ServiceProvider
         $this->registerViewFinder();
         $this->registerBladeCompiler();
         $this->registerEngineResolver();
+        $this->registerLaravelComponents();
 
         $this->app->terminating(static function () {
             Component::flushCache();
@@ -175,5 +177,11 @@ class ViewServiceProvider extends ServiceProvider
 
             return $compiler;
         });
+    }
+
+    protected function registerLaravelComponents()
+    {
+        $this->loadViewsFrom(__DIR__.'/Components/views', 'laravel');
+        Blade::componentNamespace('Illuminate\\View\\Components', 'laravel');
     }
 }


### PR DESCRIPTION
most Blade tags are just PHP logic, and make sense as Blade. however, some of them are outputting full blocks of HTML, and feel more like components.

this creates a new set of Laravel internal components, which makes it easier to override values, and append additional attributes.

my original motivation was to try and solve the problem of being able to append attributes to [Vite tags]](#53429), but clearly that is a much more complicated issue that I originally thought.

I'll admit I have low hopes for this, but I figured I'd throw it up here anyway to see if it sparks any ideas for anyone where this feature would be more impactful.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
