### PR TITLE
[11.x] Test Improvements

### DIFF
--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -94,8 +94,10 @@ jobs:
 
     strategy:
       fail-fast: true
+      matrix:
+        client: ['phpredis', 'predis']
 
-    name: Redis Driver
+    name: Redis (${{ matrix.client}}) Driver
 
     steps:
       - name: Checkout code
@@ -122,6 +124,7 @@ jobs:
       - name: Execute tests
         run: vendor/bin/phpunit tests/Integration/Queue
         env:
+          REDIS_CLIENT: ${{ matrix.client }}
           QUEUE_CONNECTION: redis
 
   beanstalkd:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
         <ini name="memory_limit" value="2048M" />
         <env name="DB_CONNECTION" value="testing" />
         <!--
+        <env name="REDIS_CLIENT" value="phpredis" />
         <env name="REDIS_HOST" value="127.0.0.1" />
         <env name="REDIS_PORT" value="6379" />
         -->

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -8,34 +8,19 @@ use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Redis\Factory as Redis;
-use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Support\Str;
 use Mockery as m;
+use Orchestra\Testbench\Attributes\RequiresEnv;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
+#[RequiresEnv('REDIS_CLIENT')]
 #[RequiresPhpExtension('redis')]
 class RateLimitedWithRedisTest extends TestCase
 {
-    use InteractsWithRedis;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setUpRedis();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDownRedis();
-
-        parent::tearDown();
-    }
-
     public function testUnlimitedJobsAreExecuted()
     {
         $rateLimiter = $this->app->make(RateLimiter::class);


### PR DESCRIPTION
Correctly test Queue using `phpredis` and `predis`. `InteractsWithRedis` configure redis as set it to `$this->redis` but the TestCase are using Redis connection set via created Application (using Testbench).

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
