### PR TITLE
[11.x] Improve doc blocks for interacting with enum inputs

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -395,7 +395,7 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as an enum.
      *
-     * @template TEnum
+     * @template TEnum of \BackedEnum
      *
      * @param  string  $key
      * @param  class-string<TEnum>  $enumClass
@@ -413,7 +413,7 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as an array of enums.
      *
-     * @template TEnum
+     * @template TEnum of \BackedEnum
      *
      * @param  string  $key
      * @param  class-string<TEnum>  $enumClass

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -4,8 +4,9 @@ use Illuminate\Http\Request;
 
 use function PHPStan\Testing\assertType;
 
-class TestEnum
+enum TestEnum: string
 {
+    case Foo = 'foo';
 }
 
 $request = Request::create('/', 'GET', [


### PR DESCRIPTION
These methods should only be used with class names of backed enums, now the doc blocks reflect that