### PR TITLE
[11.x] add optional prefix for cache key

### DIFF
--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -23,7 +23,8 @@ class CacheTokenRepository implements TokenRepositoryInterface
         protected HasherContract $hasher,
         protected string $hashKey,
         protected int $expires = 3600,
-        protected int $throttle = 60
+        protected int $throttle = 60,
+        protected string $prefix = '',
     ) {
     }
 
@@ -35,13 +36,15 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function create(CanResetPasswordContract $user)
     {
-        $email = $user->getEmailForPasswordReset();
-
         $this->delete($user);
 
         $token = hash_hmac('sha256', Str::random(40), $this->hashKey);
 
-        $this->cache->put($email, [$token, Carbon::now()->format($this->format)], $this->expires);
+        $this->cache->put(
+            $this->prefix . $user->getEmailForPasswordReset(),
+            [$token, Carbon::now()->format($this->format)],
+            $this->expires,
+        );
 
         return $token;
     }
@@ -55,7 +58,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function exists(CanResetPasswordContract $user, #[\SensitiveParameter] $token)
     {
-        [$record, $createdAt] = $this->cache->get($user->getEmailForPasswordReset());
+        [$record, $createdAt] = $this->cache->get($this->prefix . $user->getEmailForPasswordReset());
 
         return $record
             && ! $this->tokenExpired($createdAt)
@@ -81,7 +84,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function recentlyCreatedToken(CanResetPasswordContract $user)
     {
-        [$record, $createdAt] = $this->cache->get($user->getEmailForPasswordReset());
+        [$record, $createdAt] = $this->cache->get($this->prefix . $user->getEmailForPasswordReset());
 
         return $record && $this->tokenRecentlyCreated($createdAt);
     }
@@ -111,7 +114,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function delete(CanResetPasswordContract $user)
     {
-        $this->cache->forget($user->getEmailForPasswordReset());
+        $this->cache->forget($this->prefix . $user->getEmailForPasswordReset());
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -41,7 +41,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
         $token = hash_hmac('sha256', Str::random(40), $this->hashKey);
 
         $this->cache->put(
-            $this->prefix . $user->getEmailForPasswordReset(),
+            $this->prefix.$user->getEmailForPasswordReset(),
             [$token, Carbon::now()->format($this->format)],
             $this->expires,
         );
@@ -58,7 +58,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function exists(CanResetPasswordContract $user, #[\SensitiveParameter] $token)
     {
-        [$record, $createdAt] = $this->cache->get($this->prefix . $user->getEmailForPasswordReset());
+        [$record, $createdAt] = $this->cache->get($this->prefix.$user->getEmailForPasswordReset());
 
         return $record
             && ! $this->tokenExpired($createdAt)
@@ -84,7 +84,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function recentlyCreatedToken(CanResetPasswordContract $user)
     {
-        [$record, $createdAt] = $this->cache->get($this->prefix . $user->getEmailForPasswordReset());
+        [$record, $createdAt] = $this->cache->get($this->prefix.$user->getEmailForPasswordReset());
 
         return $record && $this->tokenRecentlyCreated($createdAt);
     }
@@ -114,7 +114,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function delete(CanResetPasswordContract $user)
     {
-        $this->cache->forget($this->prefix . $user->getEmailForPasswordReset());
+        $this->cache->forget($this->prefix.$user->getEmailForPasswordReset());
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -94,7 +94,8 @@ class PasswordBrokerManager implements FactoryContract
                 $this->app['hash'],
                 $key,
                 ($config['expire'] ?? 60) * 60,
-                $config['throttle'] ?? 0
+                $config['throttle'] ?? 0,
+                $config['prefix'] ?? '',
             );
         }
 


### PR DESCRIPTION
if a user does not decide to use a dedicated cache store for their password resets, there's a risk of collision/overwriting of the cache keys in the default cache store, since we are just using the user's email.  this allows the user to set an optional config value to use a prefix on the cache key.

I left the default blank to start, but we could also choose to come up with some default string.

the other option to this PR is to **force** people to use a dedicated cache store, which I think we should at least strongly encourage for other reasons as well.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
