### PR TITLE
[11.x] Alternative fix for booted callbacks being called twice

### DIFF
--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -365,6 +365,10 @@ class FoundationApplicationTest extends TestCase
             $this->assertSame($application, $app);
         };
 
+        $closure2Booted = function ($app) use ($closure2) {
+            $app->booted($closure2);
+        };
+
         $closure3 = function ($app) use (&$counter, $application) {
             $counter++;
             $this->assertSame($application, $app);
@@ -373,13 +377,14 @@ class FoundationApplicationTest extends TestCase
         $application->booting($closure);
         $application->booted($closure);
         $application->booted($closure2);
+        $application->booted($closure2Booted);
         $application->boot();
 
-        $this->assertEquals(3, $counter);
+        $this->assertEquals(4, $counter);
 
         $application->booted($closure3);
 
-        $this->assertEquals(4, $counter);
+        $this->assertEquals(5, $counter);
     }
 
     public function testGetNamespace()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/53589

This is an alternative implementation of a fix submitted in the PR https://github.com/laravel/framework/pull/53683

In consideration of potential breaking changes in the previous PR, this implementation still allows booted callbacks to be pushed onto the array while not calling the callback immediately if booted callbacks are currently being processed.