### PR TITLE
[11.x] Move `$ownerKey` check for `null` to `MorphTo` as `BelongsTo` relationship will always return a `string`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -344,10 +344,6 @@ class BelongsTo extends Relation
      */
     public function getQualifiedOwnerKeyName()
     {
-        if (is_null($this->ownerKey)) {
-            return '';
-        }
-
         return $this->related->qualifyColumn($this->ownerKey);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -99,17 +99,6 @@ class MorphTo extends BelongsTo
         $this->buildDictionary($this->models = Collection::make($models));
     }
 
-    /** @inheritDoc */
-    #[\Override]
-    public function getQualifiedOwnerKeyName()
-    {
-        if (is_null($this->ownerKey)) {
-            return '';
-        }
-
-        return parent::getQualifiedOwnerKeyName();
-    }
-
     /**
      * Build a dictionary with the models.
      *
@@ -423,6 +412,17 @@ class MorphTo extends BelongsTo
         }
 
         return $query;
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public function getQualifiedOwnerKeyName()
+    {
+        if (is_null($this->ownerKey)) {
+            return '';
+        }
+
+        return parent::getQualifiedOwnerKeyName();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -93,9 +93,21 @@ class MorphTo extends BelongsTo
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function addEagerConstraints(array $models)
     {
         $this->buildDictionary($this->models = Collection::make($models));
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public function getQualifiedOwnerKeyName()
+    {
+        if (is_null($this->ownerKey)) {
+            return '';
+        }
+
+        return parent::getQualifiedOwnerKeyName();
     }
 
     /**
@@ -199,6 +211,7 @@ class MorphTo extends BelongsTo
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function match(array $models, Collection $results, $relation)
     {
         return $models;
@@ -230,6 +243,7 @@ class MorphTo extends BelongsTo
      * @param  TRelatedModel|null  $model
      * @return TDeclaringModel
      */
+    #[\Override]
     public function associate($model)
     {
         if ($model instanceof Model) {
@@ -254,6 +268,7 @@ class MorphTo extends BelongsTo
      *
      * @return TDeclaringModel
      */
+    #[\Override]
     public function dissociate()
     {
         $this->parent->setAttribute($this->foreignKey, null);
@@ -263,11 +278,8 @@ class MorphTo extends BelongsTo
         return $this->parent->setRelation($this->relationName, null);
     }
 
-    /**
-     * Touch all of the related models for the relationship.
-     *
-     * @return void
-     */
+    /** @inheritDoc */
+    #[\Override]
     public function touch()
     {
         if (! is_null($this->getParentKey())) {
@@ -276,6 +288,7 @@ class MorphTo extends BelongsTo
     }
 
     /** @inheritDoc */
+    #[\Override]
     protected function newRelatedInstanceFor(Model $parent)
     {
         return $parent->{$this->getRelationName()}()->getRelated()->newInstance();


### PR DESCRIPTION
Improvements based on #53573 PR

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
