### PR TITLE
Fix `unless` code comment

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -334,7 +334,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whenNotEmpty(callable $callback, ?callable $default = null);
 
     /**
-     * Apply the callback if the given "value" is (or resolves to) truthy.
+     * Apply the callback if the given "value" is (or resolves to) falsy.
      *
      * @template TUnlessReturnType
      *


### PR DESCRIPTION
The existing code comment was copied from `when`, and therefore mistakenly explains the callback is called when the value is truthy.

And just for reference, here was my own sanity check, done in tinker:
```
> collect([1,2,3,4])->unless(false,fn($a)=>$a->prepend(62362))
= Illuminate\Support\Collection {#7422
    all: [
      62362,
      1,
      2,
      3,
      4,
    ],
  }

> collect([1,2,3,4])->unless(true,fn($a)=>$a->prepend(62362))
= Illuminate\Support\Collection {#7351
    all: [
      1,
      2,
      3,
      4,
    ],
  }
```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
