### PR TITLE
Making migrations. Moved the table name to a constant. Added a check for the existing of a table

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -6,18 +6,29 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const CACHE_TABLENAME = 'cache';
+    public const CACHE_LOCKS_TABLENAME = 'cache_locks';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('cache', function (Blueprint $table) {
+        if (Schema::hasTable(self::CACHE_TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::CACHE_TABLENAME, function (Blueprint $table) {
             $table->string('key')->primary();
             $table->mediumText('value');
             $table->integer('expiration');
         });
 
-        Schema::create('cache_locks', function (Blueprint $table) {
+        if (Schema::hasTable(self::CACHE_LOCKS_TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::CACHE_LOCKS_TABLENAME, function (Blueprint $table) {
             $table->string('key')->primary();
             $table->string('owner');
             $table->integer('expiration');
@@ -29,7 +40,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('cache');
-        Schema::dropIfExists('cache_locks');
+        Schema::dropIfExists(self::CACHE_TABLENAME);
+        Schema::dropIfExists(self::CACHE_LOCKS_TABLENAME);
     }
 };

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -6,12 +6,18 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = '{{table}}';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        if (Schema::hasTable(self::TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::TABLENAME, function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });
@@ -22,6 +28,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('{{ table }}');
+        Schema::dropIfExists(self::TABLENAME);
     }
 };

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -6,12 +6,14 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = '{{table}}';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table(self::TABLENAME, function (Blueprint $table) {
             //
         });
     }
@@ -21,7 +23,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table(self::TABLENAME, function (Blueprint $table) {
             //
         });
     }

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -6,12 +6,18 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = 'notifications';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('notifications', function (Blueprint $table) {
+        if (Schema::hasTable(self::TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::TABLENAME, function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
@@ -26,6 +32,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('notifications');
+        Schema::dropIfExists(self::TABLENAME);
     }
 };

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -6,12 +6,18 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = '{{table}}';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('{{table}}', function (Blueprint $table) {
+        if (Schema::hasTable(self::TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::TABLENAME, function (Blueprint $table) {
             $table->string('id')->primary();
             $table->string('name');
             $table->integer('total_jobs');
@@ -30,6 +36,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('{{table}}');
+        Schema::dropIfExists(self::TABLENAME);
     }
 };

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -6,12 +6,18 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = '{{table}}';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('{{table}}', function (Blueprint $table) {
+        if (Schema::hasTable(self::TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::TABLENAME, function (Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');
@@ -27,6 +33,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('{{table}}');
+        Schema::dropIfExists(self::TABLENAME);
     }
 };

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -6,12 +6,18 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = '{{table}}';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('{{table}}', function (Blueprint $table) {
+        if (Schema::hasTable(self::TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::TABLENAME, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('queue')->index();
             $table->longText('payload');
@@ -27,6 +33,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('{{table}}');
+        Schema::dropIfExists(self::TABLENAME);
     }
 };

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -6,12 +6,18 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public const TABLENAME = 'sessions';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('sessions', function (Blueprint $table) {
+        if (Schema::hasTable(self::TABLENAME)) {
+            return;
+        }
+
+        Schema::create(self::TABLENAME, function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
@@ -26,6 +32,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('sessions');
+        Schema::dropIfExists(self::TABLENAME);
     }
 };

--- a/tests/Integration/Generators/CacheTableCommandTest.php
+++ b/tests/Integration/Generators/CacheTableCommandTest.php
@@ -13,10 +13,12 @@ class CacheTableCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'cache\', function (Blueprint $table) {',
-            'Schema::create(\'cache_locks\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'cache\');',
-            'Schema::dropIfExists(\'cache_locks\');',
+            'public const CACHE_TABLENAME = \'cache\';',
+            'public const CACHE_LOCKS_TABLENAME = \'cache_locks\';',
+            'Schema::create(self::CACHE_TABLENAME, function (Blueprint $table) {',
+            'Schema::create(self::CACHE_LOCKS_TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::CACHE_TABLENAME);',
+            'Schema::dropIfExists(self::CACHE_LOCKS_TABLENAME);',
         ], 'create_cache_table.php');
     }
 }

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -12,7 +12,8 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foos\', function (Blueprint $table) {',
+            'public const TABLENAME = \'foos\';',
+            'Schema::table(self::TABLENAME, function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -24,7 +25,8 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foobar\', function (Blueprint $table) {',
+            'public const TABLENAME = \'foobar\';',
+            'Schema::table(self::TABLENAME, function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -36,8 +38,9 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'foos\');',
+            'public const TABLENAME = \'foos\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_foos_table.php');
     }
 
@@ -49,8 +52,9 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foobar\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'foobar\');',
+            'public const TABLENAME = \'foobar\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'foos_table.php');
     }
 }

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -185,8 +185,9 @@ class ModelMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'foos\');',
+            'public const TABLENAME = \'foos\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_foos_table.php');
 
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');

--- a/tests/Integration/Generators/NotificationTableCommandTest.php
+++ b/tests/Integration/Generators/NotificationTableCommandTest.php
@@ -13,8 +13,9 @@ class NotificationTableCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'notifications\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'notifications\');',
+            'public const TABLENAME = \'notifications\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_notifications_table.php');
     }
 }

--- a/tests/Integration/Generators/QueueBatchesTableCommandTest.php
+++ b/tests/Integration/Generators/QueueBatchesTableCommandTest.php
@@ -13,8 +13,9 @@ class QueueBatchesTableCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'job_batches\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'job_batches\');',
+            'public const TABLENAME = \'job_batches\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_job_batches_table.php');
     }
 }

