### PR TITLE
[11.x] rename the $options variable to be just $option in the specifyParameters method

### DIFF
--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -25,11 +25,11 @@ trait HasParameters
             }
         }
 
-        foreach ($this->getOptions() as $options) {
-            if ($options instanceof InputOption) {
-                $this->getDefinition()->addOption($options);
+        foreach ($this->getOptions() as $option) {
+            if ($option instanceof InputOption) {
+                $this->getDefinition()->addOption($option);
             } else {
-                $this->addOption(...$options);
+                $this->addOption(...$option);
             }
         }
     }


### PR DESCRIPTION
I believe existing test cases will validate this small change.