### PR TITLE
[11.x] Adds conditional to routes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -28,7 +28,7 @@ use function Illuminate\Support\enum_value;
 
 class Route
 {
-    use CreatesRegularExpressionRouteConstraints, Conditionable, FiltersControllerMiddleware, Macroable, ResolvesRouteDependencies;
+    use Conditionable, CreatesRegularExpressionRouteConstraints, FiltersControllerMiddleware, Macroable, ResolvesRouteDependencies;
 
     /**
      * The URI pattern the route responds to.

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -17,6 +17,7 @@ use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -27,7 +28,7 @@ use function Illuminate\Support\enum_value;
 
 class Route
 {
-    use CreatesRegularExpressionRouteConstraints, FiltersControllerMiddleware, Macroable, ResolvesRouteDependencies;
+    use CreatesRegularExpressionRouteConstraints, Conditionable, FiltersControllerMiddleware, Macroable, ResolvesRouteDependencies;
 
     /**
      * The URI pattern the route responds to.

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -943,6 +943,26 @@ class RoutingRouteTest extends TestCase
         });
         $route->where('bar', '[0-9]+');
         $this->assertFalse($route->matches($request));
+
+        /*
+         * Conditional
+         */
+        $route = new Route('GET','{subdomain}.awesome.test',function () {
+            //
+        });
+
+        $route->when(true, function ($route) {
+            $route->whereIn('subdomain', [
+                'one',
+                'two'
+            ]);
+        });
+
+        $request = Request::create('test.awesome.test', 'GET');
+        $this->assertFalse($route->matches($request));
+
+        $request = Request::create('one.awesome.test', 'GET');
+        $this->assertTrue($route->matches($request));
     }
 
     public function testRoutePrefixParameterParsing()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -947,14 +947,14 @@ class RoutingRouteTest extends TestCase
         /*
          * Conditional
          */
-        $route = new Route('GET','{subdomain}.awesome.test',function () {
+        $route = new Route('GET', '{subdomain}.awesome.test', function () {
             //
         });
 
         $route->when(true, function ($route) {
             $route->whereIn('subdomain', [
                 'one',
-                'two'
+                'two',
             ]);
         });
 


### PR DESCRIPTION
This pull request introduces the Conditionable trait to the Laravel Route class, allowing developers to add conditional logic when defining routes. Consider the following:

```
Route::middleware('shop')
    ->domain('{shop}.domain.com')
    ->when(App::isProduction(), function ($route) {
        $route->whereIn('shop', app(ShopService::class)->getShopSlugs());   
    });
```
### No Breaking Changes
This addition does not alter any existing functionality of the Route class. The Conditionable trait is introduced as an optional feature that will only be applied when explicitly used by developers. Existing routes will continue to work as expected without any modifications.

P.S. tests included. 

Thanks for your time