### PR TITLE
[11.x] Enhance testability of batched jobs

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Closure;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Number;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Throwable;
-use Closure;
-use Illuminate\Support\Number;
 
 class PendingBatchFake extends PendingBatch
 {
@@ -78,8 +78,7 @@ class PendingBatchFake extends PendingBatch
         }
 
         PHPUnit::assertTrue(
-            $this->jobs->contains(fn ($job) =>
-                get_class($job) === $expectedJob &&
+            $this->jobs->contains(fn ($job) => get_class($job) === $expectedJob &&
                     $this->parametersMatch($job, $expectedJob, $expectedParameters)
             ),
             "The batch does not contain a job of type [{$expectedJob}]."
@@ -158,7 +157,7 @@ class PendingBatchFake extends PendingBatch
             $this->jobs->contains(function ($job) use ($expectedJobs) {
                 return in_array(get_class($job), $expectedJobs);
             }),
-            "The batch does not contains any of the expected jobs."
+            'The batch does not contains any of the expected jobs.'
         );
 
         array_push($this->expected, ...$expectedJobs);
@@ -176,7 +175,7 @@ class PendingBatchFake extends PendingBatch
     {
         $firstJob = $this->jobs->first();
 
-        PHPUnit::assertNotNull($firstJob, "Failed to assert the batch contains any jobs.");
+        PHPUnit::assertNotNull($firstJob, 'Failed to assert the batch contains any jobs.');
 
         try {
             $callback(
@@ -186,7 +185,7 @@ class PendingBatchFake extends PendingBatch
                 )
             );
         } catch (Throwable $e) {
-            throw new $e('The first one in the batch does not matches the given callback: ' . $e->getMessage());
+            throw new $e('The first one in the batch does not matches the given callback: '.$e->getMessage());
         }
 
         array_push($this->expected, is_array($firstJob) ?
@@ -311,8 +310,8 @@ class PendingBatchFake extends PendingBatch
         $expectedJobs = array_map('serialize', $this->expected);
 
         $actualJobs = $this->jobs->map(
-            fn($job) => serialize(is_array($job) ?
-                array_map(fn($j) => get_class($j), $job) :
+            fn ($job) => serialize(is_array($job) ?
+                array_map(fn ($j) => get_class($j), $job) :
                 get_class($job)
             )
         )->toArray();
@@ -337,7 +336,7 @@ class PendingBatchFake extends PendingBatch
     {
         PHPUnit::assertNotEmpty(
             $expectedClass,
-            sprintf("The job of type [%s] does not exists.", get_class($actual))
+            sprintf('The job of type [%s] does not exists.', get_class($actual))
         );
 
         PHPUnit::assertEquals(

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -319,7 +319,7 @@ class PendingBatchFake extends PendingBatch
 
         PHPUnit::assertNotEmpty(
             array_diff($actualJobs, $expectedJobs),
-            'Failed to assert that there are unexpected jobs in the batch.'
+            'There are no additional jobs in the batch.'
         );
 
         return $this;

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class PendingBatchFake extends PendingBatch
 {
@@ -13,6 +14,13 @@ class PendingBatchFake extends PendingBatch
      * @var \Illuminate\Support\Testing\Fakes\BusFake
      */
     protected $bus;
+
+    /**
+     * The jobs that have been checked.
+     *
+     * @var array
+     */
+    protected $expected = [];
 
     /**
      * Create a new pending batch instance.
@@ -45,5 +53,251 @@ class PendingBatchFake extends PendingBatch
     public function dispatchAfterResponse()
     {
         return $this->bus->recordPendingBatch($this);
+    }
+
+    /**
+     * Assert that the batch contains a job of the given type.
+     *
+     * @param  string|int  $expectedJob
+     * @param  array  $expectedParameters
+     * @return $this
+     */
+    public function has(string|int $expectedJob, array $expectedParameters = [])
+    {
+        if (is_int($expectedJob)) {
+            PHPUnit::assertCount(
+                $expectedJob,
+                $this->jobs,
+                "Failed to assert the batch contains the exact number of [{$expectedJob}] jobs."
+            );
+
+            return $this;
+        }
+
+        PHPUnit::assertTrue(
+            $this->jobs->contains(fn ($job) =>
+                get_class($job) === $expectedJob &&
+                    $this->parametersMatch($job, $expectedJob, $expectedParameters)
+            ),
+            "Failed to assert the batch contains a job of type [{$expectedJob}]."
+        );
+
+        array_push($this->expected, $expectedJob);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch does not contain a job of the given type.
+     *
+     * @param  string  $expectedJob
+     * @return $this
+     */
+    public function missing(string $expectedJob)
+    {
+        PHPUnit::assertFalse(
+            $this->jobs->contains(function ($job) use ($expectedJob) {
+                return get_class($job) === $expectedJob;
+            }),
+            "Failed to assert the batch misses a job of type [{$expectedJob}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch contains all of the given jobs.
+     *
+     * @param  array  $expectedJobs
+     * @return $this
+     */
+    public function hasAll(array $expectedJobs)
+    {
+        foreach ($expectedJobs as $expectedJob) {
+            $this->has($expectedJob);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch does not contain any of the given jobs.
+     *
+     * @param  array  $expectedJobs
+     * @return $this
+     */
+    public function missingAll(array $expectedJobs)
+    {
+        foreach ($expectedJobs as $expectedJob) {
+            $this->missing($expectedJob);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch contains any of the given jobs.
+     *
+     * @param  array  $expectedJobs
+     * @return $this
+     */
+    public function hasAny(...$expectedJobs)
+    {
+        PHPUnit::assertTrue(
+            $this->jobs->contains(function ($job) use ($expectedJobs) {
+                return in_array(get_class($job), $expectedJobs);
+            }),
+            "Failed to assert the batch contains any of the specified jobs."
+        );
+
+        array_push($this->expected, ...$expectedJobs);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the first job in the batch matches the given callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function first(callable $callback)
+    {
+        $firstJob = $this->jobs->first();
+
+        PHPUnit::assertNotNull($firstJob, "Failed to assert the batch contains any jobs.");
+
+        $callback(
+            new self(
+                $this->bus,
+                is_array($firstJob) ? collect($firstJob) : collect([$firstJob])
+            )
+        );
+
+        array_push($this->expected, is_array($firstJob) ?
+            array_map(fn ($job) => get_class($job), $firstJob) :
+            get_class($firstJob)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the nth job in the batch matches the given callback.
+     *
+     * @param  int  $index
+     * @param  callable  $callback
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function nth(int $index, callable|string $callback, array $parameters = [])
+    {
+        $nthJob = $this->jobs->slice($index, 1)->first();
+
+        PHPUnit::assertNotNull($nthJob, "Failed to assert the batch contains a job at index [{$index}].");
+
+        // If the callback is a callable, we will assume the nthJob will matches the callback.
+        if (func_num_args() == 2) {
+            $callback(
+                new self(
+                    $this->bus,
+                    is_array($nthJob) ? collect($nthJob) : collect([$nthJob])
+                )
+            );
+
+            array_push($this->expected, is_array($nthJob) ?
+                array_map(fn ($job) => get_class($job), $nthJob) :
+                get_class($nthJob)
+            );
+        }
+
+        // If the callback is a string, we will assume the nthJob will matches the given type and parameters.
+        if (func_num_args() == 3) {
+            PHPUnit::assertTrue(
+                get_class($nthJob) === $callback &&
+                    $this->parametersMatch($nthJob, $callback, $parameters),
+                "Failed to assert the [{$index}]th job in the batch has a type of [{$callback}]."
+            );
+
+            array_push($this->expected, $callback);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch contains exactly the given jobs with the specified parameters.
+     *
+     * @param  array  $expectedJobs
+     * @return $this
+     */
+    public function equal(array $expectedJobs)
+    {
+        $this->jobs->each(function ($actualJob, $nth) use (&$expectedJobs) {
+            if (is_array($actualJob)) {
+                PHPUnit::assertTrue(
+                    is_array(current($expectedJobs)),
+                    "Failed to assert that the [{$nth}]th job in the batch is an array."
+                );
+
+                foreach ($actualJob as $nestedJob) {
+                    $jobClass = get_class($nestedJob);
+                    $this->parametersMatch($nestedJob, $jobClass, current($expectedJobs)[$jobClass] ?? []);
+                }
+
+                next($expectedJobs);
+
+                return true;
+            }
+
+            $jobClass = get_class($actualJob);
+            $this->parametersMatch($actualJob, $jobClass, $expectedJobs[$jobClass] ?? []);
+            next($expectedJobs);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch has unexpected jobs beyond those checked.
+     *
+     * @return $this
+     */
+    public function etc()
+    {
+        $expectedJobs = array_map('serialize', $this->expected);
+
+        $actualJobs = $this->jobs->map(
+            fn($job) => serialize(is_array($job) ?
+                array_map(fn($j) => get_class($j), $job) :
+                get_class($job)
+            )
+        )->toArray();
+
+        PHPUnit::assertNotEmpty(
+            array_diff($actualJobs, $expectedJobs),
+            'Failed to assert that there are unexpected jobs in the batch.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the batch does not contain any of the given jobs.
+     *
+     * @param  mixed  $actual
+     * @param  string  $expectedClass
+     * @param  array  $expectedParameters
+     * @return bool
+     */
+    protected function parametersMatch($actual, string $expectedClass, array $expectedParameters)
+    {
+        PHPUnit::assertEquals(
+            new $expectedClass(...$expectedParameters),
+            $actual,
+            "Failed to assert that the job parameters match the expected values for class [{$expectedClass}]."
+        );
+
+        return true;
     }
 }

--- a/tests/Testing/Fluent/AssertPendingBatchTest.php
+++ b/tests/Testing/Fluent/AssertPendingBatchTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Testing\Fluent;
 
-use Illuminate\Support\Facades\Bus;
-use Illuminate\Bus\Queueable;
 use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Testing\Fakes\PendingBatchFake;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
@@ -22,8 +22,7 @@ class AssertPendingBatchTest extends TestCase
             new DJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(AJob::class, [1, 2])
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(AJob::class, [1, 2])
                 ->has(BJob::class)
                 ->has(CJob::class)
                 ->etc()
@@ -90,8 +89,7 @@ class AssertPendingBatchTest extends TestCase
             new CJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(AJob::class)
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
                 ->missing(BJob::class)
         );
     }
@@ -122,9 +120,7 @@ class AssertPendingBatchTest extends TestCase
             new BJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->hasAll([AJob::class, BJob::class])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->hasAll([AJob::class, BJob::class]));
     }
 
     public function test_pending_batch_has_all_fail_when_missing()
@@ -139,9 +135,7 @@ class AssertPendingBatchTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('The batch does not contain all expected jobs.');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->hasAll([AJob::class, BJob::class])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->hasAll([AJob::class, BJob::class]));
     }
 
     public function test_pending_batch_missing_all()
@@ -153,9 +147,7 @@ class AssertPendingBatchTest extends TestCase
             new BJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->missingAll([CJob::class, DJob::class])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->missingAll([CJob::class, DJob::class]));
     }
 
     public function test_pending_batch_missing_all_fail_when_has()
@@ -182,8 +174,7 @@ class AssertPendingBatchTest extends TestCase
             new CJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(2)
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(2)
                 ->has(AJob::class)
                 ->hasAny(BJob::class, CJob::class, DJob::class)
         );
@@ -200,9 +191,7 @@ class AssertPendingBatchTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('The batch does not contains any of the expected jobs.');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->hasAny(BJob::class, CJob::class, DJob::class)
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->hasAny(BJob::class, CJob::class, DJob::class));
     }
 
     public function test_nested_jobs_in_pending_batch()
@@ -221,18 +210,13 @@ class AssertPendingBatchTest extends TestCase
             ],
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(3)
-                ->first(fn (PendingBatchFake $assert) =>
-                    $assert->has(AJob::class, [1])
-                        ->has(BJob::class, [1])
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(3)
+                ->first(fn (PendingBatchFake $assert) => $assert->has(AJob::class, [1])
+                    ->has(BJob::class, [1])
                 )
-                ->nth(1, fn (PendingBatchFake $assert) =>
-                    $assert->has(CJob::class, [2])
-                )
-                ->nth(2, fn (PendingBatchFake $assert) =>
-                    $assert->has(CJob::class, [2])
-                        ->has(DJob::class, [2])
+                ->nth(1, fn (PendingBatchFake $assert) => $assert->has(CJob::class, [2]))
+                ->nth(2, fn (PendingBatchFake $assert) => $assert->has(CJob::class, [2])
+                    ->has(DJob::class, [2])
                 )
         );
     }
@@ -254,12 +238,10 @@ class AssertPendingBatchTest extends TestCase
             'The first one in the batch does not matches the given callback: The batch does not contain a job of type [Illuminate\Testing\Fluent\CJob]'
         );
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->first(fn (PendingBatchFake $assert) =>
-                    $assert->has(2)
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->first(fn (PendingBatchFake $assert) => $assert->has(2)
                         ->has(BJob::class, [1])
                         ->has(CJob::class, [2])
-                )
+            )
         );
     }
 
@@ -273,8 +255,7 @@ class AssertPendingBatchTest extends TestCase
             new CJob(1),
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->nth(0, AJob::class, [0, 1])
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->nth(0, AJob::class, [0, 1])
                 ->nth(1, BJob::class, [1])
                 ->nth(2, CJob::class, [1])
         );
@@ -293,9 +274,7 @@ class AssertPendingBatchTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('The batch does not contains a job at index [3].');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->nth(3, CJob::class)
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->nth(3, CJob::class));
     }
 
     public function test_nested_jobs_in_pending_batch_fail_when_nth_missing()
@@ -315,11 +294,7 @@ class AssertPendingBatchTest extends TestCase
             'The [1st] one in the batch does not matches the given callback: The batch does not contain a job of type [Illuminate\Testing\Fluent\AJob]'
         );
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->nth(1, fn (PendingBatchFake $assert) =>
-                $assert->has(AJob::class, [1])->has(BJob::class, [1])
-            )
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->nth(1, fn (PendingBatchFake $assert) => $assert->has(AJob::class, [1])->has(BJob::class, [1])));
     }
 
     public function test_nested_jobs_in_pending_batch_fail_when_nth_does_not_match()
@@ -337,10 +312,9 @@ class AssertPendingBatchTest extends TestCase
             'The batch does not contain a job of type [Illuminate\Testing\Fluent\DJob] at index [2].'
         );
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->nth(0, AJob::class, [0, 1])
-                ->nth(1, BJob::class, [1])
-                ->nth(2, DJob::class, [1])
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->nth(0, AJob::class, [0, 1])
+            ->nth(1, BJob::class, [1])
+            ->nth(2, DJob::class, [1])
         );
     }
 
