### PR TITLE
[11.x] Add `splitLast` string helper method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1585,7 +1585,7 @@ class Str
         }
 
         if ($includeSearch === 'after') {
-            $after = $search . $after;
+            $after = $search.$after;
         }
 
         return [

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1563,10 +1563,11 @@ class Str
      * Split a string into two pieces using the last occurrence of a given value.
      *
      * @param  string  $subject
-     * @param  string|bool  $search
+     * @param  string $search
+     * @param  string $includeSearch
      * @return string[]
      */
-    public static function splitLast($subject, $search, $includeSearch = false)
+    public static function splitLast($subject, $search, $includeSearch = '')
     {
         $splitPosition = mb_strrpos($subject, $search);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1564,10 +1564,11 @@ class Str
      *
      * @param  string  $subject
      * @param  string $search
-     * @param  string $includeSearch
+     * @param  bool $prependSearch
+     * @param  bool $appendSearch
      * @return string[]
      */
-    public static function splitLast($subject, $search, $includeSearch = '')
+    public static function splitLast($subject, $search, $prependSearch = false, $appendSearch = false)
     {
         $splitPosition = mb_strrpos($subject, $search);
 
@@ -1581,11 +1582,11 @@ class Str
         $before = static::beforeLast($subject, $search);
         $after = static::afterLast($subject, $search);
 
-        if ($includeSearch === 'before') {
+        if ($prependSearch) {
             $before .= $search;
         }
 
-        if ($includeSearch === 'after') {
+        if ($appendSearch) {
             $after = $search.$after;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1563,9 +1563,9 @@ class Str
      * Split a string into two pieces using the last occurrence of a given value.
      *
      * @param  string  $subject
-     * @param  string $search
-     * @param  bool $prependSearch
-     * @param  bool $appendSearch
+     * @param  string  $search
+     * @param  bool  $prependSearch
+     * @param  bool  $appendSearch
      * @return string[]
      */
     public static function splitLast($subject, $search, $prependSearch = false, $appendSearch = false)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1560,6 +1560,41 @@ class Str
     }
 
     /**
+     * Split a string into two pieces using the last occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string|bool  $search
+     * @return string[]
+     */
+    public static function splitLast($subject, $search, $includeSearch = false)
+    {
+        $splitPosition = mb_strrpos($subject, $search);
+
+        // If the search value doesn't exist in the subject, or the search
+        // value is an empty string, then return an array that contains
+        // the subject and an empty string.
+        if ($splitPosition === false || $search === '') {
+            return [$subject, ''];
+        }
+
+        $before = static::beforeLast($subject, $search);
+        $after = static::afterLast($subject, $search);
+
+        if ($includeSearch === 'before') {
+            $before .= $search;
+        }
+
+        if ($includeSearch === 'after') {
+            $after = $search . $after;
+        }
+
+        return [
+            $before,
+            $after,
+        ];
+    }
+
+    /**
      * Remove all "extra" blank space from the given string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1032,12 +1032,14 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Split a string into two pieces using the last occurrence of a given value.
      *
-     * @param  string|bool  $search
+     * @param  string  $search
+     * @param  bool  $prependSearch
+     * @param  bool  $appendSearch
      * @return \Illuminate\Support\Collection<int, string>
      */
-    public function splitLast($search, $includeSearch = false)
+    public function splitLast($search, $prependSearch = false, $appendSearch = false)
     {
-        return collect(Str::splitLast($this->value, $search, $includeSearch));
+        return collect(Str::splitLast($this->value, $search, $prependSearch, $appendSearch));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1030,6 +1030,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Split a string into two pieces using the last occurrence of a given value.
+     *
+     * @param  string|bool  $search
+     * @return \Illuminate\Support\Collection<int, string>
+ */
+    public function splitLast($search, $includeSearch = false)
+    {
+        return collect(Str::splitLast($this->value, $search, $includeSearch));
+    }
+
+    /**
      * Make a string's first character lowercase.
      *
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1034,7 +1034,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      *
      * @param  string|bool  $search
      * @return \Illuminate\Support\Collection<int, string>
- */
+     */
     public function splitLast($search, $includeSearch = false)
     {
         return collect(Str::splitLast($this->value, $search, $includeSearch));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1149,6 +1149,45 @@ class SupportStrTest extends TestCase
         $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));
     }
 
+    public function testSplitLast()
+    {
+        $this->assertSame(['yve', ''], Str::splitLast('yvette', 'tte'));
+        $this->assertSame(['yve', 'tte'], Str::splitLast('yvette', 'tte', 'after'));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'tte', 'before'));
+
+        $this->assertSame(['yvet', 'e'], Str::splitLast('yvette', 't', false));
+        $this->assertSame(['yvet', 'te'], Str::splitLast('yvette', 't', 'after'));
+
+        $this->assertSame(['ééé ', 'tte'], Str::splitLast('ééé yvette', 'yve'));
+        $this->assertSame(['ééé ', 'yvette'], Str::splitLast('ééé yvette', 'yve', 'after'));
+        $this->assertSame(['ééé yve', 'tte'], Str::splitLast('ééé yvette', 'yve', 'before'));
+        $this->assertSame(['', 'tte'], Str::splitLast('yvette', 'yve'));
+
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx'));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx', 'before'));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx', 'after'));
+
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', ''));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', '', 'before'));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', '', 'after'));
+
+        $this->assertSame(['yv0et', 'te'], Str::splitLast('yv0et0te', '0'));
+        $this->assertSame(['yv0et0', 'te'], Str::splitLast('yv0et0te', '0', 'before'));
+        $this->assertSame(['yv0et', '0te'], Str::splitLast('yv0et0te', '0', 'after'));
+
+        $this->assertSame(['', ''], Str::splitLast('', 'test'));
+        $this->assertSame(['', ''], Str::splitLast('', 'test', 'before'));
+        $this->assertSame(['', ''], Str::splitLast('', 'test', 'after, '));
+
+        $this->assertSame(['laravel framework', '11'], Str::splitLast('laravel framework 11', ' '));
+        $this->assertSame(['laravel framework ', '11'], Str::splitLast('laravel framework 11', ' ', 'before'));
+        $this->assertSame(['laravel framework', ' 11'], Str::splitLast('laravel framework 11', ' ', 'after'));
+
+        $this->assertSame(['yvette', 'yv0et0te'], Str::splitLast("yvette\tyv0et0te", "\t"));
+        $this->assertSame(["yvette\t", 'yv0et0te'], Str::splitLast("yvette\tyv0et0te", "\t", 'before'));
+        $this->assertSame(['yvette', "\tyv0et0te"], Str::splitLast("yvette\tyv0et0te", "\t", 'after'));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1152,40 +1152,41 @@ class SupportStrTest extends TestCase
     public function testSplitLast()
     {
         $this->assertSame(['yve', ''], Str::splitLast('yvette', 'tte'));
-        $this->assertSame(['yve', 'tte'], Str::splitLast('yvette', 'tte', 'after'));
-        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'tte', 'before'));
+        $this->assertSame(['yve', 'tte'], Str::splitLast('yvette', 'tte', appendSearch: true));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'tte', prependSearch: true));
+        $this->assertSame(['yvette', 'tte'], Str::splitLast('yvette', 'tte', prependSearch: true, appendSearch: true));
 
