### PR TITLE
[11.x] Introduce method `Blueprint::rawColumn()`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1610,12 +1610,12 @@ class Blueprint
      * Create a new custom column on the table.
      *
      * @param  string  $column
-     * @param  string  $statement
+     * @param  string  $definition
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function custom($column, $statement)
+    public function rawColumn($column, $definition)
     {
-        return $this->addColumn('custom', $column, compact('statement'));
+        return $this->addColumn('raw', $column, compact('definition'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1607,6 +1607,18 @@ class Blueprint
     }
 
     /**
+     * Create a new custom column on the table.
+     *
+     * @param  string  $column
+     * @param  string  $statement
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function custom($column, $statement)
+    {
+        return $this->addColumn('custom', $column, compact('statement'));
+    }
+
+    /**
      * Add a comment to the table.
      *
      * @param  string  $comment

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -251,11 +251,11 @@ abstract class Grammar extends BaseGrammar
      * Create the column definition for a raw column type.
      *
      * @param  \Illuminate\Support\Fluent  $column
-     * @return string|(\Closure(\Illuminate\Database\Connection): string)
+     * @return string
      */
     protected function typeRaw(Fluent $column)
     {
-        return value($column->offsetGet('definition'), $this->connection);
+        return $column->offsetGet('definition');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -251,11 +251,11 @@ abstract class Grammar extends BaseGrammar
      * Create the column definition for a raw column type.
      *
      * @param  \Illuminate\Support\Fluent  $column
-     * @return string
+     * @return string|(\Closure(\Illuminate\Database\Connection): string)
      */
     protected function typeRaw(Fluent $column)
     {
-        return $column->offsetGet('definition');
+        return value($column->offsetGet('definition'), $this->connection);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -248,14 +248,14 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
-     * Create the column definition for a custom column type.
+     * Create the column definition for a raw column type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    protected function typeCustom(Fluent $column)
+    protected function typeRaw(Fluent $column)
     {
-        return $column->offsetGet('statement');
+        return $column->offsetGet('definition');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -248,6 +248,17 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Create the column definition for a custom column type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeCustom(Fluent $column)
+    {
+        return $column->offsetGet('statement');
+    }
+
+    /**
      * Add the column modifiers to the definition.
      *
      * @param  string  $sql

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -570,6 +570,36 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
+    public function testCustomColumn()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->custom('legacy_boolean', 'INT(1)')->nullable();
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `legacy_boolean` INT(1)',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $connection->shouldReceive('getServerVersion')->andReturn('3.35');
+        $this->assertEquals([
+            'alter table "posts" add column "legacy_boolean" INT(1)',
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "legacy_boolean" INT(1) null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "legacy_boolean" INT(1) null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
+
     public function testTableComment()
     {
         $base = new Blueprint('posts', function (Blueprint $table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -570,10 +570,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
-    public function testCustomColumn()
+    public function testRawColumn()
     {
         $base = new Blueprint('posts', function ($table) {
-            $table->custom('legacy_boolean', 'INT(1)')->nullable();
+            $table->rawColumn('legacy_boolean', 'INT(1)')->nullable();
         });
 
         $connection = m::mock(Connection::class);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -580,7 +580,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $blueprint = clone $base;
         $this->assertEquals([
-            'alter table `posts` add `legacy_boolean` INT(1)',
+            'alter table `posts` add `legacy_boolean` INT(1) null',
         ], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
-use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\Grammars\MariaDbGrammar;
@@ -599,40 +598,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table "posts" add "legacy_boolean" INT(1) null',
         ], $blueprint->toSql($connection, new SqlServerGrammar));
-    }
-
-    public function testRawColumnUsingCallback()
-    {
-        $connectionMock = m::mock(Connection::class);
-
-        $base = new Blueprint('posts', function ($table) use ($connectionMock) {
-            $table->rawColumn('legacy_boolean', function (ConnectionInterface $connection) use ($connectionMock) {
-                $this->assertSame($connection, $connectionMock);
-
-                return 'INT(1)';
-            })->nullable();
-        });
-
-        $blueprint = clone $base;
-        $this->assertEquals([
-            'alter table `posts` add `legacy_boolean` INT(1) null',
-        ], $blueprint->toSql($connectionMock, new MySqlGrammar));
-
-        $blueprint = clone $base;
-        $connectionMock->shouldReceive('getServerVersion')->andReturn('3.35');
-        $this->assertEquals([
-            'alter table "posts" add column "legacy_boolean" INT(1)',
-        ], $blueprint->toSql($connectionMock, new SQLiteGrammar));
-
-        $blueprint = clone $base;
-        $this->assertEquals([
-            'alter table "posts" add column "legacy_boolean" INT(1) null',
-        ], $blueprint->toSql($connectionMock, new PostgresGrammar));
-
-        $blueprint = clone $base;
-        $this->assertEquals([
-            'alter table "posts" add "legacy_boolean" INT(1) null',
-        ], $blueprint->toSql($connectionMock, new SqlServerGrammar));
     }
 
     public function testTableComment()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\Grammars\MariaDbGrammar;
@@ -598,6 +599,40 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table "posts" add "legacy_boolean" INT(1) null',
         ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
+
+    public function testRawColumnUsingCallback()
+    {
+        $connectionMock = m::mock(Connection::class);
+
+        $base = new Blueprint('posts', function ($table) use ($connectionMock) {
+            $table->rawColumn('legacy_boolean', function (ConnectionInterface $connection) use ($connectionMock) {
+                $this->assertSame($connection, $connectionMock);
+
+                return 'INT(1)';
+            })->nullable();
+        });
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `legacy_boolean` INT(1) null',
+        ], $blueprint->toSql($connectionMock, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $connectionMock->shouldReceive('getServerVersion')->andReturn('3.35');
+        $this->assertEquals([
+            'alter table "posts" add column "legacy_boolean" INT(1)',
+        ], $blueprint->toSql($connectionMock, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "legacy_boolean" INT(1) null',
+        ], $blueprint->toSql($connectionMock, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "legacy_boolean" INT(1) null',
+        ], $blueprint->toSql($connectionMock, new SqlServerGrammar));
     }
 
     public function testTableComment()


### PR DESCRIPTION
This PR introduces a new column method when creating/updating table schema.

Currently, when trying to create columns which are not natively supported by any of the grammars, we have to instead use database statements. This creates a rather big inconvenience as we cannot use a single table creation callback, because database statements are fired immediately and therefore cannot be used in `Schema::create(<table>, <callback>)`.

Imagine a scenario, where we would like to create a:
1. Table named `posts`
2. Containing auto-increment column `id`
3. Containing an integer column of display width `1` named `legacy_boolean` with a default value of `0`
4. Containing a composite index for these two columns

The example code to solve this would likely be as follows:
```php
new class extends Migration {
    public function up()
    {
        Schema::create('posts', function (Blueprint $table) {
            $table->id();
        });

        DB::statement('alter table `posts` add `legacy_boolean` int(1) default 0 not null');

        Schema::table('posts', function (Blueprint $table) {
            $table->index(['id', 'legacy_boolean']);
        });
    }
};
```

This PR introduces a new column creation method which supports directly specifiying the column type definition used for creating a column:
```php
new class extends Migration {
    public function up()
    {
        Schema::create('table', function (Blueprint $table) {
            $table->id();
            $table->rawColumn('legacy_boolean', 'int(1)')->default(0);
            $table->index(['id', 'legacy_boolean']);
        });
    }
};
```

This however has one possible drawback - this is not grammar-agnostic and therefore would be specific to the database driver used, even though, by-default, working with columns is grammar-agnostic as the underlying column definitions are compiled by the grammar implementation used by the driver.
On the other hand, the previous solution using database statements is also not grammar-agnostic and therefore we're just moving the drawback from one place to another, meaning, this should not be an issue after all, as we were already facing it elsewhere.