### PR TITLE
[11.x] Introduce whereRelationIn in eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -399,6 +399,19 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a where in clause to a relationship query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $values
+     * @return $this
+     */
+    public function whereRelationIn($relation, $column, $values)
+    {
+        return $this->whereHas($relation, fn($query) => $query->whereIn($column, $values));
+    }
+
+    /**
      * Add an "or where" clause to a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -408,7 +408,7 @@ trait QueriesRelationships
      */
     public function whereRelationIn($relation, $column, $values)
     {
-        return $this->whereHas($relation, fn($query) => $query->whereIn($column, $values));
+        return $this->whereHas($relation, fn ($query) => $query->whereIn($column, $values));
     }
 
     /**

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -158,6 +158,13 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $comments->pluck('id')->all());
     }
 
+    public function testWhereRelationIn()
+    {
+        $posts = Post::whereRelationIn('user', 'id', [1])->get();
+
+        $this->assertEquals([1], $posts->pluck('id')->all());
+    }
+
     public function testWithCount()
     {
         $users = User::whereHas('posts', function ($query) {


### PR DESCRIPTION
# Introduce `whereRelationIn()` method to eloquent models

## Description

This pull request introduces a new method called `whereRelationIn($relation, $column, $values)` to eloquent models which is more readable and easier to filter models based on related models values using a where in statement, instead of having to use more verbose approaches such as these
```php
Model::whereHas($relation, fn($query) => $query->whereIn($column, $values));
Model::whereRelation($relation, fn($query) => $query->whereIn($column, $values));
```

## Example usage
```php
Author::whereRelationIn('posts', 'id', [1, 2, 3]);
```

## Notes
which do you think is better adding the `whereRelationIn` method, or using the same whereRelation method but modifying the behaviour to handle the case when the $operator variable is 'in' and the $value is an array like this 
```php
Model::whereRelation($relation, $column, 'in', [...$values])
```

I also opened a pr in the larave/docs repo to document this method here laravel/docs#10021 