### PR TITLE
[11.x] Add `type="module"` attribute to Vite prefetch script

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -509,7 +509,7 @@ class Vite implements Htmlable
             ->pipe(fn ($assets) => with(Js::from($assets), fn ($assets) => match ($this->prefetchStrategy) {
                 'waterfall' => new HtmlString($base.<<<HTML
 
-                    <script{$this->nonceAttribute()}>
+                    <script type="module"{$this->nonceAttribute()}>
                          window.addEventListener('{$this->prefetchEvent}', () => window.setTimeout(() => {
                             const makeLink = (asset) => {
                                 const link = document.createElement('link')
@@ -552,7 +552,7 @@ class Vite implements Htmlable
                     HTML),
                 'aggressive' => new HtmlString($base.<<<HTML
 
-                    <script{$this->nonceAttribute()}>
+                    <script type="module"{$this->nonceAttribute()}>
                          window.addEventListener('{$this->prefetchEvent}', () => window.setTimeout(() => {
                             const makeLink = (asset) => {
                                 const link = document.createElement('link')

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1329,7 +1329,7 @@ class FoundationViteTest extends TestCase
         ]);
         $this->assertSame(<<<HTML
         <link rel="preload" as="style" href="https://example.com/{$buildDir}/assets/index-B3s1tYeC.css" /><link rel="modulepreload" href="https://example.com/{$buildDir}/assets/app-lliD09ip.js" /><link rel="modulepreload" href="https://example.com/{$buildDir}/assets/index-BSdK3M0e.js" /><link rel="stylesheet" href="https://example.com/{$buildDir}/assets/index-B3s1tYeC.css" /><script type="module" src="https://example.com/{$buildDir}/assets/app-lliD09ip.js"></script>
-        <script>
+        <script type="module">
              window.addEventListener('load', () => window.setTimeout(() => {
                 const makeLink = (asset) => {
                     const link = document.createElement('link')
@@ -1472,7 +1472,7 @@ class FoundationViteTest extends TestCase
 
         $this->assertSame(<<<HTML
         <link rel="preload" as="style" href="https://example.com/{$buildDir}/assets/index-B3s1tYeC.css" /><link rel="modulepreload" href="https://example.com/{$buildDir}/assets/app-lliD09ip.js" /><link rel="modulepreload" href="https://example.com/{$buildDir}/assets/index-BSdK3M0e.js" /><link rel="stylesheet" href="https://example.com/{$buildDir}/assets/index-B3s1tYeC.css" /><script type="module" src="https://example.com/{$buildDir}/assets/app-lliD09ip.js"></script>
-        <script>
+        <script type="module">
              window.addEventListener('load', () => window.setTimeout(() => {
                 const makeLink = (asset) => {
                     const link = document.createElement('link')
@@ -1607,7 +1607,7 @@ class FoundationViteTest extends TestCase
         ]);
         $this->assertSame(<<<HTML
         <link rel="preload" as="style" href="https://example.com/{$buildDir}/assets/index-B3s1tYeC.css" /><link rel="preload" as="style" href="https://example.com/{$buildDir}/assets/admin-BctAalm_.css" /><link rel="modulepreload" href="https://example.com/{$buildDir}/assets/admin-Sefg0Q45.js" /><link rel="modulepreload" href="https://example.com/{$buildDir}/assets/index-BSdK3M0e.js" /><link rel="stylesheet" href="https://example.com/{$buildDir}/assets/index-B3s1tYeC.css" /><link rel="stylesheet" href="https://example.com/{$buildDir}/assets/admin-BctAalm_.css" /><script type="module" src="https://example.com/{$buildDir}/assets/admin-Sefg0Q45.js"></script>
-        <script>
+        <script type="module">
              window.addEventListener('load', () => window.setTimeout(() => {
                 const makeLink = (asset) => {
                     const link = document.createElement('link')
@@ -1664,14 +1664,14 @@ class FoundationViteTest extends TestCase
             ->useBuildDirectory($buildDir)
             ->prefetch()
             ->toHtml();
-        $this->assertStringContainsString('<script nonce="abc123">', $html);
+        $this->assertStringContainsString('<script type="module" nonce="abc123">', $html);
 
         $html = (string) tap(ViteFacade::withEntryPoints(['resources/js/app.js']))
             ->useCspNonce('abc123')
             ->useBuildDirectory($buildDir)
             ->prefetch(concurrency: 3)
             ->toHtml();
-        $this->assertStringContainsString('<script nonce="abc123">', $html);
+        $this->assertStringContainsString('<script type="module" nonce="abc123">', $html);
 
         $this->cleanViteManifest($buildDir);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This MR adds a `type="module"` attribute to the Vite prefetch scripts, which in turn [enforces deferred behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_classic_scripts). This should push back script execution until the document has been parsed, to reduce the chance of it impacting page load time.

Although this will probably make little to no difference in most practical situations, I assume it may slightly improve performance in edge cases, where prefetches might theoretically come before other asset loads.

Alternatively one could opt to use just `defer` instead of `type="module"`, but I think most other relevant changes (e.g. isolation and strict mode) can only be consider a pro for this script.