### PR TITLE
[11.x] Fix `withoutOverlapping` for grouped scheduled closures

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -60,13 +60,6 @@ class Event
     protected $afterCallbacks = [];
 
     /**
-     * The human readable description of the event.
-     *
-     * @var string|null
-     */
-    public $description;
-
-    /**
      * The event mutex implementation.
      *
      * @var \Illuminate\Console\Scheduling\EventMutex
@@ -728,30 +721,6 @@ class Event
                             ? null
                             : $container->call($callback, ['output' => new Stringable($output)]);
         };
-    }
-
-    /**
-     * Set the human-friendly description of the event.
-     *
-     * @param  string  $description
-     * @return $this
-     */
-    public function name($description)
-    {
-        return $this->description($description);
-    }
-
-    /**
-     * Set the human-friendly description of the event.
-     *
-     * @param  string  $description
-     * @return $this
-     */
-    public function description($description)
-    {
-        $this->description = $description;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -91,6 +91,13 @@ trait ManagesAttributes
     protected $rejects = [];
 
     /**
+     * The human readable description of the event.
+     *
+     * @var string|null
+     */
+    public $description;
+
+    /**
      * Set which user the command should run as.
      *
      * @param  string  $user
@@ -196,6 +203,30 @@ trait ManagesAttributes
         $this->rejects[] = Reflector::isCallable($callback) ? $callback : function () use ($callback) {
             return $callback;
         };
+
+        return $this;
+    }
+
+    /**
+     * Set the human-friendly description of the event.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function name($description)
+    {
+        return $this->description($description);
+    }
+
+    /**
+     * Set the human-friendly description of the event.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function description($description)
+    {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -46,6 +46,10 @@ class PendingEventAttributes
             $event->timezone($this->timezone);
         }
 
+        if ($this->description !== null) {
+            $event->name($this->description);
+        }
+
         if ($this->user !== null) {
             $event->user = $this->user;
         }

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -42,12 +42,12 @@ class PendingEventAttributes
         $event->expression = $this->expression;
         $event->repeatSeconds = $this->repeatSeconds;
 
-        if ($this->timezone !== null) {
-            $event->timezone($this->timezone);
-        }
-
         if ($this->description !== null) {
             $event->name($this->description);
+        }
+
+        if ($this->timezone !== null) {
+            $event->timezone($this->timezone);
         }
 
         if ($this->user !== null) {

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -184,7 +184,7 @@ class Schedule
                 : $job::class;
         }
 
-        return $this->call(function () use ($job, $queue, $connection) {
+        return $this->name($jobName)->call(function () use ($job, $queue, $connection) {
             $job = is_string($job) ? Container::getInstance()->make($job) : $job;
 
             if ($job instanceof ShouldQueue) {
@@ -192,7 +192,7 @@ class Schedule
             } else {
                 $this->dispatchNow($job);
             }
-        })->name($jobName);
+        });
     }
 
     /**


### PR DESCRIPTION
### Description

The issue stems from combining the `withoutOverlapping` and `call` methods. The `call` method requires a name when used with `withoutOverlapping`. In schedule groups, the `withoutOverlapping` attribute was being set without the ability to provide a name or description, leading to the problem. This PR addresses and resolves this behavior.

Issue #53673 can be closed once this PR is merged.