### PR TITLE
[11.x] Introduce UrlString helper class

### DIFF
--- a/src/Illuminate/Support/UrlString.php
+++ b/src/Illuminate/Support/UrlString.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
+
+class UrlString implements Stringable, Arrayable
+{
+    /**
+     * The URL parts.
+     */
+    protected array $parts = [
+        'scheme' => null,
+        'user' => null,
+        'pass' => null,
+        'host' => null,
+        'port' => null,
+        'path' => null,
+        'query' => [],
+        'fragment' => null,
+    ];
+
+    /**
+     * Create a new URL string instance.
+     */
+    public function __construct(string $url = '')
+    {
+        if (! empty($url)) {
+            $parts = parse_url($url);
+
+            parse_str($parts['query'] ?? '', $query);
+
+            $parts['query'] = $query;
+
+            $this->parts = array_replace($this->parts, $parts);
+        }
+    }
+
+    /**
+     * Get the scheme.
+     */
+    public function getScheme(): ?string
+    {
+        return $this->parts['scheme'];
+    }
+
+    /**
+     * Set the scheme.
+     */
+    public function setScheme(string $value): static
+    {
+        $this->parts['scheme'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the protocol.
+     */
+    public function getProtocol(): ?string
+    {
+        return match ($this->parts['scheme']) {
+            '', null => null,
+            'file' => 'file:///',
+            default => sprintf('%s://', $this->parts['scheme']),
+        };
+    }
+
+    /**
+     * Get the password.
+     */
+    public function getPass(): ?string
+    {
+        return $this->parts['pass'];
+    }
+
+    /**
+     * Set the password.
+     */
+    public function setPass(string $value): static
+    {
+        $this->parts['pass'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the username.
+     */
+    public function getUser(): ?string
+    {
+        return $this->parts['user'];
+    }
+
+    /**
+     * Set the username.
+     */
+    public function setUser(string $value): static
+    {
+        $this->parts['user'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the auth credentials.
+     */
+    public function withAuth(string $username, string $password): static
+    {
+        return $this->setUser($username)->setPass($password);
+    }
+
+    /**
+     * Get the hostname.
+     */
+    public function getHost(): ?string
+    {
+        return $this->parts['host'];
+    }
+
+    /**
+     * Set the hostname.
+     */
+    public function setHost(string $value): static
+    {
+        $this->parts['host'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the port.
+     */
+    public function getPort(): ?int
+    {
+        return $this->parts['port'];
+    }
+
+    /**
+     * Set the port.
+     */
+    public function setPort(int $value): static
+    {
+        $this->parts['port'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the path.
+     */
+    public function getPath(): ?string
+    {
+        return $this->parts['path'];
+    }
+
+    /**
+     * Set the path.
+     */
+    public function setPath(string $value): static
+    {
+        $this->parts['path'] = '/'.ltrim($value, '/');
+
+        return $this;
+    }
+
+    /**
+     * Get the query as an array.
+     */
+    public function getQuery(): array
+    {
+        return $this->parts['query'];
+    }
+
+    /**
+     * Set the query.
+     */
+    public function setQuery(string|array $value): static
+    {
+        if (is_string($value)) {
+            parse_str($value, $query);
+
+            $this->parts['query'] = $query;
+        } else {
+            $this->parts['query'] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the query string.
+     */
+    public function getQueryString(): string
+    {
+        return http_build_query((array) $this->parts['query'], '', '&', PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * Merge the given value into the query.
+     */
+    public function withQuery(array $value): static
+    {
+        $this->parts['query'] = array_replace((array) $this->parts['query'], $value);
+
+        return $this;
+    }
+
+    /**
+     * Remove the given keys from the query.
+     */
+    public function withoutQuery(array|string|null $keys = null): static
+    {
+        $this->parts['query'] = match (true) {
+            is_null($keys) => [],
+            default => array_diff_key((array) $this->parts['query'], array_flip((array) $keys)),
+        };
+
+        return $this;
+    }
+
+    /**
+     * Get the fragment.
+     */
+    public function getFragment(): ?string
+    {
+        return $this->parts['fragment'];
+    }
+
+    /**
+     * Set the fragment.
+     */
+    public function setFragment(string $value): static
+    {
+        $this->parts['fragment'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Build the URL from the parts.
+     */
+    public function build(): string
+    {
+        $url = isset($this->parts['scheme']) ? $this->getProtocol() : '';
+        $url .= $this->buildAuth();
+        $url .= $this->parts['host'] ?? '';
+        $url .= $this->buildPort();
+        $url .= $this->parts['path'] ?? '';
+        $url .= $this->buildQuery();
+        $url .= $this->buildFragment();
+
+        return $url;
+    }
+
+    /**
+     * Build the auth URL part.
+     */
+    protected function buildAuth(): string
+    {
+        return isset($this->parts['user'], $this->parts['pass'])
+            ? sprintf('%s:%s@', $this->parts['user'], $this->parts['pass'])
+            : '';
+    }
+
+    /**
+     * Build the port URL part.
+     */
+    protected function buildPort(): string
+    {
+        return isset($this->parts['port']) ? sprintf(':%d', $this->parts['port']) : '';
+    }
+
+    /**
+     * Build the query URL part.
+     */
+    protected function buildQuery(): string
+    {
+        return ! empty($this->parts['query'])
+            ? sprintf('?%s', $this->getQueryString())
+            : '';
+    }
+
+    /**
+     * Build the fragment URL part.
+     */
+    protected function buildFragment(): string
+    {
+        return isset($this->parts['fragment'])
+            ? sprintf('#%s', $this->parts['fragment'])
+            : '';
+    }
+
+    /**
+     * Convert the object to an array.
+     */
+    public function toArray(): array
+    {
+        return $this->parts;
+    }
+
+    /**
+     * Convert the object to a string.
+     */
+    public function __toString(): string
+    {
+        return $this->build();
+    }
+}

--- a/src/Illuminate/Support/UrlString.php
+++ b/src/Illuminate/Support/UrlString.php
@@ -239,6 +239,16 @@ class UrlString implements Stringable, Arrayable
     }
 
     /**
+     * Removes the fragment.
+     */
+    public function withoutFragment(): static
+    {
+        $this->parts['fragment'] = null;
+
+        return $this;
+    }
+
+    /**
      * Build the URL from the parts.
      */
     public function build(): string

--- a/src/Illuminate/Support/UrlString.php
+++ b/src/Illuminate/Support/UrlString.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support;
 use Illuminate\Contracts\Support\Arrayable;
 use Stringable;
 
-class UrlString implements Stringable, Arrayable
+class UrlString implements Arrayable, Stringable
 {
     /**
      * The URL parts.

--- a/tests/Support/SupportUrlStringTest.php
+++ b/tests/Support/SupportUrlStringTest.php
@@ -109,8 +109,10 @@ class SupportUrlStringTest extends TestCase
         $this->assertNull($url->getFragment());
 
         $url->setFragment('eloquent');
-
         $this->assertSame('eloquent', $url->getFragment());
+
+        $url->withoutFragment();
+        $this->assertNull($url->getFragment());
     }
 
     public function testToString(): void

--- a/tests/Support/SupportUrlStringTest.php
+++ b/tests/Support/SupportUrlStringTest.php
@@ -143,4 +143,4 @@ class SupportUrlStringTest extends TestCase
             (new UrlString($url))->toArray()
         );
     }
-}#
+}

--- a/tests/Support/SupportUrlStringTest.php
+++ b/tests/Support/SupportUrlStringTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\UrlString;
+use PHPUnit\Framework\TestCase;
+
+class SupportUrlStringTest extends TestCase
+{
+    public function testUrlStringParsesUrl(): void
+    {
+        $url = new UrlString('https://taylor:lambo@laravel.com:80/docs?branch=master&theme=dark#eloquent');
+
+        $this->assertSame('https', $url->getScheme());
+        $this->assertSame('taylor', $url->getUser());
+        $this->assertSame('lambo', $url->getPass());
+        $this->assertSame('laravel.com', $url->getHost());
+        $this->assertSame(80, $url->getPort());
+        $this->assertSame('/docs', $url->getPath());
+        $this->assertSame(['branch' => 'master', 'theme' => 'dark'], $url->getQuery());
+        $this->assertSame('eloquent', $url->getFragment());
+    }
+
+    public function testUrlStringScheme(): void
+    {
+        $url = new UrlString();
+
+        $this->assertNull($url->getScheme());
+        $this->assertNull($url->getProtocol());
+
+        $url->setScheme('https');
+        $this->assertSame('https', $url->getScheme());
+        $this->assertSame('https://', $url->getProtocol());
+
+        $url->setScheme('file');
+        $this->assertSame('file:///', $url->getProtocol());
+    }
+
+    public function testUrlStringAuth(): void
+    {
+        $url = new UrlString();
+
+        $this->assertNull($url->getUser());
+        $this->assertNull($url->getPass());
+
+        $url->withAuth('taylor', 'lambo');
+
+        $this->assertSame('taylor', $url->getUser());
+        $this->assertSame('lambo', $url->getPass());
+    }
+
+    public function testUrlStringHost(): void
+    {
+        $url = new UrlString();
+
+        $this->assertNull($url->getHost());
+
+        $url->setHost('laravel.com');
+
+        $this->assertSame('laravel.com', $url->getHost());
+    }
+
+    public function testUrlStringPort(): void
+    {
+        $url = new UrlString();
+
+        $this->assertNull($url->getPort());
+
+        $url->setPort(80);
+
+        $this->assertSame(80, $url->getPort());
+    }
+
+    public function testUrlStringPath(): void
+    {
+        $url = new UrlString();
+
+        $this->assertNull($url->getPath());
+
+        $url->setPath('/docs');
+
+        $this->assertSame('/docs', $url->getPath());
+    }
+
+    public function testUrlStringQuery(): void
+    {
+        $url = new UrlString();
+
+        $this->assertEmpty($url->getQuery());
+        $this->assertSame('', $url->getQueryString());
+
+        $url->setQuery(['branch' => 'master', 'theme' => 'dark']);
+        $this->assertSame(['branch' => 'master', 'theme' => 'dark'], $url->getQuery());
+
+        $url->withQuery(['foo' => 'bar']);
+        $this->assertSame(['branch' => 'master', 'theme' => 'dark', 'foo' => 'bar'], $url->getQuery());
+
+        $url->withoutQuery(['branch', 'foo']);
+        $this->assertSame(['theme' => 'dark'], $url->getQuery());
+
+        $url->withoutQuery();
+        $this->assertEmpty($url->getQuery());
+    }
+
+    public function testUrlStringFragment(): void
+    {
+        $url = new UrlString();
+
+        $this->assertNull($url->getFragment());
+
+        $url->setFragment('eloquent');
+
+        $this->assertSame('eloquent', $url->getFragment());
+    }
+
+    public function testToString(): void
+    {
+        $url = 'https://taylor:lambo@laravel.com:80/docs?branch=master&theme=dark#eloquent';
+
+        $this->assertSame(
+            $url,
+            (new UrlString($url))->__toString()
+        );
+    }
+
+    public function testToArray(): void
+    {
+        $url = 'https://taylor:lambo@laravel.com:80/docs?branch=master&theme=dark#eloquent';
+
+        $this->assertSame(
+            [
+                'scheme' => 'https',
+                'user' => 'taylor',
+                'pass' => 'lambo',
+                'host' => 'laravel.com',
+                'port' => 80,
+                'path' => '/docs',
+                'query' => ['branch' => 'master', 'theme' => 'dark'],
+                'fragment' => 'eloquent',
+            ],
+            (new UrlString($url))->toArray()
+        );
+    }
+}#


### PR DESCRIPTION
### What is this?

Currently here is no easy way to manipulate URLs. This PR introduces a new `UrlString` class that helps managing URL strings easily.

The idea is having something similar to JavaScript's [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location) object.

The goal is to having an easy to use API to modify URLs without using `str_replace`, `parse_url` or `parse_str` directly all the time and have the ability to manage even complex query parameters without any problem.

### Why in the framework?

In recent projects, I often faced situations where I had to manipulate internal and external URLs. For example internal URL for a redirection or an external URL points to another site which is sent in an email with some special query parameters. For the redirection problem I opened the https://github.com/laravel/framework/pull/52562 PR not long ago.

Since I faced this problem in more applications, I thought this would be a helpful addition to the framework, others might have the same issues.

### Usage

```php
use Illuminate\Support\UrlString;

$url = new UrlString('https://taylor:lambo@laravel.com:80/docs?branch=master&theme=dark#eloquent');

// Getters
$url->getScheme(); // https
$url->getUser(); // taylor
$url->getPass(); // lambo
$url->getHost(); // laravel.com
$url->getPort(); // 80
$url->getPath(); // /docs
$url->getQuery(); // ['branch' => 'master', 'theme' => 'dark']
$url->getFragment(); // eloquent
$url->getProtocol(); // https://
$url->getQueryString(); // branch=master&theme=dark

// Setters
$url->setScheme('file'); 
$url->withAuth('taylor', 'lambo');
$url->setFragment('eloquent');
$url->withoutFragment();
$url->setQuery(['foo' => 'bar']); // overrides the query
$url->withQuery(['foo' => 'bar']); // merges the array into the query
$url->withoutQuery(['theme']); // removes the key from the query
$url->setPort(80);
$url->setPath('/docs');
$url->setHost('laravel.com');
```