### PR TITLE
[11.x] SqsQueue pushRaw options: pass to sendMessage

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -111,7 +111,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function pushRaw($payload, $queue = null, array $options = [])
     {
         return $this->sqs->sendMessage([
-            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload,
+            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, ...$options
         ])->get('MessageId');
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -111,7 +111,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function pushRaw($payload, $queue = null, array $options = [])
     {
         return $this->sqs->sendMessage([
-            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, ...$options
+            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, ...$options,
         ])->get('MessageId');
     }
 


### PR DESCRIPTION
Recently, I needed to send raw message to AWS SQS. The `pushRaw` method in `SqsQueue` accepted `$options`, but, it was not being used.

This tiny PR simply passes this `$options` to AWS SqsClient's `sendMessage()` function.

[SendMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html) accepts `MessageGroupId`, `MessageDeduplicationId`, `DelaySeconds`, and much more.
