### PR TITLE
[11.x] Update the message for the schedule:work command.

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -35,7 +35,7 @@ class ScheduleWorkCommand extends Command
     public function handle()
     {
         $this->components->info(
-            'Watching for scheduled tasks every second.',
+            'Running scheduled tasks.',
             $this->getLaravel()->environment('local') ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -35,7 +35,7 @@ class ScheduleWorkCommand extends Command
     public function handle()
     {
         $this->components->info(
-            'Running scheduled tasks every minute.',
+            'Watching for scheduled tasks every second.',
             $this->getLaravel()->environment('local') ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 


### PR DESCRIPTION
This makes the initial output of `schedule:work` more accurate. When I ran `schedule:work` to have it run a scheduled command that runs every 30 seconds and I saw that it will run scheduled tasks every minute that concerned me, but then after 30 seconds I saw that it was running the sub-minute task just fine. 

PR to update the docs: https://github.com/laravel/docs/pull/10047