### PR TITLE
refactor: Some minor performance & readability enhancements

### DIFF
--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -51,7 +51,7 @@ class BusDispatcherTest extends TestCase
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
             $mock = m::mock(Queue::class);
-            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type(BusDispatcherTestSpecificQueueAndDelayCommand::class));
+            $mock->shouldReceive('later')->once()->with(10, m::type(BusDispatcherTestSpecificQueueAndDelayCommand::class), '', 'foo');
 
             return $mock;
         });


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

During my latest Inside Laravel livestream I noticed some minor inefficiencies in the Dispatcher code. These most likely are just older code that never got updated.

This includes 3 changes:

1. Use`isset($uses[InteractsWithQueue::class], $uses[Queueable::class])` instead of a _two_ expensive `in_array()` calls, this takes two O(n) operations to just O(1). 
2. It replaces an expensive `call_user_func()` call with a dynamic method call, using `($this->queueResolver)` to dererefence the property before calling the closure within.
3. Simplifies the `pushCommandToQueue()` implementation which previously checked if queue and/or delay were set and then calling `pushOn()` or `laterOn()` when with named params we can easily just call `push()` and `later()` — the use of `queue: $command->queue ??  null` rather than just `queue: $command->queue` is for readability. This one is the only one I'm concerned about, it's _possible_ that an implementation of the `Queue` interface/child of the `Queue` abstract class  has different behavior than just wrapping `push()` and `later()` — but as those must support the `queue` param I don't see any issue with it.