### PR TITLE
[11.x] Fix: Ensure generated policies return boolean values

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -13,7 +13,7 @@ class {{ class }}
      */
     public function viewAny({{ user }} $user): bool
     {
-        //
+        return true;
     }
 
     /**
@@ -21,7 +21,7 @@ class {{ class }}
      */
     public function view({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
-        //
+        return true;
     }
 
     /**
@@ -29,7 +29,7 @@ class {{ class }}
      */
     public function create({{ user }} $user): bool
     {
-        //
+        return true;
     }
 
     /**
@@ -37,7 +37,7 @@ class {{ class }}
      */
     public function update({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
-        //
+        return true;
     }
 
     /**
@@ -45,7 +45,7 @@ class {{ class }}
      */
     public function delete({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
-        //
+        return true;
     }
 
     /**
@@ -53,7 +53,7 @@ class {{ class }}
      */
     public function restore({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
-        //
+        return true;
     }
 
     /**
@@ -61,6 +61,6 @@ class {{ class }}
      */
     public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
-        //
+        return true;
     }
 }


### PR DESCRIPTION
### Summary
This PR resolves an issue where the methods in policies generated via commands such as `make:model ModelName --policy` returned a `bool` type but lacked implementations, causing PhpStan to report type errors. The problem stems from the empty method bodies in the default policy stubs.

### Changes Made
- Updated the policy stub to include default `true` return values for all methods:
  - `viewAny`
  - `view`
  - `create`
  - `update`
  - `delete`
  - `restore`
  - `forceDelete`
  
This ensures the generated methods comply with their defined return types and eliminates PhpStan type-checking errors.

### How to Test
1. Generate a new model with a policy using `php artisan make:model Example --policy`.
2. Inspect the generated policy methods for default `true` return values.
3. Confirm that running static analysis (e.g., PhpStan) no longer raises type errors for the generated policy.

### Impact
This change improves developer experience by making generated policies immediately usable without requiring manual fixes to satisfy static analysis.

Let me know if further details are needed!
