### PR TITLE
[11.x] Introduce `TFetchMode` generic to support for different PDO fetch modes

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -227,7 +227,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     /**
      * Begin a new database query against the table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function getTable()
     {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -424,7 +424,7 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Get a query builder for the cache table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function table()
     {

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -80,7 +80,7 @@ class Manager
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $table
      * @param  string|null  $as
      * @param  string|null  $connection
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public static function table($table, $as = null, $connection = null)
     {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -21,6 +21,7 @@ use RuntimeException;
 
 /**
  * @template TValue
+ * @template TFetchMode of \PDO::FETCH_*|false
  *
  * @mixin \Illuminate\Database\Eloquent\Builder
  * @mixin \Illuminate\Database\Query\Builder
@@ -337,7 +338,7 @@ trait BuildsQueries
      * Execute the query and get the first result.
      *
      * @param  array|string  $columns
-     * @return TValue|null
+     * @return (TFetchMode is false ? TValue : (TFetchMode is 1|5|8|9 ? object : array))|null
      */
     public function first($columns = ['*'])
     {
@@ -349,7 +350,7 @@ trait BuildsQueries
      *
      * @param  array|string  $columns
      * @param  string|null  $message
-     * @return TValue
+     * @return (TFetchMode is false ? TValue : (TFetchMode is 1|5|8|9 ? object : array))
      *
      * @throws \Illuminate\Database\RecordNotFoundException
      */
@@ -366,7 +367,7 @@ trait BuildsQueries
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns
-     * @return TValue
+     * @return (TFetchMode is false ? TValue : (TFetchMode is 1|5|8|9 ? object : array))
      *
      * @throws \Illuminate\Database\RecordsNotFoundException
      * @throws \Illuminate\Database\MultipleRecordsFoundException

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -312,7 +312,7 @@ class Connection implements ConnectionInterface
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $table
      * @param  string|null  $as
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function table($table, $as = null)
     {
@@ -322,7 +322,7 @@ class Connection implements ConnectionInterface
     /**
      * Get a new query builder instance.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function query()
     {
@@ -661,8 +661,10 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback without "pretending".
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TResult
+     *
+     * @param  \Closure():TResult  $callback
+     * @return TResult
      */
     public function withoutPretending(Closure $callback)
     {
@@ -682,8 +684,10 @@ class Connection implements ConnectionInterface
     /**
      * Execute the given callback in "dry run" mode.
      *
-     * @param  \Closure  $callback
-     * @return array
+     * @template TResult of array
+     *
+     * @param  \Closure():TResult  $callback
+     * @return TResult
      */
     protected function withFreshQueryLog($callback)
     {

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -11,7 +11,7 @@ interface ConnectionInterface
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $table
      * @param  string|null  $as
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function table($table, $as = null);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -33,7 +33,7 @@ use ReflectionMethod;
  */
 class Builder implements BuilderContract
 {
-    /** @use \Illuminate\Database\Concerns\BuildsQueries<TModel> */
+    /** @use \Illuminate\Database\Concerns\BuildsQueries<TModel,false> */
     use BuildsQueries, ForwardsCalls, QueriesRelationships {
         BuildsQueries::sole as baseSole;
     }
@@ -1797,7 +1797,7 @@ class Builder implements BuilderContract
     /**
      * Get the underlying query builder instance.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function getQuery()
     {
@@ -1820,7 +1820,7 @@ class Builder implements BuilderContract
     /**
      * Get a base query builder instance.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function toBase()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1607,7 +1607,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get a new query builder instance for the connection.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function newBaseQueryBuilder()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -538,7 +538,7 @@ trait InteractsWithPivotTable
     /**
      * Get a new plain query builder for the pivot table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function newPivotStatement()
     {
@@ -549,7 +549,7 @@ trait InteractsWithPivotTable
      * Get a new pivot statement for a given "other" ID.
      *
      * @param  mixed  $id
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function newPivotStatementForId($id)
     {
@@ -559,7 +559,7 @@ trait InteractsWithPivotTable
     /**
      * Create a new query builder for the pivot table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function newPivotQuery()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -127,7 +127,7 @@ class MorphToMany extends BelongsToMany
     /**
      * Create a new query builder for the pivot table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function newPivotQuery()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -316,7 +316,7 @@ abstract class Relation implements BuilderContract
     /**
      * Get the base query builder driving the Eloquent builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function getBaseQuery()
     {
@@ -326,7 +326,7 @@ abstract class Relation implements BuilderContract
     /**
      * Get a base query builder instance.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function toBase()
     {

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -199,7 +199,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Get a query builder for the migration table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function table()
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -31,9 +31,12 @@ use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 
+/**
+ * @template TFetchMode of \PDO::FETCH_*
+ */
 class Builder implements BuilderContract
 {
-    /** @use \Illuminate\Database\Concerns\BuildsQueries<object> */
+    /** @use \Illuminate\Database\Concerns\BuildsQueries<array|object,TFetchMode> */
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }
@@ -1790,7 +1793,7 @@ class Builder implements BuilderContract
     /**
      * Create a new query instance for nested where condition.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function forNestedWhere()
     {
@@ -3030,7 +3033,7 @@ class Builder implements BuilderContract
      *
      * @param  int|string  $id
      * @param  array|string  $columns
-     * @return object|null
+     * @return (TFetchMode is 1|5|8|9 ? object : array)|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -3045,7 +3048,7 @@ class Builder implements BuilderContract
      * @param  mixed  $id
      * @param  (\Closure(): TValue)|list<string>|string  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @return object|TValue
+     * @return ($columns is Closure ? TValue|(TFetchMode is 1|5|8|9 ? object : array) : ($callback is Closure ? TValue|(TFetchMode is 1|5|8|9 ? object : array) : (TFetchMode is 1|5|8|9 ? object : array)))
      */
     public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {
@@ -3530,8 +3533,10 @@ class Builder implements BuilderContract
     /**
      * Execute the given callback if no rows exist for the current query.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TResult
+     *
+     * @param  \Closure():TResult  $callback
+     * @return true|TResult
      */
     public function existsOr(Closure $callback)
     {
@@ -3541,8 +3546,10 @@ class Builder implements BuilderContract
     /**
      * Execute the given callback if rows exist for the current query.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TResult
+     *
+     * @param  \Closure():TResult  $callback
+     * @return true|TResult
      */
     public function doesntExistOr(Closure $callback)
     {
@@ -3690,9 +3697,11 @@ class Builder implements BuilderContract
      *
      * After running the callback, the columns are reset to the original value.
      *
+     * @template TResult
+     *
      * @param  array  $columns
-     * @param  callable  $callback
-     * @return mixed
+     * @param  callable():TResult  $callback
+     * @return TResult
      */
     protected function onceWithColumns($columns, $callback)
     {
@@ -4086,7 +4095,7 @@ class Builder implements BuilderContract
     /**
      * Get a new instance of the query builder.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function newQuery()
     {
@@ -4096,7 +4105,7 @@ class Builder implements BuilderContract
     /**
      * Create a new query instance for a sub-query.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function forSubQuery()
     {

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -125,7 +125,7 @@ class JoinClause extends Builder
     /**
      * Create a new query instance for sub-query.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function forSubQuery()
     {
@@ -135,7 +135,7 @@ class JoinClause extends Builder
     /**
      * Create a new parent query instance.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function newParentQuery()
     {

--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -17,7 +17,7 @@ trait HasDatabaseNotifications
     /**
      * Get the entity's read notifications.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function readNotifications()
     {
@@ -27,7 +27,7 @@ trait HasDatabaseNotifications
     /**
      * Get the entity's unread notifications.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     public function unreadNotifications()
     {

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -163,7 +163,7 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     /**
      * Get a new query builder instance for the table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function getTable()
     {

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -176,7 +176,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     /**
      * Get a new query builder instance for the table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function getTable()
     {

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -284,7 +284,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     /**
      * Get a fresh query builder instance for the table.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function getQuery()
     {

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -75,7 +75,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $conditions
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function addConditions($query, $conditions)
     {
@@ -117,7 +117,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
      * Get a query builder for the given table.
      *
      * @param  string  $table
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>
      */
     protected function table($table)
     {

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -12,7 +12,10 @@ use User;
 
 use function PHPStan\Testing\assertType;
 
-/** @param \Illuminate\Database\Eloquent\Builder<\User> $query */
+/**
+ * @param  \Illuminate\Database\Eloquent\Builder<\User>  $query
+ * @param  \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>  $queryBuilder
+ */
 function test(
     Builder $query,
     Post $post,

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -7,54 +7,112 @@ use Illuminate\Database\Query\Builder;
 
 use function PHPStan\Testing\assertType;
 
-/** @param \Illuminate\Database\Eloquent\Builder<\User> $userQuery */
-function test(Builder $query, EloquentBuilder $userQuery): void
+/**
+ * @param  \Illuminate\Database\Query\Builder<\PDO::FETCH_OBJ>  $query
+ * @param  \Illuminate\Database\Eloquent\Builder<\User>  $userQuery
+ */
+function testWithFetchObj(Builder $query, EloquentBuilder $userQuery): void
 {
     assertType('object|null', $query->first());
     assertType('object|null', $query->find(1));
     assertType('int|object', $query->findOr(1, fn () => 42));
     assertType('int|object', $query->findOr(1, callback: fn () => 42));
-    assertType('Illuminate\Database\Query\Builder', $query->selectSub($userQuery, 'alias'));
-    assertType('Illuminate\Database\Query\Builder', $query->fromSub($userQuery, 'alias'));
-    assertType('Illuminate\Database\Query\Builder', $query->from($userQuery, 'alias'));
-    assertType('Illuminate\Database\Query\Builder', $query->joinSub($userQuery, 'alias', 'foo'));
-    assertType('Illuminate\Database\Query\Builder', $query->joinLateral($userQuery, 'alias'));
-    assertType('Illuminate\Database\Query\Builder', $query->leftJoinLateral($userQuery, 'alias'));
-    assertType('Illuminate\Database\Query\Builder', $query->leftJoinSub($userQuery, 'alias', 'foo'));
-    assertType('Illuminate\Database\Query\Builder', $query->rightJoinSub($userQuery, 'alias', 'foo'));
-    assertType('Illuminate\Database\Query\Builder', $query->crossJoinSub($userQuery, 'alias'));
-    assertType('Illuminate\Database\Query\Builder', $query->whereExists($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->orWhereExists($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->whereNotExists($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->orWhereNotExists($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->orderBy($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->orderByDesc($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->union($userQuery));
-    assertType('Illuminate\Database\Query\Builder', $query->unionAll($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->selectSub($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->fromSub($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->from($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->joinSub($userQuery, 'alias', 'foo'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->joinLateral($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->leftJoinLateral($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->leftJoinSub($userQuery, 'alias', 'foo'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->rightJoinSub($userQuery, 'alias', 'foo'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->crossJoinSub($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->whereExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->orWhereExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->whereNotExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->orWhereNotExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->orderBy($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->orderByDesc($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->union($userQuery));
+    assertType('Illuminate\Database\Query\Builder<5>', $query->unionAll($userQuery));
     assertType('int', $query->insertUsing([], $userQuery));
     assertType('int', $query->insertOrIgnoreUsing([], $userQuery));
 
     $query->chunk(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, object>', $users);
+        assertType('Illuminate\Support\Collection<int, array|object>', $users);
         assertType('int', $page);
     });
     $query->chunkById(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, object>', $users);
+        assertType('Illuminate\Support\Collection<int, array|object>', $users);
         assertType('int', $page);
     });
     $query->chunkMap(function ($users) {
-        assertType('object', $users);
+        assertType('array|object', $users);
     });
     $query->chunkByIdDesc(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, object>', $users);
+        assertType('Illuminate\Support\Collection<int, array|object>', $users);
         assertType('int', $page);
     });
     $query->each(function ($users, $page) {
-        assertType('object', $users);
+        assertType('array|object', $users);
         assertType('int', $page);
     });
     $query->eachById(function ($users, $page) {
-        assertType('object', $users);
+        assertType('array|object', $users);
+        assertType('int', $page);
+    });
+}
+
+/**
+ * @param  \Illuminate\Database\Query\Builder<\PDO::FETCH_ASSOC>  $query
+ * @param  \Illuminate\Database\Eloquent\Builder<\User>  $userQuery
+ */
+function testWithFetchArr(Builder $query, EloquentBuilder $userQuery): void
+{
+    assertType('array|null', $query->first());
+    assertType('array|null', $query->find(1));
+    assertType('array|int', $query->findOr(1, fn () => 42));
+    assertType('array|int', $query->findOr(1, callback: fn () => 42));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->selectSub($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->fromSub($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->from($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->joinSub($userQuery, 'alias', 'foo'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->joinLateral($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->leftJoinLateral($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->leftJoinSub($userQuery, 'alias', 'foo'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->rightJoinSub($userQuery, 'alias', 'foo'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->crossJoinSub($userQuery, 'alias'));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->whereExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->orWhereExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->whereNotExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->orWhereNotExists($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->orderBy($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->orderByDesc($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->union($userQuery));
+    assertType('Illuminate\Database\Query\Builder<2>', $query->unionAll($userQuery));
+    assertType('int', $query->insertUsing([], $userQuery));
+    assertType('int', $query->insertOrIgnoreUsing([], $userQuery));
+
+    $query->chunk(1, function ($users, $page) {
+        assertType('Illuminate\Support\Collection<int, array|object>', $users);
+        assertType('int', $page);
+    });
+    $query->chunkById(1, function ($users, $page) {
+        assertType('Illuminate\Support\Collection<int, array|object>', $users);
+        assertType('int', $page);
+    });
+    $query->chunkMap(function ($users) {
+        assertType('array|object', $users);
+    });
+    $query->chunkByIdDesc(1, function ($users, $page) {
+        assertType('Illuminate\Support\Collection<int, array|object>', $users);
+        assertType('int', $page);
+    });
+    $query->each(function ($users, $page) {
+        assertType('array|object', $users);
+        assertType('int', $page);
+    });
+    $query->eachById(function ($users, $page) {
+        assertType('array|object', $users);
         assertType('int', $page);
     });
 }


### PR DESCRIPTION
**PR Description:**
This PR introduces the `TFetchMode` generic to improve PHPDoc annotations in the Query Builder, ensuring better clarity and support for various PDO fetch modes.

**Reason:** 
The current default fetch mode in `Connection` is `PDO::FETCH_OBJ`. When a custom Connection is used, the Query Builder's PHPDoc does not reflect the correct fetch mode, leading to potential issues in type hinting and IDE support.