### PR TITLE
fix: use qualifyColumn rather than assuming format

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -96,9 +96,9 @@ class BelongsTo extends Relation
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $table = $this->related->getTable();
+            $key = $this->related->qualifyColumn($this->ownerKey);
 
-            $this->query->where($table.'.'.$this->ownerKey, '=', $this->getForeignKeyFrom($this->child));
+            $this->query->where($key, '=', $this->getForeignKeyFrom($this->child));
         }
     }
 
@@ -108,7 +108,7 @@ class BelongsTo extends Relation
         // We'll grab the primary key name of the related models since it could be set to
         // a non-standard name and not "id". We will then construct the constraint for
         // our eagerly loading query so it returns the proper models from execution.
-        $key = $this->related->getTable().'.'.$this->ownerKey;
+        $key = $this->related->qualifyColumn($this->ownerKey);
 
         $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -96,7 +96,7 @@ class BelongsTo extends Relation
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $key = $this->related->qualifyColumn($this->ownerKey);
+            $key = $this->getQualifiedOwnerKeyName();
 
             $this->query->where($key, '=', $this->getForeignKeyFrom($this->child));
         }
@@ -108,7 +108,7 @@ class BelongsTo extends Relation
         // We'll grab the primary key name of the related models since it could be set to
         // a non-standard name and not "id". We will then construct the constraint for
         // our eagerly loading query so it returns the proper models from execution.
-        $key = $this->related->qualifyColumn($this->ownerKey);
+        $key = $this->getQualifiedOwnerKeyName();
 
         $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -404,6 +404,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->related->shouldReceive('getKeyType')->andReturn($keyType);
         $this->related->shouldReceive('getKeyName')->andReturn('id');
         $this->related->shouldReceive('getTable')->andReturn('relation');
+        $this->related->shouldReceive('qualifyColumn')->andReturnUsing(fn (string $column) => "relation.{$column}");
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentBelongsToModelStub;
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -368,6 +368,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $related = m::mock(Model::class);
         $related->shouldReceive('getKey')->andReturn(1);
         $related->shouldReceive('getTable')->andReturn('relation');
+        $related->shouldReceive('qualifyColumn')->andReturnUsing(fn (string $column) => "relation.{$column}");
         $builder->shouldReceive('getModel')->andReturn($related);
 
         return new MorphTo($builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation');
@@ -378,8 +379,9 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->builder = $builder ?: m::mock(Builder::class);
         $this->builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $this->related = m::mock(Model::class);
-        $this->related->shouldReceive('getKeyName')->andReturn('id');
+        $this->related->shouldReceive('getcolumn')->andReturn('id');
         $this->related->shouldReceive('getTable')->andReturn('relation');
+        $this->related->shouldReceive('qualifyColumn')->andReturnUsing(fn (string $column) => "relation.{$column}");
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentMorphToModelStub;
 


### PR DESCRIPTION
In my setup I have some Laravel models stored in MongoDB and others in MySQL. MorphTo and BelongsTo relations aren't loading where the parent model is in MongoDB and the child is in MySQL, i.e:

```
class Parent extends MongoModel
{

}

class Child extends EloquentModel
{
    public function myRelation()
    {
        return $this->belongsTo(Parent::class);
    }
}
```

`Child::first()->myRelation` will return `null` because `addConstraints()` is assuming that the key name should be prepended with the table name, which isn't the case for MongoDB.

The `getQualifiedOwnerKeyName()` method already exists on the BelongsTo class, is there any reason why it's not currently being used when adding constraints?
