### PR TITLE
[11.x] Add `Request::enums` method to retrieve an array of enums

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -422,7 +422,7 @@ trait InteractsWithInput
     public function enums($key, $enumClass)
     {
         if ($this->isNotFilled($key) || ! $this->isBackedEnum($enumClass)) {
-             return [];
+            return [];
         }
 
         return $this->collect($key)->map(function ($value) use ($enumClass) {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -403,13 +403,42 @@ trait InteractsWithInput
      */
     public function enum($key, $enumClass)
     {
-        if ($this->isNotFilled($key) ||
-            ! enum_exists($enumClass) ||
-            ! method_exists($enumClass, 'tryFrom')) {
+        if ($this->isNotFilled($key) || ! $this->isBackedEnum($enumClass)) {
             return null;
         }
 
         return $enumClass::tryFrom($this->input($key));
+    }
+
+    /**
+     * Retrieve input from the request as an array of enums.
+     *
+     * @template TEnum
+     *
+     * @param  string  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @return TEnum[]
+     */
+    public function enums($key, $enumClass)
+    {
+        if ($this->isNotFilled($key) || ! $this->isBackedEnum($enumClass)) {
+             return [];
+        }
+
+        return $this->collect($key)->map(function ($value) use ($enumClass) {
+            return $enumClass::tryFrom($value);
+        })->filter()->all();
+    }
+
+    /**
+     * Determine if the given enum class is backed.
+     *
+     * @param  class-string  $enumClass
+     * @return bool
+     */
+    protected function isBackedEnum($enumClass)
+    {
+        return enum_exists($enumClass) && method_exists($enumClass, 'tryFrom');
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -795,6 +795,44 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->enum('int.doesnt_exist', TestIntegerEnumBacked::class));
     }
 
+    public function testEnumsMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'valid_enum_values' => ['test', 'test'],
+            'invalid_enum_values' => ['invalid', 'invalid'],
+            'empty_value_request' => [],
+            'string' => [
+                'minus_1' => ['-1', '0'],
+                '0' => '0',
+                'plus_1' => '1',
+                'doesnt_exist' => '-1024',
+            ],
+            'int' => [
+                'minus_1' => -1,
+                '0' => 0,
+                'plus_1' => 1,
+                'doesnt_exist' => 1024,
+            ],
+        ]);
+
+        $this->assertEmpty($request->enums('doesnt_exist', TestEnumBacked::class));
+
+        $this->assertEquals([TestEnumBacked::test, TestEnumBacked::test], $request->enums('valid_enum_values', TestEnumBacked::class));
+
+        $this->assertEmpty($request->enums('invalid_enum_value', TestEnumBacked::class));
+        $this->assertEmpty($request->enums('empty_value_request', TestEnumBacked::class));
+        $this->assertEmpty($request->enums('valid_enum_value', TestEnum::class));
+
+        $this->assertEquals([TestIntegerEnumBacked::minus_1, TestIntegerEnumBacked::zero], $request->enums('string.minus_1', TestIntegerEnumBacked::class));
+        $this->assertEquals([TestIntegerEnumBacked::zero], $request->enums('string.0', TestIntegerEnumBacked::class));
+        $this->assertEquals([TestIntegerEnumBacked::plus_1], $request->enums('string.plus_1', TestIntegerEnumBacked::class));
+        $this->assertEmpty($request->enums('string.doesnt_exist', TestIntegerEnumBacked::class));
+        $this->assertEquals([TestIntegerEnumBacked::minus_1], $request->enums('int.minus_1', TestIntegerEnumBacked::class));
+        $this->assertEquals([TestIntegerEnumBacked::zero], $request->enums('int.0', TestIntegerEnumBacked::class));
+        $this->assertEquals([TestIntegerEnumBacked::plus_1], $request->enums('int.plus_1', TestIntegerEnumBacked::class));
+        $this->assertEmpty($request->enums('int.doesnt_exist', TestIntegerEnumBacked::class));
+    }
+
     public function testArrayAccess()
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);


### PR DESCRIPTION
### Description

Right now it's possible to retrieve a single enum from a request via the `enum` method, but not an array of them easily.

This PR adds an `enums` method to retrieve a potential array of enums provided in a request.

### Usage

Consider a "webhooks" controller where a user can create a webhook for a given URL and array of events:

```php
// app/Http/Controllers/WebhookController.php

public function store(Request $request)
{
    $request->validate([
        'url' => 'required|url',
        'events' => 'required|array',
        'events.*' => Rule::enum(WebhookEvent::class),
    ]);

    // [WebhookEvent::UserCreated, WebhookEvent::UserUpdated]
    $events = $request->enums('events', WebhookEvent::class);
}
```

This works nicely in tandem with Laravel's built-in `AsEnumArrayObject` cast for Eloquent:

https://laravel.com/docs/11.x/eloquent-mutators#casting-arrays-of-enums

```php
Webhook::create([
    'events' => $request->enums('events', WebhookEvent::class),
    // ...
]);
```

Let me know your thoughts! Thanks so much for your time ❤️ 