### PR TITLE
Improve type saftey for Config/Repository.php

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -15,7 +15,7 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * All of the configuration items.
      *
-     * @var array
+     * @var array<string,mixed>
      */
     protected $items = [];
 
@@ -60,8 +60,8 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * Get many configuration values.
      *
-     * @param  array  $keys
-     * @return array
+     * @param  array<string|int,mixed>  $keys
+     * @return array<string,mixed>
      */
     public function getMany($keys)
     {


### PR DESCRIPTION
This PR improves the return type of safety for `Illuminate\Config\Repository.php` file.