### PR TITLE
[11.x] Add pending attributes to child models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -30,6 +30,8 @@ class HasMany extends HasOneOrMany
                 if ($inverse = $this->getInverseRelationship()) {
                     $hasOne->inverse($inverse);
                 }
+
+                $hasOne->pendingAttributes = $this->pendingAttributes;
             }
         ));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -523,11 +524,24 @@ abstract class HasOneOrMany extends Relation
     /**
      * Add attributes to be added to new instances of related models.
      *
-     * @param  array  $attributes
+     * @param  array|string|\Illuminate\Contracts\Database\Query\Expression  $attributes
+     * @param  mixed  $value
      * @return $this
      */
-    public function withAttributes(array $attributes)
+    public function withAttributes(array|string|Expression $attributes, $value = null)
     {
+        if (! is_array($attributes)) {
+            $attributes = [$attributes => $value];
+        }
+
+        foreach ($attributes as $column => $value) {
+            if (is_null($value)) {
+                $this->whereNull($column);
+            } else {
+                $this->where($column, $value);
+            }
+        }
+
         $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -453,7 +453,7 @@ abstract class HasOneOrMany extends Relation
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
 
         foreach ($this->pendingAttributes as $key => $value) {
-            if (!$model->hasAttribute($key)) {
+            if (! $model->hasAttribute($key)) {
                 $model->setAttribute($key, $value);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -35,6 +35,11 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
+     * Attributes to be added on new instances on related models.
+     */
+    protected array $pendingAttributes = [];
+
+    /**
      * Create a new has one or many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
@@ -447,6 +452,12 @@ abstract class HasOneOrMany extends Relation
     {
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
 
+        foreach ($this->pendingAttributes as $key => $value) {
+            if (!$model->hasAttribute($key)) {
+                $model->setAttribute($key, $value);
+            }
+        }
+
         $this->applyInverseRelationToModel($model);
     }
 
@@ -567,5 +578,15 @@ abstract class HasOneOrMany extends Relation
     public function getLocalKeyName()
     {
         return $this->localKey;
+    }
+
+    /**
+     * Add attributes to be added to new instances of related models.
+     */
+    public function withAttributes(array $attributes): static
+    {
+        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -535,11 +535,7 @@ abstract class HasOneOrMany extends Relation
         }
 
         foreach ($attributes as $column => $value) {
-            if (is_null($value)) {
-                $this->whereNull($column);
-            } else {
-                $this->where($column, $value);
-            }
+            $this->where($column, $value);
         }
 
         $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -39,7 +39,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @var array
      */
-    protected array $pendingAttributes = [];
+    protected $pendingAttributes = [];
 
     /**
      * Create a new has one or many relationship instance.
@@ -526,7 +526,7 @@ abstract class HasOneOrMany extends Relation
      * @param  array  $attributes
      * @return $this
      */
-    public function withAttributes(array $attributes): static
+    public function withAttributes(array $attributes)
     {
         $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -40,7 +40,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @var array
      */
-    protected $pendingAttributes = [];
+    public $pendingAttributes = [];
 
     /**
      * Create a new has one or many relationship instance.

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -35,7 +35,9 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
-     * Attributes to be added on new instances on related models.
+     * Attributes to be added to new instances of related models.
+     *
+     * @var array
      */
     protected array $pendingAttributes = [];
 
@@ -519,6 +521,19 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Add attributes to be added to new instances of related models.
+     *
+     * @param  array  $attributes
+     * @return $this
+     */
+    public function withAttributes(array $attributes): static
+    {
+        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
+
+        return $this;
+    }
+
+    /**
      * Get the key for comparing against the parent key in "has" query.
      *
      * @return string
@@ -578,15 +593,5 @@ abstract class HasOneOrMany extends Relation
     public function getLocalKeyName()
     {
         return $this->localKey;
-    }
-
-    /**
-     * Add attributes to be added to new instances of related models.
-     */
-    public function withAttributes(array $attributes): static
-    {
-        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
-
-        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -31,6 +31,8 @@ class MorphMany extends MorphOneOrMany
                 if ($inverse = $this->getInverseRelationship()) {
                     $morphOne->inverse($inverse);
                 }
+
+                $morphOne->pendingAttributes = $this->pendingAttributes;
             }
         ));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -97,7 +97,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getMorphType()} = $this->morphClass;
 
         foreach ($this->pendingAttributes as $key => $value) {
-            if (!$model->hasAttribute($key)) {
+            if (! $model->hasAttribute($key)) {
                 $model->setAttribute($key, $value);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -96,6 +96,12 @@ abstract class MorphOneOrMany extends HasOneOrMany
 
         $model->{$this->getMorphType()} = $this->morphClass;
 
+        foreach ($this->pendingAttributes as $key => $value) {
+            if (!$model->hasAttribute($key)) {
+                $model->setAttribute($key, $value);
+            }
+        }
+
         $this->applyInverseRelationToModel($model);
     }
 

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -202,6 +202,47 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
             'boolean' => 'and',
         ], $wheres);
     }
+
+    public function testOneKeepsAttributesFromHasMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testOneKeepsAttributesFromMorphMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
 }
 
 class RelatedWithAttributesModel extends Model

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -104,7 +104,6 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
         $defaultValue = 'a value';
         $value = 'the value';
 
