### PR TITLE
[11.x] Add ability to dynamically build cache repositories on-demand using `Cache::build`

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -90,6 +90,19 @@ class CacheManager implements FactoryContract
 
         $config = Arr::add($config, 'store', $name);
 
+        return $this->build($config);
+    }
+
+    /**
+     * Build a cache repository with the given configuration.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    public function build(array $config)
+    {
+        $config = Arr::add($config, 'store', $config['name'] ?? 'ondemand');
+
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         }

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -6,6 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
  * @method static \Illuminate\Contracts\Cache\Repository driver(string|null $driver = null)
  * @method static \Illuminate\Contracts\Cache\Repository resolve(string $name)
+ * @method static \Illuminate\Contracts\Cache\Repository build(array $config)
  * @method static \Illuminate\Cache\Repository repository(\Illuminate\Contracts\Cache\Store $store, array $config = [])
  * @method static void refreshEventDispatcher()
  * @method static string getDefaultDriver()

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -59,6 +59,18 @@ class CacheManagerTest extends TestCase
         $this->assertSame('mm(u_u)mm', $driver->flag);
     }
 
+    public function testItCanBuildRepositories()
+    {
+        $app = $this->getApp([]);
+        $cacheManager = new CacheManager($app);
+
+        $arrayCache = $cacheManager->build(['driver' => 'array']);
+        $nullCache = $cacheManager->build(['driver' => 'null']);
+
+        $this->assertInstanceOf(ArrayStore::class, $arrayCache->getStore());
+        $this->assertInstanceOf(NullStore::class, $nullCache->getStore());
+    }
+
     public function testItMakesRepositoryWhenContainerHasNoDispatcher()
     {
         $userConfig = [


### PR DESCRIPTION
### Description

Similar to https://github.com/laravel/framework/pull/53411, this PR implements a new `Cache::build` method that allows you to create new cache repositories that are not defined in your configuration file.

This is useful for circumstances where you may have cache configurations that are stored in your database, or another repository.

### Usage

```php
use Illuminate\Support\Facades\Cache;

$apc = Cache::build([
    'driver' => 'apc',
]);

$array = Cache::build([
    'driver' => 'array',
    'serialize' => false,
]);

$database = Cache::build([
    'driver' => 'database',
    'table' => 'cache',
    'connection' => null,
    'lock_connection' => null,
]);

$file = Cache::build([
    'driver' => 'file',
    'path' => storage_path('framework/cache/data'),
]); 
```