### PR TITLE
[11.x] Add isDate, isTime, and isDateTime methods to Str and Stringable classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Closure;
+use DateTime;
 use Illuminate\Support\Traits\Macroable;
 use JsonException;
 use League\CommonMark\Environment\Environment;
@@ -521,6 +522,60 @@ class Str
     public static function isAscii($value)
     {
         return ASCII::is_ascii((string) $value);
+    }
+
+    /**
+     * Determine if a given string is a date in the specified format.
+     *
+     * @param  string  $value
+     * @param  string  $format
+     * @return bool
+     */
+    public static function isDate($value, $format = 'Y-m-d')
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $date = DateTime::createFromFormat($format, $value);
+
+        return $date && $date->format($format) === $value;
+    }
+
+    /**
+     * Determine if a given string is a time in the specified format.
+     *
+     * @param  string  $value
+     * @param  string  $format
+     * @return bool
+     */
+    public static function isTime($value, $format = 'H:i:s')
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $time = DateTime::createFromFormat($format, $value);
+
+        return $time && $time->format($format) === $value;
+    }
+
+    /**
+     * Determine if a given string is a date and time in the specified format.
+     *
+     * @param  string  $value
+     * @param  string  $format
+     * @return bool
+     */
+    public static function isDateTime($value, $format = 'Y-m-d H:i:s')
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $dateTime = DateTime::createFromFormat($format, $value);
+
+        return $dateTime && $dateTime->format($format) === $value;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -525,9 +525,9 @@ class Str
     }
 
     /**
-     * Determine if a given string is a date in the specified format.
+     * Determine if a given value is a date in the specified format.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  string  $format
      * @return bool
      */
@@ -543,9 +543,9 @@ class Str
     }
 
     /**
-     * Determine if a given string is a time in the specified format.
+     * Determine if a given value is a time in the specified format.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  string  $format
      * @return bool
      */
@@ -561,9 +561,9 @@ class Str
     }
 
     /**
-     * Determine if a given string is a date and time in the specified format.
+     * Determine if a given value is a date and time in the specified format.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  string  $format
      * @return bool
      */

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -359,6 +359,39 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if the string is a date in the specified format.
+     *
+     * @param  string  $format
+     * @return bool
+     */
+    public function isDate(string $format = 'Y-m-d')
+    {
+        return Str::isDate($this->value, $format);
+    }
+
+    /**
+     * Determine if the string is a time in the specified format.
+     *
+     * @param  string  $format
+     * @return bool
+     */
+    public function isTime(string $format = 'H:i:s')
+    {
+        return Str::isTime($this->value, $format);
+    }
+
+    /**
+     * Determine if the string is a date and time in the specified format.
+     *
+     * @param  string  $format
+     * @return bool
+     */
+    public function isDateTime(string $format = 'Y-m-d H:i:s')
+    {
+        return Str::isDateTime($this->value, $format);
+    }
+
+    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -532,6 +532,33 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is([null], null));
     }
 
+    public function testIsDate()
+    {
+        $this->assertTrue(Str::isDate('2024-11-08'));
+        $this->assertTrue(Str::isDate('08/11/2024', 'd/m/Y'));
+        $this->assertFalse(Str::isDate('invalid-date'));
+        $this->assertFalse(Str::isDate('2024-13-08'));
+        $this->assertFalse(Str::isDate('2024-11-08', 'd/m/Y'));
+    }
+
+    public function testIsTime()
+    {
+        $this->assertTrue(Str::isTime('12:30:45'));
+        $this->assertTrue(Str::isTime('23:59', 'H:i'));
+        $this->assertFalse(Str::isTime('25:00:00'));
+        $this->assertFalse(Str::isTime('invalid-time'));
+        $this->assertFalse(Str::isTime('12:30:45', 'H:i'));
+    }
+
+    public function testIsDateTime()
+    {
+        $this->assertTrue(Str::isDateTime('2023-10-15 12:30:45'));
+        $this->assertTrue(Str::isDateTime('15/10/2023 12:30', 'd/m/Y H:i'));
+        $this->assertFalse(Str::isDateTime('2024-11-08'));
+        $this->assertFalse(Str::isDateTime('invalid-datetime'));
+        $this->assertFalse(Str::isDateTime('2023-10-15 12:30:45', 'd/m/Y H:i'));
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue(Str::isUrl('https://laravel.com'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -35,6 +35,33 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('ù')->isAscii());
     }
 
+    public function testIsDate()
+    {
+        $this->assertTrue($this->stringable('2024-11-08')->isDate());
+        $this->assertTrue($this->stringable('08/11/2024')->isDate('d/m/Y'));
+        $this->assertFalse($this->stringable('invalid-date')->isDate());
+        $this->assertFalse($this->stringable('2024-13-08')->isDate());
+        $this->assertFalse($this->stringable('2024-11-08')->isDate('d/m/Y'));
+    }
+
+    public function testIsTime()
+    {
+        $this->assertTrue($this->stringable('12:30:45')->isTime());
+        $this->assertTrue($this->stringable('23:59')->isTime('H:i'));
+        $this->assertFalse($this->stringable('25:00:00')->isTime());
+        $this->assertFalse($this->stringable('invalid-time')->isTime());
+        $this->assertFalse($this->stringable('12:30:45')->isTime('H:i'));
+    }
+
+    public function testIsDateTime()
+    {
+        $this->assertTrue($this->stringable('2023-10-15 12:30:45')->isDateTime());
+        $this->assertTrue($this->stringable('15/10/2023 12:30')->isDateTime('d/m/Y H:i'));
+        $this->assertFalse($this->stringable('2024-11-08')->isDateTime());
+        $this->assertFalse($this->stringable('invalid-datetime')->isDateTime());
+        $this->assertFalse($this->stringable('2023-10-15 12:30:45')->isDateTime('d/m/Y H:i'));
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue($this->stringable('https://laravel.com')->isUrl());


### PR DESCRIPTION
Added three new methods to the `Illuminate\Support\Str` and `Illuminate\Support\Stringable` classes:

- `isDate()`
- `isTime()`
- `isDateTime()`

### Str::isDate()

The `Str::isDate` method determines if a given string is a date in the specified format:

```php
use Illuminate\Support\Str;

$isDate = Str::isDate('2024-11-08');

// true

$isDate = Str::isDate('08/11/2024', 'd/m/Y');

// true

$isDate = Str::isDate('2024-13-08');

// false
```

By default, the method uses the `Y-m-d` format. You can specify a custom date format as the second argument.

### Str::isTime()

The `Str::isTime` method determines if the given string is a valid time in the specified format:

```php
use Illuminate\Support\Str;

$isTime = Str::isTime('12:30:45');

// true

$isTime = Str::isTime('23:59', 'H:i');

// true

$isTime = Str::isTime('25:00:00');

// false
```

By default, the method uses the `H:i:s` format. You can specify a custom time format as the second argument.

### Str::isDateTime()

The `Str::isDateTime` method determines if the given string is a valid date and time in the specified format:

```php
use Illuminate\Support\Str;

$isDateTime = Str::isDateTime('2024-11-08 12:30:45');

// true

$isDateTime = Str::isDateTime('08/11/2024 12:30', 'd/m/Y H:i');

// true

$isDateTime = Str::isDateTime('2024-11-08');

// false
```

By default, the method uses the `Y-m-d H:i:s` format. You can specify a custom date and time format as the second argument.