### PR TITLE
[11.x] Fix issue where booted callbacks are being called twice

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1143,10 +1143,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function booted($callback)
     {
-        $this->bootedCallbacks[] = $callback;
-
         if ($this->isBooted()) {
             $callback($this);
+        } else {
+            $this->bootedCallbacks[] = $callback;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/53589

Booted callbacks which are added during the execution of other callbacks are being called twice, once as the callback is registered and again when the `while` loop reaches that callback in the stack.

This issue was introduced  in version 8.65.0 by the commit https://github.com/laravel/framework/commit/9eadb7f25db5b0a1aa78470c864a17eb815781f8.

A number of different fixes were considered, but I believe that the best option would be to simply not append the callback and  I would think that this is likely to be the least breaking change.

In determining this, I took into consideration the fact that some applications may have existing callbacks that check the booted state of the application, and I also considered the fact that the callback was already being called as soon as it was registered but now it simply is not called a second time.

Please let me know if you would also like a test written for this.
