### PR TITLE
event name & listener callback types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -183,7 +183,7 @@ trait HasEvents
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     protected static function registerModelEvent($event, $callback)
@@ -266,7 +266,7 @@ trait HasEvents
     /**
      * Register a retrieved model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function retrieved($callback)
@@ -277,7 +277,7 @@ trait HasEvents
     /**
      * Register a saving model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function saving($callback)
@@ -288,7 +288,7 @@ trait HasEvents
     /**
      * Register a saved model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function saved($callback)
@@ -299,7 +299,7 @@ trait HasEvents
     /**
      * Register an updating model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function updating($callback)
@@ -310,7 +310,7 @@ trait HasEvents
     /**
      * Register an updated model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function updated($callback)
@@ -321,7 +321,7 @@ trait HasEvents
     /**
      * Register a creating model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function creating($callback)
@@ -332,7 +332,7 @@ trait HasEvents
     /**
      * Register a created model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function created($callback)
@@ -343,7 +343,7 @@ trait HasEvents
     /**
      * Register a replicating model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function replicating($callback)
@@ -354,7 +354,7 @@ trait HasEvents
     /**
      * Register a deleting model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function deleting($callback)
@@ -365,7 +365,7 @@ trait HasEvents
     /**
      * Register a deleted model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
      * @return void
      */
     public static function deleted($callback)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -183,7 +183,7 @@ trait HasEvents
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     protected static function registerModelEvent($event, $callback)
@@ -266,7 +266,7 @@ trait HasEvents
     /**
      * Register a retrieved model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function retrieved($callback)
@@ -277,7 +277,7 @@ trait HasEvents
     /**
      * Register a saving model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function saving($callback)
@@ -288,7 +288,7 @@ trait HasEvents
     /**
      * Register a saved model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function saved($callback)
@@ -299,7 +299,7 @@ trait HasEvents
     /**
      * Register an updating model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function updating($callback)
@@ -310,7 +310,7 @@ trait HasEvents
     /**
      * Register an updated model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function updated($callback)
@@ -321,7 +321,7 @@ trait HasEvents
     /**
      * Register a creating model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function creating($callback)
@@ -332,7 +332,7 @@ trait HasEvents
     /**
      * Register a created model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function created($callback)
@@ -343,7 +343,7 @@ trait HasEvents
     /**
      * Register a replicating model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function replicating($callback)
@@ -354,7 +354,7 @@ trait HasEvents
     /**
      * Register a deleting model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function deleting($callback)
@@ -365,7 +365,7 @@ trait HasEvents
     /**
      * Register a deleted model event with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string  $callback
      * @return void
      */
     public static function deleted($callback)

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -210,7 +210,7 @@ trait SoftDeletes
     /**
      * Register a "softDeleted" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
      * @return void
      */
     public static function softDeleted($callback)
@@ -221,7 +221,7 @@ trait SoftDeletes
     /**
      * Register a "restoring" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
      * @return void
      */
     public static function restoring($callback)
@@ -232,7 +232,7 @@ trait SoftDeletes
     /**
      * Register a "restored" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
      * @return void
      */
     public static function restored($callback)
@@ -243,7 +243,7 @@ trait SoftDeletes
     /**
      * Register a "forceDeleting" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
      * @return void
      */
     public static function forceDeleting($callback)
@@ -254,7 +254,7 @@ trait SoftDeletes
     /**
      * Register a "forceDeleted" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
+     * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback
      * @return void
      */
     public static function forceDeleted($callback)

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -210,7 +210,7 @@ trait SoftDeletes
     /**
      * Register a "softDeleted" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
      * @return void
      */
     public static function softDeleted($callback)
@@ -221,7 +221,7 @@ trait SoftDeletes
     /**
      * Register a "restoring" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
      * @return void
      */
     public static function restoring($callback)
@@ -232,7 +232,7 @@ trait SoftDeletes
     /**
      * Register a "restored" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
      * @return void
      */
     public static function restored($callback)
@@ -243,7 +243,7 @@ trait SoftDeletes
     /**
      * Register a "forceDeleting" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
      * @return void
      */
     public static function forceDeleting($callback)
@@ -254,7 +254,7 @@ trait SoftDeletes
     /**
      * Register a "forceDeleted" model event callback with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
+     * @param  \Illuminate\Events\QueuedClosure|class-string|callable  $callback
      * @return void
      */
     public static function forceDeleted($callback)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -80,8 +80,8 @@ class Dispatcher implements DispatcherContract
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $events
-     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array|null  $listener
+     * @param  \Illuminate\Events\QueuedClosure|string|class-string|array|callable  $events
+     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable|null  $listener
      * @return void
      */
     public function listen($events, $listener = null)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -80,8 +80,8 @@ class Dispatcher implements DispatcherContract
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Illuminate\Events\QueuedClosure|string|class-string|array|callable  $events
-     * @param  \Illuminate\Events\QueuedClosure|class-string|array|callable|null  $listener
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string|string  $events
+     * @param  \Illuminate\Events\QueuedClosure|callable|array|class-string|null  $listener
      * @return void
      */
     public function listen($events, $listener = null)

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Testing\Fakes\EventFake;
 
 /**
- * @method static void listen(\Illuminate\Events\QueuedClosure|\Closure|string|array $events, \Illuminate\Events\QueuedClosure|\Closure|string|array|null $listener = null)
+ * @method static void listen(\Illuminate\Events\QueuedClosure|string|class-string|array|callable $events, \Illuminate\Events\QueuedClosure|class-string|array|callable|null $listener = null)
  * @method static bool hasListeners(string $eventName)
  * @method static bool hasWildcardListeners(string $eventName)
  * @method static void push(string $event, object|array $payload = [])

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Testing\Fakes\EventFake;
 
 /**
- * @method static void listen(\Illuminate\Events\QueuedClosure|string|class-string|array|callable $events, \Illuminate\Events\QueuedClosure|class-string|array|callable|null $listener = null)
+ * @method static void listen(\Illuminate\Events\QueuedClosure|callable|array|class-string|string $events, \Illuminate\Events\QueuedClosure|callable|array|class-string|null $listener = null)
  * @method static bool hasListeners(string $eventName)
  * @method static bool hasWildcardListeners(string $eventName)
  * @method static void push(string $event, object|array $payload = [])


### PR DESCRIPTION
`$callback` type is currently `QueuedClosure|\Closure|string|array`, which includes a lot, but not invokable classes. I changed it to `QueuedClosure|class-string|array|callable` which does include invokable classes (`callable`), and is more specific about the string (`class-string`). I'm not sure though. Let's run some tests.