### PR TITLE
[11.x] Add support for syncing associations with array or base collection of models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -613,11 +613,7 @@ trait InteractsWithPivotTable
 
         if ($value instanceof BaseCollection || is_array($value)) {
             return collect($value)->map(function ($item) {
-                if ($item instanceof Model) {
-                    return $item->{$this->relatedKey};
-                }
-
-                return $item;
+                return $item instanceof Model ? $item->{$this->relatedKey} : $item;
             })->all();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -611,8 +611,14 @@ trait InteractsWithPivotTable
             return $value->pluck($this->relatedKey)->all();
         }
 
-        if ($value instanceof BaseCollection) {
-            return $value->toArray();
+        if ($value instanceof BaseCollection || is_array($value)) {
+            return collect($value)->map(function ($item) {
+                if ($item instanceof Model) {
+                    return $item->{$this->relatedKey};
+                }
+
+                return $item;
+            })->all();
         }
 
         return (array) $value;

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -789,6 +789,44 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertSame('mohamed', $post->tags[1]->pivot->flag);
     }
 
+    public function testSyncMethodWithModels()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
+
+        // Test syncing with an array of models
+        $post->tags()->sync([$tag, $tag2]);
+
+        $this->assertEquals(
+            Tag::whereIn('id', [$tag->id, $tag2->id])->pluck('name'),
+            $post->load('tags')->tags->pluck('name')
+        );
+
+        // Test syncing with a BaseCollection of models
+        $tagCollection = collect([$tag3, $tag4]);
+
+        $post->tags()->sync($tagCollection);
+
+        $this->assertEquals(
+            Tag::whereIn('id', [$tag3->id, $tag4->id])->pluck('name'),
+            $post->load('tags')->tags->pluck('name')
+        );
+
+        // Test syncing with EloquentCollection of models
+        $tagCollection = Tag::limit(2)->get();
+
+        $post->tags()->sync($tagCollection);
+
+        $this->assertEquals(
+            Tag::whereIn('id', [$tag->id, $tag2->id])->pluck('name'),
+            $post->load('tags')->tags->pluck('name')
+        );
+    }
+
     public function testSyncWithoutDetachingMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
During a code review for a teammate’s automated tests, I proposed the following change:

```diff
$tag = Tag::create([‘name’ => Str::random()]);
$tag2 = Tag::create([‘name’ => Str::random()]);

- $post->tags()->sync([$tag->id, $tag2->id]);
+ $post->tags()->sync([$tag, $tag2]);
```
However, he encountered an error when attempting to implement this change, despite I was very sure that I used `sync` with models before.

It appears that the current implementation of `parseIds` doesn't support passing models unless they are passed inside an Eloquent collection, so, to make it consistent, I updated the implementation to work with an array or base collection of models.

This will also be beneficial for situations when you already have an array of models:
```diff
- $post->tags()->sync(Arr::pluck($tags, 'id'));
+ $post->tags()->sync($tags);
```

Furthermore, it seems that there are currently no tests that cover the scenario of passing an Eloquent collection to the `sync` method, so I added a check for it inside my newly added test.