### PR TITLE
[11.x] Allow query builder to be passed to exists rule

### DIFF
--- a/src/Illuminate/Contracts/Validation/RequiresPreviousRule.php
+++ b/src/Illuminate/Contracts/Validation/RequiresPreviousRule.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface RequiresPreviousRule
+{
+}

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\ArrayRule;
@@ -10,6 +11,7 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\ExistsUsingBuilder;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
@@ -97,13 +99,15 @@ class Rule
     /**
      * Get an exists constraint builder instance.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Builder  $table
      * @param  string  $column
-     * @return \Illuminate\Validation\Rules\Exists
+     * @return ($table is string ? \Illuminate\Validation\Rules\Exists : \Illuminate\Validation\Rules\ExistsUsingBuilder)
      */
     public static function exists($table, $column = 'NULL')
     {
-        return new Exists($table, $column);
+        return $table instanceof Builder
+            ? new ExistsUsingBuilder($table, $column)
+            : new Exists($table, $column);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ExistsUsingBuilder.php
+++ b/src/Illuminate/Validation/Rules/ExistsUsingBuilder.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Contracts\Validation\RequiresPreviousRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Validation\Validator;
+
+class ExistsUsingBuilder implements ValidationRule, ValidatorAwareRule, RequiresPreviousRule
+{
+    /**
+     * The current validator.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected Validator $validator;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Builder  $query
+     * @param  string  $column
+     *
+     * @retun void
+     */
+    public function __construct(
+        protected Builder $query,
+        protected string $column,
+    ) {
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $column = $this->column === 'NULL'
+            ? $this->validator->guessColumnForQuery($attribute)
+            : $this->column;
+
+        if (is_array($value)) {
+            $expectedCount = count(array_unique($value));
+
+            if (
+                $expectedCount > 0
+                && $this->query()->whereIn($column, $value)->distinct()->count($column) < $expectedCount
+            ) {
+                $fail('validation.exists')->translate();
+            }
+        } elseif ($this->query()->where($column, $value)->doesntExist()) {
+            $fail('validation.exists')->translate();
+        }
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator(Validator $validator): self
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Get the cloned query builder instance.
+     *
+     * @return \Illuminate\Contracts\Database\Query\Builder
+     */
+    protected function query(): Builder
+    {
+        $query = method_exists($this->query, 'toBase')
+            ? $this->query->toBase()->clone()
+            : $this->query->clone();
+
+        $wheres = $query->wheres;
+        $bindings = $query->bindings['where'];
+
+        $query->wheres = [];
+        $query->bindings['where'] = [];
+
+        return $query->where(fn (Builder $query) => $query->mergeWheres($wheres, $bindings));
+    }
+}

--- a/tests/Validation/ValidationExistsUsingBuilderRuleTest.php
+++ b/tests/Validation/ValidationExistsUsingBuilderRuleTest.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\ExistsUsingBuilder;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class ValidationExistsUsingBuilderRuleTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    #[TestWith(['id'])]
+    #[TestWith(['NULL'])]
+    public function testItChoosesValidRecordsUsingWhereNotInRuleWithModel(string $column): void
+    {
+        $rule = new ExistsUsingBuilder(UserForExistsRule::query()->whereNotIn('type', ['foo', 'bar']), $column);
+
+        UserForExistsRule::query()->create(['id' => '1', 'type' => 'foo']);
+        UserForExistsRule::query()->create(['id' => '2', 'type' => 'bar']);
+        UserForExistsRule::query()->create(['id' => '3', 'type' => 'baz']);
+        UserForExistsRule::query()->create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 4, 4]]);
+        $this->assertTrue($v->passes());
+    }
+
+    #[TestWith(['id'])]
+    #[TestWith(['NULL'])]
+    public function testItChoosesValidRecordsUsingWhereNotInRuleWithDB(string $column): void
+    {
+        $rule = new ExistsUsingBuilder(DB::table('users')->whereNotIn('type', ['foo', 'bar']), $column);
+
+        UserForExistsRule::query()->create(['id' => '1', 'type' => 'foo']);
+        UserForExistsRule::query()->create(['id' => '2', 'type' => 'bar']);
+        UserForExistsRule::query()->create(['id' => '3', 'type' => 'baz']);
+        UserForExistsRule::query()->create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 4, 4]]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testItChoosesValidRecordsUsingRelation(): void
+    {
+        $user = UserForExistsRule::query()->create(['id' => 1, 'type' => 'foo']);
+        UserForExistsRule::query()->create(['id' => 2, 'type' => 'bar']);
+
+        $rule = new ExistsUsingBuilder($user->posts(), 'id');
+
+        PostForExistsRule::query()->create(['id' => 1, 'user_id' => 2]);
+        PostForExistsRule::query()->create(['id' => 2, 'user_id' => 2]);
+        PostForExistsRule::query()->create(['id' => 3, 'user_id' => 1]);
+        PostForExistsRule::query()->create(['id' => 4, 'user_id' => 1]);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 4, 4]]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testItChoosesValidRecordsUsingJoins(): void
+    {
+        UserForExistsRule::query()->create(['id' => 1, 'type' => 'foo']);
+        UserForExistsRule::query()->create(['id' => 2, 'type' => 'foo']);
+        UserForExistsRule::query()->create(['id' => 3, 'type' => 'bar']);
+
+        $rule = new ExistsUsingBuilder(
+            PostForExistsRule::query()
+                ->join('users', function (JoinClause $join) {
+                    $join->on('posts.user_id', '=', 'users.id')
+                        ->where('users.type', 'foo');
+                }),
+            'posts.id',
+        );
+
+        PostForExistsRule::query()->create(['id' => 1, 'user_id' => 3]);
+        PostForExistsRule::query()->create(['id' => 2, 'user_id' => 3]);
+        PostForExistsRule::query()->create(['id' => 3, 'user_id' => 1]);
+        PostForExistsRule::query()->create(['id' => 4, 'user_id' => 2]);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['user_with_type_foo' => $rule]);
+
+        $v->setData(['user_with_type_foo' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['user_with_type_foo' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['user_with_type_foo' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['user_with_type_foo' => 4]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['user_with_type_foo' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['user_with_type_foo' => [3, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['user_with_type_foo' => [3, 4, 4]]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testItDoesNotQueryDatabaseWhenPreviousRuleFailed(): void
+    {
+        $rule = new ExistsUsingBuilder(UserForExistsRule::query(), 'id');
+
+        DB::enableQueryLog();
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => ['uuid', $rule]]);
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    public function testItDoesNotQueryDatabaseForEmptyArrays(): void
+    {
+        $rule = new ExistsUsingBuilder(UserForExistsRule::query(), 'id');
+
+        DB::enableQueryLog();
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => [$rule]]);
+
+        $v->setData(['id' => []]);
+        $this->assertTrue($v->passes());
+
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    protected function createSchema(): void
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->unsignedInteger('id');
+            $table->string('type');
+        });
+
+        $this->schema()->create('posts', function ($table) {
+            $table->unsignedInteger('id');
+            $table->unsignedInteger('user_id');
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return $this->getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get connection resolver.
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected function getConnectionResolver()
+    {
+        return Eloquent::getConnectionResolver();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('posts');
+    }
+
+    public function getIlluminateArrayTranslator()
+    {
+        return new Translator(
+            new ArrayLoader, 'en'
+        );
+    }
+}
+
+/**
+ * Eloquent Models.
+ */
+class UserForExistsRule extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function posts()
+    {
+        return $this->hasMany(PostForExistsRule::class, 'user_id');
+    }
+}
+
+class PostForExistsRule extends Eloquent
+{
+    protected $table = 'posts';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/types/Validation/Rule.php
+++ b/types/Validation/Rule.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\ExistsUsingBuilder;
+
+use function PHPStan\Testing\assertType;
+
+/** @var \Illuminate\Database\Query\Builder $builder */
+assertType(Exists::class, Rule::exists('table', 'id'));
+assertType(ExistsUsingBuilder::class, Rule::exists($builder, 'id'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows you to pass any builder instance to `Rule::exists`.

```php
Rule::exists(User::active());
Rule::exists(User::where('some_field', 'value'));
Rule::exists($this->user()->posts());
Rule::exists(DB::table('posts')->join(...)->where(...));
```
