### PR TITLE
[11.x] Add pending attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -149,6 +149,13 @@ class Builder implements BuilderContract
     protected $afterQueryCallbacks = [];
 
     /**
+     * Attributes to be added to new instances.
+     *
+     * @var array
+     */
+    public $pendingAttributes = [];
+
+    /**
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -1601,6 +1608,8 @@ class Builder implements BuilderContract
      */
     public function newModelInstance($attributes = [])
     {
+        $attributes = array_merge($this->pendingAttributes, $attributes);
+
         return $this->model->newInstance($attributes)->setConnection(
             $this->query->getConnection()->getName()
         );
@@ -1774,6 +1783,28 @@ class Builder implements BuilderContract
     public function withCasts($casts)
     {
         $this->model->mergeCasts($casts);
+
+        return $this;
+    }
+
+    /**
+     * Add attributes to be added to new instances of models.
+     *
+     * @param  array|string|\Illuminate\Contracts\Database\Query\Expression  $attributes
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function withAttributes(array|string|Expression $attributes, $value = null)
+    {
+        if (! is_array($attributes)) {
+            $attributes = [$attributes => $value];
+        }
+
+        foreach ($attributes as $column => $value) {
+            $this->where($column, $value);
+        }
+
+        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1801,7 +1801,7 @@ class Builder implements BuilderContract
         }
 
         foreach ($attributes as $column => $value) {
-            $this->where($column, $value);
+            $this->where($this->qualifyColumn($column), $value);
         }
 
         $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -53,6 +53,13 @@ class Builder implements BuilderContract
     protected $model;
 
     /**
+     * The attributes that should be added to new models created by this builder.
+     *
+     * @var array
+     */
+    public $pendingAttributes = [];
+
+    /**
      * The relationships that should be eager loaded.
      *
      * @var array
@@ -147,13 +154,6 @@ class Builder implements BuilderContract
      * @var array
      */
     protected $afterQueryCallbacks = [];
-
-    /**
-     * Attributes to be added to new instances.
-     *
-     * @var array
-     */
-    public $pendingAttributes = [];
 
     /**
      * Create a new Eloquent query builder instance.
@@ -1775,26 +1775,13 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Apply query-time casts to the model instance.
+     * Specify attributes that should be added to any new models created by this builder.
      *
-     * @param  array  $casts
-     * @return $this
-     */
-    public function withCasts($casts)
-    {
-        $this->model->mergeCasts($casts);
-
-        return $this;
-    }
-
-    /**
-     * Add attributes to be added to new instances of models.
-     *
-     * @param  array|string|\Illuminate\Contracts\Database\Query\Expression  $attributes
+     * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
      * @param  mixed  $value
      * @return $this
      */
-    public function withAttributes(array|string|Expression $attributes, $value = null)
+    public function withAttributes(Expression|array|string $attributes, $value = null)
     {
         if (! is_array($attributes)) {
             $attributes = [$attributes => $value];
@@ -1805,6 +1792,19 @@ class Builder implements BuilderContract
         }
 
         $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Apply query-time casts to the model instance.
+     *
+     * @param  array  $casts
+     * @return $this
+     */
+    public function withCasts($casts)
+    {
+        $this->model->mergeCasts($casts);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1775,7 +1775,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Specify attributes that should be added to any new models created by this builder, as well as qualify queries executed by this builder.
+     * Specify attributes that should be added to any new models created by this builder.
+     *
+     * The given key / value pairs will also be added as where conditions to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1775,7 +1775,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Specify attributes that should be added to any new models created by this builder.
+     * Specify attributes that should be added to any new models created by this builder, as well as qualify queries executed by this builder.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1350,6 +1350,8 @@ class BelongsToMany extends Relation
      */
     public function create(array $attributes = [], array $joining = [], $touch = true)
     {
+        $attributes = array_merge($this->getQuery()->pendingAttributes, $attributes);
+
         $instance = $this->related->newInstance($attributes);
 
         // Once we save the related model, we need to attach it to the base model via

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -447,6 +447,12 @@ abstract class HasOneOrMany extends Relation
     {
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
 
+        foreach ($this->getQuery()->pendingAttributes as $key => $value) {
+            if (! $model->hasAttribute($key)) {
+                $model->setAttribute($key, $value);
+            }
+        }
+
         $this->applyInverseRelationToModel($model);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -96,6 +96,12 @@ abstract class MorphOneOrMany extends HasOneOrMany
 
         $model->{$this->getMorphType()} = $this->morphClass;
 
+        foreach ($this->getQuery()->pendingAttributes as $key => $value) {
+            if (! $model->hasAttribute($key)) {
+                $model->setAttribute($key, $value);
+            }
+        }
+
         $this->applyInverseRelationToModel($model);
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
@@ -36,6 +36,28 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
         $this->assertSame($tag->id, $pivot->tag_id);
     }
 
+    public function testQueriesWithAttributesAndPivotValues(): void
+    {
+        $post = new ManyToManyWithAttributesPost(['id' => 2]);
+        $wheres = $post->metaTags()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'visible',
+            'operator' => '=',
+            'value' => true,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'with_attributes_pivot.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+    }
+
     protected function createSchema()
     {
         $this->schema()->create('with_attributes_posts', function ($table) {

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
@@ -166,7 +166,7 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
             $table->string('type');
         });
 
-        $this->schema()->create('with_attributes_taggables', function($table){
+        $this->schema()->create('with_attributes_taggables', function($table) {
             $table->integer('tag_id');
             $table->integer('taggable_id');
             $table->string('taggable_type');
@@ -231,7 +231,8 @@ class ManyToManyWithAttributesPost extends Model
 
     public function morphedTags(): MorphToMany
     {
-        return $this->morphToMany(
+        return $this
+            ->morphToMany(
                 ManyToManyWithAttributesTag::class,
                 'taggable',
                 'with_attributes_taggables',
@@ -249,7 +250,8 @@ class ManyToManyWithAttributesTag extends Model
 
     public function morphedPosts(): MorphToMany
     {
-        return $this->morphedByMany(
+        return $this
+            ->morphedByMany(
                 ManyToManyWithAttributesPost::class,
                 'taggable',
                 'with_attributes_taggables',

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
@@ -166,7 +166,7 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
             $table->string('type');
         });
 
-        $this->schema()->create('with_attributes_taggables', function($table) {
+        $this->schema()->create('with_attributes_taggables', function ($table) {
             $table->integer('tag_id');
             $table->integer('taggable_id');
             $table->string('taggable_type');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        $this->createSchema();
+    }
+
+    public function testCreatesWithAttributesAndPivotValues(): void
+    {
+        $post = ManyToManyWithAttributesPost::create();
+        $tag = $post->metaTags()->create(['name' => 'long article']);
+
+        $this->assertSame('long article', $tag->name);
+        $this->assertTrue($tag->visible);
+
+        $pivot = DB::table('with_attributes_pivot')->first();
+        $this->assertSame('meta', $pivot->type);
+        $this->assertSame($post->id, $pivot->post_id);
+        $this->assertSame($tag->id, $pivot->tag_id);
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('with_attributes_posts', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('with_attributes_tags', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('visible')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('with_attributes_pivot', function ($table) {
+            $table->integer('post_id');
+            $table->integer('tag_id');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('with_attributes_posts');
+        $this->schema()->drop('with_attributes_tags');
+        $this->schema()->drop('with_attributes_pivot');
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Model::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class ManyToManyWithAttributesPost extends Model
+{
+    protected $guarded = [];
+    protected $table = 'with_attributes_posts';
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            ManyToManyWithAttributesTag::class,
+            'with_attributes_pivot',
+            'tag_id',
+            'post_id',
+        );
+    }
+
+    public function metaTags(): BelongsToMany
+    {
+        return $this->tags()
+            ->withAttributes('visible', true)
+            ->withPivotValue('type', 'meta');
+    }
+}
+
+class ManyToManyWithAttributesTag extends Model
+{
+    protected $guarded = [];
+    protected $table = 'with_attributes_tags';
+}

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesTest.php
@@ -44,7 +44,7 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
 
         $this->assertContains([
             'type' => 'Basic',
-            'column' => 'visible',
+            'column' => 'with_attributes_tags.visible',
             'operator' => '=',
             'value' => true,
             'boolean' => 'and',
@@ -66,7 +66,7 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
 
         $this->assertContains([
             'type' => 'Basic',
-            'column' => 'visible',
+            'column' => 'with_attributes_tags.visible',
             'operator' => '=',
             'value' => true,
             'boolean' => 'and',
@@ -110,7 +110,7 @@ class DatabaseEloquentBelongsToManyWithAttributesTest extends TestCase
 
         $this->assertContains([
             'type' => 'Basic',
-            'column' => 'title',
+            'column' => 'with_attributes_posts.title',
             'operator' => '=',
             'value' => 'Title!',
             'boolean' => 'and',

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -187,7 +187,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
 
         $this->assertContains([
             'type' => 'Basic',
-            'column' => $key,
+            'column' => 'related_with_attributes_models.'.$key,
             'operator' => '=',
             'value' => $value,
             'boolean' => 'and',
@@ -222,7 +222,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
 
         $this->assertContains([
             'type' => 'Null',
-            'column' => $key,
+            'column' => 'related_with_attributes_models.'.$key,
             'boolean' => 'and',
         ], $wheres);
     }

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    public function testHasManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testHasOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasOne(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphOne(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testWithAttributesCanBeOverriden(): void
+    {
+        $key = 'a key';
+        $defaultValue = 'a value';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $defaultValue]);
+
+        $relatedModel = $relationship->make([$key => $value]);
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testQueryingDoesNotBreakWither(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->where($key, $value)
+            ->withAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testAttributesCanBeAppended(): void
+    {
+        $parent = new RelatedWithAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes(['a' => 'A'])
+            ->withAttributes(['b' => 'B'])
+            ->withAttributes(['a' => 'AA']);
+
+        $relatedModel = $relationship->make([
+            'b' => 'BB',
+            'c' => 'C',
+        ]);
+
+        $this->assertSame('AA', $relatedModel->a);
+        $this->assertSame('BB', $relatedModel->b);
+        $this->assertSame('C', $relatedModel->c);
+    }
+
+    public function testSingleAttributeApi(): void
+    {
+        $parent = new RelatedWithAttributesModel;
+        $key = 'attr';
+        $value = 'Value';
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes($key, $value);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testWheresAreSet(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value]);
+
+        $wheres = $relationship->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $key,
+            'operator' => '=',
+            'value' => $value,
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure this doesn't break the default where either.
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'operator' => '=',
+            'value' => $parentId,
+            'boolean' => 'and',
+        ], $wheres);
+    }
+
+    public function testNullValueIsAccepted(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => null]);
+
+        $wheres = $relationship->toBase()->wheres;
+        $relatedModel = $relationship->make();
+
+        $this->assertNull($relatedModel->$key);
+
+        $this->assertContains([
+            'type' => 'Null',
+            'column' => $key,
+            'boolean' => 'and',
+        ], $wheres);
+    }
+
+    public function testOneKeepsAttributesFromHasMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes([$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testOneKeepsAttributesFromMorphMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedWithAttributesModel::class, 'relatable')
+            ->withAttributes([$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+}
+
+class RelatedWithAttributesModel extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Database/DatabaseEloquentWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentWithAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    public function testAddsAttributes(): void
+    {
+        $key = 'a key';
+        $value = 'the value';
+
+        $query = WithAttributesModel::query()
+            ->withAttributes([$key => $value]);
+
+        $model = $query->make();
+
+        $this->assertSame($value, $model->$key);
+    }
+
+    public function testAddsWheres(): void
+    {
+        $key = 'a key';
+        $value = 'the value';
+
+        $query = WithAttributesModel::query()
+            ->withAttributes([$key => $value]);
+
+        $wheres = $query->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $key,
+            'operator' => '=',
+            'value' => $value,
+            'boolean' => 'and',
+        ], $wheres);
+    }
+}
+
+class WithAttributesModel extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Database/DatabaseEloquentWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesTest.php
@@ -45,7 +45,7 @@ class DatabaseEloquentWithAttributesTest extends TestCase
 
         $this->assertContains([
             'type' => 'Basic',
-            'column' => $key,
+            'column' => 'with_attributes_models.'.$key,
             'operator' => '=',
             'value' => $value,
             'boolean' => 'and',


### PR DESCRIPTION
Provides a `withAttributes()` method for Eloquent Builder. Doing `->withAttributes(['key' => 'value'])` will instruct the Builder instance that the specified attributes must be added to new model instances if you create a model and used as `where` conditions if you end up doing a select.  

Solves the same problem as #53677 (and satisfies its tests), but also provides `withAttributes` on the base builder.

## Details

Consider this setup:

```php
class User extends Model
{
    public function posts(): HasMany
    {
        $this->hasMany(Post::class);
    }

    public function hiddenPosts(): HasMany
    {
        $this->posts()->hidden();
    }
}

class Post extends Model
{
    public function scopeHidden(Builder $posts)
    {
        $posts->where('hidden', 'y');
    }
}
```

Currently Laravel enables features like:

```php
$user->posts()->get();
$user->hiddenPosts()->get();
$user->posts()->create();

Post::all();
Post::hidden()->get();
Post::create();
```

However, syntax like `$user->activePosts()->create()` or `Post::active()->create()` will create a post without setting the value of `active`. Which means that post can be created by `$user->activePosts()->create()` but `$user->activePosts()->get()` will not select it.

This PR adds a `withAttributes` method that allows you to either

```php
// in the relationship on the User model
public function hiddenPosts(): HasMany
{
    return $this->posts()->withAttributes('hidden', 'y');
}
```
or
```php
// in the scope on the Post model
public function scopeHidden(Builder $posts)
{
    $posts->withAttributes('hidden', 'y');
}
```

And now the `$user->hiddenPosts()->create()` will create a Post with the `hidden` attribute set to `'y'` and the Post will be found by `$user->hiddenPosts()->get()`.