### PR TITLE
[11.x] Support DB aggregate by group (new methods)

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3562,6 +3562,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Retrieve the "count" of the distinct results of a given column
+     * for each group.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $columns
+     * @return \Illuminate\Support\Collection
+     */
+    public function countByGroup($columns = '*'): Collection
+    {
+        return $this->aggregateByGroup('count', Arr::wrap($columns));
+    }
+
+    /**
      * Retrieve the minimum value of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -3573,6 +3585,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Retrieve the minimum value of a given column by group.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return \Illuminate\Support\Collection
+     */
+    public function minByGroup($column): Collection
+    {
+        return $this->aggregateByGroup('min', [$column]);
+    }
+
+    /**
      * Retrieve the maximum value of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -3581,6 +3604,17 @@ class Builder implements BuilderContract
     public function max($column)
     {
         return $this->aggregate(__FUNCTION__, [$column]);
+    }
+
+    /**
+     * Retrieve the maximum value of a given column by group.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return \Illuminate\Support\Collection
+     */
+    public function maxByGroup($column): Collection
+    {
+        return $this->aggregateByGroup('max', [$column]);
     }
 
     /**
@@ -3597,6 +3631,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Retrieve the sum of the values of a given column by group.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return \Illuminate\Support\Collection
+     */
+    public function sumByGroup($column): Collection
+    {
+        return $this->aggregateByGroup('sum', [$column]);
+    }
+
+    /**
      * Retrieve the average of the values of a given column.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -3605,6 +3650,17 @@ class Builder implements BuilderContract
     public function avg($column)
     {
         return $this->aggregate(__FUNCTION__, [$column]);
+    }
+
+    /**
+     * Retrieve the average of the values of a given column by group.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return \Illuminate\Support\Collection
+     */
+    public function avgByGroup($column): Collection
+    {
+        return $this->aggregateByGroup('avg', [$column]);
     }
 
     /**
@@ -3635,6 +3691,22 @@ class Builder implements BuilderContract
         if (! $results->isEmpty()) {
             return array_change_key_case((array) $results[0])['aggregate'];
         }
+    }
+
+    /**
+     * Execute an aggregate function for each group and return the results
+     * in a collection of objects with the group columns and aggregate value.
+     *
+     * @param  string  $function  The aggregate function to call
+     * @param  array  $columns  The columns to perform the aggregate function on
+     * @return \Illuminate\Support\Collection
+     */
+    public function aggregateByGroup(string $function, array $columns = ['*']): Collection
+    {
+        return $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
+                    ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])
+                    ->setAggregate($function, $columns)
+                    ->get($columns);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3562,8 +3562,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Retrieve the "count" of the distinct results of a given column
-     * for each group.
+     * Retrieve the "count" of the distinct results of a given column for each group.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $columns
      * @return \Illuminate\Support\Collection

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3568,7 +3568,7 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $columns
      * @return \Illuminate\Support\Collection
      */
-    public function countByGroup($columns = '*'): Collection
+    public function countByGroup($columns = '*')
     {
         return $this->aggregateByGroup('count', Arr::wrap($columns));
     }
@@ -3590,7 +3590,7 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return \Illuminate\Support\Collection
      */
-    public function minByGroup($column): Collection
+    public function minByGroup($column)
     {
         return $this->aggregateByGroup('min', [$column]);
     }
@@ -3612,7 +3612,7 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return \Illuminate\Support\Collection
      */
-    public function maxByGroup($column): Collection
+    public function maxByGroup($column)
     {
         return $this->aggregateByGroup('max', [$column]);
     }
@@ -3636,7 +3636,7 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return \Illuminate\Support\Collection
      */
-    public function sumByGroup($column): Collection
+    public function sumByGroup($column)
     {
         return $this->aggregateByGroup('sum', [$column]);
     }
@@ -3658,7 +3658,7 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return \Illuminate\Support\Collection
      */
-    public function avgByGroup($column): Collection
+    public function avgByGroup($column)
     {
         return $this->aggregateByGroup('avg', [$column]);
     }
@@ -3694,14 +3694,13 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Execute an aggregate function for each group and return the results
-     * in a collection of objects with the group columns and aggregate value.
+     * Execute an aggregate function for each group.
      *
-     * @param  string  $function  The aggregate function to call
-     * @param  array  $columns  The columns to perform the aggregate function on
+     * @param  string  $function
+     * @param  array  $columns
      * @return \Illuminate\Support\Collection
      */
