### PR TITLE
[11.x] Http client: record request when faking connection exception

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -322,7 +322,7 @@ class Factory
      * Record a request response pair.
      *
      * @param  \Illuminate\Http\Client\Request  $request
-     * @param  \Illuminate\Http\Client\Response  $response
+     * @param  \Illuminate\Http\Client\Response|null  $response
      * @return void
      */
     public function recordRequestResponsePair($request, $response)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -939,8 +939,11 @@ class PendingRequest
                 });
             } catch (ConnectException $e) {
                 $exception = new ConnectionException($e->getMessage(), 0, $e);
+                $request = new Request($e->getRequest());
 
-                $this->dispatchConnectionFailedEvent(new Request($e->getRequest()), $exception);
+                $this->factory->recordRequestResponsePair($request, null);
+
+                $this->dispatchConnectionFailedEvent($request, $exception);
 
                 throw $exception;
             }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2279,7 +2279,7 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(ConnectionException::class, $exception);
         $this->assertSame('Fake', $exception->getMessage());
 
-        $this->factory->assertSentCount(1);
+        $this->factory->assertSentCount(2);
     }
 
     public function testMiddlewareRunsWhenFaked()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -37,6 +37,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;
+use Throwable;
 
 class HttpClientTest extends TestCase
 {
@@ -2200,30 +2201,60 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake($this->factory->failedConnection('Fake'));
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Fake');
+        $exception = null;
 
-        $this->factory->post('https://example.com');
+        try {
+            $this->factory->post('https://example.com');
+        } catch (Throwable $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(ConnectionException::class, $exception);
+        $this->assertSame('Fake', $exception->getMessage());
+
+        $this->factory->assertSentCount(1);
+        $this->factory->assertSent(function (Request $request, ?Response $response) {
+            return $request->url() === 'https://example.com' && $response === null;
+        });
     }
 
     public function testFakeConnectionExceptionWithinFakeClosure()
     {
         $this->factory->fake(fn () => $this->factory->failedConnection('Fake'));
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Fake');
+        $exception = null;
 
-        $this->factory->post('https://example.com');
+        try {
+            $this->factory->post('https://example.com');
+        } catch (Throwable $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(ConnectionException::class, $exception);
+        $this->assertSame('Fake', $exception->getMessage());
+
+        $this->factory->assertSentCount(1);
     }
 
     public function testFakeConnectionExceptionWithinArray()
     {
         $this->factory->fake(['*' => $this->factory->failedConnection('Fake')]);
 
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Fake');
+        $exception = null;
 
-        $this->factory->post('https://example.com');
+        try {
+            $this->factory->post('https://example.com');
+        } catch (Throwable $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(ConnectionException::class, $exception);
+        $this->assertSame('Fake', $exception->getMessage());
+
+        $this->factory->assertSentCount(1);
     }
 
     public function testFakeConnectionExceptionWithinSequence()
@@ -2247,6 +2278,8 @@ class HttpClientTest extends TestCase
         $this->assertNotNull($exception);
         $this->assertInstanceOf(ConnectionException::class, $exception);
         $this->assertSame('Fake', $exception->getMessage());
+
+        $this->factory->assertSentCount(1);
     }
 
     public function testMiddlewareRunsWhenFaked()


### PR DESCRIPTION
I added support for faking a connection exception in a test (see https://github.com/laravel/framework/pull/53485), but I noticed that the request was not being recorded. That means asserting how many requests were sent is currently not correct. This PR fixes that.

```php

Http::fake(['https://laravel.com' => Http::failedConnection()]);

try {
    Http::get('https://laravel.com')
} catch (ConnectionException) {
}

Http::assertSentCount(1); // This would fail before this PR
```