### PR TITLE
[11.x] Allow getActualClassNameForMorph() used by createModelByType() to be override

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -190,7 +190,7 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        $class = Model::getActualClassNameForMorph($type);
+        $class = $this->parent::getActualClassNameForMorph($type);
 
         return tap(new $class, function ($instance) {
             if (! $instance->getConnectionName()) {


### PR DESCRIPTION
This is an addition to #18058 and #18099 from a long time ago. @masterwto 

Use $this->parent to replace Model, which will give users the opportunity to override the default getActualClassNameForMorph behavior in the Model within their own models.

The parent here inherits from the ancestor Relation, and it will be populated when the MorphTo is initialized

Refer to #18058 #18099 



eg:

You can define a morphTo inverse relationship in the Comment model and override getActualClassNameForMorph. Now, you will be able to use 1 and 2 in commentable_type to represent Post and Video.

What differs from Relation::morphMap and Relation::enforceMorphMap is that it only applies to the Comment model, not globally.

```php

    public function commentable(): MorphTo
    {
        return $this->morphTo();
    }


    public static function getActualClassNameForMorph($class)
    {
        return match ((int) $class) {
            1 => Post::class,
            2 => Video::class,
            default => parent::getActualClassNameForMorph($class),
        };
    }
```