### PR TITLE
[11.x] Fix error event listener in Vite prefetching

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -539,7 +539,7 @@ class Vite implements Htmlable
 
                                     if (assets.length) {
                                         link.onload = () => loadNext(assets, 1)
-                                        link.error = () => loadNext(assets, 1)
+                                        link.onerror = () => loadNext(assets, 1)
                                     }
                                 }
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1359,7 +1359,7 @@ class FoundationViteTest extends TestCase
 
                         if (assets.length) {
                             link.onload = () => loadNext(assets, 1)
-                            link.error = () => loadNext(assets, 1)
+                            link.onerror = () => loadNext(assets, 1)
                         }
                     }
 
@@ -1637,7 +1637,7 @@ class FoundationViteTest extends TestCase
 
                         if (assets.length) {
                             link.onload = () => loadNext(assets, 1)
-                            link.error = () => loadNext(assets, 1)
+                            link.onerror = () => loadNext(assets, 1)
                         }
                     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently assigned as `link.error`, this handler is effectively doing nothing. This ensures the handler is actually registering the event listener.

*Edit:* for reference I discovered this on debugging with Firefox, which erred on loading the assets due to being returned with a no-cache header in my local setup, thus causing the first batch of asset loads to fail and no new batch to be scheduled. After this adjustment all of them were added.