### PR TITLE
Support ObservedBy on parent model classes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -4,8 +4,14 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Tests\Database\EloquentModelStub;
+use Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub;
+use Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandparentStub;
+use Illuminate\Tests\Database\EloquentModelWithObserveAttributeParentStub;
 use InvalidArgumentException;
 use ReflectionClass;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -8,10 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Tests\Database\EloquentModelStub;
-use Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub;
-use Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandparentStub;
-use Illuminate\Tests\Database\EloquentModelWithObserveAttributeParentStub;
 use InvalidArgumentException;
 use ReflectionClass;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -48,7 +48,14 @@ trait HasEvents
     {
         $reflectionClass = new ReflectionClass(static::class);
 
+        $isEloquentGrandchild = is_subclass_of(static::class, Model::class)
+            && get_parent_class(static::class) !== Model::class;
+
         return collect($reflectionClass->getAttributes(ObservedBy::class))
+            ->when($isEloquentGrandchild, function (Collection $attributes) {
+                $parentReflection = new ReflectionClass(get_parent_class(static::class));
+                return $attributes->merge($parentReflection->getAttributes(ObservedBy::class));
+            })
             ->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
             ->all();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -55,7 +55,8 @@ trait HasEvents
             ->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
             ->when($isEloquentGrandchild, function (Collection $attributes) {
-                return $attributes->merge(get_parent_class(static::class)::resolveObserveAttributes());
+                return collect(get_parent_class(static::class)::resolveObserveAttributes())
+                    ->merge($attributes);
             })
             ->all();
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -52,12 +52,11 @@ trait HasEvents
             && get_parent_class(static::class) !== Model::class;
 
         return collect($reflectionClass->getAttributes(ObservedBy::class))
-            ->when($isEloquentGrandchild, function (Collection $attributes) {
-                $parentReflection = new ReflectionClass(get_parent_class(static::class));
-                return $attributes->merge($parentReflection->getAttributes(ObservedBy::class));
-            })
             ->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
+            ->when($isEloquentGrandchild, function (Collection $attributes) {
+                return $attributes->merge(get_parent_class(static::class)::resolveObserveAttributes());
+            })
             ->all();
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2106,6 +2106,20 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelWithObserveAttributeUsingArrayStub::flushEventListeners();
     }
 
+    public function testModelObserversCanBeAttachedToModelsThroughAttributesOnParentClasses()
+    {
+        EloquentModelWithObserveAttributeGrandchildStub::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub', EloquentTestObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub', EloquentTestObserverStub::class.'@saved');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub', EloquentTestAnotherObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub', EloquentTestAnotherObserverStub::class.'@saved');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub', EloquentTestThirdObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelWithObserveAttributeGrandchildStub', EloquentTestThirdObserverStub::class.'@saved');
+        $events->shouldReceive('forget');
+        EloquentModelWithObserveAttributeGrandchildStub::flushEventListeners();
+    }
+
     public function testThrowExceptionOnAttachingNotExistsModelObserverWithString()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -3206,6 +3220,19 @@ class EloquentTestAnotherObserverStub
     }
 }
 
+class EloquentTestThirdObserverStub
+{
+    public function creating()
+    {
+        //
+    }
+
+    public function saved()
+    {
+        //
+    }
+}
+
 class EloquentModelStub extends Model
 {
     public $connection;
@@ -3695,6 +3722,24 @@ class EloquentModelWithObserveAttributeStub extends EloquentModelStub
 
 #[ObservedBy([EloquentTestObserverStub::class])]
 class EloquentModelWithObserveAttributeUsingArrayStub extends EloquentModelStub
+{
+    //
+}
+
+#[ObservedBy([EloquentTestObserverStub::class])]
+class EloquentModelWithObserveAttributeGrandparentStub extends EloquentModelStub
+{
+    //
+}
+
+#[ObservedBy([EloquentTestAnotherObserverStub::class])]
+class EloquentModelWithObserveAttributeParentStub extends EloquentModelWithObserveAttributeGrandparentStub
+{
+    //
+}
+
+#[ObservedBy([EloquentTestThirdObserverStub::class])]
+class EloquentModelWithObserveAttributeGrandchildStub extends EloquentModelWithObserveAttributeParentStub
 {
     //
 }


### PR DESCRIPTION
When an Eloquent model extends another Eloquent model, the check for the ObservedBy attribute only considers the class itself. Any observers registered in the parent model are ignored.

This change adds support for the ObservedBy attribute in parent classes and traverses the hierarchy until the top Model class is reached.
