### PR TITLE
Artisan Command Testing - Match default table style

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -224,7 +224,7 @@ class PendingCommand
      * @param  array  $columnStyles
      * @return $this
      */
-    public function expectsTable($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+    public function expectsTable($headers, $rows, $tableStyle = 'symfony-style-guide', array $columnStyles = [])
     {
         $table = (new Table($output = new BufferedOutput))
             ->setHeaders((array) $headers)


### PR DESCRIPTION
This PR is to match default table style to what `Illuminate\Console\Concerns\InteractsWithIO::$output->table()` uses.

Recently while writing tests for an Artisan command table output I needed to dig a little to find that the default value for the 'expectsTable()`'s parameter `$tableStyle` did not align with the default value being used in the corresponding method that creates tables when writing a command.

I did fix it, in my case, by simply providing the correct value, but this change would allow future artisans to rely on the default values.