### PR TITLE
[11.x] Don't overwrite custom replacements for count in `trans_choice`

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -211,8 +211,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         }
 
         if (! isset($replace['count'])) {
-            // Only if no replacement for ":count" is given via $replace, add it.
-            // This allows developers to pass a formatted count.
             $replace['count'] = $number;
         }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -210,7 +210,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $number = count($number);
         }
 
-        if (!isset($replace['count'])) {
+        if (! isset($replace['count'])) {
             // Only if no replacement for ":count" is given via $replace, add it.
             // This allows developers to pass a formatted count.
             $replace['count'] = $number;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -210,7 +210,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $number = count($number);
         }
 
-        $replace['count'] = $number;
+        if (!isset($replace['count'])) {
+            // Only if no replacement for ":count" is given via $replace, add it.
+            // This allows developers to pass a formatted count.
+            $replace['count'] = $number;
+        }
 
         return $this->makeReplacements(
             $this->getSelector()->choose($line, $number, $locale), $replace

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -172,6 +172,17 @@ class TranslationTranslatorTest extends TestCase
         $t->choice('foo', 10, ['replace']);
     }
 
+    public function testChoiceMethodProperlyUsesCustomCountReplacement()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo(':count foos'), $this->equalTo([]), $this->equalTo('en'))->willReturn('{1} :count foos|[2,*] :count foos');
+        $t->expects($this->once())->method('localeForChoice')->with($this->equalTo(':count foos'), $this->equalTo(null))->willReturn('en');
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->once()->with('{1} :count foos|[2,*] :count foos', 1234, 'en')->andReturn(':count foos');
+
+        $this->assertEquals('1,234 foos', $t->choice(':count foos', 1234, ['count' => '1,234']));
+    }
+
     public function testGetJson()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
Fixes #53516.

It also adds an additional unit test which fails without the bugfix.