### PR TITLE
[12.x] Get the drivers a notifiable supports routing notifications via

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -76,4 +76,14 @@ class AnonymousNotifiable
     {
         //
     }
+
+    /**
+     * Get all the drivers the notifiable supports being routed to.
+     *
+     * @return array
+     */
+    public function getDrivers(): array
+    {
+        return array_keys($this->routes);
+    }
 }

--- a/src/Illuminate/Notifications/Notifiable.php
+++ b/src/Illuminate/Notifications/Notifiable.php
@@ -5,4 +5,21 @@ namespace Illuminate\Notifications;
 trait Notifiable
 {
     use HasDatabaseNotifications, RoutesNotifications;
+
+    /**
+     * Get all the drivers the notifiable supports being routed to.
+     *
+     * @return array
+     */
+    public function getDrivers(): array
+    {
+        return collect(get_class_methods($this))
+            ->filter(fn (string $method): bool => str_starts_with($method, 'routeNotificationFor'))
+            ->map(fn (string $method): string => str($method)->replace('routeNotificationFor', '')->lower())
+            ->merge(['mail', 'database']) // via the RoutesNotifications trait
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
 }

--- a/tests/Notifications/NotifiableTest.php
+++ b/tests/Notifications/NotifiableTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Notifiable;
+use PHPUnit\Framework\TestCase;
+
+class NotifiableTest extends TestCase
+{
+    public function testGetDrivers()
+    {
+        $anonymous = new AnonymousNotifiable;
+        $anonymous->route('slack', '#laravel');
+        $anonymous->route('mail', 'taylor@laravel.com');
+        $anonymous->route('foo', 'bar');
+        $anonymous->route('foobar', 'baz');
+        $this->assertSame(['slack', 'mail', 'foo', 'foobar'], $anonymous->getDrivers());
+
+        $notifiable = new NotifiableTestInstance;
+        $this->assertSame(['slack', 'foo', 'foobar', 'mail', 'database'], $notifiable->getDrivers());
+    }
+}
+
+class NotifiableTestModelInstance
+{
+    use Notifiable;
+}
+
+class NotifiableTestInstance
+{
+    use Notifiable;
+
+    public function routeNotificationForSlack(): string
+    {
+        return '#laravel';
+    }
+
+    public function routeNotificationForFoo(): string
+    {
+        return 'bar';
+    }
+
+    public function routeNotificationForFooBar(): string
+    {
+        return 'baz';
+    }
+}

--- a/tests/Notifications/NotifiableTest.php
+++ b/tests/Notifications/NotifiableTest.php
@@ -22,11 +22,6 @@ class NotifiableTest extends TestCase
     }
 }
 
-class NotifiableTestModelInstance
-{
-    use Notifiable;
-}
-
 class NotifiableTestInstance
 {
     use Notifiable;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I work on an app where some notifiables don't support all the drivers a notification can be routed with (e.g. Slack and Mail, but only Mail applies to a `User` model).

This PR adds a `getDrivers()` method to both the `Notifiable` trait and the `AnonymousNotifiable` class that allows you to ask the notifiable which drivers it supports. You can use this in the notification to figure out what's supported:

```
class MyNotification
{
    public function via(object $notifiable): array
    {
        return array_intersect(['mail', 'slack'], $notifiable->getDrivers());
    }
}
```

I did this against master as the trait method name could possibly conflict with the class it's imported into.