### PR TITLE
[10.x] Fix append and prepend batch to chain

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -199,7 +199,12 @@ trait Queueable
      */
     public function prependToChain($job)
     {
-        $this->chained = Arr::prepend($this->chained, $this->serializeJob($this->prepareJob($job)));
+        $job = match (true) {
+            $job instanceof PendingBatch => new ChainedBatch($job),
+            default => $job,
+        };
+
+        $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
 
         return $this;
     }
@@ -212,7 +217,12 @@ trait Queueable
      */
     public function appendToChain($job)
     {
-        $this->chained = array_merge($this->chained, [$this->serializeJob($this->prepareJob($job))]);
+        $job = match (true) {
+            $job instanceof PendingBatch => new ChainedBatch($job),
+            default => $job,
+        };
+
+        $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
 
         return $this;
     }
@@ -238,14 +248,6 @@ trait Queueable
         }
 
         return serialize($job);
-    }
-
-    protected function prepareJob(mixed $job): mixed
-    {
-        return match (true) {
-            $job instanceof PendingBatch => new ChainedBatch($job),
-            default => $job,
-        };
     }
 
     /**

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -199,7 +199,7 @@ trait Queueable
      */
     public function prependToChain($job)
     {
-        $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
+        $this->chained = Arr::prepend($this->chained, $this->serializeJob($this->prepareJob($job)));
 
         return $this;
     }
@@ -212,7 +212,7 @@ trait Queueable
      */
     public function appendToChain($job)
     {
-        $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
+        $this->chained = array_merge($this->chained, [$this->serializeJob($this->prepareJob($job))]);
 
         return $this;
     }
@@ -238,6 +238,14 @@ trait Queueable
         }
 
         return serialize($job);
+    }
+
+    protected function prepareJob(mixed $job): mixed
+    {
+        return match (true) {
+            $job instanceof PendingBatch => new ChainedBatch($job),
+            default => $job,
+        };
     }
 
     /**

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -288,6 +288,30 @@ class JobChainingTest extends QueueTestCase
         $this->assertTrue(JobChainAddingAddedJob::$ranAt->isAfter(JobChainAddingExistingJob::$ranAt));
     }
 
+    public function testChainJobsCanBePrependedBatch()
+    {
+        Bus::chain([
+            new JobChainAddingPrependedBatch('j1'),
+            new JobChainingNamedTestJob('j2')
+        ])->dispatch();
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertEquals(['j1', 'b1', 'b2', 'j2'], JobRunRecorder::$results);
+    }
+
+    public function testChainJobsCanBeAppendedBatch()
+    {
+        Bus::chain([
+            new JobChainAddingAppendingBatch('j1'),
+            new JobChainingNamedTestJob('j2')
+        ])->dispatch();
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertEquals(['j1', 'j2', 'b1', 'b2'], JobRunRecorder::$results);
+    }
+
     public function testChainJobsCanBeAppendedWithoutExistingChain()
     {
         JobChainAddingAppendingJob::dispatch();
@@ -649,6 +673,50 @@ class JobChainAddingAppendingJob implements ShouldQueue
     public function handle()
     {
         $this->appendToChain(new JobChainAddingAddedJob);
+    }
+}
+
+class JobChainAddingAppendingBatch implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function handle()
+    {
+        $this->appendToChain(Bus::batch([
+            new JobChainingNamedTestJob('b1'),
+            new JobChainingNamedTestJob('b2'),
+        ]));
+
+        JobRunRecorder::record($this->id);
+    }
+}
+
+class JobChainAddingPrependedBatch implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function handle()
+    {
+        $this->prependToChain(Bus::batch([
+            new JobChainingNamedTestJob('b1'),
+            new JobChainingNamedTestJob('b2'),
+        ]));
+
+        JobRunRecorder::record($this->id);
     }
 }
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -292,7 +292,7 @@ class JobChainingTest extends QueueTestCase
     {
         Bus::chain([
             new JobChainAddingPrependedBatch('j1'),
-            new JobChainingNamedTestJob('j2')
+            new JobChainingNamedTestJob('j2'),
         ])->dispatch();
 
         $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
@@ -304,7 +304,7 @@ class JobChainingTest extends QueueTestCase
     {
         Bus::chain([
             new JobChainAddingAppendingBatch('j1'),
-            new JobChainingNamedTestJob('j2')
+            new JobChainingNamedTestJob('j2'),
         ])->dispatch();
 
         $this->runQueueWorkerCommand(['--stop-when-empty' => true]);


### PR DESCRIPTION
It is not possible to add a batch to an existing chain using \Illuminate\Bus\Queueable::prependToChain and \Illuminate\Bus\Queueable::appendToChain.

This PR fixes the bug.