### PR TITLE
[11.x] Add index hints support for update and delete queries

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1291,6 +1291,8 @@ class Grammar extends BaseGrammar
      */
     protected function compileUpdateWithoutJoins(Builder $query, $table, $columns, $where)
     {
+        $table = $this->compileTableWithIndex($query, $table);
+
         return "update {$table} set {$columns} {$where}";
     }
 
@@ -1306,6 +1308,8 @@ class Grammar extends BaseGrammar
     protected function compileUpdateWithJoins(Builder $query, $table, $columns, $where)
     {
         $joins = $this->compileJoins($query, $query->joins);
+
+        $table = $this->compileTableWithIndex($query, $table);
 
         return "update {$table} {$joins} set {$columns} {$where}";
     }
@@ -1373,6 +1377,8 @@ class Grammar extends BaseGrammar
      */
     protected function compileDeleteWithoutJoins(Builder $query, $table, $where)
     {
+        $table = $this->compileTableWithIndex($query, $table);
+
         return "delete from {$table} {$where}";
     }
 
@@ -1389,6 +1395,8 @@ class Grammar extends BaseGrammar
         $alias = last(explode(' as ', $table));
 
         $joins = $this->compileJoins($query, $query->joins);
+
+        $table = $this->compileTableWithIndex($query, $table);
 
         return "delete {$alias} from {$table} {$joins} {$where}";
     }
@@ -1573,5 +1581,23 @@ class Grammar extends BaseGrammar
     public function getBitwiseOperators()
     {
         return $this->bitwiseOperators;
+    }
+
+    /**
+     * Compile table name with index hint.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $table
+     * @return string
+     */
+    protected function compileTableWithIndex(Builder $query, $table)
+    {
+        if (! isset($query->indexHint)) {
+            return $table;
+        }
+
+        $index = $this->compileIndexHint($query, $query->indexHint);
+
+        return $index !== '' ? $table.' '.$index : $table;
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -462,7 +462,13 @@ class MySqlGrammar extends Grammar
      */
     protected function compileDeleteWithoutJoins(Builder $query, $table, $where)
     {
-        $sql = parent::compileDeleteWithoutJoins($query, $table, $where);
+        if (isset($query->indexHint)) {
+            $alias = last(explode(' as ', $table));
+            $table = $this->compileTableWithIndex($query, $table);
+            $sql = "delete {$alias} from {$table} {$where}";
+        } else {
+            $sql = parent::compileDeleteWithoutJoins($query, $table, $where);
+        }
 
         // When using MySQL, delete statements may contain order by statements and limits
         // so we will compile both of those here. Once we have finished compiling this

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6717,67 +6717,211 @@ SQL;
         $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
-    public function testUseIndexMySql()
+    public function testUseIndexMySqlSelect()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('foo')->from('users')->useIndex('test_index');
         $this->assertSame('select `foo` from `users` use index (test_index)', $builder->toSql());
     }
 
-    public function testForceIndexMySql()
+    public function testForceIndexMySqlSelect()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('foo')->from('users')->forceIndex('test_index');
         $this->assertSame('select `foo` from `users` force index (test_index)', $builder->toSql());
     }
 
-    public function testIgnoreIndexMySql()
+    public function testIgnoreIndexMySqlSelect()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('foo')->from('users')->ignoreIndex('test_index');
         $this->assertSame('select `foo` from `users` ignore index (test_index)', $builder->toSql());
     }
 
-    public function testUseIndexSqlite()
+    public function testUseIndexSqliteSelect()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('foo')->from('users')->useIndex('test_index');
         $this->assertSame('select "foo" from "users"', $builder->toSql());
     }
 
-    public function testForceIndexSqlite()
+    public function testForceIndexSqliteSelect()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('foo')->from('users')->forceIndex('test_index');
         $this->assertSame('select "foo" from "users" indexed by test_index', $builder->toSql());
     }
 
-    public function testIgnoreIndexSqlite()
+    public function testIgnoreIndexSqliteSelect()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('foo')->from('users')->ignoreIndex('test_index');
         $this->assertSame('select "foo" from "users"', $builder->toSql());
     }
 
-    public function testUseIndexSqlServer()
+    public function testUseIndexSqlServerSelect()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('foo')->from('users')->useIndex('test_index');
         $this->assertSame('select [foo] from [users]', $builder->toSql());
     }
 
-    public function testForceIndexSqlServer()
+    public function testForceIndexSqlServerSelect()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('foo')->from('users')->forceIndex('test_index');
         $this->assertSame('select [foo] from [users] with (index(test_index))', $builder->toSql());
     }
 
-    public function testIgnoreIndexSqlServer()
+    public function testIgnoreIndexSqlServerSelect()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('foo')->from('users')->ignoreIndex('test_index');
         $this->assertSame('select [foo] from [users]', $builder->toSql());
+    }
+
+    public function testUseIndexMySqlUpdate()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update `users` use index (test_index) set `email` = ?, `name` = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->useIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testForceIndexMySqlUpdate()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update `users` force index (test_index) set `email` = ?, `name` = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->forceIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIgnoreIndexMySqlUpdate()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update `users` ignore index (test_index) set `email` = ?, `name` = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->ignoreIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUseIndexSqliteUpdate()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->useIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testForceIndexSqliteUpdate()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" indexed by test_index set "email" = ?, "name" = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->forceIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIgnoreIndexSqliteUpdate()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->ignoreIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUseIndexSqlServerUpdate()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update [users] set [email] = ?, [name] = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->useIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testForceIndexSqlServerUpdate()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update [users] with (index(test_index)) set [email] = ?, [name] = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->forceIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIgnoreIndexSqlServerUpdate()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update [users] set [email] = ?, [name] = ?', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users')->ignoreIndex('test_index')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUseIndexMySqlDelete()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` use index (test_index) where `name` = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->useIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testForceIndexMySqlDelete()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` force index (test_index) where `name` = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->forceIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIgnoreIndexMySqlDelete()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` ignore index (test_index) where `name` = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->ignoreIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUseIndexSqliteDelete()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "name" = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->useIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testForceIndexSqliteDelete()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" indexed by test_index where "name" = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->forceIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIgnoreIndexSqliteDelete()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "name" = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->ignoreIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testUseIndexSqlServerDelete()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from [users] where [name] = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->useIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testForceIndexSqlServerDelete()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from [users] with (index(test_index)) where [name] = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->forceIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIgnoreIndexSqlServerDelete()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from [users] where [name] = ?', ['bar'])->andReturn(1);
+        $result = $builder->from('users')->ignoreIndex('test_index')->where('name', 'bar')->delete();
+        $this->assertEquals(1, $result);
     }
 
     public function testClone()


### PR DESCRIPTION
This pull request extends the functionality introduced in PR #46063, which added index hints to select queries. 

Select query:
```php
User::useIndex('test_index')->where('name', 'bar')->get();
```

Would generate sql:
```mysql 
select * from `users` use index (test_index) where `name` = 'bar'
```

But:
```php
User::useIndex('test_index')->where('name', 'bar')->update(['name' => 'bar2']);
```

Would generate:
```mysql 
update `users` set `name` = 'bar2' where `name` = 'bar'
```

But it should generate:
```mysql 
update `users` use index (test_index) set `name` = 'bar2' where `name` = 'bar'
```


With this update, index hints can now also be applied to update and delete queries.

Edge case for delete in mysql, because of: `Index hints work with DELETE statements, but only if you use multi-table DELETE syntax`

This would not work:
```mysql 
delete from `users` use index (test_index)
```

This would work:
```mysql 
delete `users` from `users` use index (test_index)
```
