### PR TITLE
[11.x] Comment grammar fixes

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -679,7 +679,7 @@ class Blueprint
     }
 
     /**
-     * Specify an fulltext for the table.
+     * Specify a fulltext index for the table.
      *
      * @param  string|array  $columns
      * @param  string|null  $name
@@ -1605,7 +1605,7 @@ class Blueprint
     }
 
     /**
-     * Adds the `remember_token` column to the table.
+     * Add the `remember_token` column to the table.
      *
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */


### PR DESCRIPTION
Just a couple of small grammatical fixes in the comments of the Schema facade.

The first fixes what was likely a copy/paste from the `index()` comment and makes it more grammatically correct.  The second matches the comment's tense with the rest of the comments surrounding it.