### PR TITLE
Added applyAfterQueryCallbacks to non-mutator case in pluck

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -948,7 +948,7 @@ class Builder implements BuilderContract
         if (! $this->model->hasGetMutator($column) &&
             ! $this->model->hasCast($column) &&
             ! in_array($column, $this->model->getDates())) {
-            return $results;
+            return $this->applyAfterQueryCallbacks($results);
         }
 
         return $this->applyAfterQueryCallbacks(


### PR DESCRIPTION
This change adds the applyAfterQueryCallbacks call to the non-mutator case in the pluck function.
With this update ensures that pluck behaves consistently across mutator and non-mutator scenarios, improving code reliability.

**Reasons for Change**

When using the "pluck" method, the "afterQuery" method was not working when a column without a mutator was given.