### PR TITLE
[11.x] consistent multiline constructors

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -96,14 +96,15 @@ class Gate implements GateContract
      * @param  callable|null  $guessPolicyNamesUsingCallback
      * @return void
      */
-    public function __construct(Container $container,
+    public function __construct(
+        Container $container,
         callable $userResolver,
         array $abilities = [],
         array $policies = [],
         array $beforeCallbacks = [],
         array $afterCallbacks = [],
-        ?callable $guessPolicyNamesUsingCallback = null)
-    {
+        ?callable $guessPolicyNamesUsingCallback = null,
+    ) {
         $this->policies = $policies;
         $this->container = $container;
         $this->abilities = $abilities;

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -63,10 +63,14 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * @param  int  $throttle
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, HasherContract $hasher,
-                                $table, $hashKey, $expires = 60,
-                                $throttle = 60)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        HasherContract $hasher,
+        $table,
+        $hashKey,
+        $expires = 60,
+        $throttle = 60,
+    ) {
         $this->table = $table;
         $this->hasher = $hasher;
         $this->hashKey = $hashKey;

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -128,13 +128,14 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $rehashOnLogin
      * @return void
      */
-    public function __construct($name,
-                                UserProvider $provider,
-                                Session $session,
-                                ?Request $request = null,
-                                ?Timebox $timebox = null,
-                                bool $rehashOnLogin = true)
-    {
+    public function __construct(
+        $name,
+        UserProvider $provider,
+        Session $session,
+        ?Request $request = null,
+        ?Timebox $timebox = null,
+        bool $rehashOnLogin = true,
+    ) {
         $this->name = $name;
         $this->session = $session;
         $this->request = $request;

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -54,8 +54,8 @@ class TokenGuard implements Guard
         Request $request,
         $inputKey = 'api_token',
         $storageKey = 'api_token',
-        $hash = false)
-    {
+        $hash = false,
+    ) {
         $this->hash = $hash;
         $this->request = $request;
         $this->provider = $provider;

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -115,19 +115,20 @@ class Batch implements Arrayable, JsonSerializable
      * @param  \Carbon\CarbonImmutable|null  $finishedAt
      * @return void
      */
-    public function __construct(QueueFactory $queue,
-                                BatchRepository $repository,
-                                string $id,
-                                string $name,
-                                int $totalJobs,
-                                int $pendingJobs,
-                                int $failedJobs,
-                                array $failedJobIds,
-                                array $options,
-                                CarbonImmutable $createdAt,
-                                ?CarbonImmutable $cancelledAt = null,
-                                ?CarbonImmutable $finishedAt = null)
-    {
+    public function __construct(
+        QueueFactory $queue,
+        BatchRepository $repository,
+        string $id,
+        string $name,
+        int $totalJobs,
+        int $pendingJobs,
+        int $failedJobs,
+        array $failedJobIds,
+        array $options,
+        CarbonImmutable $createdAt,
+        ?CarbonImmutable $cancelledAt = null,
+        ?CarbonImmutable $finishedAt = null,
+    ) {
         $this->queue = $queue;
         $this->repository = $repository;
         $this->id = $id;

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -68,7 +68,7 @@ class DynamoBatchRepository implements BatchRepository
         string $applicationName,
         string $table,
         ?int $ttl,
-        ?string $ttlAttribute
+        ?string $ttlAttribute,
     ) {
         $this->factory = $factory;
         $this->dynamoDbClient = $dynamoDbClient;

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -76,13 +76,14 @@ class DatabaseStore implements LockProvider, Store
      * @param  array  $lockLottery
      * @return void
      */
-    public function __construct(ConnectionInterface $connection,
-                                                    $table,
-                                                    $prefix = '',
-                                                    $lockTable = 'cache_locks',
-                                                    $lockLottery = [2, 100],
-                                                    $defaultLockTimeoutInSeconds = 86400)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        $table,
+        $prefix = '',
+        $lockTable = 'cache_locks',
+        $lockLottery = [2, 100],
+        $defaultLockTimeoutInSeconds = 86400,
+    ) {
         $this->table = $table;
         $this->prefix = $prefix;
         $this->connection = $connection;

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -68,13 +68,14 @@ class DynamoDbStore implements LockProvider, Store
      * @param  string  $prefix
      * @return void
      */
-    public function __construct(DynamoDbClient $dynamo,
-                                $table,
-                                $keyAttribute = 'key',
-                                $valueAttribute = 'value',
-                                $expirationAttribute = 'expires_at',
-                                $prefix = '')
-    {
+    public function __construct(
+        DynamoDbClient $dynamo,
+        $table,
+        $keyAttribute = 'key',
+        $valueAttribute = 'value',
+        $expirationAttribute = 'expires_at',
+        $prefix = '',
+    ) {
         $this->table = $table;
         $this->dynamo = $dynamo;
         $this->keyAttribute = $keyAttribute;

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -133,15 +133,16 @@ abstract class Factory
      * @param  \Illuminate\Support\Collection|null  $recycle
      * @return void
      */
-    public function __construct($count = null,
-                                ?Collection $states = null,
-                                ?Collection $has = null,
-                                ?Collection $for = null,
-                                ?Collection $afterMaking = null,
-                                ?Collection $afterCreating = null,
-                                $connection = null,
-                                ?Collection $recycle = null)
-    {
+    public function __construct(
+        $count = null,
+        ?Collection $states = null,
+        ?Collection $has = null,
+        ?Collection $for = null,
+        ?Collection $afterMaking = null,
+        ?Collection $afterCreating = null,
+        $connection = null,
+        ?Collection $recycle = null,
+    ) {
         $this->count = $count;
         $this->states = $states ?? new Collection;
         $this->has = $has ?? new Collection;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -151,9 +151,16 @@ class BelongsToMany extends Relation
      * @param  string|null  $relationName
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null)
-    {
+    public function __construct(
+        Builder $query,
+        Model $parent,
+        $table,
+        $foreignPivotKey,
+        $relatedPivotKey,
+        $parentKey,
+        $relatedKey,
+        $relationName = null,
+    ) {
         $this->parentKey = $parentKey;
         $this->relatedKey = $relatedKey;
         $this->relationName = $relationName;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -52,9 +52,18 @@ class MorphToMany extends BelongsToMany
      * @param  bool  $inverse
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
-    {
+    public function __construct(
+        Builder $query,
+        Model $parent,
+        $name,
+        $table,
+        $foreignPivotKey,
+        $relatedPivotKey,
+        $parentKey,
+        $relatedKey,
+        $relationName = null,
+        $inverse = false,
+    ) {
         $this->inverse = $inverse;
         $this->morphType = $name.'_type';
         $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();

--- a/src/Illuminate/Database/Events/DatabaseRefreshed.php
+++ b/src/Illuminate/Database/Events/DatabaseRefreshed.php
@@ -15,7 +15,7 @@ class DatabaseRefreshed implements MigrationEventContract
      */
     public function __construct(
         public ?string $database = null,
-        public bool $seeding = false
+        public bool $seeding = false,
     ) {
         //
     }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -87,11 +87,12 @@ class Migrator
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(MigrationRepositoryInterface $repository,
-                                Resolver $resolver,
-                                Filesystem $files,
-                                ?Dispatcher $dispatcher = null)
-    {
+    public function __construct(
+        MigrationRepositoryInterface $repository,
+        Resolver $resolver,
+        Filesystem $files,
+        ?Dispatcher $dispatcher = null,
+    ) {
         $this->files = $files;
         $this->events = $dispatcher;
         $this->resolver = $resolver;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -256,10 +256,11 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Database\Query\Processors\Processor|null  $processor
      * @return void
      */
-    public function __construct(ConnectionInterface $connection,
-                                ?Grammar $grammar = null,
-                                ?Processor $processor = null)
-    {
+    public function __construct(
+        ConnectionInterface $connection,
+        ?Grammar $grammar = null,
+        ?Processor $processor = null,
+    ) {
         $this->connection = $connection;
         $this->grammar = $grammar ?: $connection->getQueryGrammar();
         $this->processor = $processor ?: $connection->getPostProcessor();

--- a/src/Illuminate/Filesystem/ServeFile.php
+++ b/src/Illuminate/Filesystem/ServeFile.php
@@ -11,10 +11,11 @@ class ServeFile
     /**
      * Create a new invokable controller to serve files.
      */
-    public function __construct(protected string $disk,
+    public function __construct(
+        protected string $disk,
         protected array $config,
-        protected bool $isProduction)
-    {
+        protected bool $isProduction,
+    ) {
         //
     }
 

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -67,7 +67,7 @@ class Renderer
         Listener $listener,
         HtmlErrorRenderer $htmlErrorRenderer,
         BladeMapper $bladeMapper,
-        string $basePath
+        string $basePath,
     ) {
         $this->viewFactory = $viewFactory;
         $this->listener = $listener;

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -50,12 +50,13 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  bool  $dispatchAfterCommit
      * @return void
      */
-    public function __construct($pheanstalk,
-                                $default,
-                                $timeToRun,
-                                $blockFor = 0,
-                                $dispatchAfterCommit = false)
-    {
+    public function __construct(
+        $pheanstalk,
+        $default,
+        $timeToRun,
+        $blockFor = 0,
+        $dispatchAfterCommit = false,
+    ) {
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->timeToRun = $timeToRun;

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -51,12 +51,13 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  bool  $dispatchAfterCommit
      * @return void
      */
-    public function __construct(Connection $database,
-                                $table,
-                                $default = 'default',
-                                $retryAfter = 60,
-                                $dispatchAfterCommit = false)
-    {
+    public function __construct(
+        Connection $database,
+        $table,
+        $default = 'default',
+        $retryAfter = 60,
+        $dispatchAfterCommit = false,
+    ) {
         $this->table = $table;
         $this->default = $default;
         $this->database = $database;

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -75,14 +75,15 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  int  $migrationBatchSize
      * @return void
      */
-    public function __construct(Redis $redis,
-                                $default = 'default',
-                                $connection = null,
-                                $retryAfter = 60,
-                                $blockFor = null,
-                                $dispatchAfterCommit = false,
-                                $migrationBatchSize = -1)
-    {
+    public function __construct(
+        Redis $redis,
+        $default = 'default',
+        $connection = null,
+        $retryAfter = 60,
+        $blockFor = null,
+        $dispatchAfterCommit = false,
+        $migrationBatchSize = -1,
+    ) {
         $this->redis = $redis;
         $this->default = $default;
         $this->blockFor = $blockFor;

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -48,12 +48,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  bool  $dispatchAfterCommit
      * @return void
      */
-    public function __construct(SqsClient $sqs,
-                                $default,
-                                $prefix = '',
-                                $suffix = '',
-                                $dispatchAfterCommit = false)
-    {
+    public function __construct(
+        SqsClient $sqs,
+        $default,
+        $prefix = '',
+        $suffix = '',
+        $dispatchAfterCommit = false,
+    ) {
         $this->sqs = $sqs;
         $this->prefix = $prefix;
         $this->default = $default;

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -108,12 +108,13 @@ class Worker
      * @param  callable|null  $resetScope
      * @return void
      */
-    public function __construct(QueueManager $manager,
-                                Dispatcher $events,
-                                ExceptionHandler $exceptions,
-                                callable $isDownForMaintenance,
-                                ?callable $resetScope = null)
-    {
+    public function __construct(
+        QueueManager $manager,
+        Dispatcher $events,
+        ExceptionHandler $exceptions,
+        callable $isDownForMaintenance,
+        ?callable $resetScope = null,
+    ) {
         $this->events = $events;
         $this->manager = $manager;
         $this->exceptions = $exceptions;

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -97,9 +97,19 @@ class WorkerOptions
      * @param  int  $rest
      * @return void
      */
-    public function __construct($name = 'default', $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1,
-                                $force = false, $stopWhenEmpty = false, $maxJobs = 0, $maxTime = 0, $rest = 0)
-    {
+    public function __construct(
+        $name = 'default',
+        $backoff = 0,
+        $memory = 128,
+        $timeout = 60,
+        $sleep = 3,
+        $maxTries = 1,
+        $force = false,
+        $stopWhenEmpty = false,
+        $maxJobs = 0,
+        $maxTime = 0,
+        $rest = 0,
+    ) {
         $this->name = $name;
         $this->backoff = $backoff;
         $this->sleep = $sleep;

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -18,7 +18,7 @@ class Onceable
     public function __construct(
         public string $hash,
         public ?object $object,
-        public $callable
+        public $callable,
     ) {
         //
     }

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -39,17 +39,18 @@ class BatchFake extends Batch
      * @param  \Carbon\CarbonImmutable|null  $finishedAt
      * @return void
      */
-    public function __construct(string $id,
-                                string $name,
-                                int $totalJobs,
-                                int $pendingJobs,
-                                int $failedJobs,
-                                array $failedJobIds,
-                                array $options,
-                                CarbonImmutable $createdAt,
-                                ?CarbonImmutable $cancelledAt = null,
-                                ?CarbonImmutable $finishedAt = null)
-    {
+    public function __construct(
+        string $id,
+        string $name,
+        int $totalJobs,
+        int $pendingJobs,
+        int $failedJobs,
+        array $failedJobIds,
+        array $options,
+        CarbonImmutable $createdAt,
+        ?CarbonImmutable $cancelledAt = null,
+        ?CarbonImmutable $finishedAt = null,
+    ) {
         $this->id = $id;
         $this->name = $name;
         $this->totalJobs = $totalJobs;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -334,9 +334,13 @@ class Validator implements ValidatorContract
      * @param  array  $attributes
      * @return void
      */
-    public function __construct(Translator $translator, array $data, array $rules,
-                                array $messages = [], array $attributes = [])
-    {
+    public function __construct(
+        Translator $translator,
+        array $data,
+        array $rules,
+        array $messages = [],
+        array $attributes = [],
+    ) {
         $this->dotPlaceholder = Str::random();
 
         $this->initialRules = $rules;

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -61,8 +61,8 @@ abstract class Compiler
         $cachePath,
         $basePath = '',
         $shouldCache = true,
-        $compiledExtension = 'php')
-    {
+        $compiledExtension = 'php',
+    ) {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');
         }


### PR DESCRIPTION
we have a little bit of a mix-and-match for our multiline constructors through the framework. this PR makes them consistent.

- first parameter on newline
- trailing comma after last parameter
- closing parentheses on newline with opening bracket

this format is incredibly readable and makes for easy to grok diffs.

this format will also be very conducive as the framework continues to become more typed, and for more and more use of promoted properties.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
