### PR TITLE
[11.x] Make `withoutDefer` also return `$this`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -261,6 +261,8 @@ trait InteractsWithContainer
                 $value();
             }
         });
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -82,11 +82,12 @@ class InteractsWithContainerTest extends TestCase
         });
         $this->assertSame([], $called);
 
-        $this->withoutDefer();
+        $instance = $this->withoutDefer();
         defer(function () use (&$called) {
             $called[] = 2;
         });
         $this->assertSame([2], $called);
+        $this->assertSame($this, $instance);
 
         $this->withDefer();
         $this->assertSame([2], $called);


### PR DESCRIPTION
For consistency with other similar methods in the same trait, it is better to make the `withoutDefer` method also return `$this`.

I also think it may be a forgetting of the return statement since it is written as `@return $this` on the PHPDoc.