### PR TITLE
[12.x] Added Automatic Relation Loading (Eager Loading) Feature

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -857,7 +857,7 @@ class Builder implements BuilderContract
         $collection = $builder->getModel()->newCollection($models);
 
         if (Model::isAutoloadingRelationsGlobally()) {
-            $collection->enableRelationAutoload();
+            $collection->withRelationAutoload();
         }
 
         return $this->applyAfterQueryCallbacks($collection);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -857,7 +857,7 @@ class Builder implements BuilderContract
         $collection = $builder->getModel()->newCollection($models);
 
         if (Model::isAutoloadingRelationsGlobally()) {
-            $collection->primeRelationshipAutoloading();
+            $collection->withRelationshipAutoloading();
         }
 
         return $this->applyAfterQueryCallbacks($collection);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -857,7 +857,7 @@ class Builder implements BuilderContract
         $collection = $builder->getModel()->newCollection($models);
 
         if (Model::isAutoloadingRelationsGlobally()) {
-            $collection->withRelationAutoload();
+            $collection->primeRelationshipAutoloading();
         }
 
         return $this->applyAfterQueryCallbacks($collection);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -856,7 +856,7 @@ class Builder implements BuilderContract
 
         $collection = $builder->getModel()->newCollection($models);
 
-        if (Model::isAutoloadingRelationsGlobally()) {
+        if (Model::isAutomaticallyEagerLoadingRelationships()) {
             $collection->withRelationshipAutoloading();
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -854,9 +854,13 @@ class Builder implements BuilderContract
             $models = $builder->eagerLoadRelations($models);
         }
 
-        return $this->applyAfterQueryCallbacks(
-            $builder->getModel()->newCollection($models)
-        );
+        $collection = $builder->getModel()->newCollection($models);
+
+        if (Model::alwaysAutoloadsRelations()) {
+            $collection->enableRelationAutoload();
+        }
+
+        return $this->applyAfterQueryCallbacks($collection);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -856,7 +856,7 @@ class Builder implements BuilderContract
 
         $collection = $builder->getModel()->newCollection($models);
 
-        if (Model::alwaysAutoloadsRelations()) {
+        if (Model::isAutoloadingRelationsGlobally()) {
             $collection->enableRelationAutoload();
         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -348,9 +348,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $callback = fn ($path) => $this->loadMissingRelationWithTypes($path);
 
-        $this
-            ->filter(fn ($model) => ! $model->hasRelationAutoloadCallback())
-            ->each(fn ($model) => $model->usingRelationAutoloadCallback($this, $callback));
+        $this->each(fn ($model) => $model->hasRelationAutoloadCallback()
+            || $model->usingRelationAutoloadCallback($this, $callback));
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -255,7 +255,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function loadMissingRelationWithTypes(array $path)
     {
-        list($name, $class) = array_shift($path);
+        [$name, $class] = array_shift($path);
 
         $this->filter(fn ($model) => ! is_null($model) && ! $model->relationLoaded($name) && $model::class === $class)
             ->load($name);
@@ -342,7 +342,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Enable relation autoload for the collection.
      *
-     *  @return $this
+     * @return $this
      */
     public function enableRelationAutoload()
     {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -344,7 +344,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return $this
      */
-    public function enableRelationAutoload()
+    public function withRelationAutoload()
     {
         $callback = fn ($path) => $this->loadMissingRelationWithTypes($path);
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -755,7 +755,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return $this
      */
-    public function primeRelationshipAutoloading()
+    public function withRelationshipAutoloading()
     {
         $callback = fn ($tuples) => $this->loadMissingRelationsViaRelationAndClassTuples($tuples);
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -251,10 +251,10 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a relationship path for models of the given type if it is not already eager loaded.
      *
-     * @param  array  $tuples
+     * @param  array<int, <string, class-string>>  $tuples
      * @return void
      */
-    public function loadMissingRelationsViaRelationAndClassTuples(array $tuples)
+    public function loadMissingRelationshipChain(array $tuples)
     {
         [$relation, $class] = array_shift($tuples);
 
@@ -274,7 +274,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $models = $models->collapse();
         }
 
-        (new static($models))->loadMissingRelationsViaRelationAndClassTuples($tuples);
+        (new static($models))->loadMissingRelationshipChain($tuples);
     }
 
     /**
@@ -757,7 +757,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function withRelationshipAutoloading()
     {
-        $callback = fn ($tuples) => $this->loadMissingRelationsViaRelationAndClassTuples($tuples);
+        $callback = fn ($tuples) => $this->loadMissingRelationshipChain($tuples);
 
         foreach ($this as $model) {
             if (! $model->hasRelationAutoloadCallback()) {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -349,7 +349,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $callback = fn ($path) => $this->loadMissingRelationWithTypes($path);
 
         $this->each(fn ($model) => $model->hasRelationAutoloadCallback()
-            || $model->usingRelationAutoloadCallback($this, $callback));
+            || $model->usingRelationAutoloadCallback($callback));
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -551,7 +551,7 @@ trait HasAttributes
             return;
         }
 
-        if ($this->handleRelationAutoload($key)) {
+        if ($this->attemptToAutoloadRelation($key)) {
             return $this->relations[$key];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -551,6 +551,10 @@ trait HasAttributes
             return;
         }
 
+        if ($this->handleRelationAutoload($key)) {
+            return $this->relations[$key];
+        }
+
         if ($this->preventsLazyLoading) {
             $this->handleLazyLoadingViolation($key);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -140,7 +140,7 @@ trait HasRelationships
      *
      * @return $this
      */
-    public function enableRelationAutoload()
+    public function withRelationAutoload()
     {
         if ($this->hasRelationAutoloadCallback()) {
             return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -100,6 +100,16 @@ trait HasRelationships
     }
 
     /**
+     * Determine if a relationship autoloader callback has been defined.
+     *
+     * @return bool
+     */
+    public function hasRelationAutoloadCallback()
+    {
+        return ! is_null($this->relationAutoloadCallback);
+    }
+
+    /**
      * Define an automatic relationship autoloader callback for this model and its relations.
      *
      * @param  \Closure  $callback
@@ -115,16 +125,6 @@ trait HasRelationships
         }
 
         return $this;
-    }
-
-    /**
-     * Determine if a relationship autoloader callback has been defined.
-     *
-     * @return bool
-     */
-    public function hasRelationAutoloadCallback()
-    {
-        return ! is_null($this->relationAutoloadCallback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -40,6 +40,20 @@ trait HasRelationships
     protected $touches = [];
 
     /**
+     * The relationship autoload callback.
+     *
+     * @var ?Closure
+     */
+    protected $relationAutoloadCallback = null;
+
+    /**
+     * The relationship autoload context.
+     *
+     * @var ?Collection
+     */
+    protected $relationAutoloadContext = null;
+
+    /**
      * The many to many relationship methods.
      *
      * @var string[]
@@ -90,6 +104,132 @@ trait HasRelationships
             static::$relationResolvers,
             [static::class => [$name => $callback]]
         );
+    }
+
+    /**
+     * Set relation autoload callback for model and its relations.
+     *
+     * @param mixed $context
+     * @param Closure $callback
+     * @return $this
+     */
+    public function usingRelationAutoloadCallback($context, Closure $callback)
+    {
+        $this->relationAutoloadContext = $context;
+        $this->relationAutoloadCallback = $callback;
+
+        foreach ($this->relations as $key => $value) {
+            $this->applyRelationAutoloadCallbackToValue($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get relation autoload context.
+     *
+     * @return mixed
+     */
+    public function getRelationAutoloadContext()
+    {
+        return $this->relationAutoloadContext;
+    }
+
+    /**
+     * Enable relation autoload for model and its relations if not already enabled.
+     *
+     * @return $this
+     */
+    public function enableRelationAutoload()
+    {
+        if ($this->hasRelationAutoloadCallback()) {
+            return $this;
+        }
+
+        $collection = new Collection([$this]);
+
+        $this->usingRelationAutoloadCallback(
+            $collection,
+            fn ($path) => $collection->loadMissingRelationWithTypes($path)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Check if relation autoload callback is set.
+     *
+     * @return bool
+     */
+    public function hasRelationAutoloadCallback()
+    {
+        return ! is_null($this->relationAutoloadCallback);
+    }
+
+    /**
+     * Trigger relation autoload callback and check if relation is loaded.
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function handleRelationAutoload($key)
+    {
+        if (! $this->hasRelationAutoloadCallback()) {
+            return false;
+        }
+
+        $this->triggerRelationAutoloadCallback($key, []);
+
+        return $this->relationLoaded($key);
+    }
+
+    /**
+     * Trigger relation autoload callback.
+     *
+     * @param string $key
+     * @param array $keys
+     * @return void
+     */
+    protected function triggerRelationAutoloadCallback($key, $keys)
+    {
+        call_user_func(
+            $this->relationAutoloadCallback,
+            array_merge([[$key, get_class($this)]], $keys)
+        );
+    }
+
+    /**
+     * Apply relation autoload callback to value.
+     *
+     * @param string $key
+     * @param mixed $values
+     * @return void
+     */
+    protected function applyRelationAutoloadCallbackToValue($key, $values)
+    {
+        if (! $this->hasRelationAutoloadCallback() || ! $values) {
+            return;
+        }
+
+        if ($values instanceof Model) {
+            $values = [$values];
+        }
+
+        if (! is_iterable($values)) {
+            return;
+        }
+
+        $callback = fn (array $keys) => $this->triggerRelationAutoloadCallback($key, $keys);
+
+        foreach ($values as $item) {
+            $context = $item->getRelationAutoloadContext();
+
+            // check if relation autoload contexts are different
+            // to avoid circular relation autoload
+            if (is_null($context) || $context !== $this->relationAutoloadContext) {
+                $item->usingRelationAutoloadCallback($this->relationAutoloadContext, $callback);
+            }
+        }
     }
 
     /**
@@ -987,6 +1127,8 @@ trait HasRelationships
     public function setRelation($relation, $value)
     {
         $this->relations[$relation] = $value;
+
+        $this->applyRelationAutoloadCallbackToValue($relation, $value);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -109,8 +109,8 @@ trait HasRelationships
     /**
      * Set relation autoload callback for model and its relations.
      *
-     * @param mixed $context
-     * @param Closure $callback
+     * @param  mixed  $context
+     * @param  Closure  $callback
      * @return $this
      */
     public function usingRelationAutoloadCallback($context, Closure $callback)
@@ -169,7 +169,7 @@ trait HasRelationships
     /**
      * Trigger relation autoload callback and check if relation is loaded.
      *
-     * @param string $key
+     * @param  string  $key
      * @return bool
      */
     protected function handleRelationAutoload($key)
@@ -186,8 +186,8 @@ trait HasRelationships
     /**
      * Trigger relation autoload callback.
      *
-     * @param string $key
-     * @param array $keys
+     * @param  string  $key
+     * @param  array  $keys
      * @return void
      */
     protected function triggerRelationAutoloadCallback($key, $keys)
@@ -201,8 +201,8 @@ trait HasRelationships
     /**
      * Apply relation autoload callback to value.
      *
-     * @param string $key
-     * @param mixed $values
+     * @param  string  $key
+     * @param  mixed  $values
      * @return void
      */
     protected function applyRelationAutoloadCallbackToValue($key, $values)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -179,11 +179,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $modelsShouldPreventLazyLoading = false;
 
     /**
-     * Indicates whether relations should be automatically loaded on all models.
+     * Indicates whether relations should be automatically loaded on all models when they are accessed.
      *
      * @var bool
      */
-    protected static $modelsShouldGlobalAutoloadRelations = false;
+    protected static $modelsShouldAutomaticallyEagerLoadRelationships = false;
 
     /**
      * The callback that is responsible for handling lazy loading violations.
@@ -454,14 +454,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Determine if model relationships should be automatically loaded.
+     * Determine if model relationships should be automatically eager loaded when accessed.
      *
      * @param  bool  $value
      * @return void
      */
-    public static function globalAutoloadRelations($value = true)
+    public static function automaticallyEagerLoadRelationships($value = true)
     {
-        static::$modelsShouldGlobalAutoloadRelations = $value;
+        static::$modelsShouldAutomaticallyEagerLoadRelationships = $value;
     }
 
     /**
@@ -2250,13 +2250,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Determine if relations autoload is enabled.
+     * Determine if relationships are being automatically eager loaded when accessed.
      *
      * @return bool
      */
-    public static function isAutoloadingRelationsGlobally()
+    public static function isAutomaticallyEagerLoadingRelationships()
     {
-        return static::$modelsShouldGlobalAutoloadRelations;
+        return static::$modelsShouldAutomaticallyEagerLoadRelationships;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -179,6 +179,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $modelsShouldPreventLazyLoading = false;
 
     /**
+     * Indicates whether relations should be automatically loaded on all models.
+     *
+     * @var bool
+     */
+    protected static $modelsShouldAlwaysAutoloadRelations = false;
+
+    /**
      * The callback that is responsible for handling lazy loading violations.
      *
      * @var callable|null
@@ -444,6 +451,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function preventLazyLoading($value = true)
     {
         static::$modelsShouldPreventLazyLoading = $value;
+    }
+
+    /**
+     * Determine if model relationships should be automatically loaded.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function alwaysAutoloadRelations($value = true)
+    {
+        static::$modelsShouldAlwaysAutoloadRelations = $value;
     }
 
     /**
@@ -2229,6 +2247,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function preventsLazyLoading()
     {
         return static::$modelsShouldPreventLazyLoading;
+    }
+
+    /**
+     * Determine if relations autoload is enabled.
+     *
+     * @return bool
+     */
+    public static function alwaysAutoloadsRelations()
+    {
+        return static::$modelsShouldAlwaysAutoloadRelations;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -183,7 +183,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @var bool
      */
-    protected static $modelsShouldAlwaysAutoloadRelations = false;
+    protected static $modelsShouldGlobalAutoloadRelations = false;
 
     /**
      * The callback that is responsible for handling lazy loading violations.
@@ -459,9 +459,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  bool  $value
      * @return void
      */
-    public static function alwaysAutoloadRelations($value = true)
+    public static function globalAutoloadRelations($value = true)
     {
-        static::$modelsShouldAlwaysAutoloadRelations = $value;
+        static::$modelsShouldGlobalAutoloadRelations = $value;
     }
 
     /**
@@ -2254,9 +2254,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @return bool
      */
-    public static function alwaysAutoloadsRelations()
+    public static function isAutoloadingRelationsGlobally()
     {
-        return static::$modelsShouldAlwaysAutoloadRelations;
+        return static::$modelsShouldGlobalAutoloadRelations;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -27,6 +27,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
         $model1->shouldReceive('hasAttributeMutator')->andReturn(false);
+        $model1->shouldReceive('hasRelationAutoloadCallback')->andReturn(false);
         $model1->shouldReceive('getCasts')->andReturn([]);
         $model1->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
 
@@ -36,6 +37,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
         $model2->shouldReceive('hasGetMutator')->andReturn(false);
         $model2->shouldReceive('hasAttributeMutator')->andReturn(false);
+        $model2->shouldReceive('hasRelationAutoloadCallback')->andReturn(false);
         $model2->shouldReceive('getCasts')->andReturn([]);
         $model2->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
 

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelRelationAutoloadTest;
+
+use DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelRelationAutoloadTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('parent_id')->nullable();
+            $table->morphs('commentable');
+        });
+
+        Schema::create('likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('likeable');
+        });
+    }
+
+    public function testRelationAutoload()
+    {
+        $post1 = Post::create();
+        $comment1 = $post1->comments()->create(['parent_id' => null]);
+        $comment2 = $post1->comments()->create(['parent_id' => $comment1->id]);
+        $comment2->likes()->create();
+        $comment2->likes()->create();
+
+        $post2 = Post::create();
+        $comment3 = $post2->comments()->create(['parent_id' => null]);
+        $comment3->likes()->create();
+
+        $posts = Post::get();
+
+        DB::enableQueryLog();
+
+        $likes = [];
+
+        $posts->enableRelationAutoload();
+
+        foreach ($posts as $post) {
+            foreach ($post->comments as $comment) {
+                $likes = array_merge($likes, $comment->likes->all());
+            }
+        }
+
+        $this->assertCount(2, DB::getQueryLog());
+        $this->assertCount(3, $likes);
+        $this->assertTrue($posts[0]->comments[0]->relationLoaded('likes'));
+    }
+
+    public function testRelationAutoloadVariousNestedMorphRelations()
+    {
+        tap(Post::create(), function ($post) {
+            $post->likes()->create();
+            $post->comments()->create();
+            tap($post->comments()->create(), function ($comment) {
+                $comment->likes()->create();
+                $comment->likes()->create();
+            });
+        });
+
+        tap(Post::create(), function ($post) {
+            $post->likes()->create();
+            tap($post->comments()->create(), function ($comment) {
+                $comment->likes()->create();
+            });
+        });
+
+        tap(Video::create(), function ($video) {
+            tap($video->comments()->create(), function ($comment) {
+                $comment->likes()->create();
+            });
+        });
+
+        tap(Video::create(), function ($video) {
+            tap($video->comments()->create(), function ($comment) {
+                $comment->likes()->create();
+            });
+        });
+
+        Post::alwaysAutoloadRelations();
+
+        $likes = Like::get();
+
+        DB::enableQueryLog();
+
+        $videos = [];
+        $videoLike = null;
+
+//        $likes->enableRelationAutoload();
+
+        foreach ($likes as $like) {
+            $likeable = $like->likeable;
+
+            if (($likeable instanceof Comment) && ($likeable->commentable instanceof Video)) {
+                $videos[] = $likeable->commentable;
+                $videoLike = $like;
+            }
+        }
+
+        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(2, $videos);
+        $this->assertTrue($videoLike->relationLoaded('likeable'));
+        $this->assertTrue($videoLike->likeable->relationLoaded('commentable'));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class);
+    }
+
+    public function likes()
+    {
+        return $this->morphMany(Like::class, 'likeable');
+    }
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    public function likes()
+    {
+        return $this->morphMany(Like::class, 'likeable');
+    }
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    public function likes()
+    {
+        return $this->morphMany(Like::class, 'likeable');
+    }
+}
+
+class Like extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function likeable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -93,8 +93,6 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
             });
         });
 
-        Post::alwaysAutoloadRelations();
-
         $likes = Like::get();
 
         DB::enableQueryLog();
@@ -102,7 +100,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $videos = [];
         $videoLike = null;
 
-//        $likes->enableRelationAutoload();
+        $likes->enableRelationAutoload();
 
         foreach ($likes as $like) {
             $likeable = $like->likeable;

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -50,7 +50,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
 
         $likes = [];
 
-        $posts->enableRelationAutoload();
+        $posts->withRelationAutoload();
 
         foreach ($posts as $post) {
             foreach ($post->comments as $comment) {
@@ -100,7 +100,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $videos = [];
         $videoLike = null;
 
-        $likes->enableRelationAutoload();
+        $likes->withRelationAutoload();
 
         foreach ($likes as $like) {
             $likeable = $like->likeable;

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -50,7 +50,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
 
         $likes = [];
 
-        $posts->primeRelationshipAutoloading();
+        $posts->withRelationshipAutoloading();
 
         foreach ($posts as $post) {
             foreach ($post->comments as $comment) {
@@ -100,7 +100,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $videos = [];
         $videoLike = null;
 
-        $likes->primeRelationshipAutoloading();
+        $likes->withRelationshipAutoloading();
 
         foreach ($likes as $like) {
             $likeable = $like->likeable;

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -50,7 +50,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
 
         $likes = [];
 
-        $posts->withRelationAutoload();
+        $posts->primeRelationshipAutoloading();
 
         foreach ($posts as $post) {
             foreach ($post->comments as $comment) {
@@ -100,7 +100,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $videos = [];
         $videoLike = null;
 
-        $likes->withRelationAutoload();
+        $likes->primeRelationshipAutoloading();
 
         foreach ($likes as $like) {
             $likeable = $like->likeable;


### PR DESCRIPTION
## Description

In large projects it can become difficult to track and manually specify which relations should be eager-loaded, especially if those relations are deeply nested or dynamically used. Therefore, automatic relation loading can be useful.
```php
# instead of this

$projects->load([
    'client.owner.details',
    'client.customPropertyValues',
    'clientContact.customPropertyValues',
    'status',
    'company.statuses',
    'posts.authors.articles.likes',
    'related.statuses'
]);


# We can use this

$projects->withRelationshipAutoloading();
```

## Challenges include:
1. **Unnecessary overhead when relations change**: If the logic for loading relations changes and we forget to remove or update a load() or with() call, unnecessary relations may still be loaded, leading to performance inefficiencies.
2. **Tedious manual loading**: Explicitly calling load() or with() for each relation makes the code verbose and harder to read.
3. **Maintenance overhead**: As the number of relations grows, the related logic becomes increasingly difficult to maintain and prone to duplication.

## New `withRelationshipAutoloading()` Method
A new method, withRelationshipAutoloading(), has been added to models and Eloquent collections. When called, it automatically loads relations whenever they are accessed, without the need for explicit load() or with() calls.

**Example:**
```php
$orders = Order::all()->withRelationshipAutoloading();

foreach ($orders as $order) {
    echo $order->client->owner->company->name;
}

// automatic calls:
// $orders->loadMissing('client');
// $orders->loadMissing('client.owner');
// $orders->loadMissing('client.owner.company');
```

## Support for Morph Relations
The feature works seamlessly with polymorphic relations. It only loads the specific morph type that is accessed, ensuring efficient use of resources.

## Doesn’t Break Manual Relation Loading
Users can still manually load relations using load() or with() before accessing the relation. If a relation is already loaded manually, it won’t be reloaded.

## Global Automatic Loading
For cases where you want automatic loading enabled across all models, you can use the static method `
```php
Model::automaticallyEagerLoadRelationships();
```

This feature significantly simplifies working with relations and reduces the overhead of managing eager loading in Laravel projects, enabling developers to focus on application logic instead of data loading mechanics.

If you have suggestions for better method names, feel free to share them!
