### PR TITLE
[11.x] Support auto-discovery of PSR-17 implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
         "resend/resend-php": "^0.10.0",
         "symfony/cache": "^7.0.3",
         "symfony/http-client": "^7.0.3",
-        "symfony/psr-http-message-bridge": "^7.1",
+        "symfony/psr-http-message-bridge": "^7.0.3",
         "symfony/translation": "^7.0.3"
     },
     "conflict": {
@@ -196,7 +196,7 @@
         "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.0).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.0).",
         "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.0).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.1)."
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.0)."
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -109,17 +109,17 @@
         "league/flysystem-read-only": "^3.25.1",
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
-        "nyholm/psr7": "^1.2",
         "orchestra/testbench-core": "^9.6",
         "pda/pheanstalk": "^5.0.6",
+        "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^1.11.5",
         "phpunit/phpunit": "^10.5.35|^11.3.6",
         "predis/predis": "^2.3",
         "resend/resend-php": "^0.10.0",
         "symfony/cache": "^7.0.3",
         "symfony/http-client": "^7.0.3",
-        "symfony/translation": "^7.0.3",
-        "symfony/psr-http-message-bridge": "^7.0.3"
+        "symfony/psr-http-message-bridge": "^7.1",
+        "symfony/translation": "^7.0.3"
     },
     "conflict": {
         "mockery/mockery": "1.6.8",
@@ -184,8 +184,8 @@
         "league/flysystem-read-only": "Required to use read-only disks (^3.25.1)",
         "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
         "mockery/mockery": "Required to use mocking (^1.6).",
-        "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^5.0).",
+        "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
         "phpunit/phpunit": "Required to use assertions and run tests (^10.5|^11.0).",
         "predis/predis": "Required to use the predis connector (^2.3).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
@@ -196,12 +196,13 @@
         "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.0).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.0).",
         "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.0).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.0)."
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.1)."
     },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "php-http/discovery": false
         }
     },
     "minimum-stability": "stable",

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -9,11 +9,10 @@ use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Routing\Contracts\CallableDispatcher as CallableDispatcherContract;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Support\ServiceProvider;
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7\Response as PsrResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Response;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -134,10 +133,8 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerPsrRequest()
     {
         $this->app->bind(ServerRequestInterface::class, function ($app) {
-            if (class_exists(Psr17Factory::class) && class_exists(PsrHttpFactory::class)) {
-                $psr17Factory = new Psr17Factory;
-
-                return with((new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
+            if (class_exists(PsrHttpFactory::class)) {
+                return with((new PsrHttpFactory)
                     ->createRequest($illuminateRequest = $app->make('request')), function (ServerRequestInterface $request) use ($illuminateRequest) {
                         if ($illuminateRequest->getContentTypeFormat() !== 'json' && $illuminateRequest->request->count() === 0) {
                             return $request;
@@ -149,7 +146,7 @@ class RoutingServiceProvider extends ServiceProvider
                     });
             }
 
-            throw new BindingResolutionException('Unable to resolve PSR request. Please install the symfony/psr-http-message-bridge and nyholm/psr7 packages.');
+            throw new BindingResolutionException('Unable to resolve PSR request. Please install the "symfony/psr-http-message-bridge" package.');
         });
     }
 
@@ -161,11 +158,11 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerPsrResponse()
     {
         $this->app->bind(ResponseInterface::class, function () {
-            if (class_exists(PsrResponse::class)) {
-                return new PsrResponse;
+            if (class_exists(PsrHttpFactory::class)) {
+                return (new PsrHttpFactory)->createResponse(new Response);
             }
 
-            throw new BindingResolutionException('Unable to resolve PSR response. Please install the nyholm/psr7 package.');
+            throw new BindingResolutionException('Unable to resolve PSR response. Please install the "symfony/psr-http-message-bridge" package.');
         });
     }
 

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -41,11 +41,14 @@
     },
     "suggest": {
         "illuminate/console": "Required to use the make commands (^11.0).",
-        "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.0)."
+        "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.1)."
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     },
     "minimum-stability": "dev"
 }

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -42,7 +42,7 @@
     "suggest": {
         "illuminate/console": "Required to use the make commands (^11.0).",
         "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.1)."
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.0)."
     },
     "config": {
         "sort-packages": true,

--- a/tests/Integration/Routing/RoutingServiceProviderTest.php
+++ b/tests/Integration/Routing/RoutingServiceProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Orchestra\Testbench\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class RoutingServiceProviderTest extends TestCase
+{
+    public function testResolvingPsrRequest()
+    {
+        $psrRequest = $this->app->make(ServerRequestInterface::class);
+
+        $this->assertInstanceOf(ServerRequestInterface::class, $psrRequest);
+    }
+
+    public function testResolvingPsrResponse()
+    {
+        $psrResponse = $this->app->make(ResponseInterface::class);
+
+        $this->assertInstanceOf(ResponseInterface::class, $psrResponse);
+    }
+}


### PR DESCRIPTION
The `symfony/psr-http-message-bridge` supports auto-detecting PSR-17 factories: symfony/symfony#51197

This PR adds support for `php-http/discovery` on Laravel, that allows auto-discovery of PSR-17 implementations.

You may refer to [`php-http/discovery` readme](https://github.com/php-http/discovery?tab=readme-ov-file#usage-as-a-library-user) for more info:

> If you use a library/SDK that requires `php-http/discovery`, you can configure the auto-discovery mechanism to use a specific implementation when many are available in your project.

> For example, if you have both `nyholm/psr7` and `guzzlehttp/guzzle` in your project, you can enable the `php-http/discovery` composer plugin and configure it to use `guzzlehttp/guzzle` instead of `nyholm/psr7` by running the following command:
> 
> ```bash
> composer config allow-plugins.php-http/discovery true
> composer config extra.discovery.psr/http-factory-implementation GuzzleHttp\\Psr7\\HttpFactory
> ```

> This will update your composer.json file to add the following configuration:

> ```json
> {
>     "config": {
>          "allow-plugins": {
>              "php-http/discovery": true
>         }
>     },
>     "extra": {
>         "discovery": {
>             "psr/http-factory-implementation": "GuzzleHttp\\Psr7\\HttpFactory"
>         }
>     }
> }
> ```
