### PR TITLE
Introducing Arr::chunkBy(). Split an iterable into chunks based on a callback function.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -959,7 +959,7 @@ class Arr
      *
      * @param  iterable  $iterable  The iterable to chunk (e.g., array, generator).
      * @param  callable  $callback  A callback function that determines the chunking logic.
-     *                               The callback should accept the value and key as parameters.
+     *                              The callback should accept the value and key as parameters.
      * @return array An array of chunks.
      */
     public static function chunkBy(iterable $iterable, callable $callback): array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -951,4 +951,34 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Split an array into chunks based on a callback function.
+     *
+     * Each chunk will contain consecutive elements until the callback's return value changes.
+     *
+     * @param  array  $array  The array to chunk.
+     * @param  callable  $callback  A callback function that determines the chunking logic.
+     *                              The callback should accept the value and key as parameters.
+     * @return array  An array of chunks.
+     */
+    public static function chunkBy(array $array, callable $callback): array
+    {
+        $chunks = [];
+        $lastGroup = null;
+
+        foreach ($array as $key => $value) {
+            $group = $callback($value, $key);
+
+            if ($group !== $lastGroup) {
+                $chunks[] = [];
+                $lastGroup = $group;
+            }
+
+            $chunks[array_key_last($chunks)][$key] = $value;
+        }
+
+        return $chunks;
+    }
+
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -953,21 +953,21 @@ class Arr
     }
 
     /**
-     * Split an array into chunks based on a callback function.
+     * Split an iterable into chunks based on a callback function.
      *
      * Each chunk will contain consecutive elements until the callback's return value changes.
      *
-     * @param  array  $array  The array to chunk.
+     * @param  iterable  $iterable  The iterable to chunk (e.g., array, generator).
      * @param  callable  $callback  A callback function that determines the chunking logic.
-     *                              The callback should accept the value and key as parameters.
-     * @return array  An array of chunks.
+     *                               The callback should accept the value and key as parameters.
+     * @return array An array of chunks.
      */
-    public static function chunkBy(array $array, callable $callback): array
+    public static function chunkBy(iterable $iterable, callable $callback): array
     {
         $chunks = [];
         $lastGroup = null;
 
-        foreach ($array as $key => $value) {
+        foreach ($iterable as $key => $value) {
             $group = $callback($value, $key);
 
             if ($group !== $lastGroup) {
@@ -980,5 +980,4 @@ class Arr
 
         return $chunks;
     }
-
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use function PHPUnit\Framework\assertSame;
 
 class SupportArrTest extends TestCase
 {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1502,4 +1502,45 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::select($array, 'name'));
     }
+
+    public function testChunkBy(): void
+    {
+        $array = [1, 2, 2, 3, 4, 4, 5];
+        $chunks = Arr::chunkBy($array, fn ($value) => $value % 2 === 0);
+
+        $this->assertSame(
+            [
+                [0 => 1],
+                [1 => 2, 2 => 2],
+                [3 => 3],
+                [4 => 4, 5 => 4],
+                [6 => 5]
+            ],
+            $chunks
+        );
+
+        $timestamps = [
+            '2024-11-20 10:00:00',
+            '2024-11-20 10:15:00',
+            '2024-11-20 11:00:00',
+            '2024-11-21 10:00:00',
+        ];
+
+        $chunks = Arr::chunkBy($timestamps, fn ($time) => date('Y-m-d', strtotime($time)));
+
+        $this->assertSame(
+            [
+                [
+                    0 => '2024-11-20 10:00:00',
+                    1 => '2024-11-20 10:15:00',
+                    2 => '2024-11-20 11:00:00',
+                ],
+                [
+                    3 => '2024-11-21 10:00:00',
+                ],
+            ],
+            $chunks
+        );
+    }
+
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use function PHPUnit\Framework\assertSame;
 
 class SupportArrTest extends TestCase
 {
@@ -1514,7 +1515,7 @@ class SupportArrTest extends TestCase
                 [1 => 2, 2 => 2],
                 [3 => 3],
                 [4 => 4, 5 => 4],
-                [6 => 5]
+                [6 => 5],
             ],
             $chunks
         );
@@ -1543,4 +1544,35 @@ class SupportArrTest extends TestCase
         );
     }
 
+    public function testChunkByWithGenerator(): void
+    {
+        $generator = $this->generateOrders();
+
+        $grouped = Arr::chunkBy($generator, fn ($order) => $order['user_id']);
+
+        $this->assertSame(
+            [
+                [
+                    ['id' => 1, 'user_id' => 1],
+                    ['id' => 2, 'user_id' => 1],
+                ],
+                [
+                    2 => ['id' => 3, 'user_id' => 2],
+                ],
+            ],
+            $grouped
+        );
+    }
+
+    /**
+     * Generator for testing chunkBy method.
+     *
+     * @return \Generator
+     */
+    private function generateOrders(): \Generator
+    {
+        yield ['id' => 1, 'user_id' => 1];
+        yield ['id' => 2, 'user_id' => 1];
+        yield ['id' => 3, 'user_id' => 2];
+    }
 }


### PR DESCRIPTION
Introducing Arr::chunkBy(). Split an iterable into chunks based on a callback function. Each chunk will contain consecutive elements until the callback's return value changes

### Detailed Impact:
**ChunkBy Method:**
**Benefit:** Dynamically segments iterable based on conditions.
**Common Use:** Log analysis, temporal grouping, or state-based processing.
**Performance:** Efficient for moderately sized iterable with clear grouping logic.

**Example usages:**

```php        
	$orders = [
            ['id' => 1, 'user_id' => 1],
            ['id' => 2, 'user_id' => 1],
            ['id' => 3, 'user_id' => 2],
        ];
        
    $grouped = Arr::chunkBy($orders, fn ($order) => $order['user_id']);

        $this->assertSame(
            $grouped,
            [
                [
                    0 => [
                        'id' => 1,
                        'user_id' => 1,
                    ],
                    1 => [
                        'id' => 2,
                        'user_id' => 1,
                    ],
                ],
                [
                    2 => [
                        'id' => 3,
                        'user_id' => 2,
                    ],
                ],
            ]
        );