### PR TITLE
[11.x] Add builder and collection to `ModelInspector`

### DIFF
--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -51,7 +51,16 @@ class ShowModelCommand extends DatabaseInspectionCommand
             return 1;
         }
 
-        $this->display(...$info);
+        $this->display(
+            $info['class'],
+            $info['database'],
+            $info['table'],
+            $info['policy'],
+            $info['attributes'],
+            $info['relations'],
+            $info['events'],
+            $info['observers']
+        );
 
         return 0;
     }

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -58,7 +58,7 @@ class ModelInspector
      *
      * @param  class-string<\Illuminate\Database\Eloquent\Model>|string  $model
      * @param  string|null  $connection
-     * @return array{"class": class-string<\Illuminate\Database\Eloquent\Model>, database: string, table: string, policy: string|null, attributes: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, events: \Illuminate\Support\Collection, observers: \Illuminate\Support\Collection}
+     * @return array{"class": class-string<\Illuminate\Database\Eloquent\Model>, database: string, table: string, policy: class-string|null, attributes: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, events: \Illuminate\Support\Collection, observers: \Illuminate\Support\Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>>, builder: class-string<\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>>}
      *
      * @throws BindingResolutionException
      */
@@ -82,6 +82,8 @@ class ModelInspector
             'relations' => $this->getRelations($model),
             'events' => $this->getEvents($model),
             'observers' => $this->getObservers($model),
+            'collection' => $this->getCollectedBy($model),
+            'builder' => $this->getBuilder($model),
         ];
     }
 
@@ -381,5 +383,25 @@ class ModelInspector
         return collect($indexes)->contains(
             fn ($index) => count($index['columns']) === 1 && $index['columns'][0] === $column && $index['unique']
         );
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return class-string<\Illuminate\Database\Eloquent\Collection>
+     */
+    protected function getCollectedBy($model)
+    {
+        return $model->newCollection()::class;
+    }
+
+    /**
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  TModel $model
+     * @return class-string<\Illuminate\Database\Eloquent\Builder<TModel>>
+     */
+    protected function getBuilder($model)
+    {
+        return $model->newQuery()::class;
     }
 }

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -274,6 +274,30 @@ class ModelInspector
     }
 
     /**
+     * Get the collection class being used by the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return class-string<\Illuminate\Database\Eloquent\Collection>
+     */
+    protected function getCollectedBy($model)
+    {
+        return $model->newCollection()::class;
+    }
+
+    /**
+     * Get the builder class being used by the model.
+     *
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  TModel $model
+     * @return class-string<\Illuminate\Database\Eloquent\Builder<TModel>>
+     */
+    protected function getBuilder($model)
+    {
+        return $model->newQuery()::class;
+    }
+
+    /**
      * Qualify the given model class base name.
      *
      * @param  string  $model
@@ -383,25 +407,5 @@ class ModelInspector
         return collect($indexes)->contains(
             fn ($index) => count($index['columns']) === 1 && $index['columns'][0] === $column && $index['unique']
         );
-    }
-
-    /**
-     * @param  \Illuminate\Database\Eloquent\Model $model
-     * @return class-string<\Illuminate\Database\Eloquent\Collection>
-     */
-    protected function getCollectedBy($model)
-    {
-        return $model->newCollection()::class;
-    }
-
-    /**
-     * @template TModel of \Illuminate\Database\Eloquent\Model
-     *
-     * @param  TModel $model
-     * @return class-string<\Illuminate\Database\Eloquent\Builder<TModel>>
-     */
-    protected function getBuilder($model)
-    {
-        return $model->newQuery()::class;
     }
 }

--- a/tests/Integration/Database/ModelInspectorTest.php
+++ b/tests/Integration/Database/ModelInspectorTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelInspector;
@@ -34,6 +37,8 @@ class ModelInspectorTest extends DatabaseTestCase
         $extractor = new ModelInspector($this->app);
         $modelInfo = $extractor->inspect(ModelInspectorTestModel::class);
         $this->assertModelInfo($modelInfo);
+        $this->assertSame(ModelInspectorTestModelEloquentCollection::class, $modelInfo['collection']);
+        $this->assertSame(ModelInspectorTestModelBuilder::class, $modelInfo['builder']);
     }
 
     public function test_command_returns_json()
@@ -175,10 +180,12 @@ class ModelInspectorTest extends DatabaseTestCase
 }
 
 #[ObservedBy(ModelInspectorTestModelObserver::class)]
+#[CollectedBy(ModelInspectorTestModelEloquentCollection::class)]
 class ModelInspectorTestModel extends Model
 {
     use HasUuids;
 
+    protected static string $builder = ModelInspectorTestModelBuilder::class;
     public $table = 'model_info_extractor_test_model';
     protected $guarded = ['name'];
     protected $casts = ['nullable_date' => 'datetime', 'a_bool' => 'bool'];
@@ -200,4 +207,13 @@ class ModelInspectorTestModelObserver
     public function created()
     {
     }
+}
+
+class ModelInspectorTestModelEloquentCollection extends Collection
+{
+}
+
+class ModelInspectorTestModelBuilder extends Builder
+{
+
 }


### PR DESCRIPTION
This adds the collection class and builder class to the output of `ModelInspector`.

I did not add these to the output of model:show because I wasn't sure if changing the signatures of `display()`, `displayCli()`, `displayJson()` would be considered a BC. Happy to add it