### PR TITLE
[11.x] update the docblock of the runCommand method.

### DIFF
--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -53,7 +53,7 @@ trait CallsCommands
     }
 
     /**
-     * Run the given the console command.
+     * Run the given console command.
      *
      * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @param  array  $arguments


### PR DESCRIPTION
Small grammar error.