### PR TITLE
Test cleanup from #53664

### DIFF
--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -465,7 +465,7 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The following jobs were dispatched unexpectedly:', $e->getMessage());
-            $this->assertStringContainsString(get_class(new BusJobStub), $e->getMessage());
+            $this->assertStringContainsString(BusJobStub::class, $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -675,12 +675,12 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
-    public function testAssertEmptyPasses()
+    public function testAssertNothingPlacedPasses()
     {
         $this->fake->assertNothingPlaced();
     }
 
-    public function testAssertEmptyFailedWhenJobBatched()
+    public function testAssertNothingPlacedWhenJobBatched()
     {
         $this->fake->batch([new BusJobStub])->dispatch();
 
@@ -689,7 +689,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->assertNothingPlaced();
     }
 
-    public function testAssertEmptyFailedWhenJobDispatched()
+    public function testAssertNothingPlacedWhenJobDispatched()
     {
         $this->fake->dispatch(new BusJobStub);
 
@@ -698,7 +698,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->assertNothingPlaced();
     }
 
-    public function testAssertEmptyFailedWhenJobChained()
+    public function testAssertNothingPlacedWhenJobChained()
     {
         $this->fake->chain([new ChainedJobStub])->dispatch();
 
@@ -707,7 +707,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->assertNothingPlaced();
     }
 
-    public function testAssertEmptyFailedWhenJobDispatchedNow()
+    public function testAssertNothingPlacedWhenJobDispatchedNow()
     {
         $this->fake->dispatchNow(new BusJobStub);
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -557,9 +557,13 @@ class SupportTestingBusFakeTest extends TestCase
     {
         $this->fake->chain([new ChainedJobStub])->dispatch();
 
-        $this->expectException(ExpectationFailedException::class);
-
-        $this->fake->assertNothingChained();
+        try {
+            $this->fake->assertNothingDispatched();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The following jobs were dispatched unexpectedly:', $e->getMessage());
+            $this->assertStringContainsString(ChainedJobStub::class, $e->getMessage());
+        }
     }
 
     public function testAssertDispatchedWithIgnoreClass()


### PR DESCRIPTION
This cleans up the tests added in #53664 by correcting the test names given the final assertion name and strengthening the test for the new `assertNothingChained`. It also modernizes a usage of `get_class`.