-        RelatedWithAttributesModel::unguard();
         $parent = new RelatedWithAttributesModel;
 
         $relationship = $parent
@@ -157,4 +156,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
     }
 }
 
-class RelatedWithAttributesModel extends Model {}
+class RelatedWithAttributesModel extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -135,6 +135,26 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
         $this->assertSame($parentId, $relatedModel->parent_id);
         $this->assertSame($value, $relatedModel->$key);
     }
+
+    public function testAttributesCanBeAppended(): void
+    {
+        $parent = new RelatedWithAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes(['a' => 'A'])
+            ->withAttributes(['b' => 'B'])
+            ->withAttributes(['a' => 'AA']);
+
+        $relatedModel = $relationship->make([
+            'b' => 'BB',
+            'c' => 'C',
+        ]);
+
+        $this->assertSame('AA', $relatedModel->a);
+        $this->assertSame('BB', $relatedModel->b);
+        $this->assertSame('C', $relatedModel->c);
+    }
 }
 
 class RelatedWithAttributesModel extends Model {}

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -115,6 +115,26 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
 
         $this->assertSame($value, $relatedModel->$key);
     }
+
+    public function testQueryingDoesNotBreakWither(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->where($key, $value)
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
 }
 
 class RelatedWithAttributesModel extends Model {}

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    public function testHasManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testHasOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasOne(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphOne(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testWithAttributesCanBeOverriden(): void
+    {
+        $key = 'a key';
+        $defaultValue = 'a value';
+        $value = 'the value';
+
+        RelatedWithAttributesModel::unguard();
+        $parent = new RelatedWithAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $defaultValue]);
+
+        $relatedModel = $relationship->make([$key => $value]);
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+}
+
+class RelatedWithAttributesModel extends Model {}

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -203,6 +203,30 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
         ], $wheres);
     }
 
+    public function testNullValueIsAccepted(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => null]);
+
+        $wheres = $relationship->toBase()->wheres;
+        $relatedModel = $relationship->make();
+
+        $this->assertNull($relatedModel->$key);
+
+        $this->assertContains([
+            'type' => 'Null',
+            'column' => $key,
+            'boolean' => 'and',
+        ], $wheres);
+    }
+
     public function testOneKeepsAttributesFromHasMany(): void
     {
         $parentId = 123;


### PR DESCRIPTION
## Problem

Currently a relationship like this:

```php
public function children(): HasMany
{
    return $this->hasMany(ChildModel::class);
}
```

Allows you to query `$parent->children()->get()` as well as create related models `$parent->children()->create()` that can be queried by the former `$parent->children()->get()`.

Meanwhile a scoped relationship like this:

```php
public function children(): HasMany
{
    return $this->hasMany(ChildModel::class)->where('active', true);
}
```

Allows you to query for active records `$parent->children()->get()`, but doing `$parent->children()->create()` will insert an inactive (with the default value of `active` to be precise) child and `$parent->children()->get()` will not return what you just inserted.

## Solution

I propose adding "pending attributes" on relationships to allow specifying additional attributes that should be applied when creating new models. In theory this would allow setting any attributes on the newly created related models, but in particular this would allow solving the above issue like this:

```php
public function children(): HasMany
{
    return $this->hasMany(ChildModel::class)
        ->where('active', true)
        ->withAttributes([
            'active' => true,
        ]);
}
```

And with such setup `$parent->children()->create()` will create an active `ChildModel`.

The pending attributes serve as defaults that can be overriden:

```php
public function children(): HasMany
{
    
    return $this->hasMany(ChildModel::class)
        ->withAttributes(['a' => 'A'])
        ->withAttributes(['b' => 'B'])
        ->withAttributes(['a' => 'AA']); // overriding the attribute by another withAttributes()
}

$parent->children()->create(); // ['a' => 'AA', 'b' => 'B']

// overriding during creation
$parent->children()->create(['b' => 'BB']); // ['a' => 'AA', 'b' => 'BB']
```