### PR TITLE
[11.x] Add `DB::build` method

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -100,6 +100,21 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
+     * Build a database connection instance from the given configuration.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    public function build(array $config)
+    {
+        return $this->connectUsing(
+            $config['name'] ?? 'ondemand',
+            $config,
+            true,
+        );
+    }
+
+    /**
      * Get a database connection instance from the given configuration.
      *
      * @param  string  $name

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Console\WipeCommand;
 /**
  * @method static \Illuminate\Database\Connection connection(string|null $name = null)
  * @method static \Illuminate\Database\ConnectionInterface connectUsing(string $name, array $config, bool $force = false)
+ * @method static \Illuminate\Database\ConnectionInterface build(array $config)
  * @method static void purge(string|null $name = null)
  * @method static void disconnect(string|null $name = null)
  * @method static \Illuminate\Database\Connection reconnect(string|null $name = null)

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -6,11 +6,25 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Events\ConnectionEstablished;
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Events\Dispatcher;
 use RuntimeException;
 
 class DatabaseConnectionsTest extends DatabaseTestCase
 {
+    public function testBuildDatabaseConnection()
+    {
+        /** @var \Illuminate\Database\DatabaseManager $manager */
+        $manager = $this->app->make(DatabaseManager::class);
+
+        $connection = $manager->build([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $this->assertInstanceOf(SQLiteConnection::class, $connection);
+    }
+
     public function testEstablishDatabaseConnection()
     {
         /** @var \Illuminate\Database\DatabaseManager $manager */


### PR DESCRIPTION
### Description

Similar to https://github.com/laravel/framework/pull/53411, this PR implements a new `DB::build` method that allows you to create new DB connections that are not defined in your configuration file.

### Usage

```php
use Illuminate\Support\Facades\DB;

$sqlite = DB::build([
    'driver' => 'sqlite',
    'database' => ':memory:',
]);

$mysql = DB::build([
    'driver' => 'mysql',
    'database' => 'forge',
    'username' => 'root',
    'password' => 'secret',
]);

$pgsql = DB::build([
    'driver' => 'pgsql',
    // ...
]);

$sqlsrv = DB::build([
    'driver' => 'sqlsrv',
    // ...
]);
```