### PR TITLE
[11.x] Replace get_called_class with static::class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -18,7 +18,7 @@ trait Prunable
         $total = 0;
 
         $this->prunable()
-            ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($this))), function ($query) {
+            ->when(in_array(SoftDeletes::class, class_uses_recursive(static::class)), function ($query) {
                 $query->withTrashed();
             })->chunkById($chunkSize, function ($models) use (&$total) {
                 $models->each->prune();
@@ -50,7 +50,7 @@ trait Prunable
     {
         $this->pruning();
 
-        return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+        return in_array(SoftDeletes::class, class_uses_recursive(static::class))
                 ? $this->forceDelete()
                 : $this->delete();
     }


### PR DESCRIPTION
Replace: get_class to static::class in the file for consistency