### PR TITLE
[11.x] Fix attribute inheritance for nested scheduled groups

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -454,7 +454,7 @@ class Schedule
         }
 
         if (method_exists(PendingEventAttributes::class, $method)) {
-            $this->attributes ??= new PendingEventAttributes($this);
+            $this->attributes ??= end($this->groupStack) ?: new PendingEventAttributes($this);
 
             return $this->attributes->$method(...$parameters);
         }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -75,19 +75,14 @@ class ScheduleGroupTest extends TestCase
             ->timezone('UTC')
             ->group(function () {
                 Schedule::command('inspire');
-                Schedule::timezone('Asia/Dhaka')
-                    ->everyMinute()
-                    ->group(function () {
-                        Schedule::command('inspire');
-                    });
+                Schedule::timezone('Asia/Dhaka')->group(function () {
+                    Schedule::command('inspire');
+                });
             });
 
         $events = Schedule::events();
         $this->assertSame('UTC', $events[0]->timezone);
-        $this->assertSame('0 0 * * *', $events[0]->expression);
-
         $this->assertSame('Asia/Dhaka', $events[1]->timezone);
-        $this->assertSame('* * * * *', $events[1]->expression);
     }
 
     #[DataProvider('groupAttributes')]


### PR DESCRIPTION
### Description

This PR resolves a bug in which the attributes of the parent schedule group were not applied to the nested group's events. @rcerljenko reported the issue in #53608.

Example of unexpected behavior:
```php
Schedule::onOneServer()->group(function () {
    Schedule::command('command-one');
    Schedule::runInBackground()->group(function () {
        // The `onOneServer` attribute is not applied to this event
        Schedule::command('command-two');
    });
});
```

### P.S.

While debugging, I encountered two behaviors that I’m unsure how to handle, and I’d appreciate feedback.

#### Behavior One

Both examples below throw fatal exceptions because no `PendingEventAttribute` is set before creating a group.

```php
// Example #1
Schedule::group(function () { // throws an exception here
    Schedule::command('command-one');
});

// Example #2
Schedule::daily()->group(function () {
    Schedule::command('command-one');
    Schedule::group(function () { // throws an exception here
        Schedule::command('command-two');
    });
});
```

What should be done, as I think groups should not be created without common attributes?
 1. Move the `group` method to the `PendingEventAttribute` class to prevent calling `Schedule::group` directly
 2. Catch the fatal exceptions and throw a new exception with a clear message
 3. Keep the current behavior

#### Behavior Two

```php
Schedule::daily()->group(function () {
    Schedule::command('command-one');
    Schedule::command('command-two')->hourly();
});
```
The frequency of the second event becomes this:
```php
Schedule::command('command-two')->daily()->hourly();
```

The `hourly()` method with the group's `daily()` results in a cron expression like `0 0 * * *`, whereas the expected expression is `0 * * * *`. 

Again what should be done when modifying group events?
1. Keep the current behavior
2. Somehow reset the expression to `* * * * *` so that the `hourly()` generates correct frequency

---
@stevebauman @rodrigopedra @taylorotwell Tagging you for your valuable input during the initial PR and hoping to get your feedback on this one as well.