-        $this->assertSame(['yvet', 'e'], Str::splitLast('yvette', 't', false));
-        $this->assertSame(['yvet', 'te'], Str::splitLast('yvette', 't', 'after'));
+        $this->assertSame(['yvet', 'e'], Str::splitLast('yvette', 't'));
+        $this->assertSame(['yvet', 'te'], Str::splitLast('yvette', 't', appendSearch: true));
 
         $this->assertSame(['ééé ', 'tte'], Str::splitLast('ééé yvette', 'yve'));
-        $this->assertSame(['ééé ', 'yvette'], Str::splitLast('ééé yvette', 'yve', 'after'));
-        $this->assertSame(['ééé yve', 'tte'], Str::splitLast('ééé yvette', 'yve', 'before'));
+        $this->assertSame(['ééé ', 'yvette'], Str::splitLast('ééé yvette', 'yve', appendSearch: true));
+        $this->assertSame(['ééé yve', 'tte'], Str::splitLast('ééé yvette', 'yve', prependSearch: true));
         $this->assertSame(['', 'tte'], Str::splitLast('yvette', 'yve'));
 
         $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx'));
-        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx', 'before'));
-        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx', 'after'));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx', prependSearch: true));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', 'xxxx', appendSearch: true));
 
         $this->assertSame(['yvette', ''], Str::splitLast('yvette', ''));
