### PR TITLE
[11.x] Add `assertCount` method to `EventFake` for asserting total dispatched events

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -208,6 +208,22 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
+     * Assert the total number of events dispatched.
+     *
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function assertCount($expectedCount)
+    {
+        $actualCount = collect($this->events)->flatten(1)->count();
+
+        PHPUnit::assertSame(
+            $expectedCount, $actualCount,
+            "Expected {$expectedCount} events to be dispatched, but found {$actualCount} instead."
+        );
+    }
+
+    /**
      * Get all of the events matching a truth-test callback.
      *
      * @param  string  $event

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -154,6 +154,22 @@ class SupportTestingEventFakeTest extends TestCase
             $this->assertStringContainsString("2 unexpected events were dispatched:\n\n- Illuminate\Tests\Support\EventStub dispatched 2 times", $e->getMessage());
         }
     }
+
+    public function testAssertCount()
+    {
+        $this->fake->assertCount(0);
+
+        $this->fake->dispatch(EventStub::class);
+        $this->fake->dispatch(EventStub::class);
+
+        $this->fake->assertCount(2);
+
+        try {
+            $this->fake->assertCount(1);
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString("Expected 1 events to be dispatched, but found 2 instead.", $e->getMessage());
+        }
+    }
 }
 
 class EventStub

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -167,7 +167,7 @@ class SupportTestingEventFakeTest extends TestCase
         try {
             $this->fake->assertCount(1);
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("Expected 1 events to be dispatched, but found 2 instead.", $e->getMessage());
+            $this->assertStringContainsString('Expected 1 events to be dispatched, but found 2 instead.', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `assertCount` method in the `EventFake` class, providing a simple and reliable way to assert the total number of events dispatched.

