### PR TITLE
[11.x] Fix `withoutOverlapping` via `PendingEventAttributes` proxy 

### DIFF
--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -18,6 +18,22 @@ class PendingEventAttributes
     }
 
     /**
+     * Do not allow the event to overlap each other.
+     * The expiration time of the underlying cache lock may be specified in minutes.
+     *
+     * @param  int  $expiresAt
+     * @return $this
+     */
+    public function withoutOverlapping($expiresAt = 1440)
+    {
+        $this->withoutOverlapping = true;
+
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    /**
      * Merge the current attributes into the given event.
      */
     public function mergeAttributes(Event $event): void

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -19,6 +19,7 @@ class PendingEventAttributes
 
     /**
      * Do not allow the event to overlap each other.
+     *
      * The expiration time of the underlying cache lock may be specified in minutes.
      *
      * @param  int  $expiresAt


### PR DESCRIPTION
This PR addresses a bug with the `withoutOverlapping` method when used through the `PendingEventAttributes` proxy.

Example Code:
```php
Schedule::runInBackground()
    ->withoutOverlapping()
    ->everyMinute()
    ->command('inspire');
```

The above throws the following exception:
```
Undefined property: Illuminate\Console\Scheduling\PendingEventAttributes::$mutex, vendor/laravel/framework/src/Illuminate/Console/Scheduling/ManagesAttributes.php, 145
```

This issue occurs during schedule execution, not at `Event` instance creation, so existing tests didn’t catch it.

---
Thanks to @decadence for [reporting this bug](https://github.com/laravel/framework/pull/53427#issuecomment-2482251772).