### PR TITLE
[11.x] Improved `class-string` types

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -7,7 +7,7 @@ class ModelIdentifier
     /**
      * The class name of the model.
      *
-     * @var string
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
      */
     public $class;
 
@@ -37,14 +37,14 @@ class ModelIdentifier
     /**
      * The class name of the model collection.
      *
-     * @var string|null
+     * @var class-string<\Illuminate\Database\Eloquent\Collection>|null
      */
     public $collectionClass;
 
     /**
      * Create a new model identifier.
      *
-     * @param  string  $class
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $class
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
@@ -61,7 +61,7 @@ class ModelIdentifier
     /**
      * Specify the collection class that should be used when serializing / restoring collections.
      *
-     * @param  string|null  $collectionClass
+     * @param  class-string<\Illuminate\Database\Eloquent\Collection>  $collectionClass
      * @return $this
      */
     public function useCollectionClass(?string $collectionClass)

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -166,7 +166,7 @@ class CallQueuedListener implements ShouldQueue
     /**
      * Get the display name for the queued job.
      *
-     * @return class-string
+     * @return string
      */
     public function displayName()
     {

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -15,7 +15,7 @@ class CallQueuedListener implements ShouldQueue
     /**
      * The listener class name.
      *
-     * @var string
+     * @var class-string
      */
     public $class;
 
@@ -85,7 +85,7 @@ class CallQueuedListener implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param  string  $class
+     * @param  class-string  $class
      * @param  string  $method
      * @param  array  $data
      * @return void
@@ -166,7 +166,7 @@ class CallQueuedListener implements ShouldQueue
     /**
      * Get the display name for the queued job.
      *
-     * @return string
+     * @return class-string
      */
     public function displayName()
     {


### PR DESCRIPTION
Making the types of these strings more explicit.

These listeners are consumed by user-land code, so having these types can improve end-user project static analysis / auto-complete.