### PR TITLE
Set default column name to 'id' for all Increments functions

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -750,7 +750,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function increments($column)
+    public function increments($column = 'id')
     {
         return $this->unsignedInteger($column, true);
     }
@@ -761,7 +761,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function integerIncrements($column)
+    public function integerIncrements($column = 'id')
     {
         return $this->unsignedInteger($column, true);
     }
@@ -772,7 +772,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function tinyIncrements($column)
+    public function tinyIncrements($column = 'id')
     {
         return $this->unsignedTinyInteger($column, true);
     }
@@ -783,7 +783,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function smallIncrements($column)
+    public function smallIncrements($column = 'id')
     {
         return $this->unsignedSmallInteger($column, true);
     }
@@ -794,7 +794,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function mediumIncrements($column)
+    public function mediumIncrements($column = 'id')
     {
         return $this->unsignedMediumInteger($column, true);
     }
@@ -805,7 +805,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function bigIncrements($column)
+    public function bigIncrements($column = 'id')
     {
         return $this->unsignedBigInteger($column, true);
     }


### PR DESCRIPTION
Set the default column name for all Increments functions to 'id.'

The benefit of this pull request to end users are:
1) The default of 'id' of an increment column is encouraged throughout the project.
2) Users no longer need to specify the column name when using an increments function other than the id() function.

This does not break any existing features because there is currently no default, so any existing implementations will already specify what the application needs.