### PR TITLE
Fix unserialize(): Argument laravel#1 ($data) must be of type string

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -419,6 +419,10 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function unserialize($value)
     {
+        if ($value instanceof \Redis) {
+            return $value;
+        }
+        
         return is_numeric($value) ? $value : unserialize($value);
     }
 }


### PR DESCRIPTION
**Configurations**
```
<?php

// queue.php

return [

    'default' => env('QUEUE_CONNECTION', 'sync'),

    'connections' => [

        'sync' => [
            'driver' => 'sync',
        ],

        'redis' => [
            'driver' => 'redis',
            'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
            'queue' => env('REDIS_QUEUE', 'default'),
            'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
            'block_for' => null,
            'after_commit' => false,
            'serialize' => 'json',
        ],

    ],

    'batching' => [
        'database' => 'redis',
        'redis_connection' => 'default',
        'table' => 'job_batches',
        'debug' => false,
    ],

    'failed' => [
        'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
        'database' => env('DB_CONNECTION', 'mysql'),
        'table' => 'failed_jobs',
    ],
];
```

```
<?php

// database.php

return [

    // ....

    'redis' => [

        'client' => 'phpredis',

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'redis'),
            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_'),
        ],

        'default' => [
            'url' => env('REDIS_URL'),
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'username' => env('REDIS_USERNAME'),
            'password' => env('REDIS_PASSWORD'),
            'port' => env('REDIS_PORT', '6379'),
            'database' => env('REDIS_DB', '0'),
        ],

        // ...

    ],

];

```

**ContactsImport**

```
<?php

class ContactsImport implements ShouldQueue, ToCollection, WithChunkReading, WithHeadingRow
{
    use HasAbossCommonMethods;
    use HasImportConditions;
    use HasShiftTracker;
    use SerializesModels;

    public function __construct(
        protected Team $team,
        protected User $importer,
        protected array $conditions = [],
    ) {}

    public function collection(Collection $collection): void
    {
        disable_max_execution_time();

        Config::set(key: 'scout.queue', value: false);

        $executeAbossImports = $this->filterCollectionByConditions($collection)
            ->map(
                function (Collection $item): ExecuteAbossImport {
                    // ....

                    return new ExecuteAbossImport(
                        $this->team,
                        new ContactImportRow,
                        $attributes,
                    );
                },
            )
            ->toArray();

        $this->dispatchBatchImports(
            $executeAbossImports,
            function (): void {
               // Do something here
            },
        );
    }

    public function chunkSize(): int
    {
        return 5000;
    }
}
```

The `dispatchBatchImports` method
```
    public function dispatchBatchImports(array $jobs, ?Closure $onFinish = null): void
    {
        $trackShiftImports = $this->getTrackShiftImportsCallback();
        $catchShiftImportsError = $this->getCatchShiftImportsErrorCallback();

        $batch = Bus::batch($jobs)
            ->name(name: $this->getShiftBatchName())
            ->finally($trackShiftImports)
            ->progress($trackShiftImports)
            ->catch($catchShiftImportsError)
            ->allowFailures()
            ->onQueue(queue: 'shift');

        if ($onFinish instanceof Closure) {
            $batch = $batch->then($onFinish);
        }

        $this->trackImports(
            batch: $batch->dispatch(),
            team: $this->team,
            importer: $this->importer,
            importType: $this->getCurrentShiftJobImportType(),
            dataSourceFiles: $this->dataSourceFiles ?? [],
        );
    }
```

The importer job
```
<?php

class ExecuteAbossImport implements ShouldQueue
{
    use Batchable;
    use Queueable;

    public function __construct(
        protected Team $team,
        protected AbossImportableRow $row,
        protected array $attributes,
    ) {}

    public function handle(): void
    {
        if ($this->batch()->cancelled()) {
            return;
        }

        Config::set(key: 'scout.queue', value: false);

        $attributes = $this->attributes;
        $attributes['team'] = $this->team;

        $this->row->from($attributes)->import();
    }
}

```

**Reproduce steps**:
1. Use the configuration specified above (specifically when using `phpredis` -- the issue will not be shown when using `predis`)
2. Dispatch a batch of jobs using Redis
3. See the `laravel.log`, it will contain the error `Argument #1 ($data) must be of type string, Redis given {"exception":"[object] (TypeError(code: 0): unserialize(): Argument #1 ($data) must be of type string, Redis given at`