@@ -361,11 +335,7 @@ class AssertPendingBatchTest extends TestCase
             'The [0th] one in the batch does not matches the given callback: The job parameters does not match the expected values for class [Illuminate\Testing\Fluent\AJob].'
         );
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->nth(0, fn (PendingBatchFake $assert) =>
-                $assert->has(AJob::class, [2])->has(BJob::class)
-            )
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->nth(0, fn (PendingBatchFake $assert) => $assert->has(AJob::class, [2])->has(BJob::class)));
     }
 
     public function test_equal_jobs_in_pending_batch()
@@ -380,15 +350,13 @@ class AssertPendingBatchTest extends TestCase
             new EJob(2, 3),
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->equal([
-                AJob::class => [0, 1],
-                BJob::class => [1],
-                CJob::class => [1],
-                DJob::class => [2],
-                EJob::class => [2, 3],
-            ])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->equal([
+            AJob::class => [0, 1],
+            BJob::class => [1],
+            CJob::class => [1],
+            DJob::class => [2],
+            EJob::class => [2, 3],
+        ]));
     }
 
     public function test_equal_jobs_in_pending_batch_fail_when_job_missing()
@@ -408,14 +376,12 @@ class AssertPendingBatchTest extends TestCase
             'The job of type [Illuminate\Testing\Fluent\EJob] does not exists.'
         );
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->equal([
-                AJob::class => [0, 1],
-                BJob::class => [1],
-                CJob::class => [1],
-                DJob::class => [2],
-            ])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->equal([
+            AJob::class => [0, 1],
+            BJob::class => [1],
+            CJob::class => [1],
+            DJob::class => [2],
+        ]));
     }
 
     public function test_equal_jobs_in_pending_batch_fail_when_job_parameters_does_not_match()
