### PR TITLE
[12.x] Add step parameter to LazyCollection range method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -49,11 +49,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int  $step
      * @return static<int, int>
      */
-    public static function range($from, $to)
+    public static function range($from, $to, $step = 1)
     {
-        return new static(range($from, $to));
+        return new static(range($from, $to, $step));
     }
 
     /**

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -45,9 +45,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int  $step
      * @return static
      */
-    public static function range($from, $to);
+    public static function range($from, $to, $step = 1);
 
     /**
      * Wrap the given value in a collection if applicable.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -75,12 +75,13 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int  $step
      * @return static<int, int>
      */
     public static function range($from, $to, $step = 1)
     {
         if ($step == 0) {
-            throw new InvalidArgumentException("Step value cannot be zero.");
+            throw new InvalidArgumentException('Step value cannot be zero.');
         }
 
         return new static(function () use ($from, $to, $step) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -77,15 +77,19 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  int  $to
      * @return static<int, int>
      */
-    public static function range($from, $to)
+    public static function range($from, $to, $step = 1)
     {
-        return new static(function () use ($from, $to) {
+        if ($step == 0) {
+            throw new InvalidArgumentException("Step value cannot be zero.");
+        }
+
+        return new static(function () use ($from, $to, $step) {
             if ($from <= $to) {
-                for (; $from <= $to; $from++) {
+                for (; $from <= $to; $from += abs($step)) {
                     yield $from;
                 }
             } else {
-                for (; $from >= $to; $from--) {
+                for (; $from >= $to; $from -= abs($step)) {
                     yield $from;
                 }
             }


### PR DESCRIPTION
The range method is designed to create a collection with integer values within a specified range, allowing the caller to define both a starting point ($from) and an endpoint ($to). An optional $step parameter specifies the increment or decrement for each iteration through the range.

**Here's a breakdown of its behavior:**

**Parameters:**
$from: The starting integer of the range.
$to: The ending integer of the range.
$step (optional): The amount by which the range increments or decrements. By default, this is set to 1.

**Validation:**
If $step is set to 0, an InvalidArgumentException is thrown. This validation ensures that there is no infinite loop caused by a zero increment, which would result in the range generator producing the same number indefinitely.

**Range Generation Logic:**
The method uses a generator to yield each value in the range without requiring memory to store all values at once, making it efficient for large ranges.
If $from is less than or equal to $to, it iterates by adding the absolute value of $step until reaching or surpassing $to.
If $from is greater than $to, it iterates by subtracting the absolute value of $step until it reaches or is less than $to.


**Example Usage:**

```php

// Example for a forward range
$range = Collection::range(1, 10); // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

// Example for a range with a step of 2
$range = Collection::range(1, 10, 2); // [1, 3, 5, 7, 9]

// Example for a reverse range
$range = Collection::range(10, 1); // [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]

// Example for a reverse range with a step of 2
$range = Collection::range(10, 1, 2); // [10, 8, 6, 4, 2]
```


This method provides a flexible way to generate ranges with custom increments or decrements, making it suitable for various use cases in numerical data processing or iteration.

