### PR TITLE
[11.x] Add deepArrayify Method to Easily Convert Nested Objects into Arrays in Obj.php

### DIFF
--- a/src/Illuminate/Collections/Obj.php
+++ b/src/Illuminate/Collections/Obj.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Collections;
+
+use Illuminate\Support\Traits\Macroable;
+
+class Obj
+{
+    use Macroable;
+
+    /**
+     * Recursively convert all objects to arrays.
+     *
+     * @param  mixed  $object
+     * @return array
+     */
+    public static function deepArrayify($object)
+    {
+        if (is_object($object)) {
+            $object = get_object_vars($object);
+        }
+
+        return array_map(function ($value) {
+            if (is_object($value) || is_array($value)) {
+                return self::deepArrayify($value);
+            }
+            return $value;
+        }, $object);
+    }
+}

--- a/src/Illuminate/Collections/Obj.php
+++ b/src/Illuminate/Collections/Obj.php
@@ -24,6 +24,7 @@ class Obj
             if (is_object($value) || is_array($value)) {
                 return self::deepArrayify($value);
             }
+
             return $value;
         }, $object);
     }

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -30,15 +30,15 @@ class SupportObjTest extends TestCase
 
         $this->assertEquals(
             [
-                  'name' => 'Acme Corp',
-                  'departments' =>  [
-                        0 =>  [
-                          'budget' => 12000,
-                          'team' =>  [
-                            'description' => 'Research and Development'
-                          ]
-                        ]
-                  ]
+                 'name' => 'Acme Corp',
+                 'departments' =>  [
+                       0 =>  [
+                         'budget' => 12000,
+                         'team' =>  [
+                           'description' => 'Research and Development',
+                         ],
+                       ],
+                 ],
             ], $array
         );
     }

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -31,13 +31,13 @@ class SupportObjTest extends TestCase
         $this->assertEquals(
             [
                 'name' => 'Acme Corp',
-                'departments' =>  [
-                      0 =>  [
+                'departments' => [
+                     0 =>  [
                         'budget' => 12000,
-                        'team' =>  [
-                          'description' => 'Research and Development',
+                        'team' => [
+                            'description' => 'Research and Development',
                         ],
-                      ],
+                     ],
                 ],
             ], $array
         );

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -30,15 +30,15 @@ class SupportObjTest extends TestCase
 
         $this->assertEquals(
             [
-                 'name' => 'Acme Corp',
-                 'departments' =>  [
-                       0 =>  [
-                         'budget' => 12000,
-                         'team' =>  [
-                           'description' => 'Research and Development',
-                         ],
-                       ],
-                 ],
+                'name' => 'Acme Corp',
+                'departments' =>  [
+                      0 =>  [
+                        'budget' => 12000,
+                        'team' =>  [
+                          'description' => 'Research and Development',
+                        ],
+                      ],
+                ],
             ], $array
         );
     }

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -20,7 +20,7 @@ class SupportObjTest extends TestCase
 
         // Second level nested object within $department, representing a team or project
         $team = new stdClass();
-        $team->description = "Research and Development";
+        $team->description = 'Research and Development';
 
         // Assign nested structure
         $department->team = $team;  // $department contains $team as a nested object
@@ -30,15 +30,15 @@ class SupportObjTest extends TestCase
 
         $this->assertEquals(
             [
-              "name" => "Acme Corp",
-              "departments" =>  [
-                    0 =>  [
-                      "budget" => 12000,
-                      "team" =>  [
-                        "description" => "Research and Development"
-                      ]
-                    ]
-              ]
+                  'name' => 'Acme Corp',
+                  'departments' =>  [
+                        0 =>  [
+                          'budget' => 12000,
+                          'team' =>  [
+                            'description' => 'Research and Development'
+                          ]
+                        ]
+                  ]
             ], $array
         );
     }

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -32,12 +32,12 @@ class SupportObjTest extends TestCase
             [
                 'name' => 'Acme Corp',
                 'departments' => [
-                     0 =>  [
+                    0 =>  [
                         'budget' => 12000,
                         'team' => [
                             'description' => 'Research and Development',
                         ],
-                     ],
+                    ],
                 ],
             ], $array
         );

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -32,7 +32,7 @@ class SupportObjTest extends TestCase
             [
                 'name' => 'Acme Corp',
                 'departments' => [
-                    0 =>  [
+                    0 => [
                         'budget' => 12000,
                         'team' => [
                             'description' => 'Research and Development',

--- a/tests/Support/SupportObjTest.php
+++ b/tests/Support/SupportObjTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Collections\Obj;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class SupportObjTest extends TestCase
+{
+    public function testDeepArrayify(): void
+    {
+        // Main object representing a company or organization
+        $organization = new stdClass();
+        $organization->name = 'Acme Corp';
+
+        // First level nested object representing a department
+        $department = new stdClass();
+        $department->budget = 12000;
+
+        // Second level nested object within $department, representing a team or project
+        $team = new stdClass();
+        $team->description = "Research and Development";
+
+        // Assign nested structure
+        $department->team = $team;  // $department contains $team as a nested object
+        $organization->departments = [$department]; // $organization contains $department as a nested object
+
+        $array = Obj::deepArrayify($organization);
+
+        $this->assertEquals(
+            [
+              "name" => "Acme Corp",
+              "departments" =>  [
+                    0 =>  [
+                      "budget" => 12000,
+                      "team" =>  [
+                        "description" => "Research and Development"
+                      ]
+                    ]
+              ]
+            ], $array
+        );
+    }
+}


### PR DESCRIPTION
This pull request adds a deepArrayify function to Obj.php, making it easier to convert all objects in a data structure into arrays, even in deeply nested setups. This function helps developers get consistent array outputs, making it simpler to work with complex structures.

### Usage Example

```php
$object = new StdClass();
      $object->name = 'Laravel';
      $object->features = [
          (object) ['feature' => 'Eloquent'],
          (object) ['feature' => 'Blade']
      ];
      

// Result dd((array) $object);

array:2 [▼ 
  "name" => "Laravel"
  "features" => array:2 [▼
    0 => {#257 ▼
      +"feature": "Eloquent"
    }
    1 => {#258 ▼
      +"feature": "Blade"
    }
  ]

// Result dd(Obj::deepArrayify($object));

array:2 [▼ 
  "name" => "Laravel"
  "features" => array:2 [▼
    0 => array:1 [▼
      "feature" => "Eloquent"
    ]
    1 => array:1 [▼
      "feature" => "Blade"
    ]
  ]
]

``` 