@@ -435,15 +401,13 @@ class AssertPendingBatchTest extends TestCase
             'The job parameters does not match the expected values for class [Illuminate\Testing\Fluent\EJob].'
         );
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->equal([
-                AJob::class => [0, 1],
-                BJob::class => [1],
-                CJob::class => [1],
-                DJob::class => [2],
-                EJob::class,
-            ])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->equal([
+            AJob::class => [0, 1],
+            BJob::class => [1],
+            CJob::class => [1],
+            DJob::class => [2],
+            EJob::class,
+        ]));
     }
 
     public function test_equal_with_nested_jobs_in_pending_batch()
@@ -464,21 +428,19 @@ class AssertPendingBatchTest extends TestCase
             new CJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->equal([
-                AJob::class => [1],
-                [
-                    BJob::class => [2, 3],
-                    CJob::class,
-                    DJob::class => [4],
-                ],
-                [
-                    AJob::class => [1, 2],
-                    BJob::class,
-                ],
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->equal([
+            AJob::class => [1],
+            [
+                BJob::class => [2, 3],
                 CJob::class,
-            ])
-        );
+                DJob::class => [4],
+            ],
+            [
+                AJob::class => [1, 2],
+                BJob::class,
+            ],
+            CJob::class,
+        ]));
     }
 
     public function test_equal_with_nested_jobs_in_pending_batch_fail_when_is_not_array()
