### PR TITLE
[11.x] Fix `ResendTransport` missing custom headers

### DIFF
--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -70,12 +70,12 @@ class ResendTransport extends AbstractTransport
 
         if ($email->getAttachments()) {
             foreach ($email->getAttachments() as $attachment) {
-                $headers = $attachment->getPreparedHeaders();
+                $attachmentHeaders = $attachment->getPreparedHeaders();
 
-                $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
+                $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
                 $item = [
-                    'content_type' => $headers->get('Content-Type')->getBody(),
+                    'content_type' => $attachmentHeaders->get('Content-Type')->getBody(),
                     'content' => str_replace("\r\n", '', $attachment->bodyToString()),
                     'filename' => $filename,
                 ];


### PR DESCRIPTION
When using Resend, if I pass a custom header in my mail and that there are attachments, the custom header will not be used.

This PR ensure that another variable name is used so that the initial `$headers` array is not overwritten. 
