### PR TITLE
[12.x] Avoid breaking change `RefreshDatabase::usingInMemoryDatabase()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -48,7 +48,7 @@ trait RefreshDatabase
      *
      * @return bool
      */
-    protected function usingInMemoryDatabase(?string $name)
+    protected function usingInMemoryDatabase(?string $name = null)
     {
         if (is_null($name)) {
             $name = config('database.default');

--- a/tests/Integration/Queue/SerializableClosureV1QueueTest.php
+++ b/tests/Integration/Queue/SerializableClosureV1QueueTest.php
@@ -17,7 +17,7 @@ class SerializableClosureV1QueueTest extends TestCase
     #[\Override]
     protected function defineEnvironment($app)
     {
-        $this->markTestSkippedWhen($this->usingInMemoryDatabase(null), 'Test does not support using :memory: database connection');
+        $this->markTestSkippedWhen($this->usingInMemoryDatabase(), 'Test does not support using :memory: database connection');
 
         tap($app->make('config'), function ($config) {
             $config->set([


### PR DESCRIPTION
While we do allows BC on major release I do feel that this is not needed for the following use case.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
