### PR TITLE
[11.x] Use `never` type for methods that always throws

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -93,7 +93,7 @@ class Authenticate implements AuthenticatesRequests
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $guards
-     * @return void
+     * @return never
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -171,7 +171,7 @@ trait ResponseTrait
     /**
      * Throws the response in a HttpResponseException instance.
      *
-     * @return void
+     * @return never
      *
      * @throws \Illuminate\Http\Exceptions\HttpResponseException
      */

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -113,7 +113,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $others
      * @param  string  $method
-     * @return void
+     * @return never
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
      */

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -58,7 +58,7 @@ trait ForwardsCalls
      * Throw a bad method call exception for the given method.
      *
      * @param  string  $method
-     * @return void
+     * @return never
      *
      * @throws \BadMethodCallException
      */


### PR DESCRIPTION
Since a method that always throws never returns any value, this pull request proposes to use the more precise `never` type.