### PR TITLE
[11.x] Authorization using Ability Objects

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -17,6 +17,7 @@ use ReflectionFunction;
 
 use function Illuminate\Support\enum_value;
 use function is_object;
+use function method_exists;
 
 class Gate implements GateContract
 {
@@ -650,6 +651,10 @@ class Gate implements GateContract
 
         if (is_object($ability)) {
             return [$ability, 'granted'];
+        }
+
+        if (method_exists($abilityName, 'granted')) {
+            return [new $abilityName(...$arguments), 'granted'];
         }
 
         return function () {

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -7,7 +7,7 @@ interface Gate
     /**
      * Determine if a given ability has been defined.
      *
-     * @param  string  $ability
+     * @param  string|array  $ability
      * @return bool
      */
     public function has($ability);
@@ -59,7 +59,7 @@ interface Gate
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $ability
+     * @param  iterable|string|object  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -68,7 +68,7 @@ interface Gate
     /**
      * Determine if any of the given abilities should be denied for the current user.
      *
-     * @param  iterable|string  $ability
+     * @param  iterable|string|object  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -77,7 +77,7 @@ interface Gate
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|string|object  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -86,7 +86,7 @@ interface Gate
     /**
      * Determine if any one of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|string|object  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -95,7 +95,7 @@ interface Gate
     /**
      * Determine if the given ability should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  string|object  $ability
      * @param  array|mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      *
@@ -106,7 +106,7 @@ interface Gate
     /**
      * Inspect the user for the given ability.
      *
-     * @param  string  $ability
+     * @param  string|object  $ability
      * @param  array|mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      */
@@ -115,7 +115,7 @@ interface Gate
     /**
      * Get the raw result from the authorization callback.
      *
-     * @param  string  $ability
+     * @param  string|object  $ability
      * @param  array|mixed  $arguments
      * @return mixed
      *

--- a/src/Illuminate/Foundation/Console/AbilityMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/AbilityMakeCommand.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use LogicException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_keys;
+use function array_values;
+use function class_basename;
+use function file_exists;
+use function is_null;
+use function Laravel\Prompts\suggest;
+use function preg_quote;
+use function preg_replace;
+use function str_replace;
+use function trim;
+use function vsprintf;
+
+#[AsCommand(name: 'make:ability')]
+class AbilityMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:ability';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new ability class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Ability';
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->replaceUserNamespace(
+            parent::buildClass($name)
+        );
+
+        $model = $this->option('model');
+
+        return $model ? $this->replaceModel($stub, $model) : $stub;
+    }
+
+    /**
+     * Replace the User model namespace.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function replaceUserNamespace($stub)
+    {
+        $model = $this->userProviderModel();
+
+        if (! $model) {
+            return $stub;
+        }
+
+        return str_replace(
+            $this->rootNamespace().'User',
+            $model,
+            $stub
+        );
+    }
+
+    /**
+     * Get the model for the guard's user provider.
+     *
+     * @return string|null
+     *
+     * @throws \LogicException
+     */
+    protected function userProviderModel()
+    {
+        $config = $this->laravel['config'];
+
+        $guard = $this->option('guard') ?: $config->get('auth.defaults.guard');
+
+        if (is_null($guardProvider = $config->get('auth.guards.'.$guard.'.provider'))) {
+            throw new LogicException('The ['.$guard.'] guard is not defined in your "auth" configuration file.');
+        }
+
+        if (! $config->get('auth.providers.'.$guardProvider.'.model')) {
+            return 'App\\Models\\User';
+        }
+
+        return $config->get(
+            'auth.providers.'.$guardProvider.'.model'
+        );
+    }
+
+    /**
+     * Replace the model for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $model
+     * @return string
+     */
+    protected function replaceModel($stub, $model)
+    {
+        $model = str_replace('/', '\\', $model);
+
+        if (str_starts_with($model, '\\')) {
+            $namespacedModel = trim($model, '\\');
+        } else {
+            $namespacedModel = $this->qualifyModel($model);
+        }
+
+        $model = class_basename(trim($model, '\\'));
+
+        $dummyUser = class_basename($this->userProviderModel());
+
+        $dummyModel = Str::camel($model) === 'user' ? 'model' : $model;
+
+        $replace = [
+            '{{ namespacedModel }}' => $namespacedModel,
+            '{{namespacedModel}}' => $namespacedModel,
+            '{{ model }}' => $model,
+            '{{model}}' => $model,
+            '{{ modelVariable }}' => Str::camel($dummyModel),
+            '{{modelVariable}}' => Str::camel($dummyModel),
+            '{{ user }}' => $dummyUser,
+            '{{user}}' => $dummyUser,
+            '$user' => '$'.Str::camel($dummyUser),
+        ];
+
+        $stub = str_replace(
+            array_keys($replace), array_values($replace), $stub
+        );
+
+        return preg_replace(
+            vsprintf('/use %s;[\r\n]+use %s;/', [
+                preg_quote($namespacedModel, '/'),
+                preg_quote($namespacedModel, '/'),
+            ]),
+            "use {$namespacedModel};",
+            $stub
+        );
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('model')
+            ? $this->resolveStubPath('/stubs/ability.stub')
+            : $this->resolveStubPath('/stubs/ability.plain.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Abilities';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the ability already exists'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the ability applies to'],
+            ['guard', 'g', InputOption::VALUE_OPTIONAL, 'The guard that the ability relies on'],
+        ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $model = suggest(
+            'What model should this ability apply to? (Optional)',
+            $this->possibleModels(),
+        );
+
+        if ($model) {
+            $input->setOption('model', $model);
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/ability.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/ability.plain.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Auth\Access\Response;
+use {{ namespacedUserModel }};
+
+class {{ class }}
+{
+    /**
+     * Determine whether the ability is granted to the user.
+     */
+    public function granted({{ user }} $user): bool
+    {
+        return false;
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/ability.stub
+++ b/src/Illuminate/Foundation/Console/stubs/ability.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Auth\Access\Response;
+use {{ namespacedModel }};
+use {{ namespacedUserModel }};
+
+class {{ class }}
+{
+    public function __construct(
+        public {{ model }} ${{ modelVariable }},
+    ) {}
+
+    /**
+     * Determine whether the ability is granted to the user.
+     */
+    public function granted({{ user }} $user): bool
+    {
+        return false;
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/ability.stub
+++ b/src/Illuminate/Foundation/Console/stubs/ability.stub
@@ -10,7 +10,8 @@ class {{ class }}
 {
     public function __construct(
         public {{ model }} ${{ modelVariable }},
-    ) {}
+    ) {
+    }
 
     /**
      * Determine whether the ability is granted to the user.

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Console\ShowCommand;
 use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Foundation\Console\AbilityMakeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
@@ -182,6 +183,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected $devCommands = [
         'ApiInstall' => ApiInstallCommand::class,
+        'AbilityMake' => AbilityMakeCommand::class,
         'BroadcastingInstall' => BroadcastingInstallCommand::class,
         'CacheTable' => CacheTableCommand::class,
         'CastMake' => CastMakeCommand::class,

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -80,13 +80,17 @@ class AuthAccessGateTest extends TestCase
     public function testAfterCanTakeObjectAbilityAsArgument()
     {
         $gate = $this->getBasicGate();
-        $ability = new ObjectAbility(false);
+        $ability = new ObjectAbility(true);
+        $afterCalledWithArg = null;
 
-        $gate->after(function ($user, ObjectAbility $ability) {
-            return true;
+        $gate->after(function ($user, ObjectAbility $ability) use (&$afterCalledWithArg) {
+            $afterCalledWithArg = $ability;
+
+            return false;
         });
 
         $this->assertTrue($gate->check($ability));
+        $this->assertSame($ability, $afterCalledWithArg);
     }
 
     public function testBeforeCanAllowGuests()
@@ -402,6 +406,36 @@ class AuthAccessGateTest extends TestCase
         $ability = new ObjectAbility(false);
 
         $this->assertTrue($gate->denies($ability));
+    }
+
+    public function testObjectAbilityUsingClassNameInAllows()
+    {
+        $gate = $this->getBasicGate();
+
+        $ability = new class
+        {
+            public function granted()
+            {
+                return true;
+            }
+        };
+
+        $this->assertTrue($gate->allows($ability::class));
+    }
+
+    public function testObjectAbilityUsingClassNameInDenies()
+    {
+        $gate = $this->getBasicGate();
+
+        $ability = new class
+        {
+            public function granted()
+            {
+                return false;
+            }
+        };
+
+        $this->assertTrue($gate->denies($ability::class));
     }
 
     public function testObjectAbilitiesCanAllowGuestUsers()

--- a/tests/Auth/Fixtures/ObjectAbility.php
+++ b/tests/Auth/Fixtures/ObjectAbility.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Auth\Fixtures;
+
+class ObjectAbility
+{
+    public function __construct(
+        public bool $granted = true,
+    ) {}
+
+    public function granted($user)
+    {
+        return $this->granted;
+    }
+}

--- a/tests/Auth/Fixtures/ObjectAbility.php
+++ b/tests/Auth/Fixtures/ObjectAbility.php
@@ -8,7 +8,8 @@ class ObjectAbility
 {
     public function __construct(
         public bool $granted = true,
-    ) {}
+    ) {
+    }
 
     public function granted($user)
     {

--- a/tests/Integration/Generators/AbilityMakeCommandTest.php
+++ b/tests/Integration/Generators/AbilityMakeCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class AbilityMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Abilities/FooAbility.php',
+    ];
+
+    public function testItCanGenerateAbilityFile()
+    {
+        $this->artisan('make:ability', ['name' => 'FooAbility'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Abilities;',
+            'use Illuminate\Foundation\Auth\User;',
+            'class FooAbility',
+        ], 'app/Abilities/FooAbility.php');
+    }
+
+    public function testItCanGenerateAbilityFileWithModelOption()
+    {
+        $this->artisan('make:ability', ['name' => 'FooAbility', '--model' => 'Post'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Abilities;',
+            'use App\Models\Post;',
+            'use Illuminate\Foundation\Auth\User;',
+            'class FooAbility',
+            'public function __construct',
+            'public Post $post',
+            'public function granted(User $user)',
+        ], 'app/Abilities/FooAbility.php');
+    }
+}


### PR DESCRIPTION
Ever since Gates and Policies were introduced in Laravel, they've been essential for every application I've worked on. Gates in particular have proven extremely useful whenever I wanted to keep authorization logic for each possible ability separate from each other (using invokable classes) to avoid large and complex policies. The only "downside" of Gates compared to Policies (which have auto-discovery) is the need to explicitly define them (and the risk of forgetting to do so). We can use inline authorization using `Gate::allowIf` and `Gate::denyIf` to eliminate the need of manually defining gates, but then before and after authorization hooks don't get executed.

This is something I also "struggled" with with custom validation rules before [Rule Objects](https://laravel.com/docs/11.x/validation#using-rule-objects) were introduced, which led me to wonder if this could be solved in a similar fashion: authorization using Ability Objects.

I originally implemented this concept in a codebase as a before authorization hook (which has been working great), but felt like it might be a nice addition to the framework and decided to try and translate this into the core. I presume this PR may not cover everything yet or may require some extra test coverage, but I'm not really familiar with these internals. So any guidance is welcome.

# Proposal

Ability objects are plain php classes that provide a `granted` method, e.g.:
```php
class ViewDashboardAbility
{
    public function granted(User $user): bool
    {
        // Some authorization logic...
        return false;
    }
}
```

There is no interface to implement, as gates can be used to authorise different types of resources, not only users/authenticatables.

They can be passed as an instance to the `Gate`, which can then evaluate the ability without the need if it being explicitly defined:
```php
use Illuminate\Auth\Access\Gate;

Gate::allows(new ViewDashboardAbility());
```

## Benefits

Ability objects allow developers to isolate authorization of individual abilities into separate classes without having to define them explicitly in the `Gate`. They can therefore be evaluated "on the fly":
```php
use Illuminate\Auth\Access\Gate;

Gate::allows(new ViewDashboard());

// vs

Gate::define('view-dashboard', function (User $user): bool {
    // Some authorization logic...
});
Gate::allows('view-dashboard');
```

Additionally, they also eliminate the need to lookup the ability to determine the expected arguments, as arguments can be provided to the ability's constructor rather than through `Gate` methods:
```php
use Illuminate\Auth\Access\Gate;

Gate::allows(new ViewCompanyInfoAbility($company));

// vs

Gate::allows('view-company-info', $company);
```

## Integration within the framework

### Artisan generator command

This PR includes a new `make:ability` Artisan command with similar behaviour compared to the `make:policy` command.

### Support in Authorization middleware

Ability objects can be used in middleware as follow:
```php
use Illuminate\Auth\Middleware\Authorize;

Route::put('/post/{post}', function (Post $post) {
    // The current user may update the post...
})->middleware(Authorize::using(ViewPostAbility::class, 'post'));
```

### Support in Blade directives

Ability objects can be used in Blade's authorization directives the same way they can be used through `Gate` directly:
```blade
@can(new ViewDashboard)
@cannot(new ViewCompanyInfo($company))
// ... and so on
```

## Backwards compatibility

In order to try not breaking current behaviour, I implemented resolving auth callbacks for ability objects as the last possible use case. `Gate` will always first look for policies, string callbacks and explicitly defined ability callbacks before attempting to resolve ability objects.

The additional benefit of this sequence is that developers can still explicitly define a `Gate` callback for an ability class name, which is useful to fake checking abilities when running tests:
```php
// Arrange
Gate::define(ViewDashboardAbility::class, fn (): bool => false);

// Act
$subject->performActionRequiringAuthorization();

// Assert
$this->assertBasedOnFakedAbility();
```

## Questions

- My current implementation will evaluate `Gate::has(new ViewDashboardAbility)` as false as ability objects are not explicitly defined. Would this be considered the correct outcome? Or is the purpose of `Gate::has()` to be able to determine whether an ability can be resolved?
- When providing an object instance without a `granted()` method, this implementation would currently throw a `Call to undefined method granted()` error. Should it perhaps throw a custom exception instead?