### PR TITLE
[11.x] add support for `similar_text`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1437,6 +1437,19 @@ class Str
     }
 
     /**
+     * Calculate the similarity between two strings.
+     *
+     * @param  string  $string1
+     * @param  string  $string2
+     * @param  float|null  $percent
+     * @return int
+     */
+    public static function similar(string $string1, string $string2, float|null &$percent = null): int
+    {
+        return similar_text($string1, $string2, $percent);
+    }
+
+    /**
      * Get the singular form of an English word.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -877,6 +877,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Calculate the similarity between two strings.
+     *
+     * @param  string  $string
+     * @param  float|null  $percent
+     * @return int
+     */
+    public function similar(string $string, float|null &$percent = null): int
+    {
+        return Str::similar($this->value, $string, $percent);
+    }
+
+    /**
      * Get the singular form of an English word.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1629,6 +1629,9 @@ class SupportStrTest extends TestCase
 
     public function testSimilar()
     {
+        // percent is optional
+        $this->assertSame(3, Str::similar('foo', 'foo'));
+
         $percent = null;
         $this->assertSame(3, Str::similar('foo', 'foo', $percent));
         $this->assertSame(100.0, $percent);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1626,6 +1626,13 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    public function testSimilar()
+    {
+        $percent = null;
+        $this->assertSame(3, Str::similar('foo', 'foo', $percent));
+        $this->assertSame(100.0, $percent);
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1356,4 +1356,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
+
+    public function testSimilar()
+    {
+        $percent = null;
+        $this->assertSame(3, $this->stringable('foo')->similar('foo', $percent));
+        $this->assertSame(100.0, $percent);
+    }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1359,6 +1359,9 @@ class SupportStringableTest extends TestCase
 
     public function testSimilar()
     {
+        // percent is optional
+        $this->assertSame(3, $this->stringable('foo')->similar('foo'));
+
         $percent = null;
         $this->assertSame(3, $this->stringable('foo')->similar('foo', $percent));
         $this->assertSame(100.0, $percent);


### PR DESCRIPTION
This PR adds a simple method to the `Stringable` and `Str` classes.

Its a simple wrapper around the native PHP function [similar_text](https://www.php.net/manual/en/function.similar-text.php) to get the similarity between two strings.

Cheers
Adrian