-        $this->assertSame(['yvette', ''], Str::splitLast('yvette', '', 'before'));
-        $this->assertSame(['yvette', ''], Str::splitLast('yvette', '', 'after'));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', '', prependSearch: true));
+        $this->assertSame(['yvette', ''], Str::splitLast('yvette', '', appendSearch: true));
 
         $this->assertSame(['yv0et', 'te'], Str::splitLast('yv0et0te', '0'));
-        $this->assertSame(['yv0et0', 'te'], Str::splitLast('yv0et0te', '0', 'before'));
-        $this->assertSame(['yv0et', '0te'], Str::splitLast('yv0et0te', '0', 'after'));
+        $this->assertSame(['yv0et0', 'te'], Str::splitLast('yv0et0te', '0', prependSearch: true));
+        $this->assertSame(['yv0et', '0te'], Str::splitLast('yv0et0te', '0', appendSearch: true));
 
         $this->assertSame(['', ''], Str::splitLast('', 'test'));
-        $this->assertSame(['', ''], Str::splitLast('', 'test', 'before'));
-        $this->assertSame(['', ''], Str::splitLast('', 'test', 'after, '));
+        $this->assertSame(['', ''], Str::splitLast('', 'test', prependSearch: true));
+        $this->assertSame(['', ''], Str::splitLast('', 'test', appendSearch: true));
 
         $this->assertSame(['laravel framework', '11'], Str::splitLast('laravel framework 11', ' '));
-        $this->assertSame(['laravel framework ', '11'], Str::splitLast('laravel framework 11', ' ', 'before'));
-        $this->assertSame(['laravel framework', ' 11'], Str::splitLast('laravel framework 11', ' ', 'after'));
+        $this->assertSame(['laravel framework ', '11'], Str::splitLast('laravel framework 11', ' ', prependSearch: true));
+        $this->assertSame(['laravel framework', ' 11'], Str::splitLast('laravel framework 11', ' ', appendSearch: true));
 
         $this->assertSame(['yvette', 'yv0et0te'], Str::splitLast("yvette\tyv0et0te", "\t"));
-        $this->assertSame(["yvette\t", 'yv0et0te'], Str::splitLast("yvette\tyv0et0te", "\t", 'before'));
-        $this->assertSame(['yvette', "\tyv0et0te"], Str::splitLast("yvette\tyv0et0te", "\t", 'after'));
+        $this->assertSame(["yvette\t", 'yv0et0te'], Str::splitLast("yvette\tyv0et0te", "\t", prependSearch: true));
+        $this->assertSame(['yvette', "\tyv0et0te"], Str::splitLast("yvette\tyv0et0te", "\t", appendSearch: true));
     }
 
     public function testUuid()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -242,40 +242,41 @@ class SupportStringableTest extends TestCase
     public function testSplitLast()
     {
         $this->assertSame(['yve', ''], $this->stringable('yvette')->splitLast('tte')->toArray());
-        $this->assertSame(['yve', 'tte'], $this->stringable('yvette')->splitLast('tte', 'after')->toArray());
-        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('tte', 'before')->toArray());
+        $this->assertSame(['yve', 'tte'], $this->stringable('yvette')->splitLast('tte', appendSearch: true)->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('tte', prependSearch: true)->toArray());
+        $this->assertSame(['yvette', 'tte'], $this->stringable('yvette')->splitLast('tte', prependSearch: true, appendSearch: true)->toArray());
 
-        $this->assertSame(['yvet', 'e'], $this->stringable('yvette')->splitLast('t', false)->toArray());
-        $this->assertSame(['yvet', 'te'], $this->stringable('yvette')->splitLast('t', 'after')->toArray());
+        $this->assertSame(['yvet', 'e'], $this->stringable('yvette')->splitLast('t')->toArray());
+        $this->assertSame(['yvet', 'te'], $this->stringable('yvette')->splitLast('t', appendSearch: true)->toArray());
 
         $this->assertSame(['ééé ', 'tte'], $this->stringable('ééé yvette')->splitLast('yve')->toArray());
-        $this->assertSame(['ééé ', 'yvette'], $this->stringable('ééé yvette')->splitLast('yve', 'after')->toArray());
-        $this->assertSame(['ééé yve', 'tte'], $this->stringable('ééé yvette')->splitLast('yve', 'before')->toArray());
+        $this->assertSame(['ééé ', 'yvette'], $this->stringable('ééé yvette')->splitLast('yve', appendSearch: true)->toArray());
+        $this->assertSame(['ééé yve', 'tte'], $this->stringable('ééé yvette')->splitLast('yve', prependSearch: true)->toArray());
         $this->assertSame(['', 'tte'], $this->stringable('yvette')->splitLast('yve')->toArray());
 
         $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx')->toArray());
