### PR TITLE
[11.x] Fix configuration files merge

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -96,7 +96,7 @@ class LoadConfiguration
         $config = (fn () => require $path)();
 
         if (isset($base[$name])) {
-            $config += $base[$name];
+            $config = array_merge($base[$name], $config);
 
             foreach ($this->mergeableOptions($name) as $option) {
                 if (isset($config[$option])) {

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -96,11 +96,11 @@ class LoadConfiguration
         $config = (fn () => require $path)();
 
         if (isset($base[$name])) {
-            $config = array_merge($base[$name], $config);
+            $config += $base[$name];
 
             foreach ($this->mergeableOptions($name) as $option) {
                 if (isset($config[$option])) {
-                    $config[$option] = array_merge($base[$name][$option], $config[$option]);
+                    $config[$option] += $base[$name][$option];
                 }
             }
 


### PR DESCRIPTION
Using `array_merge` is changing keys order, 
Example `auth.guards`: https://onlinephp.io/c/4ad71

If you set a custom file, the laravel internal file change `auth.guards` order, this causes problems when upgrading from previous versions, with array union operator (`+`), the keys order is preserved

Is there a better solution?

Closes https://github.com/spatie/laravel-permission/issues/2729