### PR TITLE
[11.x] Http Client: fake connection exception

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -165,6 +166,22 @@ class Factory
     }
 
     /**
+     * Create a new connection exception for use during stubbing.
+     *
+     * @param  string|null  $message
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public static function failedConnection($message = null)
+    {
+        return function ($request) use ($message) {
+            return Create::rejectionFor(new ConnectException(
+                $message ?? "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
+                $request->toPsrRequest(),
+            ));
+        };
+    }
+
+    /**
      * Get an invokable object that returns a sequence of responses in order for use during stubbing.
      *
      * @param  array  $responses
@@ -203,9 +220,11 @@ class Factory
 
         $this->stubCallbacks = $this->stubCallbacks->merge(collect([
             function ($request, $options) use ($callback) {
-                $response = $callback instanceof Closure
-                                ? $callback($request, $options)
-                                : $callback;
+                $response = $callback;
+
+                while ($response instanceof Closure) {
+                    $response = $response($request, $options);
+                }
 
                 if ($response instanceof PromiseInterface) {
                     $options['on_stats'](new TransferStats(

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
+use Closure;
 use Illuminate\Support\Traits\Macroable;
 use OutOfBoundsException;
 
@@ -71,7 +72,7 @@ class ResponseSequence
     }
 
     /**
-     * Push response with the contents of a file as the body to the sequence.
+     * Push a response with the contents of a file as the body to the sequence.
      *
      * @param  string  $filePath
      * @param  int  $status
@@ -88,7 +89,7 @@ class ResponseSequence
     }
 
     /**
-     * Push connection exception to the sequence.
+     * Push a connection exception to the sequence.
      *
      * @param  string|null  $message
      * @return $this
@@ -167,6 +168,6 @@ class ResponseSequence
 
         $response = array_shift($this->responses);
 
-        return $response instanceof \Closure ? $response($request) : $response;
+        return $response instanceof Closure ? $response($request) : $response;
     }
 }

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -88,6 +88,19 @@ class ResponseSequence
     }
 
     /**
+     * Push connection exception to the sequence.
+     *
+     * @param  string|null  $message
+     * @return $this
+     */
+    public function pushFailedConnection($message = null)
+    {
+        return $this->pushResponse(
+            Factory::failedConnection($message)
+        );
+    }
+
+    /**
      * Push a response to the sequence.
      *
      * @param  mixed  $response
@@ -137,11 +150,12 @@ class ResponseSequence
     /**
      * Get the next response in the sequence.
      *
+     * @param  \Illuminate\Http\Client\Request  $request
      * @return mixed
      *
      * @throws \OutOfBoundsException
      */
-    public function __invoke()
+    public function __invoke($request)
     {
         if ($this->failWhenEmpty && $this->isEmpty()) {
             throw new OutOfBoundsException('A request was made, but the response sequence is empty.');
@@ -151,6 +165,8 @@ class ResponseSequence
             return value($this->emptyResponse ?? Factory::response());
         }
 
-        return array_shift($this->responses);
+        $response = array_shift($this->responses);
+
+        return $response instanceof \Closure ? $response($request) : $response;
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2247,7 +2247,6 @@ class HttpClientTest extends TestCase
         $this->assertNotNull($exception);
         $this->assertInstanceOf(ConnectionException::class, $exception);
         $this->assertSame('Fake', $exception->getMessage());
-
     }
 
     public function testMiddlewareRunsWhenFaked()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -25,7 +25,6 @@ use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -2232,7 +2231,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake([
             '*' => $this->factory->sequence()
                 ->pushFailedConnection('Fake')
-                ->push('Success')
+                ->push('Success'),
         ]);
 
         $exception = null;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -25,6 +25,7 @@ use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -2194,6 +2195,60 @@ class HttpClientTest extends TestCase
             Sleep::usleep(100_000),
             Sleep::usleep(200_000),
         ]);
+    }
+
+    public function testFakeConnectionException()
+    {
+        $this->factory->fake($this->factory->failedConnection('Fake'));
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('Fake');
+
+        $this->factory->post('https://example.com');
+    }
+
+    public function testFakeConnectionExceptionWithinFakeClosure()
+    {
+        $this->factory->fake(fn () => $this->factory->failedConnection('Fake'));
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('Fake');
+
+        $this->factory->post('https://example.com');
+    }
+
+    public function testFakeConnectionExceptionWithinArray()
+    {
+        $this->factory->fake(['*' => $this->factory->failedConnection('Fake')]);
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('Fake');
+
+        $this->factory->post('https://example.com');
+    }
+
+    public function testFakeConnectionExceptionWithinSequence()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->pushFailedConnection('Fake')
+                ->push('Success')
+        ]);
+
+        $exception = null;
+
+        $response = $this->factory->retry(3, function ($attempt, $e) use (&$exception) {
+            $exception = $e;
+
+            return true;
+        })->post('https://example.com');
+
+        $this->assertSame('Success', $response->body());
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(ConnectionException::class, $exception);
+        $this->assertSame('Fake', $exception->getMessage());
+
     }
 
     public function testMiddlewareRunsWhenFaked()


### PR DESCRIPTION
Currently it is possible to fake every possible response when faking the http client in a test, but it is currently not possible to fake a connection exception. This PR makes that possible.
```php
try {
    Http::get('https://laravel.com')
} catch (ConnectionException) {
    // Some special handling that you want to test.
}
```
I made this possible by providing an easy way to create failed connection similar to creating a fake response:
```php
Http::fake(['https://laravel.com' => Http::failedConnection()]);

// Similar syntax to:
Http::fake(['https://laravel.com' => Http::response()]);
```
I ensured faking a connection exception works in all different ways you can currently create fake responses (e.g. closure, response sequence) and I added a test for each one.