### PR TITLE
[11.x] replace assertEquals('') with assertEmpty

### DIFF
--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -82,7 +82,7 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->queue($cookie->make('foo', ''));
         $this->assertTrue($cookie->hasQueued('foo'));
-        $this->assertEquals('', $cookie->queued('foo')->getValue());
+        $this->assertEmpty($cookie->queued('foo')->getValue());
     }
 
     public function testQueuedCookiesWithRepeatedValue(): void

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -23,7 +23,7 @@ class ProcessTest extends TestCase
         $this->assertFalse($result->failed());
         $this->assertEquals(0, $result->exitCode());
         $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
-        $this->assertEquals('', $result->errorOutput());
+        $this->assertEmpty($result->errorOutput());
 
         $result->throw();
         $result->throwIf(true);
@@ -168,8 +168,8 @@ class ProcessTest extends TestCase
 
         $result = $factory->run('ls -la');
 
-        $this->assertEquals('', $result->output());
-        $this->assertEquals('', $result->errorOutput());
+        $this->assertEmpty($result->output());
+        $this->assertEmpty($result->errorOutput());
         $this->assertEquals(0, $result->exitCode());
         $this->assertTrue($result->successful());
     }
@@ -352,7 +352,7 @@ class ProcessTest extends TestCase
         $this->assertEquals("ls command 2\n", $result->output());
 
         $result = $factory->run('ls -la');
-        $this->assertEquals('', $result->output());
+        $this->assertEmpty($result->output());
     }
 
     public function testProcessFakeSequencesCanThrowWhenSequenceIsEmpty()
@@ -479,7 +479,7 @@ class ProcessTest extends TestCase
         $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
 
         $this->assertFalse($result->successful());
-        $this->assertEquals('', $result->output());
+        $this->assertEmpty($result->output());
         $this->assertEquals("Hello World\n", $result->errorOutput());
     }
 
@@ -738,7 +738,7 @@ class ProcessTest extends TestCase
         $this->assertEquals("THREE\n", $latestOutput[1]);
         $this->assertEquals("ONE\nTWO\nTHREE\n", $output[1]);
 
-        $this->assertEquals('', $latestOutput[2]);
+        $this->assertEmpty($latestOutput[2]);
         $this->assertEquals("ONE\nTWO\nTHREE\n", $output[2]);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3872,7 +3872,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->after('', true));
         $this->assertEquals(0, $c->after(false, true));
         $this->assertEquals([], $c->after(1, true));
-        $this->assertEquals('', $c->after([], true));
+        $this->assertEmpty($c->after([], true));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -26,7 +26,7 @@ class SupportHtmlStringTest extends TestCase
 
         // Check if HtmlString correctly handles an empty string
         $emptyHtml = new HtmlString('');
-        $this->assertEquals('', $emptyHtml->toHtml());
+        $this->assertEmpty($emptyHtml->toHtml());
 
         // Check if HtmlString correctly converts a plain text string
         $str = 'foo bar';


### PR DESCRIPTION
In some test cases I replaced assertEquals('') to assertEmpty.