-        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx', 'before')->toArray());
-        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx', 'after')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx', prependSearch: true)->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx', appendSearch: true)->toArray());
 
         $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('')->toArray());
-        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('', 'before')->toArray());
-        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('', 'after')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('', prependSearch: true)->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('', appendSearch: true)->toArray());
 
         $this->assertSame(['yv0et', 'te'], $this->stringable('yv0et0te')->splitLast('0')->toArray());
-        $this->assertSame(['yv0et0', 'te'], $this->stringable('yv0et0te')->splitLast('0', 'before')->toArray());
-        $this->assertSame(['yv0et', '0te'], $this->stringable('yv0et0te')->splitLast('0', 'after')->toArray());
+        $this->assertSame(['yv0et0', 'te'], $this->stringable('yv0et0te')->splitLast('0', prependSearch: true)->toArray());
+        $this->assertSame(['yv0et', '0te'], $this->stringable('yv0et0te')->splitLast('0', appendSearch: true)->toArray());
 
         $this->assertSame(['', ''], $this->stringable('')->splitLast('test')->toArray());
-        $this->assertSame(['', ''], $this->stringable('')->splitLast('test', 'before')->toArray());
-        $this->assertSame(['', ''], $this->stringable('')->splitLast('test', 'after, ')->toArray());
+        $this->assertSame(['', ''], $this->stringable('')->splitLast('test', prependSearch: true)->toArray());
+        $this->assertSame(['', ''], $this->stringable('')->splitLast('test', appendSearch: true)->toArray());
 
         $this->assertSame(['laravel framework', '11'], $this->stringable('laravel framework 11')->splitLast(' ')->toArray());
-        $this->assertSame(['laravel framework ', '11'], $this->stringable('laravel framework 11')->splitLast(' ', 'before')->toArray());
-        $this->assertSame(['laravel framework', ' 11'], $this->stringable('laravel framework 11')->splitLast(' ', 'after')->toArray());
+        $this->assertSame(['laravel framework ', '11'], $this->stringable('laravel framework 11')->splitLast(' ', prependSearch: true)->toArray());
+        $this->assertSame(['laravel framework', ' 11'], $this->stringable('laravel framework 11')->splitLast(' ', appendSearch: true)->toArray());
 
         $this->assertSame(['yvette', 'yv0et0te'], $this->stringable("yvette\tyv0et0te")->splitLast("\t")->toArray());
-        $this->assertSame(["yvette\t", 'yv0et0te'], $this->stringable("yvette\tyv0et0te")->splitLast("\t", 'before')->toArray());
-        $this->assertSame(['yvette', "\tyv0et0te"], $this->stringable("yvette\tyv0et0te")->splitLast("\t", 'after')->toArray());
+        $this->assertSame(["yvette\t", 'yv0et0te'], $this->stringable("yvette\tyv0et0te")->splitLast("\t", prependSearch: true)->toArray());
+        $this->assertSame(['yvette', "\tyv0et0te"], $this->stringable("yvette\tyv0et0te")->splitLast("\t", appendSearch: true)->toArray());
     }
 
     public function testWhenEndsWith()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -239,6 +239,45 @@ class SupportStringableTest extends TestCase
         $this->assertSame(['He_llo_', 'World'], $this->stringable('He_llo_World')->ucsplit()->toArray());
     }
 
