### PR TITLE
Refactor notification sending methods in ChannelManager to remove cod…

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -34,9 +34,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function send($notifiables, $notification)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
-        )->send($notifiables, $notification);
+        $this->sender()->send($notifiables, $notification);
     }
 
     /**
@@ -49,9 +47,17 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function sendNow($notifiables, $notification, ?array $channels = null)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
-        )->sendNow($notifiables, $notification, $channels);
+        $this->sender()->sendNow($notifiables, $notification, $channels);
+    }
+
+    /**
+     * @return \Illuminate\Notifications\NotificationSender
+     */
+    private function sender()
+    {
+        return new NotificationSender(
+            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale
+        );
     }
 
     /**


### PR DESCRIPTION
Both `send()` and` sendNow()` in `ChannelManager` were using the `NotificationSender` object, causing code duplication.
Moved the `NotificationSender` instantiation to a private sender() method to streamline and clean up the code.