### PR TITLE
Bus assertempty

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -362,6 +362,16 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
+     * Assert no chained jobs was dispatched.
+     *
+     * @return void
+     */
+    public function assertNothingChained()
+    {
+        $this->assertNothingDispatched();
+    }
+
+    /**
      * Reset the chain properties to their default values on the job.
      *
      * @param  mixed  $job

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -505,6 +505,17 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
+     * Assert that no jobs were dispatched, chained, or batched.
+     *
+     * @return void
+     */
+    public function assertNothingPlaced()
+    {
+        $this->assertNothingDispatched();
+        $this->assertNothingBatched();
+    }
+
+    /**
      * Get all of the jobs matching a truth-test callback.
      *
      * @param  string  $command

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -661,6 +661,47 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
+    public function testAssertEmptyPasses()
+    {
+        $this->fake->assertNothingPlaced();
+    }
+
+    public function testAssertEmptyFailedWhenJobBatched()
+    {
+        $this->fake->batch([new BusJobStub])->dispatch();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertNothingPlaced();
+    }
+
+    public function testAssertEmptyFailedWhenJobDispatched()
+    {
+        $this->fake->dispatch(new BusJobStub);
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertNothingPlaced();
+    }
+
+    public function testAssertEmptyFailedWhenJobChained()
+    {
+        $this->fake->chain([new ChainedJobStub])->dispatch();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertNothingPlaced();
+    }
+
+    public function testAssertEmptyFailedWhenJobDispatchedNow()
+    {
+        $this->fake->dispatchNow(new BusJobStub);
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertNothingPlaced();
+    }
+
     public function testFindBatch()
     {
         $this->assertNull($this->fake->findBatch('non-existent-batch'));

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -548,6 +548,20 @@ class SupportTestingBusFakeTest extends TestCase
         Container::setInstance(null);
     }
 
+    public function testAssertNothingChained()
+    {
+        $this->fake->assertNothingChained();
+    }
+
+    public function testAssertNothingChainedFails()
+    {
+        $this->fake->chain([new ChainedJobStub])->dispatch();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->fake->assertNothingChained();
+    }
+
     public function testAssertDispatchedWithIgnoreClass()
     {
         $dispatcher = m::mock(QueueingDispatcher::class);


### PR DESCRIPTION
Similar to the `MailFake`, this adds a unified assertion to test nothing was placed on the bus - either dispatched, chained, or batched.

**Before**
```php
Bus::fake()

// ...

Bus::assertNothingDispatched();
Bus::assertNothingBatched();
```

**After**
```php
Bus::fake()

// ...

Bus::assertNothingPlaced();
```

This also adds `assertNothingChained` which is simply an alias for `assertNothingDispatched`. However, it provides some symmetry with the other assertions and lowers to barrier to entry. Otherwise the developer needs to know that a job chain immediately dispatches the first job and therefore they can use `assertNothingDispatched`.