### PR TITLE
[11.x] Add non-static JsonResource wrapping

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -43,13 +43,18 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $additional = [];
 
     /**
+     * The instance level wrapper configured for the resource.
+     *
+     * @var string|null
+     */
+    public $wrapper = null;
+
+    /**
      * The "data" wrapper that should be applied.
      *
      * @var string|null
      */
     public static $wrap = 'data';
-
-    public ?string $wrapper = null;
 
     /**
      * Create a new resource instance.
@@ -207,24 +212,35 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Set the string that should wrap the outer-most resource array.
      *
+     * @param  string|null  $value
+     * @return $this
+     */
+    public function withWrapper(?string $value)
+    {
+        $this->wrapper = $value;
+
+        return $this;
+    }
+
+    /**
+     * Disable wrapping of the outer-most resource array.
+     *
+     * @return $this
+     */
+    public function withoutWrapper()
+    {
+        return $this->withWrapper(null);
+    }
+
+    /**
+     * Set the string that should wrap the outer-most resource array.
+     *
      * @param  string  $value
      * @return void
      */
     public static function wrap($value)
     {
         static::$wrap = $value;
-    }
-
-    /**
-     * Set the string that should wrap the outer-most resource array.
-     *
-     * @return $this
-     */
-    public function withWrapper(?string $value): static
-    {
-        $this->wrapper = $value;
-
-        return $this;
     }
 
     /**
@@ -235,16 +251,6 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public static function withoutWrapping()
     {
         static::$wrap = null;
-    }
-
-    /**
-     * Disable wrapping of the outer-most resource array.
-     *
-     * @return $this
-     */
-    public function withoutWrapper(): static
-    {
-        return $this->withWrapper(null);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -49,6 +49,8 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static $wrap = 'data';
 
+    public ?string $wrapper = null;
+
     /**
      * Create a new resource instance.
      *
@@ -58,6 +60,8 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function __construct($resource)
     {
         $this->resource = $resource;
+
+        $this->withWrapper(static::$wrap);
     }
 
     /**
@@ -212,6 +216,18 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
+     * Set the string that should wrap the outer-most resource array.
+     *
+     * @return $this
+     */
+    public function withWrapper(?string $value): static
+    {
+        $this->wrapper = $value;
+
+        return $this;
+    }
+
+    /**
      * Disable wrapping of the outer-most resource array.
      *
      * @return void
@@ -219,6 +235,16 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public static function withoutWrapping()
     {
         static::$wrap = null;
+    }
+
+    /**
+     * Disable wrapping of the outer-most resource array.
+     *
+     * @return $this
+     */
+    public function withoutWrapper(): static
+    {
+        return $this->withWrapper(null);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -102,10 +102,14 @@ class ResourceResponse implements Responsable
     /**
      * Get the default data wrapper for the resource.
      *
-     * @return string
+     * @return string|null
      */
     protected function wrapper()
     {
+        if ($this->resource instanceof JsonResource) {
+            return $this->resource->wrapper;
+        }
+
         return get_class($this->resource)::$wrap;
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -106,11 +106,9 @@ class ResourceResponse implements Responsable
      */
     protected function wrapper()
     {
-        if ($this->resource instanceof JsonResource) {
-            return $this->resource->wrapper;
-        }
-
-        return get_class($this->resource)::$wrap;
+        return $this->resource instanceof JsonResource
+            ? $this->resource->wrapper
+            : get_class($this->resource)::$wrap;
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -145,6 +145,94 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function testResourcesCanSetWithoutWrapper()
+    {
+        Route::get('/', function () {
+            return (new PostResource(new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ])))->withoutWrapper();
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertJson([
+            'id' => 5,
+            'title' => 'Test Title',
+        ]);
+    }
+
+    public function testResourcesCanSetWithWrapper()
+    {
+        Route::get('/', function () {
+            return (new PostResourceWithoutWrap(new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ])))->withWrapper('postData');
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertJson([
+            'postData' => [
+                'id' => 5,
+                'title' => 'Test Title',
+            ],
+        ]);
+    }
+
+    public function testResourceCollectionCanSetWithWrapper()
+    {
+        Route::get('/', function () {
+            return PostResourceWithoutWrap::collection([
+                new Post([
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ]),
+            ])->withWrapper('posts');
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertJson([
+            'posts' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ],
+            ],
+        ]);
+    }
+
+    public function testResourceCollectionCanSetWithoutWrapper()
+    {
+        Route::get('/', function () {
+            return PostResource::collection([
+                new Post([
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ]),
+            ])->withoutWrapper();
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertJson([
+            [
+                'id' => 5,
+                'title' => 'Test Title',
+            ],
+        ]);
+    }
+
     public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {


### PR DESCRIPTION
#### **Overview**
This PR addresses an issue with setting JSON wrappers on resource collections or other general-purpose JSON resource classes where adjusting the wrapper for an `AnonymousResourceCollection` or other generic resource class would affect all instances in the same request or following tests. This PR introduces instance-specific JSON wrapping to `JsonResource` through a new `$wrapper` property, along with `withWrapper()` and `withoutWrapper()` methods. This change allows developers to set a wrapper for individual resources without impacting others globally.

#### **Example of the Issue**
Currently, modifying the wrapper for a resource collection applies globally within the same request or test:

```php
// Setting a wrapper for a resource collection
AnonymousResourceCollection::wrap('posts');

// This affects ALL instances of PostResource in the same request
$postsCollection = PostResource::collection($posts); // Wrapped with 'posts'
$booksCollection = BookResource::collection($books); // Also wrapped with 'posts'
```

With this PR, the wrapper can be set on a per-instance basis:

```php
// Per-instance wrapper configuration
$postsCollection = PostResource::collection($posts)->withWrapper('posts');
$booksCollection = BookResource::collection($books)->withWrapper('books');

// Result: Different wrappers for different instances
// $postsCollection is wrapped with 'posts'
// $booksCollection is wrapped with 'books'
```

#### **Benefits**
- **Fine-Grained Control**: Customize JSON wrappers for each resource instance, preventing unintended global side effects.
- **More Flexible API Design**: Easier to handle unique formatting requirements on a per-instance basis, particularly useful when working with collections.
- **Consistency in Tests**: Ensures that modifications to one test case's wrapper configuration won't carry over to others, making tests more reliable and isolated.

#### **Why This Change Doesn't Break Existing Features**
The default behavior remains the same because the new instance-specific `$wrapper` property respects the global `$wrap` setting unless overridden. Existing resource configurations and behaviors are not altered unless explicitly changed.

#### **How It Makes Building Web Applications Easier**
- **Instance-Specific Adjustments**: Developers can define how each resource or collection is wrapped, reducing complexity and avoiding the need for duplicate resource classes just to modify the wrapper behavior.
- **Better Test Coverage**: Isolated control over wrappers simplifies testing, allowing for more focused test cases without unintended side effects.
- **Simpler Code**: Reduces the need for workarounds or extra conditionals to handle resource-specific JSON wrapping, leading to cleaner and more maintainable code.