### PR TITLE
[11.x] use a consistent alias for `Illuminate\Database\Eloquent\Collection`

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -4,7 +4,7 @@ namespace Illuminate\Notifications;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
-use Illuminate\Database\Eloquent\Collection as ModelCollection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
@@ -247,7 +247,7 @@ class NotificationSender
     {
         if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
             return $notifiables instanceof Model
-                            ? new ModelCollection([$notifiables]) : [$notifiables];
+                            ? new EloquentCollection([$notifiables]) : [$notifiables];
         }
 
         return $notifiables;


### PR DESCRIPTION
this file was the only one to use a unique alias for the `Eloquent\Collection`. this PR introduces alias consistency.

- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php#L8
- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Factories/Factory.php#L9
- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Model.php#L14
- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/SoftDeletes.php#L5
- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Notifications/NotificationSender.php#L7
- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Notifications/SendQueuedNotifications.php#L9
- https://github.com/laravel/framework/blob/11.x/src/Illuminate/Testing/TestResponse.php#L10

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
