### PR TITLE
Add assertCount() for fake storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -157,7 +157,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $actual = count($this->files($path, $recursive));
 
         PHPUnit::assertEquals(
-            $actual, $count, "The expected count for [{$path}] was [{$count}], but [{$actual}] was given."
+            $actual, $count, "The expected number of files at [{$path}] was [{$count}], but found [{$actual}]."
         );
 
         return $this;

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -157,7 +157,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $actual = count($this->files($path, $recursive));
 
         PHPUnit::assertEquals(
-            $actual, $count, "The expected number of files at [{$path}] was [{$count}], but found [{$actual}]."
+            $actual, $count, "Expected [{$count}] files at [{$path}], but found [{$actual}]."
         );
 
         return $this;

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -143,6 +143,27 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Assert that the number of files in path equals the expected count.
+     *
+     * @param  string  $path
+     * @param  int  $count
+     * @param  bool  $recursive
+     * @return $this
+     */
+    public function assertCount($path, $count, $recursive = false)
+    {
+        clearstatcache();
+
+        $actual = count($this->files($path, $recursive));
+
+        PHPUnit::assertEquals(
+            $actual, $count, "The expected count for [{$path}] was [{$count}], but [{$actual}] was given."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the given file or directory does not exist.
      *
      * @param  string|array  $path

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -44,6 +44,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static array allDirectories(string|null $directory = null)
  * @method static bool makeDirectory(string $path)
  * @method static bool deleteDirectory(string $directory)
+ * @method static \Illuminate\Filesystem\FilesystemAdapter assertCount(string $path, int $count, bool $recursive)
  * @method static \Illuminate\Filesystem\FilesystemAdapter assertExists(string|array $path, string|null $content = null)
  * @method static \Illuminate\Filesystem\FilesystemAdapter assertMissing(string|array $path)
  * @method static \Illuminate\Filesystem\FilesystemAdapter assertDirectoryEmpty(string $path)


### PR DESCRIPTION
This change adds a new method to the fake storage called ```assertCount```.
This assertion checks that the number of files in a given path matches the expected value.
Additionally, it supports the **recursive** option to compare the total number of files, including those in subdirectories, with the expected value.