--- a/tests/Integration/Generators/QueueFailedTableCommandTest.php
+++ b/tests/Integration/Generators/QueueFailedTableCommandTest.php
@@ -13,8 +13,9 @@ class QueueFailedTableCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'failed_jobs\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'failed_jobs\');',
+            'public const TABLENAME = \'failed_jobs\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_failed_jobs_table.php');
     }
 }

--- a/tests/Integration/Generators/QueueTableCommandTest.php
+++ b/tests/Integration/Generators/QueueTableCommandTest.php
@@ -13,8 +13,9 @@ class QueueTableCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'jobs\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'jobs\');',
+            'public const TABLENAME = \'jobs\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_jobs_table.php');
     }
 }

--- a/tests/Integration/Generators/SessionTableCommandTest.php
+++ b/tests/Integration/Generators/SessionTableCommandTest.php
@@ -13,8 +13,9 @@ class SessionTableCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'sessions\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'sessions\');',
+            'public const TABLENAME = \'sessions\';',
+            'Schema::create(self::TABLENAME, function (Blueprint $table) {',
+            'Schema::dropIfExists(self::TABLENAME);',
         ], 'create_sessions_table.php');
     }
 }


### PR DESCRIPTION
When creating a migration via make:migration, the table name is hardcoded in several places. Also, there is no check in the "up" method that the table has not been created yet (which is strange, because in "down" the presence of the table is checked). As a result, when creating a new migration, you have to eliminate these points yourself every time. I really want these things to be out of the box.

Now:
```
public function up(): void
{
    Schema::create('mytable', function (Blueprint $table) {
    ...

public function down(): void
{
    Schema::dropIfExists('mytable');
    ...
```

My way:
```
public const TABLENAME = 'mytable';

public function up(): void
{
    if (Schema::hasTable(self::TABLENAME)) {
        return;
    }

    Schema::create(self::TABLENAME, function (Blueprint $table) {
    ...
}

public function down(): void
{
    Schema::dropIfExists(self::TABLENAME);
```

Benefit - is subjectively convenient
This does not break any existing features as it does not affect logic. These are minor edits in migration templates. The tests have been updated according to the new templates