### PR TITLE
Fix Paginator __construct parameter typehint for phpstan

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -35,7 +35,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     /**
      * Create a new paginator instance.
      *
-     * @param  TValue[]  $items
+     * @param  Collection<TKey, TValue>|Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  int  $perPage
      * @param  int|null  $currentPage
      * @param  array  $options  (path, query, fragment, pageName)


### PR DESCRIPTION
Since the update to [v11.32.0](https://github.com/laravel/framework/releases/tag/v11.32.0)
 this [commit](https://github.com/laravel/framework/pull/53512) introduced type hints for the Paginator Class. The @param for $items was defined too narrow, restricting the use of Collections, but they are supported and it seems like to be preffered, as the protected `setItems()` method which is called from within the constructor is supporting Collections and converts any array in to one. 
 
 This is not a bugfix as the code works, but a type fix supporting the usage of phpstan/larastan
 
This PR broadens the type hint for the param $items to be compatible with `setItems()` by allowing Collections with `Tkey` and `TValue` 

I did not add null as allowed, although it is supported in the setItems method, but maybe that should be supported as well? 