### PR TITLE
[11.x] Add `hasMorePages()` to CursorPaginator contract

### DIFF
--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -98,6 +98,13 @@ interface CursorPaginator
     public function hasPages();
 
     /**
+     * Determine if there are more items in the data source.
+     *
+     * @return bool
+     */
+    public function hasMorePages();
+
+    /**
      * Get the base path for paginator generated URLs.
      *
      * @return string|null


### PR DESCRIPTION
This is a useful method that was previously missing. The regular `Paginator` contract already implements this.