### PR TITLE
Make the bearerToken method case-insensitive

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -58,7 +58,7 @@ trait InteractsWithInput
     {
         $header = $this->header('Authorization', '');
 
-        $position = strrpos($header, 'Bearer ');
+        $position = strripos($header, 'Bearer ');
 
         if ($position !== false) {
             $header = substr($header, $position + 7);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1074,10 +1074,16 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fooBearerbar']);
         $this->assertSame('fooBearerbar', $request->bearerToken());
 
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'bearer fooBearerbar']);
+        $this->assertSame('fooBearerbar', $request->bearerToken());
+
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Basic foo, Bearer bar']);
         $this->assertSame('bar', $request->bearerToken());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer foo,bar']);
+        $this->assertSame('foo', $request->bearerToken());
+
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'bearer foo,bar']);
         $this->assertSame('foo', $request->bearerToken());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'foo,bar']);


### PR DESCRIPTION
Currently the bearerToken() method used in the TokenGuard requires the auth-scheme, "Bearer", to be capitalized as it uses the strrpos method to locate the position of the string "Bearer".
 
While this has been a point of contention and discussion among many groups, the upcoming [OAuth 2.1 ](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11#section-5.1.1)specification clarifies that the string "Bearer" should be case insensitive. 

The fix is simple, replace the use of strrpos with the case insensitive version strripos.

This would allow Laravel to validate both "Bearer" and "bearer" and "bEaReR" for the auth schema as defined in the draft OAuth 2.1 specifications.

More background and discussion can be viewed in this [blog article](https://auth0.com/blog/the-bearer-token-case/) from Auth0/Okta.