### PR TITLE
[11.x] Do not overwrite existing link header(s) in `AddLinkHeadersForPreloadedAssets` middleware

### DIFF
--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -21,7 +21,7 @@ class AddLinkHeadersForPreloadedAssets
             if ($response instanceof Response && Vite::preloadedAssets() !== []) {
                 $response->header('Link', Collection::make(Vite::preloadedAssets())
                     ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
-                    ->join(', '));
+                    ->join(', '), false);
             }
         });
     }


### PR DESCRIPTION

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When looking into adding some manual `Link` headers for some static assets, I noticed I could not manage to add any when the `AddLinkHeadersForPreloadedAssets` is active. This PR alters the behavior to not overwrite the `Link` header, but rather add to it. This ensures developers have the opportunity to also add `Link` headers of their own within the scope of their application logic.

I also reversed an expected vs. actual ordering in an existing test.