### PR TITLE
[11.x] hash the token going into the cache

### DIFF
--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -42,7 +42,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
 
         $this->cache->put(
             $this->prefix.$user->getEmailForPasswordReset(),
-            [$token, Carbon::now()->format($this->format)],
+            [$this->hasher->make($token), Carbon::now()->format($this->format)],
             $this->expires,
         );
 


### PR DESCRIPTION
this is a bugfix for the new password reset cache driver. when translating from the `DatabaseTokenRepository`, I forgot to mimic the behavior of hashing the token going into storage.

thanks to @christophrumpel for finding this.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
