### PR TITLE
[11.x] Fix `SyntaxError` on Vite prefetch with empty assets

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -564,7 +564,7 @@ class Vite implements Htmlable
                                 return link
                             }
 
-                            const fragment = new DocumentFragment
+                            const fragment = new DocumentFragment;
                             {$assets}.forEach((asset) => fragment.append(makeLink(asset)))
                             document.head.append(fragment)
                          }))

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1484,7 +1484,7 @@ class FoundationViteTest extends TestCase
                     return link
                 }
 
-                const fragment = new DocumentFragment
+                const fragment = new DocumentFragment;
                 {$expectedAssets}.forEach((asset) => fragment.append(makeLink(asset)))
                 document.head.append(fragment)
              }))


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When `$assets` is empty and the `'aggressive'` strategy is applied in the Vite prefetcher, the resulting JS includes the fragment:
```js
        const fragment = new DocumentFragment
        [].forEach((asset) => fragment.append(makeLink(asset)))
        document.head.append(fragment)
```

When executed this yields an error `Uncaught SyntaxError: expected expression, got ']'`. Although not hurtful (there is nothing to do anyways), it is still a slight nuisance.

This MR fixes the issue by adding a semicolon to eagerly terminate the previous statement. An alternative way would be to rewrite the entire statement to not write any html at all when `$assets` is empty, given that there is nothing to do.