@@ -490,21 +452,19 @@ class AssertPendingBatchTest extends TestCase
             [
                 new BJob(2, 3),
                 new CJob,
-                new DJob(4),
+                new DJob(4)
             ]
         ])->dispatch();
 
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('The one in the batch at index [1] is not an array.');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->equal([
-                AJob::class => [1],
-                BJob::class => [2, 3],
-                CJob::class,
-                DJob::class => [4],
-            ])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->equal([
+            AJob::class => [1],
+            BJob::class => [2, 3],
+            CJob::class,
+            DJob::class => [4],
+        ]));
     }
 
     public function test_equal_with_nested_jobs_in_pending_batch_fail_when_is_not_same()
@@ -523,15 +483,13 @@ class AssertPendingBatchTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('The [1st] one in the batch at index [2] does not match: The job of type [Illuminate\Testing\Fluent\DJob] does not exists.');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->equal([
-                AJob::class => [1],
-                [
-                    BJob::class => [2, 3],
-                    CJob::class,
-                ]
-            ])
-        );
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->equal([
+            AJob::class => [1],
+            [
+                BJob::class => [2, 3],
+                CJob::class,
+            ]
+        ]));
     }
 
     public function test_etc_with_additional_job()
@@ -545,11 +503,10 @@ class AssertPendingBatchTest extends TestCase
             new DJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(AJob::class)
