### PR TITLE
[11.x] Fix extensions of contextual bindings

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -836,7 +836,9 @@ class Container implements ArrayAccess, ContainerContract
         // Before returning, we will also set the resolved flag to "true" and pop off
         // the parameter overrides for this build. After those two things are done
         // we will be ready to return back the fully constructed class instance.
-        $this->resolved[$abstract] = true;
+        if (! $needsContextualBuild) {
+            $this->resolved[$abstract] = true;
+        }
 
         array_pop($this->with);
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/53501

Right now, Laravel always marks a binding as resolved when its done resolving them, even if the binding in question was a contextual binding. When extending bindings Laravel will check if a binding was resolved, and if it was it will retrieve it and extend it.

The problem here is that if a binding is **only** contextual, it cannot be resolved, but the framework will still attempt to. This PR aims to fix this by only marking bindings as resolved when they aren't contextual. This allows contextual bindings and extensions to work together in the event where the extension happens after the contextual binding is resolved (it already worked without the binding being resolved before the extension)