### PR TITLE
Fix issue where overwriting middleware variable when setting middleware priority

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -271,14 +271,14 @@ class ApplicationBuilder
             }
 
             if ($priorityAppends = $middleware->getMiddlewarePriorityAppends()) {
-                foreach ($priorityAppends as $middleware => $after) {
-                    $kernel->addToMiddlewarePriorityAfter($after, $middleware);
+                foreach ($priorityAppends as $newMiddleware => $after) {
+                    $kernel->addToMiddlewarePriorityAfter($after, $newMiddleware);
                 }
             }
 
             if ($priorityPrepends = $middleware->getMiddlewarePriorityPrepends()) {
-                foreach ($priorityPrepends as $middleware => $before) {
-                    $kernel->addToMiddlewarePriorityBefore($before, $middleware);
+                foreach ($priorityPrepends as $newMiddleware => $before) {
+                    $kernel->addToMiddlewarePriorityBefore($before, $newMiddleware);
                 }
             }
         });


### PR DESCRIPTION
This fixes a bug introduced by #53326 where the `$middleware` variable is overwritten when it comes to prepending.