### PR TITLE
Add dailyAtRandomTime frequency

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Random\Engine;
+use Random\Randomizer;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 
@@ -321,6 +323,19 @@ trait ManagesFrequencies
     public function daily()
     {
         return $this->hourBasedSchedule(0, 0);
+    }
+
+    /**
+     * Schedule the event to run daily at random time.
+     *
+     * @param \Random\Engine|null $engine
+     * @return $this
+     */
+    public function dailyAtRandomTime(?Engine $engine = null)
+    {
+        $randomizer = (new Randomizer($engine ?? new SeededRandomEngine(sha1($this->buildCommand()))));
+
+        return $this->at($randomizer->getInt(0, 23) . ':' . $randomizer->getInt(0, 59));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/SeededRandomEngine.php
+++ b/src/Illuminate/Console/Scheduling/SeededRandomEngine.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Console\Scheduling;
+
+use Random\Engine;
+
+class SeededRandomEngine implements Engine
+{
+    /**
+     * @param string $seed
+     */
+    public function __construct(
+        #[\SensitiveParameter]
+        private $seed,
+    ) {
+    }
+
+    /**
+     * @return string
+     */
+    public function generate()
+    {
+        return $this->seed;
+    }
+}


### PR DESCRIPTION
Sometimes I like to add scheduled commands to run daily but I dont care at what time it is going to run. To distribute load on my personal project I added utility to generate random cron expression by utilizing Random extension that was added to PHP 8.2. Maybe someone else will find this useful. 

This PR add ability to specify `dailyAtRandomTime` schedule.

```php
$schedule->command(PruneFailedJobsCommand::class)->dailyAtRandomTime();
```