### PR TITLE
[11.x] Set smtp as default scheme which is in the supported schemes list from Symfony Mailer

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -196,7 +196,7 @@ class MailManager implements FactoryContract
         if (! $scheme) {
             $scheme = ! empty($config['encryption']) && $config['encryption'] === 'tls'
                 ? (($config['port'] == 465) ? 'smtps' : 'smtp')
-                : '';
+                : 'smtp';
         }
 
         $transport = $factory->create(new Dsn(


### PR DESCRIPTION
Fix #53704

**Description:**
This pull request addresses an issue introduced by Symfony Mailer 7.2.0, where the UnsupportedSchemeException is thrown if the specified scheme is not explicitly set to smtp or smtps. Currently, MailManager::createSmtpTransport sets the scheme to an empty string ("") by default, which is no longer supported.

The change ensures the default scheme is explicitly set to smtp to maintain compatibility with Symfony Mailer 7.2.0 and prevent runtime errors.

Relevant Change in Symfony Mailer:

[symfony/mailer@v7.1.6...v7.2.0#diff-034fdf635bc919f1ba58fb3cac83ce59f111a73c1ee72d63055f752c4b3668dd](https://github.com/symfony/mailer/compare/v7.1.6...v7.2.0#diff-034fdf635bc919f1ba58fb3cac83ce59f111a73c1ee72d63055f752c4b3668dd)

**Steps to Reproduce:**

- Update composer dependencies to use Symfony Mailer 7.2.0 or later.
- Configure the mail driver with an smtp transport in Laravel.
- Attempt to send an email.
- Observe the exception:
```
Symfony\Component\Mailer\Exception\UnsupportedSchemeException: The "" scheme is not supported; supported schemes for mailer "smtp" are: "smtp", "smtps".
```

**Benefit to End Users:**
This fix ensures that users leveraging the smtp transport in Laravel's mail configuration do not encounter errors after updating their dependencies. It provides a seamless experience and prevents breaking changes when using Symfony Mailer 7.2.0+.

**Impact on Existing Features:**
This change does not break any existing features or functionality. It simply ensures compatibility with the latest Symfony Mailer updates.