-                ->has(BJob::class)
-                ->has(CJob::class)
-                ->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
+            ->has(BJob::class)
+            ->has(CJob::class)
+            ->etc()
         );
     }
 
@@ -564,11 +521,10 @@ class AssertPendingBatchTest extends TestCase
             new DJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(CJob::class)
-                ->has(AJob::class)
-                ->has(BJob::class)
-                ->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(CJob::class)
+            ->has(AJob::class)
+            ->has(BJob::class)
+            ->etc()
         );
     }
 
@@ -584,12 +540,11 @@ class AssertPendingBatchTest extends TestCase
             new DJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(AJob::class)
-                ->has(BJob::class)
-                ->has(AJob::class)
-                ->has(CJob::class)
-                ->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
+            ->has(BJob::class)
+            ->has(AJob::class)
+            ->has(CJob::class)
+            ->etc()
         );
     }
 
@@ -606,13 +561,12 @@ class AssertPendingBatchTest extends TestCase
             new DJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(AJob::class)
-                ->has(BJob::class)
-                ->has(AJob::class)
-                ->has(BJob::class)
-                ->has(CJob::class)
-                ->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
+            ->has(BJob::class)
+            ->has(AJob::class)
+            ->has(BJob::class)
+            ->has(CJob::class)
+            ->etc()
         );
     }
 
@@ -628,12 +582,11 @@ class AssertPendingBatchTest extends TestCase
             new DJob,
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(BJob::class)
-                ->has(AJob::class)
-                ->has(CJob::class)
-                ->has(AJob::class)
-                ->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(BJob::class)
+            ->has(AJob::class)
+            ->has(CJob::class)
+            ->has(AJob::class)
+            ->etc()
         );
     }
 
@@ -649,10 +602,9 @@ class AssertPendingBatchTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('There are no additional jobs in the batch.');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->has(AJob::class)
-                ->has(BJob::class)
-                ->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
+            ->has(BJob::class)
+            ->etc()
         );
     }
 
@@ -672,14 +624,10 @@ class AssertPendingBatchTest extends TestCase
             ],
         ])->dispatch();
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->first(fn (PendingBatchFake $assert) =>
-                    $assert->has(AJob::class)
-                        ->has(BJob::class)
-                )
-                ->nth(1, fn (PendingBatchFake $assert) =>
-                    $assert->has(CJob::class)
-                )->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->first(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
+            ->has(BJob::class))
+            ->nth(1, fn (PendingBatchFake $assert) => $assert->has(CJob::class))
+            ->etc()
         );
     }
 
