### PR TITLE
[11.x] Allow `BackedEnum` when using `fromRoute()` in `MakesHttpRequests`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use BackedEnum;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Http\Request;
@@ -335,7 +336,7 @@ trait MakesHttpRequests
      * @param  mixed  $parameters
      * @return $this
      */
-    public function fromRoute(\BackedEnum|string $name, $parameters = [])
+    public function fromRoute(BackedEnum|string $name, $parameters = [])
     {
         return $this->from($this->app['url']->route($name, $parameters));
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -331,11 +331,11 @@ trait MakesHttpRequests
     /**
      * Set the referer header and previous URL session value from a given route in order to simulate a previous request.
      *
-     * @param  string  $name
+     * @param  \BackedEnum|string  $name
      * @param  mixed  $parameters
      * @return $this
      */
-    public function fromRoute(string $name, $parameters = [])
+    public function fromRoute(\BackedEnum|string $name, $parameters = [])
     {
         return $this->from($this->app['url']->route($name, $parameters));
     }


### PR DESCRIPTION
Since routes accept BackedEnums it makes sense to allow them when using fromRoute in tests too