### PR TITLE
[11.x] Add `Request::fluent` method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -453,6 +453,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input from the request as a fluent instance.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Fluent
+     */
+    public function fluent($key = null)
+    {
+        return fluent(is_array($key) ? $this->only($key) : $this->input($key));
+    }
+
+    /**
      * Get a subset containing the provided keys with values from the input data.
      *
      * @param  array|mixed  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -453,7 +453,7 @@ trait InteractsWithInput
     }
 
     /**
-     * Retrieve input from the request as a fluent instance.
+     * Retrieve input from the request as a Fluent object instance.
      *
      * @param  array|string|null  $key
      * @return \Illuminate\Support\Fluent

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -455,7 +455,7 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as a fluent instance.
      *
-     * @param  string|null  $key
+     * @param  array|string|null  $key
      * @return \Illuminate\Support\Fluent
      */
     public function fluent($key = null)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -169,7 +169,7 @@ if (! function_exists('filled')) {
 
 if (! function_exists('fluent')) {
     /**
-     * Create an Fluent object from the given value.
+     * Create a Fluent object from the given value.
      *
      * @param  object|array  $value
      * @return \Illuminate\Support\Fluent


### PR DESCRIPTION
### Description

This PR adds a new `fluent()` method to the `Illuminate\Http\Request` class. 

Similar to the `Request::collect` method, being able to transform the request input to a `Fluent` instance helps in being able to transport the input data around your application (such as an action or a queued job) and provides you null-safe access instead of using an array.

### Usage

Consider an action that consumes a `Fluent` instance to access request data safely that may be nullable, while also being portable for easy testing without having to provide a request instance:

```php
use App\Actions\CreateComment;

class CommentController extends Controller
{
    public function store(CommentRequest $request)
    {
        $comment = (new CreateComment)->handle(
            $request->fluent()
        );

        return response($comment);
    }
}

class StoreComment extends QueuedJob
{
    public function __construct(
        public Fluent $data
    ) {}

    public function handle(): Comment
    {
        return Comment::create([
            'title' => $this->data->title,
            'body' => $this->data->body,
            // ...
        ]);
    }
}
```