@@ -702,17 +650,12 @@ class AssertPendingBatchTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('There are no additional jobs in the batch.');
 
-        Bus::assertBatched(fn (PendingBatchFake $assert) =>
-            $assert->first(fn (PendingBatchFake $assert) =>
-                    $assert->has(AJob::class)
-                        ->has(BJob::class)
-                )
-                ->nth(1, fn (PendingBatchFake $assert) =>
-                    $assert->has(CJob::class)
-                )->nth(2, fn (PendingBatchFake $assert) =>
-                    $assert->has(CJob::class)
-                        ->has(DJob::class)
-                )->etc()
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->first(fn (PendingBatchFake $assert) => $assert->has(AJob::class)
+            ->has(BJob::class))
+            ->nth(1, fn (PendingBatchFake $assert) => $assert->has(CJob::class))
+            ->nth(2, fn (PendingBatchFake $assert) => $assert->has(CJob::class)
+                ->has(DJob::class)
+            )->etc()
         );
     }
 }
@@ -721,7 +664,8 @@ trait Parameterable
 {
     public $parameters = [];
 
-    public function __construct(...$parameters) {
+    public function __construct(...$parameters)
+    {
         $this->parameters = $parameters;
     }
 }

--- a/tests/Testing/Fluent/AssertPendingBatchTest.php
+++ b/tests/Testing/Fluent/AssertPendingBatchTest.php
@@ -452,8 +452,8 @@ class AssertPendingBatchTest extends TestCase
             [
                 new BJob(2, 3),
                 new CJob,
-                new DJob(4)
-            ]
+                new DJob(4),
+            ],
         ])->dispatch();
 
         $this->expectException(AssertionFailedError::class);

--- a/tests/Testing/Fluent/AssertPendingBatchTest.php
+++ b/tests/Testing/Fluent/AssertPendingBatchTest.php
@@ -2,6 +2,196 @@
 
 namespace Illuminate\Testing\Fluent;
 
-class AssertPendingBatchTest{
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Bus\Queueable;
+use Illuminate\Bus\Batchable;
+use Illuminate\Support\Testing\Fakes\PendingBatchFake;
+use Orchestra\Testbench\TestCase;
 
+class AssertPendingBatchTest extends TestCase
+{
+    public function test_pending_batch_has()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob(1, 2),
+            new BJob,
+            new CJob,
+            new DJob,
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->has(AJob::class, [1, 2])
+                ->has(BJob::class)
+                ->has(CJob::class)
+                ->etc()
+        );
+    }
+
+    public function test_pending_batch_missing()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new CJob,
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->has(AJob::class)
+                ->missing(BJob::class)
+        );
+    }
+
+    public function test_pending_batch_has_all_and_missing_all()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new BJob,
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->hasAll([AJob::class, BJob::class])
+                ->missingAll([CJob::class, DJob::class])
+        );
+    }
+
+    public function test_pending_batch_has_and_has_any()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new CJob,
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->has(2)
+                ->has(AJob::class)
+                ->hasAny(BJob::class, CJob::class, DJob::class)
+        );
+    }
+
+    public function test_nested_jobs_in_pending_batch()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            [
+                new AJob(1),
+                new BJob(1),
+            ],
+            new CJob(2),
+            [
+                new CJob(2),
+                new DJob(2),
+            ],
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->has(3)
+                ->first(fn (PendingBatchFake $assert) =>
+                    $assert->has(AJob::class, [1])
+                        ->has(BJob::class, [1])
+                )
+                ->nth(1, fn (PendingBatchFake $assert) =>
+                    $assert->has(CJob::class, [2])
+                )
+                ->nth(2, fn (PendingBatchFake $assert) =>
+                    $assert->has(CJob::class, [2])
+                        ->has(DJob::class, [2])
+                )
+        );
+    }
+
+    public function test_nth_job_in_pending_batch()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob(0, 1),
+            new BJob(1),
+            new CJob(1),
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->nth(0, AJob::class, [0, 1])
+                ->nth(1, BJob::class, [1])
+                ->nth(2, CJob::class, [1])
+        );
+    }
+
+    public function test_equal_jobs_in_pending_batch()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob(0, 1),
+            new BJob(1),
+            new CJob(1),
+            new DJob(2),
+            new EJob(2, 3),
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->equal([
+                AJob::class => [0, 1],
+                BJob::class => [1],
+                CJob::class => [1],
+                DJob::class => [2],
+                EJob::class => [2, 3],
+            ])
+        );
+    }
+
+    public function test_etc_with_additional_job()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new BJob,
+            new CJob,
+            new DJob,
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->has(AJob::class)
+                ->has(BJob::class)
+                ->has(CJob::class)
+                ->etc()
+        );
+    }
+}
+
+trait Parameterable
+{
+    public $parameters = [];
+
+    public function __construct(...$parameters) {
+        $this->parameters = $parameters;
+    }
+}
+
+class AJob {
+    use Queueable, Batchable, Parameterable;
+}
+
+class BJob {
+    use Queueable, Batchable, Parameterable;
+}
+
+class CJob {
+    use Queueable, Batchable, Parameterable;
+}
+
+class DJob {
+    use Queueable, Batchable, Parameterable;
+}
+
+class EJob {
+    use Queueable, Batchable, Parameterable;
 }

