### PR TITLE
[12.x] fix: container resolution order when resolving class dependencies

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1110,16 +1110,16 @@ class Container implements ArrayAccess, ContainerContract
     {
         $className = Util::getParameterClassName($parameter);
 
-        // First, we check if the dependency has been explicitly bound in
-        // the container, and if so, we resolve it directly from there
-        // to respect explicit bindings over developer set defaults.
+        // First, we check if the dependency has been explicitly bound in the container
+        // and if so, we will resolve it directly from there to respect any explicit
+        // bindings the developer has defined rather than using any default value.
         if ($this->bound($className)) {
             return $this->make($className);
         }
 
-        // If no binding exists, we check if any default value is
-        // available and return it. This avoids overriding any
-        // developer set defaults when constructing classes.
+        // If no binding exists, we will check if a default value has been defined for
+        // the parameter. If it has, we should return it to avoid overriding any of
+        // the developer specified default values for the constructor parameters.
         if ($parameter->isDefaultValueAvailable()) {
             return $parameter->getDefaultValue();
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1130,9 +1130,9 @@ class Container implements ArrayAccess, ContainerContract
                         : $this->make($className);
         }
 
-        // If we can not resolve the class instance, we will check to see if the
-        // value is variadic, and if it is we will return an empty array as the
-        // value of the dependency, similarly to how we do this with scalars.
+        // If we can not resolve the class instance, we will check to see if the value
+        // is variadic. If it is, we will return an empty array as the value of the
+        // dependency similarly to how we handle scalar values in this situation.
         catch (BindingResolutionException $e) {
             if ($parameter->isVariadic()) {
                 array_pop($this->with);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -289,6 +289,18 @@ class ContainerTest extends TestCase
         $this->assertSame('taylor', $instance->default);
     }
 
+    public function testResolutionOfClassWithDefaultParameters()
+    {
+        $container = new Container;
+        $instance = $container->make(ContainerClassWithDefaultValueStub::class);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $instance->noDefault);
+        $this->assertSame(null, $instance->default);
+
+        $container->bind(ContainerConcreteStub::class, fn () => new ContainerConcreteStub);
+        $instance = $container->make(ContainerClassWithDefaultValueStub::class);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $instance->default);
+    }
+
     public function testBound()
     {
         $container = new Container;
@@ -762,6 +774,15 @@ class ContainerDefaultValueStub
     {
         $this->stub = $stub;
         $this->default = $default;
+    }
+}
+
+class ContainerClassWithDefaultValueStub
+{
+    public function __construct(
+        public ?ContainerConcreteStub $noDefault,
+        public ?ContainerConcreteStub $default = null,
+    ) {
     }
 }
 


### PR DESCRIPTION
Hello!

This was deemed too risky to merge to 11.x in #53519, so trying for 12.x.

### Changes

Currently, when resolving a class with with dependencies, the container only falls back to the parameter default value if the class dependency failed to resolve. However, this is not intuitive---if I specify a default value for a parameter then I would expect that default value to be used (if I have not **explicitly** bound that parameter class to the container). This updates the container resolution logic to use the default value for a dependency (when available) before trying to resolve a class instance. The container class dependency logic flow now looks like:
1. check for explicitly bound instance
2. check for default value
3. attempt to make instance
4. if 3) fails and variadic then return array

For example, consider resolving the following class from the container:

```php
class Foo
{
    public function __construct(
        // non-nullable with no default, I would expect this to be resolved with a class instance
        public Carbon $date,
        // nullable with no default, I would expect this to be resolved with a class instance
        public ?Carbon $noDefault,
        // nullable with default specified, I would expect this to be resolved with null
        public ?Carbon $default = null,
    ) {}
}
$foo = app()->make(Foo::class);

// before
$foo->date instanceof Carbon; // expected
$foo->noDefault instanceof Carbon; // expected
$foo->default instanceof Carbon; // NOT expected or intuitive!!

// now
$foo->date instanceof Carbon; // same 
$foo->noDefault instanceof Carbon; // same
$foo->default === null; // changed, the default is now used as expected

app()->bind(Carbon, fn () => now());
$foo = app()->make(Foo::class);
$foo->default instanceof Carbon; // expected as I explicitly bound the class
```

### Motivation
I would consider this particular container nuance to be a bug and this has bitten us several times (usually when dealing with Model or Carbon instances) resulting in lengthy debugging efforts for seemingly obscure problems.

Most recently, this reared its head when using a scheduled, dispatched job. This particular job is designed to be executed early in the morning and it aggregates results for the previous day. We do allow a date to be passed into the constructor so the same job can be manually dispatched for a particular date if necessary---**it is considered an override when anything other than `null` is passed in**.

```php
class ScheduledJob implements ShouldQueue
{
    use Dispatchable;
    use InteractsWithQueue;
    use Queueable;

    public function __construct(protected ?CarbonImmutable $date = null) 
    {
        $this->date ??= now()->subDay()->toImmutable();
    }

    public function __invoke(): void {/* ... */}
}
Schedule::job(ScheduledJob::class)->cron('...'); // the scheduled jobs fail
ScheduleJob::dispatch(); // dispatching manually works
```

However, this job fails when executed via the scheduler every morning because the Scheduler uses the container to make the job class:

https://github.com/laravel/framework/blob/a296e813d041ddff000d856aa2f7ae1cd4d616b7/src/Illuminate/Console/Scheduling/Schedule.php#L165-L166

and the container **ignores the default value and instead constructs the job with a Carbon instance = now---the logic to handle the default case is never executed**. This works just fine as intended when dispatching the job with `ScheduledJob::dispatch()` (because of which, this was a tricky bug to troubleshoot). I would expect the job to have the same behaviour regardless if it was dispatched manually via `::dispatch()` or automatically via the scheduler.

I know I can use
```php
Schedule::job(new ScheduledJob())->cron('...');
```
to schedule the job with a class instance, however:
1. we have many scheduled jobs and `new`ing them all up would incur unnecessary overhead on every console invocation
5. this would fail with `schedule:work` because the constructor would be invoked when the app is booted and not right before the job is dispatched to the queue---resulting in a stale `$date` property

> [!NOTE]
> I recognize that there are many ways to work around this current behaviour, but the crux of the issue is that the resolution logic is not intuitive and ignores the developer provided default. This issue has continued to pop up in various locations in the app when using the container to resolve classes with dependencies that have default values.

Thanks!