### PR TITLE
[11.x] Fix `#but return statement is missing.#` errors

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -8,7 +8,6 @@ parameters:
     ignoreErrors:
         - "#\\(void\\) is used#"
         - "#Access to an undefined property#"
-        - "#but return statement is missing.#"
         - "#Call to an undefined method#"
         - "#Caught class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Class [a-zA-Z0-9\\\\_]+ not found.#"

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -16,7 +16,7 @@ trait ManagesTransactions
      *
      * @param  (\Closure(static): TReturn)  $callback
      * @param  int  $attempts
-     * @return TReturn
+     * @return TReturn|null
      *
      * @throws \Throwable
      */
@@ -70,6 +70,8 @@ trait ManagesTransactions
 
             return $callbackResult;
         }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -18,7 +18,7 @@ class TableGuesser
      * Attempt to guess the table name and "creation" status of the given migration.
      *
      * @param  string  $migration
-     * @return array
+     * @return array|null
      */
     public static function guess($migration)
     {
@@ -33,5 +33,7 @@ class TableGuesser
                 return [$matches[2], $create = false];
             }
         }
+
+        return null;
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -318,7 +318,7 @@ class MySqlGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @return string|null
      */
     public function compileAutoIncrementStartingValues(Blueprint $blueprint, Fluent $command)
     {
@@ -326,6 +326,8 @@ class MySqlGrammar extends Grammar
             && $value = $command->column->get('startingValue', $command->column->get('from'))) {
             return 'alter table '.$this->wrapTable($blueprint).' auto_increment = '.$value;
         }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -242,7 +242,7 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @return string|null
      */
     public function compileAutoIncrementStartingValues(Blueprint $blueprint, Fluent $command)
     {
@@ -252,6 +252,8 @@ class PostgresGrammar extends Grammar
 
             return 'alter sequence '.$blueprint->getPrefix().$table.'_'.$command->column->name.'_seq restart with '.$value;
         }
+
+        return null;
     }
 
     /**
@@ -626,7 +628,7 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @return string|null
      */
     public function compileComment(Blueprint $blueprint, Fluent $command)
     {
@@ -637,6 +639,8 @@ class PostgresGrammar extends Grammar
                 is_null($comment) ? 'NULL' : "'".str_replace("'", "''", $comment)."'"
             );
         }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -317,13 +317,15 @@ class SQLiteGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
-     * @return array|string
+     * @return null
      *
      * @throws \RuntimeException
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         // Handled on table alteration...
+
+        return null;
     }
 
     /**
@@ -331,11 +333,13 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @return null
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
         // Handled on table creation or alteration...
+
+        return null;
     }
 
     /**
@@ -389,11 +393,13 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string|null
+     * @return null
      */
     public function compileForeign(Blueprint $blueprint, Fluent $command)
     {
         // Handled on table creation or alteration...
+
+        return null;
     }
 
     /**
@@ -478,11 +484,13 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @return null
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
         // Handled on table alteration...
+
+        return null;
     }
 
     /**
@@ -532,7 +540,7 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return array
+     * @return null
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
     {
@@ -541,6 +549,8 @@ class SQLiteGrammar extends Grammar
         }
 
         // Handled on table alteration...
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -82,6 +82,8 @@ class ApiInstallCommand extends Command
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');
         }
+
+        return 0;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -78,6 +78,8 @@ class BroadcastingInstallCommand extends Command
         $this->installReverb();
 
         $this->installNodeDependencies();
+
+        return 0;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -59,6 +59,8 @@ class ConfigPublishCommand extends Command
         }
 
         $this->publish($name, $config[$name], $this->laravel->configPath().'/'.$name.'.php');
+
+        return 0;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -72,6 +72,8 @@ class DownCommand extends Command
 
             return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -701,7 +701,7 @@ class ResourceRegistrar
      * Get or set the action verbs used in the resource URIs.
      *
      * @param  array  $verbs
-     * @return array
+     * @return array|null
      */
     public static function verbs(array $verbs = [])
     {
@@ -710,5 +710,7 @@ class ResourceRegistrar
         }
 
         static::$verbs = array_merge(static::$verbs, $verbs);
+
+        return null;
     }
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -58,7 +58,7 @@ abstract class Facade
     /**
      * Convert the facade into a Mockery spy.
      *
-     * @return \Mockery\MockInterface
+     * @return \Mockery\MockInterface|null
      */
     public static function spy()
     {
@@ -69,6 +69,8 @@ abstract class Facade
                 static::swap($spy);
             });
         }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -398,7 +398,7 @@ abstract class ServiceProvider
      *
      * @param  string|null  $provider
      * @param  string|null  $group
-     * @return array
+     * @return array|null
      */
     protected static function pathsForProviderOrGroup($provider, $group)
     {
@@ -411,6 +411,8 @@ abstract class ServiceProvider
         } elseif ($group || $provider) {
             return [];
         }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -107,11 +107,11 @@ class BatchFake extends Batch
      * Decrement the pending jobs for the batch.
      *
      * @param  string  $jobId
-     * @return \Illuminate\Bus\UpdatedBatchJobCounts
+     * @return null
      */
     public function decrementPendingJobs(string $jobId)
     {
-        //
+        return null;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -543,11 +543,11 @@ class QueueFake extends QueueManager implements Fake, Queue
     /**
      * Get the connection name for the queue.
      *
-     * @return string
+     * @return null
      */
     public function getConnectionName()
     {
-        //
+        return null;
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -328,6 +328,7 @@ if (! function_exists('retry')) {
         $attempts++;
         $times--;
 
+        /** @phpstan-ignore return.missing */
         try {
             return $callback($attempts);
         } catch (Throwable $e) {


### PR DESCRIPTION
This pull request fixes existing `#but return statement is missing.#` PHPStan errors that are [currently suppressed by config](https://github.com/laravel/framework/blob/14677ad1fad65e07762f395d2900067ac4b0d113/phpstan.src.neon.dist#L11). Thus, if the same errors are detected in the future, they will be treated as errors by PHPStan.

This will help prevent simple mistakes like https://github.com/laravel/framework/pull/53644 and help keep the codebase consistent 👍.