--- a/tests/Testing/Fluent/AssertPendingBatchTest.php
+++ b/tests/Testing/Fluent/AssertPendingBatchTest.php
@@ -30,6 +30,40 @@ class AssertPendingBatchTest extends TestCase
         );
     }
 
+    public function test_pending_batch_has_fail_when_missing()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob(1, 2),
+            new BJob,
+        ])->dispatch();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            'The batch does not contain a job of type [Illuminate\Testing\Fluent\CJob].'
+        );
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(CJob::class));
+    }
+
+    public function test_pending_batch_has_count_fail_when_incorrect()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob(1, 2),
+            new BJob,
+        ])->dispatch();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            'Failed to assert the batch contains the exact number of [3] jobs.'
+        );
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->has(3));
+    }
+
     public function test_pending_batch_missing()
     {
         Bus::fake();
@@ -45,7 +79,24 @@ class AssertPendingBatchTest extends TestCase
         );
     }
 
-    public function test_pending_batch_has_all_and_missing_all()
+    public function test_pending_batch_missing_fail_when_has()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new CJob,
+        ])->dispatch();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            'The batch does not miss a job of type [Illuminate\Testing\Fluent\AJob].'
+        );
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->missing(AJob::class));
+    }
+
+    public function test_pending_batch_has_all()
     {
         Bus::fake();
 
@@ -56,8 +107,53 @@ class AssertPendingBatchTest extends TestCase
 
         Bus::assertBatched(fn (PendingBatchFake $assert) =>
             $assert->hasAll([AJob::class, BJob::class])
-                ->missingAll([CJob::class, DJob::class])
         );
+    }
+
+    public function test_pending_batch_has_all_fail_when_missing()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new BJob,
+            new CJob,
+        ])->dispatch();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The batch does not contain all expected jobs.');
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->hasAll([AJob::class, BJob::class])
+        );
+    }
+
+    public function test_pending_batch_missing_all()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new BJob,
+        ])->dispatch();
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->missingAll([CJob::class, DJob::class])
+        );
+    }
+
+    public function test_pending_batch_missing_all_fail_when_has()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+            new BJob,
+        ])->dispatch();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The batch does not miss all of given jobs.');
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->missingAll([AJob::class]));
     }
 
     public function test_pending_batch_has_and_has_any()
@@ -73,6 +169,22 @@ class AssertPendingBatchTest extends TestCase
             $assert->has(2)
                 ->has(AJob::class)
                 ->hasAny(BJob::class, CJob::class, DJob::class)
+        );
+    }
+
+    public function test_pending_batch_has_any_fail_when_missing()
+    {
+        Bus::fake();
+
+        Bus::batch([
+            new AJob,
+        ])->dispatch();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The batch does not contains any of the expected jobs.');
+
+        Bus::assertBatched(fn (PendingBatchFake $assert) =>
+            $assert->hasAny(BJob::class, CJob::class, DJob::class)
         );
     }
 

--- a/tests/Testing/Fluent/AssertPendingBatchTest.php
+++ b/tests/Testing/Fluent/AssertPendingBatchTest.php
@@ -241,7 +241,7 @@ class AssertPendingBatchTest extends TestCase
         Bus::assertBatched(fn (PendingBatchFake $assert) => $assert->first(fn (PendingBatchFake $assert) => $assert->has(2)
                         ->has(BJob::class, [1])
                         ->has(CJob::class, [2])
-            )
+        )
         );
     }
 
@@ -477,7 +477,7 @@ class AssertPendingBatchTest extends TestCase
                 new BJob(2, 3),
                 new CJob,
                 new DJob(4),
