### PR TITLE
[11.x] Execute event listener using Fiber

### DIFF
--- a/src/Illuminate/Contracts/Events/RunsOnFiber.php
+++ b/src/Illuminate/Contracts/Events/RunsOnFiber.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Contracts\Events;
+
+use Fiber;
+
+trait RunsOnFiber
+{
+    public function handleWithFiber(...$arguments)
+    {
+        $self = $this;
+        $fiber = new Fiber(function () use ($arguments, $self) {
+            return $self->handle(...$arguments);
+        });
+        $fiber->start();
+
+        return $fiber->getReturn();
+    }
+}

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -4,11 +4,13 @@ namespace Illuminate\Events;
 
 use Closure;
 use Exception;
+use Fiber;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Events\RunsOnFiber;
 use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
@@ -514,6 +516,10 @@ class Dispatcher implements DispatcherContract
      */
     protected function parseClassCallable($listener)
     {
+        if (in_array(RunsOnFiber::class, class_uses_recursive($listener))) {
+            return Str::parseCallback($listener, 'handleWithFiber');
+        }
+
         return Str::parseCallback($listener, 'handle');
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
**Summary**
This PR introduces the ability to execute Event Listeners using PHP Fibers. This enhancement can significantly improve performance, especially when the _sync_ driver is used for event dispatching.

**How it works**
To leverage this feature, a Listener class simply needs to include the `RunsOnFiber` trait—no additional setup required. The event dispatcher automatically detects listeners using this trait and executes their handling logic inside a Fiber. The `RunsOnFiber` trait provides a built-in decorator to handle the execution seamlessly.

This approach ensures a lightweight integration of Fibers, offering better responsiveness and concurrency for event-driven workflows.
