### PR TITLE
[11.x] Add PausePrompt fallback

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -56,6 +56,7 @@ trait ConfiguresPrompts
         PausePrompt::fallbackUsing(fn (PausePrompt $prompt) => $this->promptUntilValid(
             function () use ($prompt) {
                 $this->components->ask($prompt->message, $prompt->value());
+
                 return $prompt->value();
             },
             $prompt->required,

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -7,6 +7,7 @@ use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
 use Laravel\Prompts\PasswordPrompt;
+use Laravel\Prompts\PausePrompt;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SearchPrompt;
 use Laravel\Prompts\SelectPrompt;
@@ -48,6 +49,15 @@ trait ConfiguresPrompts
 
         PasswordPrompt::fallbackUsing(fn (PasswordPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->secret($prompt->label) ?? '',
+            $prompt->required,
+            $prompt->validate
+        ));
+
+        PausePrompt::fallbackUsing(fn (PausePrompt $prompt) => $this->promptUntilValid(
+            function () use ($prompt) {
+                $this->components->ask($prompt->message, $prompt->value());
+                return $prompt->value();
+            },
             $prompt->required,
             $prompt->validate
         ));

--- a/tests/Integration/Console/PromptsAssertionTest.php
+++ b/tests/Integration/Console/PromptsAssertionTest.php
@@ -10,6 +10,7 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multisearch;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\password;
+use function Laravel\Prompts\pause;
 use function Laravel\Prompts\search;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\suggest;
@@ -38,6 +39,32 @@ class PromptsAssertionTest extends TestCase
             ->artisan('test:text')
             ->expectsQuestion('What is your name?', 'Jane')
             ->expectsOutput('Jane');
+    }
+
+    public function testAssertionForPausePrompt()
+    {
+        $self = $this;
+        $this->app[Kernel::class]->registerCommand(
+            new class($this) extends Command
+            {
+                protected $signature = 'test:pause';
+
+                public function __construct(public PromptsAssertionTest $test)
+                {
+                    parent::__construct();
+                }
+
+                public function handle()
+                {
+                    $value = pause('Press any key to continue...');
+                    $this->test->assertEquals(true, $value);
+                }
+            }
+        );
+
+        $this
+            ->artisan('test:pause')
+            ->expectsQuestion('Press any key to continue...', '');
     }
 
     public function testAssertionForTextareaPrompt()


### PR DESCRIPTION
This PR adds a fallback for the `\Laravel\Prompts\PausePrompt` to the `Illuminate\Console\Concerns\ConfiguresPrompts` to fallback to using a Symfony question.

This allows users to use `$pendingCommand->expectsQuestion('Press enter to continue', '')` in their tests when there is a `PausePrompt` in their command.

The fallback discards the result of the question and instead uses the result of the underlying `PausePrompt::value()`, as is the expected behaviour when not using the fallback.

In the test, it adds the current test case instance into the test command constructor so that we can assert upon the prompt's return value.