### PR TITLE
[11.x] Removing unused var assignment in Illuminate Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -709,7 +709,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $route->setAction($this->mergeWithLastGroup(
             $route->getAction(),
-            $prependExistingPrefix = false
+            false
         ));
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -709,7 +709,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $route->setAction($this->mergeWithLastGroup(
             $route->getAction(),
-            false
+            prependExistingPrefix: false
         ));
     }
 


### PR DESCRIPTION
It won't benefit any end user, it can't break any existing feature since the variable was unused, it doesn't make building applications easier: I just noticed that while debugging some stuff in the vendor of my application.