### PR TITLE
[11.x] Change the `migrate` returned status code

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -81,7 +81,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     public function handle()
     {
         if (! $this->confirmToProceed()) {
-            return 1;
+            return 0;
         }
 
         try {
@@ -90,7 +90,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
             if ($this->option('graceful')) {
                 $this->components->warn($e->getMessage());
 
-                return 0;
+                return 1;
             }
 
             throw $e;


### PR DESCRIPTION
While it may seem like a small change, it carries significant meaning. In Symfony, `1` reflects **FAILUER**, and `0` represents **SUCCESS**. Similarly, Laravel adopts the same approach in some classes, such as `\Illuminate\Console\Command`.