-            ]
+            ],
         ])->dispatch();
 
         $this->expectException(AssertionFailedError::class);
@@ -488,7 +488,7 @@ class AssertPendingBatchTest extends TestCase
             [
                 BJob::class => [2, 3],
                 CJob::class,
-            ]
+            ],
         ]));
     }
 

--- a/tests/Testing/Fluent/AssertPendingBatchTest.php
+++ b/tests/Testing/Fluent/AssertPendingBatchTest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Testing\Fluent;
+
+class AssertPendingBatchTest{
+
+}


### PR DESCRIPTION
The current approach to testing batched jobs, as shown below, is somewhat unconventional:

```
Bus::assertBatched(fn (PendingBatchFake $batchedCollection) =>
    $batchedCollection->jobs->count() === 1 && $batchedCollection->jobs->first()->value === 'hello';
);
```

This pull request introduces some helper functions to enhance the testability of batched jobs. Inspired by [fluent JSON testing](https://laravel.com/docs/11.x/http-tests#fluent-json-testing), these methods provide a more streamlined and readable approach to testing job batches within the Laravel application. The goal is to improve developer experience by offering clear, concise methods with illustrative examples.

## Example Usage

### `has`

```php
public function has(string|int $expectedJob, array $expectedParameters = [])
```

Assert that the batch contains a job of the given type. You can also pass an integer to assert that the batch contains the exact number of jobs.

**Example:**

```php
Bus::fake();

Bus::batch([
    new AJob(1, 2),
    new BJob,
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->has(2)
        ->has(AJob::class, [1, 2])
);
```

### `missing`

```php
public function missing(string $expectedJob)
```

Assert that the batch does not contain a job of the given type.

**Example:**

```php
Bus::fake();

Bus::batch([
    new BJob,
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->missing(AJob::class)
);
```

### `hasAll`

```php
public function hasAll(array $expectedJobs)
```

Assert that the batch contains all of the given jobs.

**Example:**

```php
Bus::fake();

Bus::batch([
    new AJob,
    new BJob,
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->hasAll([AJob::class, BJob::class])
);
```

### `missingAll`

```php
public function missingAll(array $expectedJobs)
```

Assert that the batch does not contain any of the given jobs.

**Example:**

```php
Bus::fake();

Bus::batch([
    new AJob,
    new BJob,
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->missingAll([CJob::class, DJob::class])
);
```

### `hasAny`

```php
public function hasAny(...$expectedJobs)
```

Assert that the batch contains any of the given jobs.

**Example:**

```php
Bus::fake();

Bus::batch([
    new AJob(1, 2),
    new BJob,
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->hasAny(AJob::class, CJob::class)
);
```

### `first`

```php
public function first(callable $callback)
```

Assert that the first job in the batch matches the given callback.

**Example:**

```php
Bus::fake();

Bus::batch([
    [
        new AJob(1, 2),
        new BJob,
    ],
    new CJob,
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->first(fn (PendingBatchFake $firstBatch) =>
        $firstBatch->has(AJob::class, [1, 2])
            ->has(BJob::class)
    )
);
```

### `nth`

```php
public function nth(int $index, callable|string $callback, array $parameters = [])
```

Assert that the nth job in the batch matches the given callback or type and parameters.

**Example:**

```php
Bus::fake();

Bus::batch([
    [
        new AJob(1, 2),
        new BJob
    ],
    new CJob::class(1)
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->nth(0, fn (PendingBatchFake $batch) =>
        $batch->has(AJob::class, [1, 2])
            ->has(BJob::class)
    )->nth(1, CJob::class, [1])
);
```

### `equal`

```php
public function equal(array $expectedJobs)
```

Assert that the batch contains exactly the given jobs with the specified parameters.

**Example:**

```php
Bus::fake();

Bus::batch([
    [
        new AJob(1, 2),
        new BJob
    ],
    new CJob::class(1)
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->equal([
        [
            AJob::class => [1, 2],
            BJob::class
        ],
        CJob::class => [1]
    ])
);
```

### `etc`

```php
public function etc()
```

Assert that the batch has unexpected jobs beyond those checked.

**Example:**

```php
Bus::fake();

Bus::batch([
    new AJob(1, 2),
    new BJob,
    new CJob::class(1)
])->dispatch();

Bus::assertBatched(fn (PendingBatchFake $batch) =>
    $batch->has(AJob::class, [1, 2])
        ->has(BJob::class)
        ->etc()
);
```
