### PR TITLE
[11.x] Support named in-memory SQLite connections

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -20,9 +20,8 @@ class SQLiteConnector extends Connector implements ConnectorInterface
 
         // SQLite supports "in-memory" databases that only last as long as the owning
         // connection does. These are useful for tests or for short lifetime store
-        // querying. In-memory databases may be anonymous (:memory:) or named.
-        if (
-            $config['database'] === ':memory:' ||
+        // querying. In-memory databases shall be anonymous (:memory:) or named.
+        if ($config['database'] === ':memory:' ||
             str_contains($config['database'], '?mode=memory') ||
             str_contains($config['database'], '&mode=memory')
         ) {

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -26,7 +26,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             str_contains($config['database'], '?mode=memory') ||
             str_contains($config['database'], '&mode=memory')
         ) {
-            return $this->createConnection('sqlite:' . $config['database'], $config, $options);
+            return $this->createConnection('sqlite:'.$config['database'], $config, $options);
         }
 
         $path = realpath($config['database']);

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -20,9 +20,13 @@ class SQLiteConnector extends Connector implements ConnectorInterface
 
         // SQLite supports "in-memory" databases that only last as long as the owning
         // connection does. These are useful for tests or for short lifetime store
-        // querying. In-memory databases may only have a single open connection.
-        if ($config['database'] === ':memory:') {
-            return $this->createConnection('sqlite::memory:', $config, $options);
+        // querying. In-memory databases may be anonymous (:memory:) or named.
+        if (
+            $config['database'] === ':memory:' ||
+            str_contains($config['database'], '?mode=memory') ||
+            str_contains($config['database'], '&mode=memory')
+        ) {
+            return $this->createConnection('sqlite:' . $config['database'], $config, $options);
         }
 
         $path = realpath($config['database']);

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -92,8 +92,7 @@ class SQLiteBuilder extends Builder
     {
         $database = $this->connection->getDatabaseName();
 
-        if (
-            $database !== ':memory:' &&
+        if ($database !== ':memory:' &&
             ! str_contains($database, '?mode=memory') &&
             ! str_contains($database, '&mode=memory')
         ) {

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -90,7 +90,13 @@ class SQLiteBuilder extends Builder
      */
     public function dropAllTables()
     {
-        if ($this->connection->getDatabaseName() !== ':memory:') {
+        $database = $this->connection->getDatabaseName();
+
+        if (
+            $database !== ':memory:' &&
+            ! str_contains($database, '?mode=memory') &&
+            ! str_contains($database, '&mode=memory')
+        ) {
             return $this->refreshDatabaseFile();
         }
 

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -60,7 +60,13 @@ class SqliteSchemaState extends SchemaState
      */
     public function load($path)
     {
-        if ($this->connection->getDatabaseName() === ':memory:') {
+        $database = $this->connection->getDatabaseName();
+
+        if (
+            $database === ':memory:' ||
+            str_contains($database, '?mode=memory') ||
+            str_contains($database, '&mode=memory')
+        ) {
             $this->connection->getPdo()->exec($this->files->get($path));
 
             return;

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -62,8 +62,7 @@ class SqliteSchemaState extends SchemaState
     {
         $database = $this->connection->getDatabaseName();
 
-        if (
-            $database === ':memory:' ||
+        if ($database === ':memory:' ||
             str_contains($database, '?mode=memory') ||
             str_contains($database, '&mode=memory')
         ) {

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -270,6 +270,19 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testSQLiteNamedMemoryDatabasesMayBeConnectedTo()
+    {
+        $dsn = 'sqlite:file:mydb?mode=memory&cache=shared';
+        $config = ['database' => 'file:mydb?mode=memory&cache=shared'];
+        $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(stdClass::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testSQLiteFileDatabasesMayBeConnectedTo()
     {
         $dsn = 'sqlite:'.__DIR__;


### PR DESCRIPTION
SQLite supports *named* in-memory databases. The benefit of named connections is that you can essentially "reconnect" to the same memory region even **without passing a PDO instance around**. Only the DSN needs to be the same.

Here's an example:
```php
<?php

function ensure_table_exists(PDO $conn) {
    if (! $conn->query('SELECT name FROM sqlite_master WHERE type="table" AND name="my_table"')->fetch()) {
        $conn->exec('CREATE TABLE my_table (name text)');
    }
}

function foo(string $dsn) {
    $conn = new PDO($dsn);
    ensure_table_exists($conn);

    $conn->exec('INSERT INTO my_table VALUES ("foo")');
    var_dump(array_map(fn ($res) => $res[0], $conn->query('SELECT * from my_table')->fetchAll())); // foo

    return $conn;
}

function bar(string $dsn) {
    $conn = new PDO($dsn);
    ensure_table_exists($conn);

    $conn->exec('INSERT INTO my_table VALUES ("bar")');
    var_dump(array_map(fn ($res) => $res[0], $conn->query('SELECT * from my_table')->fetchAll())); // foo + bar

    return $conn;
}

$dsn = "sqlite:file:mydb?mode=memory&cache=shared";
// $dsn = 'sqlite::memory:';

$_ = foo($dsn);
bar($dsn);
```

It shows how you can connect to the same database, without passing the PDO instance directly, as long as the DSN string is identical. `foo()` will log `foo` while `bar()` will log `foo` **and** `bar`. The only condition here is that the connection is kept alive *somehow*.

If you swap the `$dsn` definitions, both `foo()` and `bar()` will create their own database when the PDO connection is created (and free it once `$conn` goes out of scope). Additionally, if you remove the `$_ =`, the memory of the database will be freed as there's no longer any open connection, so it'll behave identically to `:memory:`.

### Practical use case

This lets me support `:memory:` in my tenancy package for testing tenant databases, providing a nice speedup. During the tenant creation process there's a lot of logic that essentially keeps connecting to and disconnecting from the tenant DB. Users may also switch to the central context using `tenancy()->end()` or `tenancy()->central(closure)` which closes the tenant connection.

With named databases, I only need to keep a connection to the tenant DB alive *somewhere* (literally just `register_shutdown_function(fn () => $conn)` works) and then the package can seamlessly connect to and disconnect from tenant databases that live entirely in process memory and don't need any special cleanup.

### Code style

I could just check for `mode=memory` but that could *in theory* be part of a real filename. Don't think it'd make anything vulnerable if the `realpath()` check got skipped, but I went with `?mode` || `&mode` just in case since it's a little more restrictive.

The DSN syntax for named in-memory databases [is just `mode=memory` in URI format](https://www.sqlite.org/inmemorydb.html#:~:text=then%20the%20mode%3Dmemory%20query%20parameter%20can%20be%20used) typically paired with `cache=shared`. The order being arbitrary.

I also tried to respect the 3 char rule in the comment but couldn't think of anything that'd fit here better, so the last line is an extra character shorter.