### PR TITLE
[11.x] Add "head" slot to email layout

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -23,6 +23,7 @@ width: 100% !important;
 }
 }
 </style>
+{{ $head ?? '' }}
 </head>
 <body>
 


### PR DESCRIPTION
Currently if I want to add a few lines of code to the head of email layout, I have to publish the entire file. But I'd prefer not to do it to keep the repository cleaner and to keep the email layout file up-to-date with the framework.

This PR adds a `head` slot which allows me to easily add a few lines of code to the head of email layout, like this:

```
<x-slot:head>
<style>
@media only screen and (max-width: 600px) {
.inner-body {
border-radius: 0 !important;
}
}
</style>
</x-slot:head>
```

If you find this addition useful, it would be cool to see it merged. If not, it's fine too because I can always publish the entire email layout file, even though I'd prefer not to.