### PR TITLE
[11.x] Enable listening to multiple Eloquent events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -253,6 +253,25 @@ trait HasEvents
 
         return $result;
     }
+    /**
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $events
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array|null  $callback
+     * @return void
+     */
+    public static function listen($events, $callback = null)
+    {
+        if (! is_string($events) && ! is_array($events)) {
+            $callback = $events;
+            $events = '*';
+        }
+
+        if (isset(static::$dispatcher)) {
+            $name = static::class;
+            $events = Arr::map((array) $events, fn ($event) => "eloquent.{$event}: {$name}");
+
+            static::$dispatcher->listen($events, $callback);
+        }
+    }
 
     /**
      * Register a retrieved model event with the dispatcher.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -253,6 +253,7 @@ trait HasEvents
 
         return $result;
     }
+
     /**
      * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $events
      * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array|null  $callback

--- a/tests/Integration/Database/EloquentModelListenToMultipleEventsTest.php
+++ b/tests/Integration/Database/EloquentModelListenToMultipleEventsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Closure;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\Fixtures\Post;
+
+class EloquentModelListenToMultipleEventsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Post::unguard();
+    }
+
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    public function testEloquentModelCanListenToMultipleEvents()
+    {
+        Event::fake();
+
+        Post::listen(['saved', 'deleted'], function () {
+            // do something
+        });
+
+        $post = Post::query()->create(['title' => 'Third post']);
+        $post->delete();
+
+        Event::assertListening('eloquent.saved: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.deleted: '.Post::class, Closure::class);
+    }
+
+    public function testEloquentModelCanListenToWildcardEvents()
+    {
+        Event::fake();
+
+        Post::listen(function () {
+            // do something
+        });
+
+        Post::query()->create(['title' => 'First post']);
+
+        Event::assertListening('eloquent.booting: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.booted: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.saving: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.creating: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.created: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.saved: '.Post::class, Closure::class);
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces a new `Model::listen` method, allowing developers to listen to multiple Eloquent events at once. 

This enhancement improves the developer experience and aligns with the existing `Event::listen` behavior. Additionally, it introduces support for wildcard event listening for Eloquent models.

Currently, performing the same action for multiple events looks like this:

```php
Categories::created(function () {
    Cache::forget('categories');
});

Categories::deleted(function () {
    Cache::forget('categories');
});
```

With This PR:

```php
Categories::listen(['created', 'deleted'], function () {
    Cache::forget('categories');
});

// Listen to all Eloquent events for the model
Categories::listen(function () {
    // Do something
});
```

Looking forward to hearing your thoughts! Thank you for all the amazing work you guys do! 🙏

---
Previous attempt: #49949 — I’ve optimized the implementation, enhanced the "wildcard listener" dx, and added more comprehensive tests in this iteration.