### PR TITLE
[11.x] Trim log channel names

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -633,7 +633,7 @@ class LogManager implements LoggerInterface
             $driver ??= 'null';
         }
 
-        return $driver;
+        return trim($driver);
     }
 
     /**

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -97,6 +97,25 @@ class LogManagerTest extends TestCase
         $this->assertTrue($handlers[1]->getBubble());
     }
 
+    public function testParsingStackChannels()
+    {
+        $config = $this->app['config'];
+
+        $config->set('logging.channels.stack', [
+            'driver' => 'stack',
+            'channels' => 'single, daily, stderr',
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        $manager->channel('stack');
+
+        $this->assertSame(
+            array_keys($manager->getChannels()),
+            ['single', 'daily', 'stderr', 'stack']
+        );
+    }
+
     public function testLogManagerCreatesConfiguredMonologHandler()
     {
         $config = $this->app['config'];


### PR DESCRIPTION
Hi,

When passing a string to the stack channel, it explodes by comma.

I just found that there was an issue on a project I'm working on because the string was written with spaces. Basically, something like`LOG_STACK="daily, stderr"`.

This PR trim the channel name to be sure it will remove an extra space.

It also adds a test that does not pass without the fix.

Thanks.
Mathieu.