### PR TITLE
Add isAnagram method to Str class for checking anagrams

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2009,4 +2009,18 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Determine if two strings are anagrams of each other.
+     *
+     * @param  string  $string1
+     * @param  string  $string2
+     */
+    public static function isAnagram($string1, $string2): bool
+    {
+        $string1 = preg_replace('/\s+/', '', mb_strtolower($string1));
+        $string2 = preg_replace('/\s+/', '', mb_strtolower($string2));
+
+        return count_chars($string1, 1) === count_chars($string2, 1);
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1626,6 +1626,35 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    public function testIsAnagram()
+    {
+        // Valid anagrams
+        $this->assertTrue(Str::isAnagram('listen', 'silent'));
+        $this->assertTrue(Str::isAnagram('triangle', 'integral'));
+        $this->assertTrue(Str::isAnagram('anagram', 'nagaram'));
+
+        // Invalid anagrams
+        $this->assertFalse(Str::isAnagram('hello', 'world'));
+        $this->assertFalse(Str::isAnagram('test', 'settle'));
+        $this->assertFalse(Str::isAnagram('example', 'samples'));
+
+        // Case-insensitive anagrams
+        $this->assertTrue(Str::isAnagram('Listen', 'Silent'));
+        $this->assertTrue(Str::isAnagram('Triangle', 'Integral'));
+
+        // Anagrams with spaces
+        $this->assertTrue(Str::isAnagram('a gentleman', 'elegant man'));
+        $this->assertTrue(Str::isAnagram('The Morse Code', 'Here come dots'));
+
+        // Empty strings
+        $this->assertTrue(Str::isAnagram('', ''));
+        $this->assertFalse(Str::isAnagram('', 'notempty'));
+
+        // Special characters
+        $this->assertTrue(Str::isAnagram('!@#$', '#$@!'));
+        $this->assertFalse(Str::isAnagram('hello!', 'olleh'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
This pull request introduces a new method `isAnagram` to the `Str` class which allows developers to easily determine if two strings are anagrams of each other.

### How to use it? 

```php 
use Illuminate\Support\Str;

$isAnagram = Str::isAnagram('listen', 'silent'); // Returns true
$isAnagram = Str::isAnagram('hello', 'world');   // Returns false
```
