### PR TITLE
[11.x] Fix: Mixed used of hardcoded slashes and DIRECTORY_SEPARATOR

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -306,10 +306,10 @@ class MigrateCommand extends BaseCommand implements Isolatable
             return $this->option('schema-path');
         }
 
-        if (file_exists($path = database_path('schema/'.$connection->getName().'-schema.dump'))) {
+        if (file_exists($path = database_path('schema'.DIRECTORY_SEPARATOR.$connection->getName().'-schema.dump'))) {
             return $path;
         }
 
-        return database_path('schema/'.$connection->getName().'-schema.sql');
+        return database_path('schema'.DIRECTORY_SEPARATOR.$connection->getName().'-schema.sql');
     }
 }


### PR DESCRIPTION
The MigrateCommand@schemaPath method contained a hardcoded forward slash and invoked Illuminate\Filesystem\join_paths through database_path. Since database_path internally uses DIRECTORY_SEPARATOR, this led to inconsistent behavior in non-Unix environments.