### PR TITLE
[11.x] Allow callable transformation for `data_set` values

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -121,7 +121,7 @@ if (! function_exists('data_set')) {
                 }
             } elseif ($overwrite) {
                 foreach ($target as &$inner) {
-                    $inner = is_callable($value) ? $value($inner) : $value;
+                    $inner = $value instanceof Closure ? $value($inner) : $value;
                 }
             }
         } elseif (Arr::accessible($target)) {
@@ -132,7 +132,7 @@ if (! function_exists('data_set')) {
 
                 data_set($target[$segment], $segments, $value, $overwrite);
             } elseif ($overwrite || ! Arr::exists($target, $segment)) {
-                $target[$segment] = is_callable($value) ? $value(Arr::get($target, $segment)) : $value;
+                $target[$segment] = $value instanceof Closure ? $value(Arr::get($target, $segment)) : $value;
             }
         } elseif (is_object($target)) {
             if ($segments) {
@@ -142,7 +142,7 @@ if (! function_exists('data_set')) {
 
                 data_set($target->{$segment}, $segments, $value, $overwrite);
             } elseif ($overwrite || ! isset($target->{$segment})) {
-                $target->{$segment} = is_callable($value) ? $value($target->{$segment}) : $value;
+                $target->{$segment} = $value instanceof Closure ? $value($target->{$segment}) : $value;
             }
         } else {
             $target = [];
@@ -150,7 +150,7 @@ if (! function_exists('data_set')) {
             if ($segments) {
                 data_set($target[$segment], $segments, $value, $overwrite);
             } elseif ($overwrite) {
-                $target[$segment] = is_callable($value) ? $value(null) : $value;
+                $target[$segment] = $value instanceof Closure ? $value(null) : $value;
             }
         }
 

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -98,7 +98,7 @@ if (! function_exists('data_get')) {
 
 if (! function_exists('data_set')) {
     /**
-     * Set an item on an array or object using dot notation.
+     * Set an item on an array or object using dot notation, with the ability to use a callable to transform the old data.
      *
      * @param  mixed  $target
      * @param  string|array  $key
@@ -121,7 +121,7 @@ if (! function_exists('data_set')) {
                 }
             } elseif ($overwrite) {
                 foreach ($target as &$inner) {
-                    $inner = $value;
+                    $inner = is_callable($value) ? $value($inner) : $value;
                 }
             }
         } elseif (Arr::accessible($target)) {
@@ -132,7 +132,7 @@ if (! function_exists('data_set')) {
 
                 data_set($target[$segment], $segments, $value, $overwrite);
             } elseif ($overwrite || ! Arr::exists($target, $segment)) {
-                $target[$segment] = $value;
+                $target[$segment] = is_callable($value) ? $value(Arr::get($target, $segment)) : $value;
             }
         } elseif (is_object($target)) {
             if ($segments) {
@@ -142,7 +142,7 @@ if (! function_exists('data_set')) {
 
                 data_set($target->{$segment}, $segments, $value, $overwrite);
             } elseif ($overwrite || ! isset($target->{$segment})) {
-                $target->{$segment} = $value;
+                $target->{$segment} = is_callable($value) ? $value($target->{$segment}) : $value;
             }
         } else {
             $target = [];
@@ -150,7 +150,7 @@ if (! function_exists('data_set')) {
             if ($segments) {
                 data_set($target[$segment], $segments, $value, $overwrite);
             } elseif ($overwrite) {
-                $target[$segment] = $value;
+                $target[$segment] = is_callable($value) ? $value(null) : $value;
             }
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -510,7 +510,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertEquals(
             ['foo' => 'barboom'],
-            data_set($data, 'foo', fn ($old) => $old . 'boom')
+            data_set($data, 'foo', fn ($old) => $old.'boom')
         );
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -507,6 +507,11 @@ class SupportHelpersTest extends TestCase
             ['foo' => ['bar' => 'boom'], 'baz' => ['bar' => ['boom' => ['kaboom' => 'boom']]]],
             data_set($data, 'baz.bar.boom.kaboom', 'boom')
         );
+
+        $this->assertEquals(
+            ['foo' => 'barboom'],
+            data_set($data, 'foo', fn ($old) => $old . 'boom')
+        );
     }
 
     public function testDataSetWithStar()
@@ -531,6 +536,11 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(
             ['foo' => [], 'bar' => ['overwritten', 'overwritten']],
             data_set($data, 'bar.*', 'overwritten')
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => ['overwritten', 'overwritten']],
+            data_set($data, 'bar.*', fn ($old) => 'overwritten')
         );
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -509,8 +509,8 @@ class SupportHelpersTest extends TestCase
         );
 
         $this->assertEquals(
-            ['foo' => 'barboom'],
-            data_set($data, 'foo', fn ($old) => $old.'boom')
+            ['foo' => ['bar' => 'boomboom'], 'baz' => ['bar' => ['boom' => ['kaboom' => 'boom']]]],
+            data_set($data, 'foo.bar', fn ($old) => $old.'boom')
         );
     }
 
@@ -539,8 +539,8 @@ class SupportHelpersTest extends TestCase
         );
 
         $this->assertEquals(
-            ['foo' => [], 'bar' => ['overwritten', 'overwritten']],
-            data_set($data, 'bar.*', fn ($old) => 'overwritten')
+            ['foo' => [], 'bar' => ['overwrittenboom', 'overwrittenboom']],
+            data_set($data, 'bar.*', fn ($old) => $old.'boom')
         );
     }
 


### PR DESCRIPTION
This pull request introduces enhancements to the `data_set` function, allowing it to handle callable values for transforming existing data. Additionally, corresponding tests have been added to ensure the new functionality works as expected.

In my case, I needed to apply transformers to data that I did not fully understand beforehand, using a mapping card. For example, I defined a set of anonymizers as follows:

```php
$anonymizers = [
    'string' => fn($value) => md5($value),
    'email' => fn($value) => md5($value) . '@anonymized',
];
```

Here, I created two types of anonymizers: one for general strings, which generates an MD5 hash of the input value, and another specifically for email addresses, which not only hashes the value but also appends `@anonymized` to it.

Next, I set up a data map that specifies how to apply these anonymizers to various fields in the data structure:

```php
$datamap = [
    'users' => [
        'emails.*.address' => 'email',
        'profile.oldEmail' => 'email',
        'profile.firstName' => 'string',
        'profile.phone' => 'string',
    ],
];
```

In this mapping, I indicated that any email address in the `emails` array, as well as the `oldEmail`, `firstName`, and `phone` fields in the `profile`, should be processed using the corresponding anonymizer.

To apply these transformations, I utilized the `each()` method alongside `data_set`, allowing me to dynamically invoke the appropriate anonymizer based on the defined mapping. For instance, I would execute the following:

```php
data_set($model, $field, $anonymizers[$type]($oldValue));
```

This line effectively takes the model, the specific field to be transformed, and applies the corresponding anonymizer function to the old value, storing the result back in the model.