### PR TITLE
[11.x] Allow custom base framework configuration

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -202,6 +202,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $mergeFrameworkConfiguration = true;
 
     /**
+     * The custom framework's base configuration path defined by the developer.
+     *
+     * @var string|null
+     */
+    protected $frameworkConfigurationPath = null;
+
+    /**
      * The prefixes of absolute cache paths for use during normalization.
      *
      * @var string[]
@@ -1231,6 +1238,27 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->mergeFrameworkConfiguration = false;
 
+        return $this;
+    }
+
+    /**
+     * Get the path to the developer's custom framework's base configuration folder.
+     *
+     * @return string
+     */
+    public function getFrameworkConfigurationPath()
+    {
+        return $this->frameworkConfigurationPath;
+    }
+
+    /**
+     * Set the path for the developer's custom framework's base configuration folder.
+     *
+     * @return $this
+     */
+    public function setFrameworkConfigurationPath($path)
+    {
+        $this->frameworkConfigurationPath = $path;
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -66,7 +66,7 @@ class LoadConfiguration
             : true;
 
         $base = $shouldMerge
-            ? $this->getBaseConfiguration()
+            ? $this->getBaseConfiguration(method_exists($app, 'getFrameworkConfigurationPath') ? $app->getFrameworkConfigurationPath() : null)
             : [];
 
         foreach (array_diff(array_keys($base), array_keys($files)) as $name => $config) {
@@ -180,13 +180,14 @@ class LoadConfiguration
     /**
      * Get the base configuration files.
      *
+     * @param  string|null $path
      * @return array
      */
-    protected function getBaseConfiguration()
+    protected function getBaseConfiguration($path)
     {
         $config = [];
 
-        foreach (Finder::create()->files()->name('*.php')->in(__DIR__.'/../../../../config') as $file) {
+        foreach (Finder::create()->files()->name('*.php')->in($path === null ? __DIR__.'/../../../../config' : $path) as $file) {
             $config[basename($file->getRealPath(), '.php')] = require $file->getRealPath();
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In microservice architecture all microservices require a base config. 
Most changes to a microservice base configuration usually requires that all other microservices configuration to be updated as well.

### Change description:
This allows common default config to defined separately like in a package, while still allowing to override them individually if needed. This also allows custom default config for 3rd party packages.

### Usage: 
Add setFrameworkConfigurationPath in `bootstrap/app.php`:
`return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )->create()
    ->setFrameworkConfigurationPath(__DIR__.'/../vendor/...') ;`

This change should have no breaking effect.
