### PR TITLE
[11.x] Add lrange method to PhpRedisConnection and corresponding tests

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -162,6 +162,21 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Returns the specified elements of the list stored at key.
+     *
+     * @param string $key
+     * @param int|string $start
+     * @param int|string $stop
+     * @return array|null
+     */
+    public function lrange($key, $start, $stop)
+    {
+        $result = $this->command('lrange', [$key, $start, $stop]);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
      * Removes and returns the first element of the list stored at key.
      *
      * @param  mixed  ...$arguments

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -164,9 +164,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Returns the specified elements of the list stored at key.
      *
-     * @param  string $key
-     * @param  int|string $start
-     * @param  int|string $stop
+     * @param  string  $key
+     * @param  int|string  $start
+     * @param  int|string  $stop
      * @return array|null
      */
     public function lrange($key, $start, $stop)

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -164,9 +164,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Returns the specified elements of the list stored at key.
      *
-     * @param string $key
-     * @param int|string $start
-     * @param int|string $stop
+     * @param  string $key
+     * @param  int|string $start
+     * @param  int|string $stop
      * @return array|null
      */
     public function lrange($key, $start, $stop)

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -697,7 +697,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             // Inserts to the head of the list
             $redis->lpush('list', 'one');
-            $redis->lpush('list','two');
+            $redis->lpush('list', 'two');
             $redis->lpush('list', 'three');
 
             $this->assertEquals(['three', 'two'], $redis->lrange('list', 0, 1));

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -692,6 +692,21 @@ class RedisConnectionTest extends TestCase
         }
     }
 
+    public function testItReturnKeysByLrange(): void
+    {
+        foreach ($this->connections() as $redis) {
+            // Inserts to the head of the list
+            $redis->lpush('list', 'one');
+            $redis->lpush('list','two');
+            $redis->lpush('list', 'three');
+
+            $this->assertEquals(['three', 'two'], $redis->lrange('list', 0, 1));
+            $this->assertEquals(['two', 'one'], $redis->lrange('list', 1, 2));
+
+            $redis->flushall();
+        }
+    }
+
     public function testItSscansForKeys()
     {
         foreach ($this->connections() as $redis) {


### PR DESCRIPTION
This PR defines the `lrange` function in `PhpRedisConnection` class, instead of letting it pass to the `__call(...` method.

**Benefits**
- IDEs understand what is happening and support autocompletion
- opens the way for type hinting at some point
- tested

**Why This Change Doesn't Break Existing Features**
It is using the same function declaration as the underlying client expects, the feature was already there, just not defined.

**How It Makes Building Web Applications Easier**
By enhancing autocompletion and suggestions and better test coverage.