### PR TITLE
Marking password params in Database connector with SensitiveParameter attribute

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -60,7 +60,7 @@ class Connector
      * @param  array  $options
      * @return \PDO
      */
-    protected function createPdoConnection($dsn, $username, $password, $options)
+    protected function createPdoConnection($dsn, $username, #[\SensitiveParameter] $password, $options)
     {
         return version_compare(phpversion(), '8.4.0', '<')
             ? new PDO($dsn, $username, $password, $options)
@@ -79,7 +79,7 @@ class Connector
      *
      * @throws \Throwable
      */
-    protected function tryAgainIfCausedByLostConnection(Throwable $e, $dsn, $username, $password, $options)
+    protected function tryAgainIfCausedByLostConnection(Throwable $e, $dsn, $username, #[\SensitiveParameter] $password, $options)
     {
         if ($this->causedByLostConnection($e)) {
             return $this->createPdoConnection($dsn, $username, $password, $options);


### PR DESCRIPTION
This change marks the `$password` parameter used in `Illuminate\Database\Connectors\Connector` with the SensitiveParameter attribute so it's properly redacted in stack traces.