### PR TITLE
[11.x] Add `Process::assertSequencesAreEmpty()` method

### DIFF
--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -21,6 +21,13 @@ class Factory
     protected $recording = false;
 
     /**
+     * All created process sequences.
+     *
+     * @var \Illuminate\Process\FakeProcessSequence[]
+     */
+    protected $processSequences = [];
+
+    /**
      * All of the recorded processes.
      *
      * @var array
@@ -76,7 +83,7 @@ class Factory
      */
     public function sequence(array $processes = [])
     {
-        return new FakeProcessSequence($processes);
+        return $this->processSequences[] = new FakeProcessSequence($processes);
     }
 
     /**
@@ -171,6 +178,21 @@ class Factory
     public function preventingStrayProcesses()
     {
         return $this->preventStrayProcesses;
+    }
+
+    /**
+     * Assert that every created process sequence is empty.
+     *
+     * @return void
+     */
+    public function assertSequencesAreEmpty()
+    {
+        foreach ($this->processSequences as $processSequence) {
+            PHPUnit::assertTrue(
+                $processSequence->isEmpty(),
+                'Not all process sequences are empty.'
+            );
+        }
     }
 
     /**

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -8,6 +8,7 @@ use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
 use OutOfBoundsException;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -770,6 +771,29 @@ class ProcessTest extends TestCase
         $factory->fake();
 
         $factory->assertNothingRan();
+    }
+
+    public function testAssertSequencesAreEmpty()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            'ls *' => $factory->sequence()
+                ->push('ls command 1')
+                ->push('ls command 2'),
+        ]);
+
+        $factory->run('ls la');
+
+        try {
+            $factory->assertSequencesAreEmpty();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('Not all process sequences are empty.', $e->getMessage());
+        }
+
+        $factory->run('ls la');
+
+        $factory->assertSequencesAreEmpty();
     }
 
     protected function ls()


### PR DESCRIPTION
Add the `assertSequencesAreEmpty()` method to the `Process` facade, providing an easy way to assert that all process sequences are empty in tests.
