### PR TITLE
Add helper functions to check string types

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1999,6 +1999,105 @@ class Str
     }
 
     /**
+     * Checks if a given string contains only digits.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isNumeric($value)
+    {
+        return ctype_digit($value);
+    }
+
+    /**
+     * Checks if a given string contains only alphabetic characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isAlphabetic($value)
+    {
+        return ctype_alpha($value);
+    }
+
+    /**
+     * Checks if a given string contains only alphabetic characters and digits.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isAlphaNumeric($value)
+    {
+        return ctype_alnum($value);
+    }
+
+    /**
+     * Checks if a given string contains only binary characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isBinary($value)
+    {
+        return ctype_xdigit($value);
+    }
+
+    /**
+     * Checks if a given string contains only whitespace characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isWhitespace($value)
+    {
+        return ctype_space($value);
+    }
+
+    /**
+     * Checks if a given string contains only printable characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isPrintable($value)
+    {
+        return ctype_print($value);
+    }
+
+    /**
+     * Checks if a given string contains only lower case characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isLowerCase($value)
+    {
+        return ctype_lower($value);
+    }
+
+    /**
+     * Checks if a given string contains only upper case characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isUpperCase($value)
+    {
+        return ctype_upper($value);
+    }
+
+    /**
+     * Checks if a given string contains only puctuation characters.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function containsPunctuationsOnly($value)
+    {
+        return ctype_punct($value);
+    }
+
+    /**
      * Remove all strings from the casing caches.
      *
      * @return void

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1399,6 +1399,96 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Checks if a given string contains only digits.
+     *
+     * @return bool
+     */
+    public function isNumeric()
+    {
+        return Str::isNumeric($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only alphabetic characters.
+     *
+     * @return bool
+     */
+    public function isAlphabetic()
+    {
+        return Str::isAlphabetic($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only alphabetic characters and digits.
+     *
+     * @return bool
+     */
+    public function isAlphaNumeric()
+    {
+        return Str::isAlphaNumeric($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only binary characters.
+     *
+     * @return bool
+     */
+    public function isBinary()
+    {
+        return Str::isBinary($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only whitespace characters.
+     *
+     * @return bool
+     */
+    public function isWhitespace()
+    {
+        return Str::isWhitespace($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only printable characters.
+     *
+     * @return bool
+     */
+    public function isPrintable()
+    {
+        return Str::isPrintable($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only lower case characters.
+     *
+     * @return bool
+     */
+    public function isLowerCase()
+    {
+        return Str::isLowerCase($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only upper case characters.
+     *
+     * @return bool
+     */
+    public function isUpperCase()
+    {
+        return Str::isUpperCase($this->value);
+    }
+
+    /**
+     * Checks if a given string contains only puctuation characters.
+     *
+     * @return bool
+     */
+    public function containsPunctuationsOnly()
+    {
+        return Str::containsPunctuationsOnly($this->value);
+    }
+
+    /**
      * Convert the object to a string when JSON encoded.
      *
      * @return string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1626,6 +1626,37 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    public function testStringTypes()
+    {
+        $this->assertTrue(Str::isNumeric('123'));
+        $this->assertFalse(Str::isNumeric('A123'));
+
+        $this->assertTrue(Str::isAlphabetic('Abc'));
+        $this->assertFalse(Str::isAlphabetic('123'));
+
+        $this->assertTrue(Str::isAlphaNumeric('Abc123'));
+        $this->assertFalse(Str::isAlphaNumeric('Abc123!'));
+
+        $this->assertTrue(Str::isBinary('0F'));
+        $this->assertFalse(Str::isBinary('0FZ'));
+
+        $this->assertTrue(Str::isWhitespace('   ')); 
+        $this->assertTrue(Str::isWhitespace("\n\r\t"));
+        $this->assertFalse(Str::isWhitespace('Abc'));
+
+        $this->assertTrue(Str::isPrintable('Hello World'));
+        $this->assertFalse(Str::isPrintable("Hello World\n\r\t"));
+
+        $this->assertTrue(Str::isLowerCase('abc'));
+        $this->assertFalse(Str::isLowerCase('ABC'));
+
+        $this->assertTrue(Str::isUpperCase('ABC'));
+        $this->assertFalse(Str::isUpperCase('abc'));
+
+        $this->assertTrue(Str::containsPunctuationsOnly('*&$()!'));
+        $this->assertFalse(Str::containsPunctuationsOnly('Hello World'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1641,7 +1641,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isBinary('0F'));
         $this->assertFalse(Str::isBinary('0FZ'));
 
-        $this->assertTrue(Str::isWhitespace('   ')); 
+        $this->assertTrue(Str::isWhitespace('   '));
         $this->assertTrue(Str::isWhitespace("\n\r\t"));
         $this->assertFalse(Str::isWhitespace('Abc'));
 


### PR DESCRIPTION
This PR attempts to add the following helper functions to check the type of a string based on PHP's [`ctype_*` functions](https://www.php.net/manual/en/book.ctype.php).

```php
use Illuminate\Support\Str;

Str::isNumeric('123'); // true
Str::isNumeric('A123'); // false

Str::isAlphabetic('Abc'); // true
Str::isAlphabetic('123'); // false

Str::isAlphaNumeric('Abc123'); // true
Str::isAlphaNumeric('Abc123!'); // false

Str::isBinary('0F'); // true
Str::isBinary('0FZ'); // false

Str::isWhitespace("\n\r\t"); // true
Str::isWhitespace('Abc'); // false

Str::isPrintable('Hello World'); // true
Str::isPrintable("Hello World\n\r\t"); // false

Str::isLowerCase('abc'); // true
Str::isLowerCase('ABC'); // false

Str::isUpperCase('ABC'); // true
Str::isUpperCase('abc'); // false

Str::containsPunctuationsOnly('*&$()!'); // true
Str::containsPunctuationsOnly('Hello World'); // false
```

I believe having these helpers in Laravel's core would be pretty convenient!

