### PR TITLE
[11.x] Fixes old() function param & return type

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -604,8 +604,8 @@ if (! function_exists('old')) {
      * Retrieve an old input item.
      *
      * @param  string|null  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  \Illuminate\Database\Eloquent\Model|string|array|null  $default
+     * @return string|array|null
      */
     function old($key = null, $default = null)
     {


### PR DESCRIPTION
Fix param & returntype to match actual values, see: https://github.com/laravel/framework/blob/923ee74bff9aeb16919f7bfbc14cde9091b4949b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php