### PR TITLE
[11.x] Support regular expressions for cookies to exclude from encryption

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -221,7 +221,7 @@ class EncryptCookies
             ->filter(fn ($cookie) => Str::contains($cookie,'*'));
 
         return $exclude->isEmpty()
-            ? in_array($name, $exclude->toArray())
+            ? in_array($name, $exclude->collapse()->toArray())
             : $exclude->filter(fn ($cookie) => Str::startsWith(
                 $name, Str::replace('*', '', $cookie)
             ))->isNotEmpty();

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Cookie;

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -221,7 +221,7 @@ class EncryptCookies
             ->filter(fn ($cookie) => Str::contains($cookie,'*'));
 
         return $exclude->isEmpty()
-            ? in_array($name, $exclude->collapse()->toArray())
+            ? in_array($name, array_merge($this->except, static::$neverEncrypt))
             : $exclude->filter(fn ($cookie) => Str::startsWith(
                 $name, Str::replace('*', '', $cookie)
             ))->isNotEmpty();

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -218,7 +218,7 @@ class EncryptCookies
     {
         $except = Collection::make($this->except)->merge(static::$neverEncrypt);
 
-        return $except->some(fn ($cookie) => Str::contains($cookie, '*'))
+        return $except->doesntContain(fn ($cookie) => Str::contains($cookie, '*'))
             ? $except->contains($name)
             : $except->filter(fn ($cookie) => Str::startsWith(
                 $name, Str::replace('*', '', $cookie)

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -6,9 +6,9 @@ use Closure;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Cookie\CookieValuePrefix;
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -218,7 +218,7 @@ class EncryptCookies
     {
         $except = Collection::make($this->except)->merge(static::$neverEncrypt);
 
-        return $except->some(fn ($cookie) => Str::contains($cookie,'*'))
+        return $except->some(fn ($cookie) => Str::contains($cookie, '*'))
             ? $except->contains($name)
             : $except->filter(fn ($cookie) => Str::startsWith(
                 $name, Str::replace('*', '', $cookie)

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -216,13 +216,11 @@ class EncryptCookies
      */
     public function isDisabled($name)
     {
-        $exclude = Collection::make($this->except)
-            ->merge(static::$neverEncrypt)
-            ->filter(fn ($cookie) => Str::contains($cookie,'*'));
+        $except = Collection::make($this->except)->merge(static::$neverEncrypt);
 
-        return $exclude->isEmpty()
-            ? in_array($name, array_merge($this->except, static::$neverEncrypt))
-            : $exclude->filter(fn ($cookie) => Str::startsWith(
+        return $except->some(fn ($cookie) => Str::contains($cookie,'*'))
+            ? $except->contains($name)
+            : $except->filter(fn ($cookie) => Str::startsWith(
                 $name, Str::replace('*', '', $cookie)
             ))->isNotEmpty();
     }


### PR DESCRIPTION
Cookies that should be excluded from encryption currently support saving individually and directly with the cookie name. However, sometimes we may need to create multiple cookies that start with a specific name and exclude all of them from encryption. When this happens, we can make it easier to exclude all cookies that start with the '*' character, rather than excluding cookies one by one.

For example, when you add collapse and expand feature to the components in the dashboard, you want to store the data in cookies or you want to store the user's preferences such as language and currency in cookies. Although it is possible to do this on the Laravel side, when you try to change this in normal javascript frameworks, you may have problems getting the cookie value due to encryption.

However, once this pull request is implemented, you can now exclude such cookies as follows instead of excluding them one by one.

`laravel_user_*`
`laravel_online_widget_*`

When you define the $except property in this way, all cookies starting with `laravel_user_xxx` or `laravel_online_widget_xxxx` are considered excluded from encryption.