### PR TITLE
Introduce Http status code response helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -21,6 +21,7 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
 if (! function_exists('abort')) {
@@ -902,6 +903,36 @@ if (! function_exists('session')) {
         }
 
         return app('session')->get($key, $default);
+    }
+}
+
+if (! function_exists('status')) {
+    /**
+     * Create a response with the given code.
+     *
+     * @param  int|null  $code
+     * @return ($code is null ? object : \Illuminate\Http\Response)
+     *
+     * @throws RuntimeException
+     */
+    function status($code = null)
+    {
+        if (! is_null($code)) {
+            return response()->noContent($code);
+        }
+
+        return new class
+        {
+            public function __call(string $name, array $arguments)
+            {
+                $constant = 'Symfony\Component\HttpFoundation\Response::HTTP_'.Str::upper(Str::snake($name));
+                if (! defined($constant)) {
+                    throw new RuntimeException('Invalid status code method: '.$name);
+                }
+
+                return response()->noContent(constant($constant));
+            }
+        };
     }
 }
 


### PR DESCRIPTION
Anytime I work on APIs I alway feel it would be smooth to quickly return a status code from a controller action.

```php
public function store(Request $request)
{
    // ...

    return 201;
}
```

However, this has underlying challenges - breaking change with existing apps and [potentially unexpected side-effects](https://github.com/laravel/framework/pull/53663) of returning a raw integer.

So, in the spirit of the `to_route()` helper, I propose `status`. Similarly this code reads very well, "return status 201". I've added a fluent API for named status.

**Examples**
```php
// passing integer
return status(201);

// fluent API
return status()->created();
```

The fluent API method names are the snake case names of the [Response constants](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/HttpFoundation/Response.php#L24).

**Additional Examples**
```php
return status()->ok();
return status()->unauthorized();
return status()->methodNotAllowed();
return status()->iAmATeapot();
```

