### PR TITLE
Created a changelog website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
+<a href="https://laravel-frame.openchangelog.com"><img src="https://img.shields.io/badge/changelog-black" alt="Changelog"></a>
 </p>
 
 ## About Laravel


### PR DESCRIPTION
Hi, I'm the creator of [Openchangelog](https://github.com/JonasHiltl/openchangelog) and a big fan of the whole laravel ecosystem. 

I saw that this repo uses the `keep a changelog` format so I thought I would create a changelog website which you can check out at [laravel-frame.openchangelog.com](https://laravel-frame.openchangelog.com/).
It automatically stays in sync with your `CHANGELOG.md` file.

Would love to have this linked in your `README`. After all who really wants to read a `CHANGELOG.md` file when they could have a beautiful, styled website.

The badge I created for the `README` is just an idea, if you have a different idea or don't want the link in the repo just let me know.