+    public function testSplitLast()
+    {
+        $this->assertSame(['yve', ''], $this->stringable('yvette')->splitLast('tte')->toArray());
+        $this->assertSame(['yve', 'tte'], $this->stringable('yvette')->splitLast('tte', 'after')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('tte', 'before')->toArray());
+
+        $this->assertSame(['yvet', 'e'], $this->stringable('yvette')->splitLast('t', false)->toArray());
+        $this->assertSame(['yvet', 'te'], $this->stringable('yvette')->splitLast('t', 'after')->toArray());
+
+        $this->assertSame(['ééé ', 'tte'], $this->stringable('ééé yvette')->splitLast('yve')->toArray());
+        $this->assertSame(['ééé ', 'yvette'], $this->stringable('ééé yvette')->splitLast('yve', 'after')->toArray());
+        $this->assertSame(['ééé yve', 'tte'], $this->stringable('ééé yvette')->splitLast('yve', 'before')->toArray());
+        $this->assertSame(['', 'tte'], $this->stringable('yvette')->splitLast('yve')->toArray());
+
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx', 'before')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('xxxx', 'after')->toArray());
+
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('', 'before')->toArray());
+        $this->assertSame(['yvette', ''], $this->stringable('yvette')->splitLast('', 'after')->toArray());
+
+        $this->assertSame(['yv0et', 'te'], $this->stringable('yv0et0te')->splitLast('0')->toArray());
+        $this->assertSame(['yv0et0', 'te'], $this->stringable('yv0et0te')->splitLast('0', 'before')->toArray());
+        $this->assertSame(['yv0et', '0te'], $this->stringable('yv0et0te')->splitLast('0', 'after')->toArray());
+
+        $this->assertSame(['', ''], $this->stringable('')->splitLast('test')->toArray());
+        $this->assertSame(['', ''], $this->stringable('')->splitLast('test', 'before')->toArray());
+        $this->assertSame(['', ''], $this->stringable('')->splitLast('test', 'after, ')->toArray());
+
+        $this->assertSame(['laravel framework', '11'], $this->stringable('laravel framework 11')->splitLast(' ')->toArray());
+        $this->assertSame(['laravel framework ', '11'], $this->stringable('laravel framework 11')->splitLast(' ', 'before')->toArray());
+        $this->assertSame(['laravel framework', ' 11'], $this->stringable('laravel framework 11')->splitLast(' ', 'after')->toArray());
+
+        $this->assertSame(['yvette', 'yv0et0te'], $this->stringable("yvette\tyv0et0te")->splitLast("\t")->toArray());
+        $this->assertSame(["yvette\t", 'yv0et0te'], $this->stringable("yvette\tyv0et0te")->splitLast("\t", 'before')->toArray());
+        $this->assertSame(['yvette', "\tyv0et0te"], $this->stringable("yvette\tyv0et0te")->splitLast("\t", 'after')->toArray());
+    }
+
     public function testWhenEndsWith()
     {
         $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenEndsWith('ark', function ($stringable) {


### PR DESCRIPTION
Hey! This PR proposes a new `Str::splitLast` helper method for use with strings. It splits a string into 2 pieces based on the last occurrence of a search value.

Apologies if something like this already exists and I've just not seen it haha!

I'm not sure if it's something that'd be useful to anyone else outside my current project, but I thought I'd propose it just in case.

## Context

I've recently been working on a feature for a project where I need to split a full software name (e.g. Google Chrome 10) to get it's name and version number (e.g. "Google Chrome" and "10").

I was using something like this:

```php
$fullSoftwareName = 'laravel framework 12';

$softwareName = Str::beforeLast($fullSoftwareName, ' '); // laravel framework
$softwareVersion = Str::afterLast($fullSoftwareName, ' '); // 12
```

I thought it'd be nice to use something like this that wraps it all up:

```php
$fullSoftwareName = 'laravel framework 12';

[$softwareName, $softwareVersion] = Str::splitLast($fullSoftwareName, ' ');

// $softwareName: 'laravel framework'
// $softwareVersion: '12'
```

## Examples

By default, the search value won't be included in the returned result:

```php
[$before, $after] = Str::splitLast('taylor otwell', 'twe');

// $before: 'taylor o'
// $after: 'll'
```

Or, you can pass `"before"` to the `includeSearch` argument to append the search value to the first item:

```php
[$before, $after] = Str::splitLast('taylor otwell', 'twe', includeSearch: 'before');

// $before: 'taylor otwe'
// $after: 'll'
```

Or, you can pass `"after"` to the `includeSearch` argument to prepend the search value to the second item:

```php
[$before, $after] = Str::splitLast('taylor otwell', 'twe', includeSearch: 'after');

// $before: 'taylor o'
// $after: 'twell'
```

If the search value isn't found (or an empty string is passed as the search value), then the subject will be returned as the first value of the array:

```php
[$before, $after] = Str::splitLast('taylor otwell', 'ash');

// $before: 'taylor otwell'
// $after: ''
```

As I say, I don't know if this is just a niche use case that won't be encountered that often, but I thought I'd propose it in case in could come in handy for anyone else.

If it's something you think might be worth merging, please let me know if there's anything you'd like me to change 😄