### PR TITLE
Add shorthands for fake HTTP responses

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -275,9 +275,11 @@ class Factory
                 return static::response($callback);
             }
 
-            return $callback instanceof Closure || $callback instanceof ResponseSequence
-                        ? $callback($request, $options)
-                        : $callback;
+            if ($callback instanceof Closure || $callback instanceof ResponseSequence) {
+                return $callback($request, $options);
+            }
+
+            return $callback;
         });
     }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -257,7 +257,7 @@ class Factory
      * Stub the given URL using the given callback.
      *
      * @param  string  $url
-     * @param  \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface|callable  $callback
+     * @param  \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface|callable|int|string|array  $callback
      * @return $this
      */
     public function stubUrl($url, $callback)
@@ -265,6 +265,14 @@ class Factory
         return $this->fake(function ($request, $options) use ($url, $callback) {
             if (! Str::is(Str::start($url, '*'), $request->url())) {
                 return;
+            }
+
+            if (is_int($callback) && $callback >= 100 && $callback < 600) {
+                return static::response(status: $callback);
+            }
+
+            if (is_int($callback) || is_string($callback)) {
+                return static::response($callback);
             }
 
             return $callback instanceof Closure || $callback instanceof ResponseSequence

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -83,6 +83,53 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->created());
     }
 
+    public function testStatusCodeShorthand()
+    {
+        $this->factory->fake([
+            'forge.laravel.com' => 204,
+            'vapor.laravel.com' => HttpResponse::HTTP_CREATED,
+        ]);
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertTrue($response->noContent());
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->created());
+    }
+
+    public function testStatusCodeShorthandAssumeBodyWhenInvalidHttpStatusCode()
+    {
+        $this->factory->fake([
+            'forge.laravel.com' => 999,
+            'vapor.laravel.com' => 1,
+        ]);
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertTrue($response->ok());
+        $this->assertSame('999', $response->body());
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->ok());
+        $this->assertSame('1', $response->body());
+    }
+
+    public function testBodyShorthands()
+    {
+        $this->factory->fake([
+            'google.com' => 'Hello World',
+            'github.com' => ['foo' => 'bar'],
+        ]);
+
+        $response = $this->factory->get('http://google.com');
+        $this->assertTrue($response->ok());
+        $this->assertSame('Hello World', $response->body());
+
+        $response = $this->factory->post('http://github.com');
+        $this->assertTrue($response->ok());
+        $this->assertSame('{"foo":"bar"}', $response->body());
+        $this->assertSame(['foo' => 'bar'], $response->json());
+    }
+
     public function testAcceptedRequest()
     {
         $this->factory->fake([


### PR DESCRIPTION
Similar to `Process::fake()`, this adds _shorthands_ when faking HTTP responses. A shorthand for passing arrays already existed. This adds an explicit test for that, plus shorthands for strings for the body or an integer for a valid HTTP status code (1xx-5xx).

**Before**
```php
Http::fake([
    'google.com' => Http::response('Hello World'),
    'github.com' => Http::response(['foo' => 'bar']),
    'forge.laravel.com' => Http::response(status: 204),
]);
```

**After**
```php
Http::fake([
    'google.com' => 'Hello World',
    'github.com' => ['foo' => 'bar'],
    'forge.laravel.com' => 204,
]);
```