### PR TITLE
[11.x] Introduce freezing Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Casts\Json;
+use Illuminate\Database\Eloquent\FrozenModelException;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MissingAttributeException;
@@ -1006,10 +1007,16 @@ trait HasAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @return mixed
+     *
+     * @throws \Illuminate\Database\Eloquent\FrozenModelException
      */
     public function setAttribute($key, $value)
     {
-        // First we will check for the presence of a mutator for the set operation
+        if ($this->frozen) {
+            throw FrozenModelException::forSetAttribute($this, $key);
+        }
+
+        // Next we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // this model, such as "json_encoding" a listing of data for storage.
         if ($this->hasSetMutator($key)) {

--- a/src/Illuminate/Database/Eloquent/FrozenModelException.php
+++ b/src/Illuminate/Database/Eloquent/FrozenModelException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+class FrozenModelException extends \RuntimeException
+{
+    /**
+     * @param  Model  $model
+     * @return self
+     */
+    public static function forFill(Model $model)
+    {
+        return new self(sprintf("Cannot fill properties on Model [%s] because it is frozen.", $model::class));
+    }
+
+    public static function forSetAttribute(Model $model, $attribute)
+    {
+        return new self(sprintf("Cannot set property [%s] on Model [%s] because it is frozen.", $attribute, $model::class));
+    }
+}

--- a/src/Illuminate/Database/Eloquent/FrozenModelException.php
+++ b/src/Illuminate/Database/Eloquent/FrozenModelException.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
 class FrozenModelException extends \RuntimeException
 {
     /**
@@ -13,8 +16,25 @@ class FrozenModelException extends \RuntimeException
         return new self(sprintf("Cannot fill properties on Model [%s] because it is frozen.", $model::class));
     }
 
-    public static function forSetAttribute(Model $model, $attribute)
+    /**
+     * @param  Model  $model
+     * @param  string  $attribute
+     * @return self
+     */
+    public static function forSetAttribute(Model $model, string $attribute)
     {
-        return new self(sprintf("Cannot set property [%s] on Model [%s] because it is frozen.", $attribute, $model::class));
+        return new self(sprintf("Cannot set property [%s] on Model [%s] because it is frozen.", $attribute,
+            $model::class));
+    }
+
+    public static function forRelations(Model $model, array $relations)
+    {
+        return new self(
+            sprintf(
+                "Cannot load relation(s) [%s] on Model [%s] because it is frozen.",
+                Arr::join($relations, ', '),
+                model::class
+            )
+        );
     }
 }

--- a/src/Illuminate/Database/Eloquent/FrozenModelException.php
+++ b/src/Illuminate/Database/Eloquent/FrozenModelException.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use PhpParser\Node\Expr\AssignOp\Mod;
 
 class FrozenModelException extends \RuntimeException
 {
@@ -33,8 +34,13 @@ class FrozenModelException extends \RuntimeException
             sprintf(
                 "Cannot load relation(s) [%s] on Model [%s] because it is frozen.",
                 Arr::join($relations, ', '),
-                model::class
+                $model::class
             )
         );
+    }
+
+    public static function forUnset(Model $model)
+    {
+        return new self(sprintf("Cannot unset properties or relations on Model [%s] because it is frozen.", $model::class));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2134,7 +2134,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * @param $frozen
+     * @param  bool $frozen
      * @return $this
      */
     public function freeze($frozen = true)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -275,7 +275,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function bootIfNotBooted()
     {
-        if (!isset(static::$booted[static::class])) {
+        if (! isset(static::$booted[static::class])) {
             static::$booted[static::class] = true;
 
             $this->fireModelEvent('booting', false);
@@ -324,7 +324,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         foreach (class_uses_recursive($class) as $trait) {
             $method = 'boot'.class_basename($trait);
 
-            if (method_exists($class, $method) && !in_array($method, $booted)) {
+            if (method_exists($class, $method) && ! in_array($method, $booted)) {
                 forward_static_call([$class, $method]);
 
                 $booted[] = $method;
@@ -413,7 +413,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $class = $class ?: static::class;
 
-        if (!get_class_vars($class)['timestamps'] || !$class::UPDATED_AT) {
+        if (! get_class_vars($class)['timestamps'] || ! $class::UPDATED_AT) {
             return true;
         }
 
@@ -586,7 +586,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function forceFill(array $attributes)
     {
-        return static::unguarded(fn() => $this->fill($attributes));
+        return static::unguarded(fn () => $this->fill($attributes));
     }
 
     /**
@@ -746,7 +746,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function loadMorph($relation, $relations)
     {
-        if (!$this->{$relation}) {
+        if (! $this->{$relation}) {
             return $this;
         }
 
@@ -870,7 +870,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function loadMorphAggregate($relation, $relations, $column, $function = null)
     {
-        if (!$this->{$relation}) {
+        if (! $this->{$relation}) {
             return $this;
         }
 
@@ -982,7 +982,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function incrementOrDecrement($column, $amount, $extra, $method)
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return $this->newQueryWithoutRelationships()->{$method}($column, $amount, $extra);
         }
 
@@ -1000,14 +1000,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $amount = (clone $this)->setAttribute($column, $amount)->getAttributeFromArray($column);
         }
 
-        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($column, $amount, $extra),
-            function () use ($column) {
-                $this->syncChanges();
+        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($column, $amount, $extra), function () use ($column) {
+            $this->syncChanges();
 
-                $this->fireModelEvent('updated', false);
+            $this->fireModelEvent('updated', false);
 
-                $this->syncOriginalAttribute($column);
-            });
+            $this->syncOriginalAttribute($column);
+        });
     }
 
     /**
@@ -1019,7 +1018,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function update(array $attributes = [], array $options = [])
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return false;
         }
 
@@ -1037,7 +1036,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function updateOrFail(array $attributes = [], array $options = [])
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return false;
         }
 
@@ -1053,7 +1052,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function updateQuietly(array $attributes = [], array $options = [])
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return false;
         }
 
@@ -1098,7 +1097,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function push()
     {
         return $this->withoutRecursion(function () {
-            if (!$this->save()) {
+            if (! $this->save()) {
                 return false;
             }
 
@@ -1110,7 +1109,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                     ? $models->all() : [$models];
 
                 foreach (array_filter($models) as $model) {
-                    if (!$model->push()) {
+                    if (! $model->push()) {
                         return false;
                     }
                 }
@@ -1127,7 +1126,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function pushQuietly()
     {
-        return static::withoutEvents(fn() => $this->push());
+        return static::withoutEvents(fn () => $this->push());
     }
 
     /**
@@ -1138,7 +1137,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function saveQuietly(array $options = [])
     {
-        return static::withoutEvents(fn() => $this->save($options));
+        return static::withoutEvents(fn () => $this->save($options));
     }
 
     /**
@@ -1174,7 +1173,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         else {
             $saved = $this->performInsert($query);
 
-            if (!$this->getConnectionName() &&
+            if (! $this->getConnectionName() &&
                 $connection = $query->getConnection()) {
                 $this->setConnection($connection->getName());
             }
@@ -1200,7 +1199,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function saveOrFail(array $options = [])
     {
-        return $this->getConnection()->transaction(fn() => $this->save($options));
+        return $this->getConnection()->transaction(fn () => $this->save($options));
     }
 
     /**
@@ -1429,7 +1428,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // If the model doesn't exist, there is nothing to delete so we'll just return
         // immediately and not do anything else. Otherwise, we will continue with a
         // deletion process on the model, firing the proper events, and so forth.
-        if (!$this->exists) {
+        if (! $this->exists) {
             return;
         }
 
@@ -1459,7 +1458,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function deleteQuietly()
     {
-        return static::withoutEvents(fn() => $this->delete());
+        return static::withoutEvents(fn () => $this->delete());
     }
 
     /**
@@ -1471,11 +1470,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function deleteOrFail()
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return false;
         }
 
-        return $this->getConnection()->transaction(fn() => $this->delete());
+        return $this->getConnection()->transaction(fn () => $this->delete());
     }
 
     /**
@@ -1674,8 +1673,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function toArray()
     {
         return $this->withoutRecursion(
-            fn() => array_merge($this->attributesToArray(), $this->relationsToArray()),
-            fn() => $this->attributesToArray(),
+            fn () => array_merge($this->attributesToArray(), $this->relationsToArray()),
+            fn () => $this->attributesToArray(),
         );
     }
 
@@ -1716,7 +1715,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function fresh($with = [])
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return;
         }
 
@@ -1733,7 +1732,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function refresh()
     {
-        if (!$this->exists) {
+        if (! $this->exists) {
             return $this;
         }
 
@@ -1791,7 +1790,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function replicateQuietly(?array $except = null)
     {
-        return static::withoutEvents(fn() => $this->replicate($except));
+        return static::withoutEvents(fn () => $this->replicate($except));
     }
 
     /**
@@ -1802,7 +1801,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function is($model)
     {
-        return !is_null($model) &&
+        return ! is_null($model) &&
             $this->getKey() === $model->getKey() &&
             $this->getTable() === $model->getTable() &&
             $this->getConnectionName() === $model->getConnectionName();
@@ -1816,7 +1815,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function isNot($model)
     {
-        return !$this->is($model);
+        return ! $this->is($model);
     }
 
     /**
@@ -2027,7 +2026,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $relations = [];
 
             foreach ($this->getRelations() as $key => $relation) {
-                if (!method_exists($this, $key)) {
+                if (! method_exists($this, $key)) {
                     continue;
                 }
 
@@ -2312,7 +2311,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function offsetExists($offset): bool
     {
         try {
-            return !is_null($this->getAttribute($offset));
+            return ! is_null($this->getAttribute($offset));
         } catch (MissingAttributeException) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2349,9 +2349,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  mixed  $offset
      * @return void
+     * @throws  FrozenModelException
      */
     public function offsetUnset($offset): void
     {
+        if ($this->frozen) {
+            throw FrozenModelException::forUnset($this);
+        }
+
         unset($this->attributes[$offset], $this->relations[$offset]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -728,6 +728,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function load($relations)
     {
+        if ($this->frozen) {
+            throw FrozenModelException::forRelations($this, Arr::wrap($relations));
+        }
+
         $query = $this->newQueryWithoutRelationships()->with(
             is_string($relations) ? func_get_args() : $relations
         );

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3204,6 +3204,19 @@ class DatabaseEloquentModelTest extends TestCase
         }
     }
 
+    public function testCannotOffsetSetAttributeOnFrozenModel()
+    {
+        $model = new EloquentModelStub();
+        $model->freeze();
+
+        try {
+            $model['castedFloat'] = 199.2;
+            $this->fail("No FrozenModelException thrown");
+        } catch (FrozenModelException $exception) {
+            $this->assertEquals("Cannot set property [castedFloat] on Model [Illuminate\Tests\Database\EloquentModelStub] because it is frozen.", $exception->getMessage());
+        }
+    }
+
     #[DataProvider('cannotLoadRelationsDataProvider')]
     public function testCannotLoadRelationOnFrozenModel($relations, $relationsAsString)
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -49,6 +49,7 @@ use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
@@ -3201,6 +3202,29 @@ class DatabaseEloquentModelTest extends TestCase
         } catch (FrozenModelException $exception) {
             $this->assertEquals("Cannot set property [castedFloat] on Model [Illuminate\Tests\Database\EloquentModelStub] because it is frozen.", $exception->getMessage());
         }
+    }
+
+    #[DataProvider('cannotLoadRelationsDataProvider')]
+    public function testCannotLoadRelationOnFrozenModel($relations, $relationsAsString)
+    {
+        $model = new EloquentModelStub();
+        $model->freeze();
+
+        try {
+            $model->load($relations);
+            $this->fail("No exception thrown");
+        } catch (FrozenModelException $exception) {
+            $this->assertEquals("Cannot load relation(s) [$relationsAsString] on Model [Illuminate\Database\Eloquent\model] because it is frozen.", $exception->getMessage());
+        }
+    }
+
+    public static function cannotLoadRelationsDataProvider()
+    {
+        return [
+            'single relation as string' => ['morphToStub', 'morphToStub'],
+            'single relation in array' => [['morphToStub'], 'morphToStub'],
+            'multiple relations in array' => [['belongsToStub', 'morphsToStub'], 'belongsToStub, morphsToStub']
+        ];
     }
 
     public function testCannotFillOnFrozenModel()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3227,7 +3227,7 @@ class DatabaseEloquentModelTest extends TestCase
             $model->load($relations);
             $this->fail("No exception thrown");
         } catch (FrozenModelException $exception) {
-            $this->assertEquals("Cannot load relation(s) [$relationsAsString] on Model [Illuminate\Database\Eloquent\model] because it is frozen.", $exception->getMessage());
+            $this->assertEquals("Cannot load relation(s) [$relationsAsString] on Model [Illuminate\Tests\Database\EloquentModelStub] because it is frozen.", $exception->getMessage());
         }
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3257,6 +3257,34 @@ class DatabaseEloquentModelTest extends TestCase
             );
         }
     }
+
+    public function testCannotUnsetAttributeOnFrozenModel()
+    {
+        $model = new EloquentModelStub();
+        $model->freeze();
+
+        try {
+            unset($model['castedFloat']);
+            $this->fail("No exception was thrown");
+        } catch (FrozenModelException $exception) {
+            $this->assertEquals("Cannot unset properties or relations on Model [Illuminate\Tests\Database\EloquentModelStub] because it is frozen.", $exception->getMessage());
+        }
+    }
+
+    public function testCannotOffsetUnsetAttributeOnFrozenModel()
+    {
+        $model = new EloquentModelStub();
+        $model->freeze();
+
+        try {
+            $model->offsetUnset('castedFloat');
+            $this->fail("No exception was thrown");
+        } catch (FrozenModelException $exception) {
+            $this->assertEquals("Cannot unset properties or relations on Model [Illuminate\Tests\Database\EloquentModelStub] because it is frozen.", $exception->getMessage());
+        }
+    }
+
+
 }
 
 class EloquentTestObserverStub


### PR DESCRIPTION
In this PR, we introduce the concept of a _frozen model_.

A frozen model is disallowed to do the following:
- [x] Fill attributes
- [x] Set attributes
- [ ] Load new relations
- [ ] Update
- [ ] Touch
- [ ] Save, SaveQuietly
- [ ] Delete
- [ ] Increment, incrementQuietly
- [ ] decrement, decrementQuietly
- [ ] pre-emptively freeze loaded relations
- [ ] disallow loading on Eloquent\Collection
- [ ] disallow "fresh" on Eloquent\Collection
- [ ] other Eloquent\Collection concerns?

Basically, the model becomes an inert object which disallows fetching relations and modifying the underlying table.

## Why?
The goal here is to allow passing models as "dumb objects." One of the biggest pains I have experienced is models get passed to resources and or actions/services and end up performing side effects. These side effects can cause things like N+1 problems, plus hard to follow/maintain logic. The lazy-loading violation kind of helps us here, but it has the weird gotcha that it can still load relations if it was loaded singly.

A frozen model communicates intent: you can look, but you don't touch.

## Alternatives approaches as of today
Map the model to a data object and pass that around instead. I think that's honestly probably the best, since they are inert. But mapping from a model to a DTO can bring its own headaches.

## Alternate approaches to this PR
<details>
<summary>Create a FrozenModel class</summary>
This would quite possibly be better, as it could leverage strong type-hints, but would only be able to indicate the model is frozen via a template. Something like:

```php
/**
 * @template TModel of Model
 */
class FrozenModel
{
    /** @var TModel $model */
    protected Model $model;

    public function __construct(Model $model)
    {
        $this->model = $model;
    }

    public function __call($method, $parameters)
    {
        if (in_array($method, ['save', 'fill', 'update', 'touch', 'loadMissing', /* ... */])) {
            throw new FrozenModelException("Cannot call [$method] on frozen model[$model->getKey()]");
        }
        return $this->model->__call($method, $parameters);
    }
}
```

and give the model class a simple method.
```php
class Model // ...
{
    /** all the use stuff */

   /**
    * @return FrozenModel<$this>
    */
   public function freeze(): FrozenModel
   {
       return new FrozenModel($this);
   }
}
```
</details>

As I'm writing the description, I think I kind of prefer this approach, but figured I'd float out an idea and get maintainer/community feedback.

I do realize while this is a draft, there won't be a formal review.