### PR TITLE
[11.x] Fix for breaking change in #53543 when ::withoutWrapping() is called after instance creation

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -50,7 +50,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $wrapper = null;
 
     /**
-     * Indicates if the wrapper has been set on this instance
+     * Indicates if the wrapper has been set on this instance.
      *
      * @var bool
      */

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -50,6 +50,13 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $wrapper = null;
 
     /**
+     * Indicates if the wrapper has been set on this instance
+     *
+     * @var bool
+     */
+    public $wrapperSet = false;
+
+    /**
      * The "data" wrapper that should be applied.
      *
      * @var string|null
@@ -65,8 +72,6 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function __construct($resource)
     {
         $this->resource = $resource;
-
-        $this->withWrapper(static::$wrap);
     }
 
     /**
@@ -218,6 +223,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function withWrapper(?string $value)
     {
         $this->wrapper = $value;
+        $this->wrapperSet = true;
 
         return $this;
     }

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -106,7 +106,7 @@ class ResourceResponse implements Responsable
      */
     protected function wrapper()
     {
-        return $this->resource instanceof JsonResource
+        return $this->resource instanceof JsonResource && $this->resource->wrapperSet
             ? $this->resource->wrapper
             : get_class($this->resource)::$wrap;
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -233,6 +233,29 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function testResourcesCanSetWithoutWrappingAfterCreatingInstance()
+    {
+        Route::get('/', function () {
+            $resource = new PostResource(new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ]));
+
+            $resource::withoutWrapping();
+
+            return $resource;
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertJson([
+            'id' => 5,
+            'title' => 'Test Title',
+        ]);
+    }
+
     public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {


### PR DESCRIPTION
Fixes breaking change introduced in #53543

Comment finding the breaking change: https://github.com/laravel/framework/pull/53543#issuecomment-2503670622

See failing test which is added to test the code below now is without a wrapper:
```php
$resource = new PostResource(new Post([
    'id' => 5,
    'title' => 'Test Title',
]));
$resource::withoutWrapping();
```


This PR adds a check to determine if an explicit wrapper has been set on the instance, if not, use the logic from before #53543, this allows for static wrapper changes after the instance is created to have impact.

### 12.x consideration
It's worth considering making an intended breaking change in 12.x to no longer let static updates change the wrapper after instantiation, but this PR focuses on removing the breaking change I introduced with #53543

### `wrapper` property consideration
Edit: this fix does introduce the side effect that manually setting `$instance->wrapper = 'posts'` will now have no effect, since that doesn't set the `wrapperSet` flag. Maybe the `wrapper` property should be protected/private with a getter (or async visibility in the future 👀)