### PR TITLE
[11.x] prefer `new Collection()` over `collect()`

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -354,7 +354,7 @@ class Gate implements GateContract
      */
     public function check($abilities, $arguments = [])
     {
-        return collect($abilities)->every(
+        return (new Collection($abilities))->every(
             fn ($ability) => $this->inspect($ability, $arguments)->allowed()
         );
     }
@@ -368,7 +368,7 @@ class Gate implements GateContract
      */
     public function any($abilities, $arguments = [])
     {
-        return collect($abilities)->contains(fn ($ability) => $this->check($ability, $arguments));
+        return (new Collection($abilities))->contains(fn ($ability) => $this->check($ability, $arguments));
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -5,8 +5,8 @@ namespace Illuminate\Auth\Middleware;
 use Closure;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
-
 use Illuminate\Support\Collection;
+
 use function Illuminate\Support\enum_value;
 
 class Authorize

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Database\Eloquent\Model;
 
+use Illuminate\Support\Collection;
 use function Illuminate\Support\enum_value;
 
 class Authorize
@@ -72,7 +73,7 @@ class Authorize
             return [];
         }
 
-        return collect($models)->map(function ($model) use ($request) {
+        return (new Collection($models))->map(function ($model) use ($request) {
             return $model instanceof Model ? $model : $this->getModel($request, $model);
         })->all();
     }

--- a/src/Illuminate/Broadcasting/AnonymousEvent.php
+++ b/src/Illuminate/Broadcasting/AnonymousEvent.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class AnonymousEvent implements ShouldBroadcast
 {
@@ -73,7 +74,7 @@ class AnonymousEvent implements ShouldBroadcast
     {
         $this->payload = $payload instanceof Arrayable
             ? $payload->toArray()
-            : collect($payload)->map(
+            : (new Collection($payload))->map(
                 fn ($p) => $p instanceof Arrayable ? $p->toArray() : $p
             )->all();
 

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -58,7 +58,7 @@ class ChainedBatch implements ShouldQueue
     public static function prepareNestedBatches(Collection $jobs): Collection
     {
         return $jobs->map(fn ($job) => match (true) {
-            is_array($job) => static::prepareNestedBatches(collect($job))->all(),
+            is_array($job) => static::prepareNestedBatches(new Collection($job))->all(),
             $job instanceof Collection => static::prepareNestedBatches($job),
             $job instanceof PendingBatch => new ChainedBatch($job),
             default => $job,

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -402,7 +402,7 @@ class PendingBatch
     {
         $batch = $repository->store($this);
 
-        collect($this->beforeCallbacks())->each(function ($handler) use ($batch) {
+        (new Collection($this->beforeCallbacks()))->each(function ($handler) use ($batch) {
             try {
                 return $handler($batch);
             } catch (Throwable $e) {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -10,6 +10,7 @@ use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 
@@ -378,7 +379,7 @@ class DatabaseStore implements LockProvider, Store
      */
     protected function forgetMany(array $keys)
     {
-        $this->table()->whereIn('key', collect($keys)->flatMap(fn ($key) => [
+        $this->table()->whereIn('key', (new Collection($keys))->flatMap(fn ($key) => [
             $this->prefix.$key,
             "{$this->prefix}illuminate:cache:flexible:created:{$key}",
         ])->all())->delete();
@@ -396,7 +397,7 @@ class DatabaseStore implements LockProvider, Store
     protected function forgetManyIfExpired(array $keys, bool $prefixed = false)
     {
         $this->table()
-            ->whereIn('key', collect($keys)->flatMap(fn ($key) => $prefixed ? [
+            ->whereIn('key', (new Collection($keys))->flatMap(fn ($key) => $prefixed ? [
                 $key,
                 $this->prefix.'illuminate:cache:flexible:created:'.Str::chopStart($key, $this->prefix),
             ] : [

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -7,6 +7,7 @@ use Aws\DynamoDb\Exception\DynamoDbException;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -141,7 +142,7 @@ class DynamoDbStore implements LockProvider, Store
             'RequestItems' => [
                 $this->table => [
                     'ConsistentRead' => false,
-                    'Keys' => collect($prefixedKeys)->map(function ($key) {
+                    'Keys' => (new Collection($prefixedKeys))->map(function ($key) {
                         return [
                             $this->keyAttribute => [
                                 'S' => $key,
@@ -154,9 +155,9 @@ class DynamoDbStore implements LockProvider, Store
 
         $now = Carbon::now();
 
-        return array_merge(collect(array_flip($keys))->map(function () {
+        return array_merge((new Collection(array_flip($keys)))->map(function () {
             //
-        })->all(), collect($response['Responses'][$this->table])->mapWithKeys(function ($response) use ($now) {
+        })->all(), (new Collection($response['Responses'][$this->table]))->mapWithKeys(function ($response) use ($now) {
             if ($this->isExpired($response, $now)) {
                 $value = null;
             } else {
@@ -231,7 +232,7 @@ class DynamoDbStore implements LockProvider, Store
 
         $this->dynamo->batchWriteItem([
             'RequestItems' => [
-                $this->table => collect($values)->map(function ($value, $key) use ($expiration) {
+                $this->table => (new Collection($values))->map(function ($value, $key) use ($expiration) {
                     return [
                         'PutRequest' => [
                             'Item' => [

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Closure;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 
 use function Illuminate\Support\enum_value;
@@ -76,7 +77,7 @@ class RateLimiter
                 return $result;
             }
 
-            $duplicates = collect($result)->duplicates('key');
+            $duplicates = (new Collection($result))->duplicates('key');
 
             if ($duplicates->isEmpty()) {
                 return $result;

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Concerns;
 use Closure;
 use Illuminate\Contracts\Console\PromptsForMissingInput as PromptsForMissingInputContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -38,7 +39,7 @@ trait PromptsForMissingInput
      */
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        $prompted = collect($this->getDefinition()->getArguments())
+        $prompted = (new Collection($this->getDefinition()->getArguments()))
             ->reject(fn (InputArgument $argument) => $argument->getName() === 'command')
             ->filter(fn (InputArgument $argument) => $argument->isRequired() && match (true) {
                 $argument->isArray() => empty($input->getArgument($argument->getName())),
@@ -101,7 +102,7 @@ trait PromptsForMissingInput
      */
     protected function didReceiveOptions(InputInterface $input)
     {
-        return collect($this->getDefinition()->getOptions())
+        return (new Collection($this->getDefinition()->getOptions()))
             ->reject(fn ($option) => $input->getOption($option->getName()) === $option->getDefault())
             ->isNotEmpty();
     }

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -129,7 +130,7 @@ class ComponentMakeCommand extends GeneratorCommand
 
         $path[] = $name;
 
-        return collect($path)
+        return (new Collection($path))
             ->map(fn ($segment) => Str::kebab($segment))
             ->implode('.');
     }

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -22,7 +23,7 @@ class SetCacheHeaders
             return static::class.':'.$options;
         }
 
-        return collect($options)
+        return (new Collection($options))
             ->map(function ($value, $key) {
                 if (is_bool($value)) {
                     return $value ? $key : null;
@@ -87,7 +88,7 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return collect(explode(';', rtrim($options, ';')))->mapWithKeys(function ($option) {
+        return (new Collection(explode(';', rtrim($options, ';'))))->mapWithKeys(function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Log;
 
 use Closure;
 use Illuminate\Log\Context\Repository as ContextRepository;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Monolog\Formatter\LineFormatter;
@@ -280,13 +281,13 @@ class LogManager implements LoggerInterface
             $config['channels'] = explode(',', $config['channels']);
         }
 
-        $handlers = collect($config['channels'])->flatMap(function ($channel) {
+        $handlers = (new Collection($config['channels']))->flatMap(function ($channel) {
             return $channel instanceof LoggerInterface
                 ? $channel->getHandlers()
                 : $this->channel($channel)->getHandlers();
         })->all();
 
-        $processors = collect($config['channels'])->flatMap(function ($channel) {
+        $processors = (new Collection($config['channels']))->flatMap(function ($channel) {
             return $channel instanceof LoggerInterface
                 ? $channel->getProcessors()
                 : $this->channel($channel)->getProcessors();
@@ -405,7 +406,7 @@ class LogManager implements LoggerInterface
             );
         }
 
-        collect($config['processors'] ?? [])->each(function ($processor) {
+        (new Collection($config['processors'] ?? []))->each(function ($processor) {
             $processor = $processor['processor'] ?? $processor;
 
             if (! is_a($processor, ProcessorInterface::class, true)) {
@@ -425,7 +426,7 @@ class LogManager implements LoggerInterface
             $this->app->make($config['handler'], $with), $config
         );
 
-        $processors = collect($config['processors'] ?? [])
+        $processors = (new Collection($config['processors'] ?? []))
             ->map(fn ($processor) => $this->app->make($processor['processor'] ?? $processor, $processor['with'] ?? []))
             ->toArray();
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail\Transport;
 
 use Aws\Exception\AwsException;
 use Aws\Ses\SesClient;
+use Illuminate\Support\Collection;
 use Stringable;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
@@ -66,7 +67,7 @@ class SesTransport extends AbstractTransport implements Stringable
                 array_merge(
                     $options, [
                         'Source' => $message->getEnvelope()->getSender()->toString(),
-                        'Destinations' => collect($message->getEnvelope()->getRecipients())
+                        'Destinations' => (new Collection($message->getEnvelope()->getRecipients()))
                                 ->map
                                 ->toString()
                                 ->values()

--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail\Transport;
 
 use Aws\Exception\AwsException;
 use Aws\SesV2\SesV2Client;
+use Illuminate\Support\Collection;
 use Stringable;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
@@ -67,7 +68,7 @@ class SesV2Transport extends AbstractTransport implements Stringable
                     $options, [
                         'Source' => $message->getEnvelope()->getSender()->toString(),
                         'Destination' => [
-                            'ToAddresses' => collect($message->getEnvelope()->getRecipients())
+                            'ToAddresses' => (new Collection($message->getEnvelope()->getRecipients()))
                                     ->map
                                     ->toString()
                                     ->values()

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -205,7 +205,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function getParametersForItem($item)
     {
-        return collect($this->parameters)
+        return (new Collection($this->parameters))
             ->filter()
             ->flip()
             ->map(function ($_, $parameterName) use ($item) {

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -155,7 +155,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function getUrlRange($start, $end)
     {
-        return collect(range($start, $end))->mapWithKeys(function ($page) {
+        return (new Collection(range($start, $end)))->mapWithKeys(function ($page) {
             return [$page => $this->url($page)];
         })->all();
     }

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
-
 use Illuminate\Support\Collection;
+
 use function Illuminate\Support\enum_value;
 
 trait CreatesRegularExpressionRouteConstraints

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
 
+use Illuminate\Support\Collection;
 use function Illuminate\Support\enum_value;
 
 trait CreatesRegularExpressionRouteConstraints
@@ -74,7 +75,7 @@ trait CreatesRegularExpressionRouteConstraints
     {
         return $this->assignExpressionToParameters(
             $parameters,
-            collect($values)
+            (new Collection($values))
                 ->map(fn ($value) => enum_value($value))
                 ->implode('|')
         );
@@ -89,7 +90,7 @@ trait CreatesRegularExpressionRouteConstraints
      */
     protected function assignExpressionToParameters($parameters, $expression)
     {
-        return $this->where(collect(Arr::wrap($parameters))
+        return $this->where((new Collection(Arr::wrap($parameters)))
                     ->mapWithKeys(fn ($parameter) => [$parameter => $expression])
                     ->all());
     }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -223,7 +223,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      */
     protected function getMessagesForWildcardKey($key, $format)
     {
-        return collect($this->messages)
+        return (new Collection($this->messages))
                 ->filter(function ($messages, $messageKey) use ($key) {
                     return Str::is($key, $messageKey);
                 })
@@ -291,7 +291,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
             return (array) $messages;
         }
 
-        return collect((array) $messages)
+        return (new Collection((array) $messages))
             ->map(function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -18,6 +18,7 @@ use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
@@ -905,7 +906,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        $validations = collect($parameters)
+        $validations = (new Collection($parameters))
             ->unique()
             ->map(fn ($validation) => match (true) {
                 $validation === 'strict' => new NoRFCWarningsValidation(),

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\View\Component;
@@ -220,7 +221,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function getOpenAndClosingPhpTokens($contents)
     {
-        return collect(token_get_all($contents))
+        return (new Collection(token_get_all($contents)))
             ->pluck(0)
             ->filter(function ($token) {
                 return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
@@ -760,7 +761,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
         if (is_null($alias)) {
             $alias = str_contains($class, '\\View\\Components\\')
-                            ? collect(explode('\\', Str::after($class, '\\View\\Components\\')))->map(function ($segment) {
+                            ? (new Collection(explode('\\', Str::after($class, '\\View\\Components\\'))))->map(function ($segment) {
                                 return Str::kebab($segment);
                             })->implode(':')
                             : Str::kebab(class_basename($class));

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\View\AnonymousComponent;
 use Illuminate\View\DynamicComponent;
@@ -362,7 +363,7 @@ class ComponentTagCompiler
      */
     protected function guessAnonymousComponentUsingNamespaces(Factory $viewFactory, string $component)
     {
-        return collect($this->blade->getAnonymousComponentNamespaces())
+        return (new Collection($this->blade->getAnonymousComponentNamespaces()))
             ->filter(function ($directory, $prefix) use ($component) {
                 return Str::startsWith($component, $prefix.'::');
             })
@@ -478,16 +479,16 @@ class ComponentTagCompiler
         // return all of the attributes as both data and attributes since we have
         // now way to partition them. The user can exclude attributes manually.
         if (! class_exists($class)) {
-            return [collect($attributes), collect($attributes)];
+            return [new Collection($attributes), new Collection($attributes)];
         }
 
         $constructor = (new ReflectionClass($class))->getConstructor();
 
         $parameterNames = $constructor
-                    ? collect($constructor->getParameters())->map->getName()->all()
+                    ? (new Collection($constructor->getParameters()))->map->getName()->all()
                     : [];
 
-        return collect($attributes)->partition(function ($value, $key) use ($parameterNames) {
+        return (new Collection($attributes))->partition(function ($value, $key) use ($parameterNames) {
             return in_array(Str::camel($key), $parameterNames);
         })->all();
     }
@@ -618,7 +619,7 @@ class ComponentTagCompiler
             return [];
         }
 
-        return collect($matches)->mapWithKeys(function ($match) {
+        return (new Collection($matches))->mapWithKeys(function ($match) {
             $attribute = $match['attribute'];
             $value = $match['value'] ?? null;
 
@@ -765,7 +766,7 @@ class ComponentTagCompiler
      */
     protected function escapeSingleQuotesOutsideOfPhpBlocks(string $value)
     {
-        return collect(token_get_all($value))->map(function ($token) {
+        return (new Collection(token_get_all($value)))->map(function ($token) {
             if (! is_array($token)) {
                 return $token;
             }
@@ -785,7 +786,7 @@ class ComponentTagCompiler
      */
     protected function attributesToString(array $attributes, $escapeBound = true)
     {
-        return collect($attributes)
+        return (new Collection($attributes))
                 ->map(function (string $value, string $attribute) use ($escapeBound) {
                     return $escapeBound && isset($this->boundAttributes[$attribute]) && $value !== 'true' && ! is_numeric($value)
                                 ? "'{$attribute}' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute({$value})"

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
@@ -169,7 +170,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      */
     public function filter($callback)
     {
-        return new static(collect($this->attributes)->filter($callback)->all());
+        return new static((new Collection($this->attributes))->filter($callback)->all());
     }
 
     /**
@@ -272,7 +273,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
                         : $value;
         }, $attributeDefaults);
 
-        [$appendableAttributes, $nonAppendableAttributes] = collect($this->attributes)
+        [$appendableAttributes, $nonAppendableAttributes] = (new Collection($this->attributes))
                     ->partition(function ($value, $key) use ($attributeDefaults) {
                         return $key === 'class' || $key === 'style' || (
                             isset($attributeDefaults[$key]) &&

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Support\Collection;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -101,7 +102,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
     {
         return is_null($fragments)
             ? $this->allFragments()
-            : collect($fragments)->map(fn ($f) => $this->fragment($f))->implode('');
+            : (new Collection($fragments))->map(fn ($f) => $this->fragment($f))->implode('');
     }
 
     /**
@@ -143,7 +144,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
      */
     protected function allFragments()
     {
-        return collect($this->render(fn () => $this->factory->getFragments()))->implode('');
+        return (new Collection($this->render(fn () => $this->factory->getFragments())))->implode('');
     }
 
     /**


### PR DESCRIPTION
the [`collect()`](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Collections/helpers.php#L16) helper is a basic wrapper for `new Collection()`. because there is no logic in the helper, I believe the framework should internally only use `new Collection()`.

I'm guessing the general sentiment will be "it's fine", and I understand the performance hit is miniscule. However, I believe the framework should avoid aliases and no-logic helpers to try and have the shortest and most performant call graph it can.

this also makes DX slightly better when navigating the framework as you don't have a middleman to click through.

---

There is A LOT of usage of `collect()` in this repo. I've included a good chunk of them in this PR, but didn't want to commit the time until a decision is made on it, but will do so if it's accepted.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
