### PR TITLE
[11.x] Add generics for Arr::last()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -216,10 +216,14 @@ class Arr
     /**
      * Return the last element in an array passing a given truth test.
      *
-     * @param  array  $array
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
+     * @template TKey
+     * @template TValue
+     * @template TLastDefault
+     *
+     * @param  iterable<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  TLastDefault|(\Closure(): TLastDefault)  $default
+     * @return TValue|TLastDefault
      */
     public static function last($array, ?callable $callback = null, $default = null)
     {

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -24,33 +24,3 @@ assertType('string|User', Arr::first($array, function ($user) {
 assertType('string|User', Arr::first($array, null, function () {
     return 'string';
 }));
-
-assertType('User|null', Arr::first($iterable));
-assertType('User|null', Arr::first($iterable, function ($user) {
-    assertType('User', $user);
-
-    return true;
-}));
-assertType('string|User', Arr::first($iterable, function ($user) {
-    assertType('User', $user);
-
-    return false;
-}, 'string'));
-assertType('string|User', Arr::first($iterable, null, function () {
-    return 'string';
-}));
-
-assertType('User|null', Arr::first($traversable));
-assertType('User|null', Arr::first($traversable, function ($user) {
-    assertType('User', $user);
-
-    return true;
-}));
-assertType('string|User', Arr::first($traversable, function ($user) {
-    assertType('User', $user);
-
-    return false;
-}, 'string'));
-assertType('string|User', Arr::first($traversable, null, function () {
-    return 'string';
-}));

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -25,6 +25,36 @@ assertType('string|User', Arr::first($array, null, function () {
     return 'string';
 }));
 
+assertType('User|null', Arr::first($iterable));
+assertType('User|null', Arr::first($iterable, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::first($iterable, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::first($iterable, null, function () {
+    return 'string';
+}));
+
+assertType('User|null', Arr::first($traversable));
+assertType('User|null', Arr::first($traversable, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::first($traversable, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::first($traversable, null, function () {
+    return 'string';
+}));
+
 assertType('User|null', Arr::last($array));
 assertType('User|null', Arr::last($array, function ($user) {
     assertType('User', $user);
@@ -37,5 +67,35 @@ assertType('string|User', Arr::last($array, function ($user) {
     return false;
 }, 'string'));
 assertType('string|User', Arr::last($array, null, function () {
+    return 'string';
+}));
+
+assertType('User|null', Arr::last($iterable));
+assertType('User|null', Arr::last($iterable, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::last($iterable, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::last($iterable, null, function () {
+    return 'string';
+}));
+
+assertType('User|null', Arr::last($traversable));
+assertType('User|null', Arr::last($traversable, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::last($traversable, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::last($traversable, null, function () {
     return 'string';
 }));

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -24,3 +24,18 @@ assertType('string|User', Arr::first($array, function ($user) {
 assertType('string|User', Arr::first($array, null, function () {
     return 'string';
 }));
+
+assertType('User|null', Arr::last($array));
+assertType('User|null', Arr::last($array, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::last($array, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::last($array, null, function () {
+    return 'string';
+}));


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/50514 implemented generics for `Arr::first()`

This PR does exactly the same for `Arr::last()`