### PR TITLE
[11.x] Add the pivot's related model when creating from attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,12 +1622,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  string  $table
      * @param  bool  $exists
      * @param  string|null  $using
+     * @param  \Illuminate\Database\Eloquent\Model|null  $related
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(self $parent, array $attributes, $table, $exists, $using = null)
+    public function newPivot(self $parent, array $attributes, $table, $exists, $using = null, ?self $related = null)
     {
-        return $using ? $using::fromRawAttributes($parent, $attributes, $table, $exists)
-            : Pivot::fromAttributes($parent, $attributes, $table, $exists);
+        return $using ? $using::fromRawAttributes($parent, $attributes, $table, $exists, $related)
+            : Pivot::fromAttributes($parent, $attributes, $table, $exists, $related);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,13 +1622,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  string  $table
      * @param  bool  $exists
      * @param  string|null  $using
-     * @param  \Illuminate\Database\Eloquent\Model|null  $related
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(self $parent, array $attributes, $table, $exists, $using = null, ?self $related = null)
+    public function newPivot(self $parent, array $attributes, $table, $exists, $using = null)
     {
-        return $using ? $using::fromRawAttributes($parent, $attributes, $table, $exists, $related)
-            : Pivot::fromAttributes($parent, $attributes, $table, $exists, $related);
+        return $using ? $using::fromRawAttributes($parent, $attributes, $table, $exists)
+            : Pivot::fromAttributes($parent, $attributes, $table, $exists);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -15,6 +15,13 @@ trait AsPivot
     public $pivotParent;
 
     /**
+     * The related model of the relationship.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    public $pivotRelated;
+
+    /**
      * The name of the foreign key column.
      *
      * @var string
@@ -35,9 +42,10 @@ trait AsPivot
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
+     * @param  \Illuminate\Database\Eloquent\Model|null  $related
      * @return static
      */
-    public static function fromAttributes(Model $parent, $attributes, $table, $exists = false)
+    public static function fromAttributes(Model $parent, $attributes, $table, $exists = false, ?Model $related = null)
     {
         $instance = new static;
 
@@ -56,6 +64,11 @@ trait AsPivot
         // from the developer's point of view. We can use the parents to get these.
         $instance->pivotParent = $parent;
 
+        // Also store a model instance of the relationship that was called on the parent
+        // so the developer is able to identify which relationship methods were used
+        // in their custom pivot class, and within their fromRawAttributes method.
+        $instance->pivotRelated = $related;
+
         $instance->exists = $exists;
 
         return $instance;
@@ -68,11 +81,12 @@ trait AsPivot
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
+     * @param  \Illuminate\Database\Eloquent\Model|null  $related
      * @return static
      */
-    public static function fromRawAttributes(Model $parent, $attributes, $table, $exists = false)
+    public static function fromRawAttributes(Model $parent, $attributes, $table, $exists = false, ?Model $related = null)
     {
-        $instance = static::fromAttributes($parent, [], $table, $exists);
+        $instance = static::fromAttributes($parent, [], $table, $exists, $related);
 
         $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -42,10 +42,9 @@ trait AsPivot
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
-     * @param  \Illuminate\Database\Eloquent\Model|null  $related
      * @return static
      */
-    public static function fromAttributes(Model $parent, $attributes, $table, $exists = false, ?Model $related = null)
+    public static function fromAttributes(Model $parent, $attributes, $table, $exists = false)
     {
         $instance = new static;
 
@@ -64,11 +63,6 @@ trait AsPivot
         // from the developer's point of view. We can use the parents to get these.
         $instance->pivotParent = $parent;
 
-        // Also store a model instance of the relationship that was called on the parent
-        // so the developer is able to identify which relationship methods were used
-        // in their custom pivot class, and within their fromRawAttributes method.
-        $instance->pivotRelated = $related;
-
         $instance->exists = $exists;
 
         return $instance;
@@ -81,12 +75,11 @@ trait AsPivot
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
-     * @param  \Illuminate\Database\Eloquent\Model|null  $related
      * @return static
      */
-    public static function fromRawAttributes(Model $parent, $attributes, $table, $exists = false, ?Model $related = null)
+    public static function fromRawAttributes(Model $parent, $attributes, $table, $exists = false)
     {
-        $instance = static::fromAttributes($parent, [], $table, $exists, $related);
+        $instance = static::fromAttributes($parent, [], $table, $exists);
 
         $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 
@@ -229,6 +222,19 @@ trait AsPivot
     }
 
     /**
+     * Set the related model of the relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $related
+     * @return $this
+     */
+    public function setRelatedModel(?Model $related = null)
+    {
+        $this->pivotRelated = $related;
+
+        return $this;
+    }
+
+    /**
      * Determine if the pivot model or given attributes has timestamp attributes.
      *
      * @param  array|null  $attributes
@@ -340,6 +346,7 @@ trait AsPivot
     public function unsetRelations()
     {
         $this->pivotParent = null;
+        $this->pivotRelated = null;
         $this->relations = [];
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -500,7 +500,7 @@ trait InteractsWithPivotTable
         return $this->newPivotQuery()->get()->map(function ($record) {
             $class = $this->using ?: Pivot::class;
 
-            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
+            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true, $this->related);
 
             return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
         });
@@ -518,7 +518,7 @@ trait InteractsWithPivotTable
         $attributes = array_merge(array_column($this->pivotValues, 'value', 'column'), $attributes);
 
         $pivot = $this->related->newPivot(
-            $this->parent, $attributes, $this->table, $exists, $this->using
+            $this->parent, $attributes, $this->table, $exists, $this->using, $this->related
         );
 
         return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -500,10 +500,11 @@ trait InteractsWithPivotTable
         return $this->newPivotQuery()->get()->map(function ($record) {
             $class = $this->using ?: Pivot::class;
 
-            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true)
-                ->setRelatedModel($this->related);
+            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
 
-            return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
+            return $pivot
+                ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
+                ->setRelatedModel($this->related);
         });
     }
 
@@ -520,9 +521,11 @@ trait InteractsWithPivotTable
 
         $pivot = $this->related->newPivot(
             $this->parent, $attributes, $this->table, $exists, $this->using
-        )->setRelatedModel($this->related);
+        );
 
-        return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
+        return $pivot
+            ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
+            ->setRelatedModel($this->related);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -500,7 +500,8 @@ trait InteractsWithPivotTable
         return $this->newPivotQuery()->get()->map(function ($record) {
             $class = $this->using ?: Pivot::class;
 
-            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true, $this->related);
+            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true)
+                ->setRelatedModel($this->related);
 
             return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
         });
@@ -518,8 +519,8 @@ trait InteractsWithPivotTable
         $attributes = array_merge(array_column($this->pivotValues, 'value', 'column'), $attributes);
 
         $pivot = $this->related->newPivot(
-            $this->parent, $attributes, $this->table, $exists, $this->using, $this->related
-        );
+            $this->parent, $attributes, $this->table, $exists, $this->using
+        )->setRelatedModel($this->related);
 
         return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -156,8 +156,8 @@ class MorphToMany extends BelongsToMany
 
         $attributes = array_merge([$this->morphType => $this->morphClass], $attributes);
 
-        $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
-                        : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
+        $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists, $this->related)
+                        : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists, $this->related);
 
         $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
               ->setMorphType($this->morphType)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -156,10 +156,11 @@ class MorphToMany extends BelongsToMany
 
         $attributes = array_merge([$this->morphType => $this->morphClass], $attributes);
 
-        $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists, $this->related)
-                        : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists, $this->related);
+        $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
+                        : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
 
         $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
+              ->setRelatedModel($this->related)
               ->setMorphType($this->morphType)
               ->setMorphClass($this->morphClass);
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -35,6 +35,16 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertSame('connection', $pivot->getConnectionName());
         $this->assertSame('table', $pivot->getTable());
         $this->assertTrue($pivot->exists);
+        $this->assertSame($parent, $pivot->pivotParent);
+    }
+
+    public function testRelatedPivotModelCanBeSetCorrectly()
+    {
+        $parent = new DummyModel;
+        $related = new DummyModel;
+        $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2024-11-27'], 'table', true, $related);
+
+        $this->assertSame($related, $pivot->pivotRelated);
     }
 
     public function testMutatorsAreCalledFromConstructor()

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -38,15 +38,6 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertSame($parent, $pivot->pivotParent);
     }
 
-    public function testRelatedPivotModelCanBeSetCorrectly()
-    {
-        $parent = new DummyModel;
-        $related = new DummyModel;
-        $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2024-11-27'], 'table', true, $related);
-
-        $this->assertSame($related, $pivot->pivotRelated);
-    }
-
     public function testMutatorsAreCalledFromConstructor()
     {
         $parent = m::mock(Model::class.'[getConnectionName]');


### PR DESCRIPTION
### Problem
For advanced model relationships where a [custom pivot model has been created](https://laravel.com/docs/11.x/eloquent-relationships#defining-custom-intermediate-table-models), the developer has [the opportunity](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Model.php#L1629) to define their own `fromRawAttributes` method.

Within this they may wish to conduct certain actions depending on the relationship. For me, this is for the purpose of auditing.

Currently I am auditing all models through their events, including the pivots when extending the above class. However when I `attach`, `detach`, or `updateExistingPivot`, I can only identify the parent with `$pivot->pivotParent`. There is no way of knowing which relationship was called on the parent model so you don't know _what_ was attached/detached/updated (which isn't ideal for an audit). 

For example:
```php
use App\Models\User;
 
$user = User::find(1);
 
$user->roles()->attach($roleId);
```

`$pivot->pivotParent` will be the User model, but the Pivot model doesn't know it's the Role model being attached.

Whilst the pivot keys are set (so we have `role_id` and `user_id`), there is no reliable way to identify the pivot's "child" (related) as the column names could potentially not follow convention (e.g. `parent_role` and `user`). 

As `$related` is only calculated on the relationship, you could not handle this in `fromRawAttributes` without overwriting all the core model methods that call it, which will increase upgrade friction.

### Solution
As we're already setting the `pivotParent`, I'm proposing we also set the related model (`pivotRelated`) on the Pivot. Even though the relationship builds this as an empty class, it still helps developers reliably get the accurate class. This could easily be combined with `$pivot->getAttribute($pivot->getRelatedKey())` to get the model's ID, then a fresh instance if required.

Whilst I would prefer the property order to be slightly different so `$related` followed `$parent`, this solution felt the least intrusive option so we can retain backwards compatibility and not introduce any breaking changes.

Happy to look at alternative options though if I'm missing a simpler solution!