### PR TITLE
[11.x] Allow sorting routes by precedence in artisan routes:list.

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -116,7 +116,11 @@ class RouteListCommand extends Command
             return $this->getRouteInformation($route);
         })->filter()->all();
 
-        $routes = $this->sortRoutes($this->option('sort'), $routes);
+        if (($sort = $this->option('sort')) !== null) {
+            $routes = $this->sortRoutes($sort, $routes);
+        } else {
+            $routes = $this->sortRoutes('uri', $routes);
+        }
 
         if ($this->option('reverse')) {
             $routes = array_reverse($routes);
@@ -153,7 +157,7 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-        if ($sort === 'precedence') {
+        if ($sort === 'definition') {
             return $routes;
         }
 
@@ -495,7 +499,7 @@ class RouteListCommand extends Command
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware, precedence) to sort by', 'uri'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware, definition) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
             ['only-vendor', null, InputOption::VALUE_NONE, 'Only display routes defined by vendor packages'],
         ];

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -153,7 +153,6 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-
         if ($sort === 'precedence') {
             return $routes;
         }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -116,11 +116,7 @@ class RouteListCommand extends Command
             return $this->getRouteInformation($route);
         })->filter()->all();
 
-        if (($sort = $this->option('sort')) !== null) {
-            $routes = $this->sortRoutes($sort, $routes);
-        } else {
-            $routes = $this->sortRoutes('uri', $routes);
-        }
+        $routes = $this->sortRoutes($this->option('sort'), $routes);
 
         if ($this->option('reverse')) {
             $routes = array_reverse($routes);
@@ -157,6 +153,11 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
+
+        if ($sort === 'precedence') {
+            return $routes;
+        }
+
         if (Str::contains($sort, ',')) {
             $sort = explode(',', $sort);
         }
@@ -495,7 +496,7 @@ class RouteListCommand extends Command
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware, precedence) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
             ['only-vendor', null, InputOption::VALUE_NONE, 'Only display routes defined by vendor packages'],
         ];

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -109,7 +109,7 @@ class RouteListCommandTest extends TestCase
 
     public function testSortRouteListPrecedence()
     {
-        $this->app->call('route:list', ['--json' => true, '--sort' => 'precedence']);
+        $this->app->call('route:list', ['--json' => true, '--sort' => 'definition']);
         $output = $this->app->output();
 
         $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}, {"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -97,6 +97,26 @@ class RouteListCommandTest extends TestCase
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
 
+    public function testSortRouteListDefault()
+    {
+        $this->app->call('route:list', ['--json' => true]);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}, {"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+    }
+
+    public function testSortRouteListPrecedence()
+    {
+        $this->app->call('route:list', ['--json' => true, '--sort' => 'precedence']);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}, {"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+    }
+
     public function testMiddlewareGroupsAssignmentInCli()
     {
         $this->app->call('route:list', ['-v' => true]);


### PR DESCRIPTION
Hello, 

By default, routes are sorted by `uri`.
However, it's not easy to see which routes will take precedence on the others (especially when routes are coming from a package).

This PR adds a `--sort=precedence` option to display the routes by their original order.

It also removes useless code, and adds a test to be sure we don't have any regression.

_PS: in the edge case where an array is passed like `['domain', 'precedence']`, it still will work as planned, as null will be compared to null in the sort callback._

Thanks.
Mathieu.