-    public function aggregateByGroup(string $function, array $columns = ['*']): Collection
+    public function aggregateByGroup(string $function, array $columns = ['*'])
     {
         return $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
                     ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -139,7 +139,15 @@ class Grammar extends BaseGrammar
             $column = 'distinct '.$column;
         }
 
-        return 'select '.$aggregate['function'].'('.$column.') as aggregate';
+        $sql = 'select ';
+
+        if ($query->groups) {
+            $sql .= $this->columnize($query->groups).', ';
+        }
+
+        $sql .= $aggregate['function'].'('.$column.') as aggregate';
+
+        return $sql;
     }
 
     /**
@@ -1131,10 +1139,12 @@ class Grammar extends BaseGrammar
     protected function compileUnionAggregate(Builder $query)
     {
         $sql = $this->compileAggregate($query, $query->aggregate);
+        $groups = $query->groups ? ' '.$this->compileGroups($query, $query->groups) : '';
 
         $query->aggregate = null;
+        $query->groups = null;
 
-        return $sql.' from ('.$this->compileSelect($query).') as '.$this->wrapTable('temp_table');
+        return $sql.' from ('.$this->compileSelect($query).') as '.$this->wrapTable('temp_table').$groups;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -141,11 +141,11 @@ class Grammar extends BaseGrammar
 
         $sql = 'select ';
 
-        if ($query->groups) {
-            $sql .= $this->columnize($query->groups).', ';
-        }
-
         $sql .= $aggregate['function'].'('.$column.') as aggregate';
+
+        if ($query->groups) {
+            $sql .= ', '.$this->columnize($query->groups);
+        }
 
         return $sql;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1812,10 +1812,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $queryResults = [['aggregate' => 2, 'role' => 'admin', 'city' => 'NY'], ['aggregate' => 5, 'role' => 'user', 'city' => 'LA']];
         $builder->getConnection()
             ->shouldReceive('select')->once()
-            ->with('select "role", "city", count(*) as aggregate from "users" group by "role", "city"', [], true)
+            ->with('select count(*) as aggregate, "role", "city" from "users" group by "role", "city"', [], true)
             ->andReturn($queryResults);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
-        $results = $builder->from('users')->groupBy('role', 'city')->aggregateByGroup('count');
+        $builder->from('users')->groupBy('role', 'city');
+        $builder->aggregate = ['function' => 'count', 'columns' => ['*']];
+        $results = $builder->get();
         $this->assertEquals($queryResults, $results->toArray());
     }
 
@@ -1826,7 +1828,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $queryResults = [['aggregate' => 2, 'role' => 'admin'], ['aggregate' => 5, 'role' => 'user']];
         $builder->getConnection()
             ->shouldReceive('select')->once()
-            ->with('select "role", count(*) as aggregate from ((select * from "users") union (select * from "members")) as "temp_table" group by "role"', [], true)
+            ->with('select count(*) as aggregate, "role" from ((select * from "users") union (select * from "members")) as "temp_table" group by "role"', [], true)
             ->andReturn($queryResults);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
         $results = $builder->from('users')
@@ -3498,35 +3500,35 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testAggregateFunctionsWithGroupBy()
     {
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", count(*) as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate, "role" from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
         $results = $builder->from('users')->groupBy('role')->countByGroup();
         $this->assertInstanceOf(Collection::class, $results);
         $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", max("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select max("id") as aggregate, "role" from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
         $results = $builder->from('users')->groupBy('role')->maxByGroup('id');
         $this->assertInstanceOf(Collection::class, $results);
         $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", min("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select min("id") as aggregate, "role" from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
         $results = $builder->from('users')->groupBy('role')->minByGroup('id');
         $this->assertInstanceOf(Collection::class, $results);
         $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", sum("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select sum("id") as aggregate, "role" from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
         $results = $builder->from('users')->groupBy('role')->sumByGroup('id');
         $this->assertInstanceOf(Collection::class, $results);
         $this->assertEquals([['role' => 'admin', 'aggregate' => 1]], $results->toArray());
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select "role", avg("id") as aggregate from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select avg("id") as aggregate, "role" from "users" group by "role"', [], true)->andReturn([['role' => 'admin', 'aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(fn ($builder, $results) => $results);
         $results = $builder->from('users')->groupBy('role')->avgByGroup('id');
         $this->assertInstanceOf(Collection::class, $results);


### PR DESCRIPTION
Replaces https://github.com/laravel/framework/pull/53209 that have been reverted by https://github.com/laravel/framework/pull/53582.

This new version adds new methods: `countByGroup`, `minByGroup`, `maxByGroup`, `sumByGroup` and `avgByGroup`. I did not create the alias `averageByGroup`, but I can if you believe that's useful.