### PR TITLE
[11.x] Silence Deprecation Warnings in Concurrency Process Driver for PHP 8.4 Compatibility

### DIFF
--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -28,7 +28,7 @@ class ProcessDriver implements Driver
      */
     public function run(Closure|array $tasks): array
     {
-        $command = Application::formatCommandString('invoke-serialized-closure', true);
+        $command = Application::formatCommandString('invoke-serialized-closure', silenceDeprecations: true);
 
         $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $task) {

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -28,7 +28,7 @@ class ProcessDriver implements Driver
      */
     public function run(Closure|array $tasks): array
     {
-        $command = Application::formatCommandString('invoke-serialized-closure');
+        $command = Application::formatCommandString('invoke-serialized-closure', true);
 
         $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $task) {

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -102,22 +102,26 @@ class Application extends SymfonyApplication implements ApplicationContract
      * Format the given command as a fully-qualified executable command.
      *
      * @param  string  $string
+     * @param  bool  $silenceDeprecations
      * @return string
      */
     public static function formatCommandString($string, $silenceDeprecations = false)
     {
-        if ($silenceDeprecations) {
-            $errorReportingWithoutDeprecations = error_reporting() & ~E_DEPRECATED;
+        $phpOptions = $silenceDeprecations ? self::getPhpOptionsWithoutDeprecations() : '';
 
-            return sprintf('%s %s %s %s',
-                static::phpBinary(),
-                '-d error_reporting="' . $errorReportingWithoutDeprecations . '"',
-                static::artisanBinary(),
-                'invoke-serialized-closure'
-            );
-        }
+        return sprintf('%s %s %s %s', static::phpBinary(), $phpOptions, static::artisanBinary(), $string);
+    }
 
-        return sprintf('%s %s %s', static::phpBinary(), static::artisanBinary(), $string);
+    /**
+     * Get PHP options to exclude deprecation warnings.
+     *
+     * @return string
+     */
+    protected static function getPhpOptionsWithoutDeprecations()
+    {
+        $errorReportingWithoutDeprecations = error_reporting() & ~E_DEPRECATED;
+
+        return '-d error_reporting="' . $errorReportingWithoutDeprecations . '"';
     }
 
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -119,9 +119,14 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     protected static function getPhpOptionsWithoutDeprecations()
     {
-        $errorReportingWithoutDeprecations = error_reporting() & ~E_DEPRECATED;
+        $currentErrorReporting = error_reporting();
+        $errorReportingWithoutDeprecations = $currentErrorReporting & ~E_DEPRECATED;
 
-        return '-d error_reporting="' . $errorReportingWithoutDeprecations . '"';
+        if ($currentErrorReporting !== $errorReportingWithoutDeprecations) {
+            return '-d error_reporting="' . $errorReportingWithoutDeprecations . '"';
+        }
+
+        return '';
     }
 
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -112,7 +112,7 @@ class Application extends SymfonyApplication implements ApplicationContract
         $php = static::phpBinary();
 
         if ($phpOptions) {
-            $php .= ' ' . $phpOptions;
+            $php .= ' '.$phpOptions;
         }
 
         return sprintf('%s %s %s', $php, static::artisanBinary(), $string);
@@ -129,7 +129,7 @@ class Application extends SymfonyApplication implements ApplicationContract
         $errorReportingWithoutDeprecations = $currentErrorReporting & ~E_DEPRECATED;
 
         if ($currentErrorReporting !== $errorReportingWithoutDeprecations) {
-            return '-d error_reporting="' . $errorReportingWithoutDeprecations . '"';
+            return '-d error_reporting="'.$errorReportingWithoutDeprecations.'"';
         }
 
         return '';

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -126,6 +126,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     protected static function getPhpOptionsWithoutDeprecations()
     {
         $currentErrorReporting = error_reporting();
+
         $errorReportingWithoutDeprecations = $currentErrorReporting & ~E_DEPRECATED;
 
         if ($currentErrorReporting !== $errorReportingWithoutDeprecations) {

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -109,7 +109,13 @@ class Application extends SymfonyApplication implements ApplicationContract
     {
         $phpOptions = $silenceDeprecations ? self::getPhpOptionsWithoutDeprecations() : '';
 
-        return sprintf('%s %s %s %s', static::phpBinary(), $phpOptions, static::artisanBinary(), $string);
+        $php = static::phpBinary();
+
+        if ($phpOptions) {
+            $php .= ' ' . $phpOptions;
+        }
+
+        return sprintf('%s %s %s', $php, static::artisanBinary(), $string);
     }
 
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -104,8 +104,19 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  string  $string
      * @return string
      */
-    public static function formatCommandString($string)
+    public static function formatCommandString($string, $silenceDeprecations = false)
     {
+        if ($silenceDeprecations) {
+            $errorReportingWithoutDeprecations = error_reporting() & ~E_DEPRECATED;
+
+            return sprintf('%s %s %s %s',
+                static::phpBinary(),
+                '-d error_reporting="' . $errorReportingWithoutDeprecations . '"',
+                static::artisanBinary(),
+                'invoke-serialized-closure'
+            );
+        }
+
         return sprintf('%s %s %s', static::phpBinary(), static::artisanBinary(), $string);
     }
 


### PR DESCRIPTION
### Description:

This PR improves the Concurrency process driver’s compatibility with PHP 8.4 by silencing deprecation warnings that could interfere with task execution in the process pool. It introduces a flag to conditionally exclude deprecation warnings during task execution, without altering the application's global error reporting settings.

#### Current issue:
Deprecation messages malform the command output making it invalid JSON, resulting in an Exception.

![image](https://github.com/user-attachments/assets/f7ec1d97-a312-4865-a0a6-e66351332c6d)

![image](https://github.com/user-attachments/assets/16845e91-d4f8-44b0-b9f0-555627f23966)

#### Key Changes:
- **`formatCommandString` method update**: Adds a `$silenceDeprecations` flag to suppress deprecation warnings when running concurrency tasks.
- **Helper method `getPhpOptionsWithoutDeprecations`**: Ensures deprecation warnings are excluded without affecting global error reporting settings.

#### Benefits:
- **End Users**: Ensures cleaner output and smoother execution of concurrency tasks, especially when running on PHP 8.4.
- **Non-breaking**: The change is optional, maintaining existing error reporting configurations and not affecting current behavior unless explicitly enabled.
- **Improved Compatibility**: This resolves issues caused by PHP 8.4 deprecation notices that could disrupt background tasks or JSON output.
- **Ease of Use**: Developers can now run concurrent tasks without worrying about unwanted warnings, improving task reliability and output cleanliness.

This enhancement improves stability and error reporting control when using Laravel's Concurrency process driver, particularly on PHP 8.4, while ensuring no existing features are broken.
