### PR TITLE
Fix schema foreign ID support for tables with non-standard primary key

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1039,16 +1039,16 @@ class Blueprint
         $column = $column ?: $model->getForeignKey();
 
         if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
-            return $this->foreignId($column)->table($model->getTable());
+            return $this->foreignId($column)->table($model->getTable())->referencesColumn($model->getKeyName());
         }
 
         $modelTraits = class_uses_recursive($model);
 
         if (in_array(HasUlids::class, $modelTraits, true)) {
-            return $this->foreignUlid($column, 26)->table($model->getTable());
+            return $this->foreignUlid($column, 26)->table($model->getTable())->referencesColumn($model->getKeyName());
         }
 
-        return $this->foreignUuid($column)->table($model->getTable());
+        return $this->foreignUuid($column)->table($model->getTable())->referencesColumn($model->getKeyName());
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1039,16 +1039,22 @@ class Blueprint
         $column = $column ?: $model->getForeignKey();
 
         if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
-            return $this->foreignId($column)->table($model->getTable())->referencesColumn($model->getKeyName());
+            return $this->foreignId($column)
+                ->table($model->getTable())
+                ->referencesModelColumn($model->getKeyName());
         }
 
         $modelTraits = class_uses_recursive($model);
 
         if (in_array(HasUlids::class, $modelTraits, true)) {
-            return $this->foreignUlid($column, 26)->table($model->getTable())->referencesColumn($model->getKeyName());
+            return $this->foreignUlid($column, 26)
+                ->table($model->getTable())
+                ->referencesModelColumn($model->getKeyName());
         }
 
-        return $this->foreignUuid($column)->table($model->getTable())->referencesColumn($model->getKeyName());
+        return $this->foreignUuid($column)
+            ->table($model->getTable())
+            ->referencesModelColumn($model->getKeyName());
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -38,7 +38,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     public function constrained($table = null, $column = null, $indexName = null)
     {
         $table ??= $this->table;
-        $column ??= $this->referencesColumn ?? 'id';
+        $column ??= $this->referencesModelColumn ?? 'id';
 
         return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -35,9 +35,10 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      * @param  string|null  $indexName
      * @return \Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function constrained($table = null, $column = 'id', $indexName = null)
+    public function constrained($table = null, $column = null, $indexName = null)
     {
         $table ??= $this->table;
+        $column ??= $this->referencesColumn ?? 'id';
 
         return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -444,6 +444,22 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new MySqlGrammar()));
     }
 
+    public function testGenerateRelationshipConstrainedColumn()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->foreignIdFor('Illuminate\Foundation\Auth\User')->constrained();
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `user_id` bigint unsigned not null',
+            'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
     public function testDropRelationshipColumnWithIncrementalModel()
     {
         $base = new Blueprint('posts', function ($table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+use Illuminate\Tests\Database\Fixtures\Models\User;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -457,6 +458,22 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` add `user_id` bigint unsigned not null',
             'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testGenerateRelationshipForModelWithNonStandardPrimaryKeyName()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->foreignIdFor(User::class)->constrained();
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `user_internal_id` bigint unsigned not null',
+            'alter table `posts` add constraint `posts_user_internal_id_foreign` foreign key (`user_internal_id`) references `users` (`internal_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 

--- a/tests/Database/Fixtures/Models/User.php
+++ b/tests/Database/Fixtures/Models/User.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Foundation\Auth\User as FoundationUser;
+
+class User extends FoundationUser
+{
+    protected $primaryKey = 'internal_id';
+}


### PR DESCRIPTION
This allows `foreignIdFor` to automatically set the referenced column name for tables/models with non-standard primary key names.