### PR TITLE
[11.x] Add Mail::raw support to MailFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -9,10 +9,12 @@ use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\MailManager;
+use Illuminate\Mail\Message;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Symfony\Component\Mime\Email;
 
 class MailFake implements Factory, Fake, Mailer, MailQueue
 {
@@ -462,7 +464,11 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function raw($text, $callback)
     {
-        //
+        $message = (new Message(new Email()))->text($text);
+        if (is_callable($callback)) {
+            $callback($message);
+        }
+        $this->mailables[] = $message;
     }
 
     /**

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -167,7 +167,7 @@ class SupportTestingMailFakeTest extends TestCase
     public function testAssertNotSentWithClosure_withMailRaw()
     {
         $callback = function (Message $mail) {
-            return in_array('taylor@laravel.com', array_map(fn($a) => $a->getAddress(), $mail->getTo()));
+            return in_array('taylor@laravel.com', array_map(fn ($a) => $a->getAddress(), $mail->getTo()));
         };
 
         $this->fake->assertNotSent($callback);
@@ -439,7 +439,7 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->raw('email text body', fn (Message $m) => $m->to($user->email));
 
         $this->fake->assertSent(function (Message $mail) use ($user) {
-            return in_array($user->email, array_map(fn($a) => $a->getAddress(), $mail->getTo()));
+            return in_array($user->email, array_map(fn ($a) => $a->getAddress(), $mail->getTo()));
         });
     }
 


### PR DESCRIPTION
Currently test assertions fail if mails are sent by Mail::raw - `assertSent`, `assertCount`, etc.
and `assertNothingSent` does not detect that mails were actually sent.

This PR adds basic support for raw mails to MailFake.
Some assertions will still not work (ex. `assertSentTo`) as `Illuminate\Mail\Message` does not have `hasX` methods. (should I add them in this PR?)