### PR TITLE
URI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
-        "league/uri": "^7.4",
+        "league/uri": "^7.5.1",
         "monolog/monolog": "^3.0",
         "nesbot/carbon": "^2.72.2|^3.4",
         "nunomaduro/termwind": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
+        "league/uri": "^7.4",
         "monolog/monolog": "^3.0",
         "nesbot/carbon": "^2.72.2|^3.4",
         "nunomaduro/termwind": "^2.0",

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -27,6 +27,7 @@ use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Support\AggregateServiceProvider;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Uri;
 use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Testing\ParallelTestingServiceProvider;
 use Illuminate\Validation\ValidationException;
@@ -89,6 +90,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
         $this->registerDumper();
         $this->registerRequestValidation();
         $this->registerRequestSignatureValidation();
+        $this->registerUriUrlGeneration();
         $this->registerDeferHandler();
         $this->registerExceptionTracking();
         $this->registerExceptionRenderer();
@@ -186,6 +188,16 @@ class FoundationServiceProvider extends AggregateServiceProvider
         Request::macro('hasValidRelativeSignatureWhileIgnoring', function ($ignoreQuery = []) {
             return URL::hasValidSignature($this, $absolute = false, $ignoreQuery);
         });
+    }
+
+    /**
+     * Register the "defer" function termination handler.
+     *
+     * @return void
+     */
+    protected function registerUriUrlGeneration()
+    {
+        Uri::setUrlGeneratorResolver(fn () => app('url'));
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -9,6 +9,7 @@ use Illuminate\Session\SymfonySessionDecorator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Uri;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\InputBag;
@@ -86,6 +87,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function method()
     {
         return $this->getMethod();
+    }
+
+    /**
+     * Get a URI instance for the request.
+     *
+     * @return \Illuminate\Support\Uri
+     */
+    public function uri()
+    {
+        return Uri::of($this->fullUrl());
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -197,7 +197,11 @@ class Uri implements Htmlable, Responsable
 
             $newQuery = $mergedQuery;
         } else {
-            $newQuery = $query;
+            $newQuery = [];
+
+            foreach ($query as $key => $value) {
+                data_set($newQuery, $key, $value);
+            }
         }
 
         return new static($this->uri->withQuery(Arr::query($newQuery)));

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Closure;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\Conditionable;
@@ -14,6 +15,11 @@ use Stringable;
 class Uri implements Htmlable
 {
     use Conditionable, Tappable;
+
+    /**
+     * The URL generator resolver.
+     */
+    protected static ?Closure $urlGeneratorResolver = null;
 
     /**
      * Create a new parsed URI instance.
@@ -29,6 +35,29 @@ class Uri implements Htmlable
     public static function of(UriInterface|Stringable|string $uri = ''): static
     {
         return new static($uri);
+    }
+
+    /**
+     * Generate an absolute URL to the given path.
+     */
+    public static function to(string $path): static
+    {
+        return new static(call_user_func(static::$urlGeneratorResolver)->to($path));
+    }
+
+    /**
+     * Get a URI instance for a named route.
+     *
+     * @param  \BackedEnum|string  $name
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
+     * @return static
+     *
+     * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException|\InvalidArgumentException
+     */
+    public static function route($name, $parameters = [], $absolute = true): static
+    {
+        return new static(call_user_func(static::$urlGeneratorResolver)->route($name, $parameters, $absolute));
     }
 
     /**
@@ -195,6 +224,14 @@ class Uri implements Htmlable
     public function withFragment(string $fragment): static
     {
         return new static($this->uri->withFragment($fragment));
+    }
+
+    /**
+     * Set the URL generator resolver.
+     */
+    public static function setUrlGeneratorResolver(Closure $urlGeneratorResolver): void
+    {
+        static::$urlGeneratorResolver = $urlGeneratorResolver;
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Tappable;
 use League\Uri\Contracts\UriInterface;

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -233,11 +233,13 @@ class Uri implements Htmlable, Responsable
     {
         $currentValue = data_get($this->query()->all(), $key);
 
+        $values = Arr::wrap($value);
+
         return $this->withQuery([$key => match (true) {
-            is_array($currentValue) && array_is_list($currentValue) => array_values(array_unique([...$currentValue, $value])),
-            is_array($currentValue) => [...$currentValue, $value],
-            ! is_null($currentValue) => [$currentValue, $value],
-            default => Arr::wrap($value),
+            is_array($currentValue) && array_is_list($currentValue) => array_values(array_unique([...$currentValue, ...$values])),
+            is_array($currentValue) => [...$currentValue, ...$values],
+            ! is_null($currentValue) => [$currentValue, ...$values],
+            default => $values,
         }]);
     }
 

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Tappable;
 use League\Uri\Contracts\UriInterface;
@@ -291,6 +292,18 @@ class Uri implements Htmlable, Responsable
     public function toHtml()
     {
         return $this->value();
+    }
+
+    /**
+     * Get the decoded string representation of the URI.
+     */
+    public function decode(): string
+    {
+        if (empty($this->query()->toArray())) {
+            return $this->value();
+        }
+
+        return Str::replace(Str::after($this->value(), '?'), $this->query()->decode(), $this->value());
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -19,6 +19,11 @@ class Uri implements Htmlable, Responsable
     use Conditionable, Tappable;
 
     /**
+     * The URI instance.
+     */
+    protected UriInterface $uri;
+
+    /**
      * The URL generator resolver.
      */
     protected static ?Closure $urlGeneratorResolver = null;
@@ -75,19 +80,9 @@ class Uri implements Htmlable, Responsable
      */
     public function user(bool $withPassword = false): ?string
     {
-        if ($withPassword) {
-            return $this->uri->getUserInfo();
-        }
-
-        $userInfo = $this->uri->getUserInfo();
-
-        if (is_null($userInfo)) {
-            return null;
-        }
-
-        return str_contains($userInfo, ':')
-            ? Str::before($userInfo, ':')
-            : $userInfo;
+        return $withPassword
+            ? $this->uri->getUserInfo()
+            : $this->uri->getUsername();
     }
 
     /**
@@ -95,9 +90,7 @@ class Uri implements Htmlable, Responsable
      */
     public function password(): ?string
     {
-        $userInfo = $this->uri->getUserInfo();
-
-        return ! is_null($userInfo) ? Str::after($userInfo, ':') : null;
+        return $this->uri->getPassword();
     }
 
     /**
@@ -272,7 +265,7 @@ class Uri implements Htmlable, Responsable
      */
     public function redirect(int $status = 302, array $headers = []): RedirectResponse
     {
-        return new RedirectResponse((string) $this, $status, $headers);
+        return new RedirectResponse($this->value(), $status, $headers);
     }
 
     /**
@@ -283,7 +276,7 @@ class Uri implements Htmlable, Responsable
      */
     public function toResponse($request)
     {
-        return new RedirectResponse((string) $this);
+        return new RedirectResponse($this->value());
     }
 
     /**
@@ -293,7 +286,7 @@ class Uri implements Htmlable, Responsable
      */
     public function toHtml()
     {
-        return (string) $this;
+        return $this->value();
     }
 
     /**
@@ -309,7 +302,7 @@ class Uri implements Htmlable, Responsable
      */
     public function isEmpty(): bool
     {
-        return trim((string) $this) === '';
+        return trim($this->value()) === '';
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Tappable;
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri as LeagueUri;
+use SensitiveParameter;
+use Stringable;
+
+class Uri implements Htmlable
+{
+    use Conditionable, Tappable;
+
+    /**
+     * Create a new parsed URI instance.
+     */
+    public function __construct(UriInterface|Stringable|string $uri = '')
+    {
+        $this->uri = $uri instanceof UriInterface ? $uri : LeagueUri::new((string) $uri);
+    }
+
+    /**
+     * Create a new URI instance.
+     */
+    public static function of(UriInterface|Stringable|string $uri = ''): static
+    {
+        return new static($uri);
+    }
+
+    /**
+     * Get the URI's scheme.
+     */
+    public function scheme(): ?string
+    {
+        return $this->uri->getScheme();
+    }
+
+    /**
+     * Get the user from the URI.
+     */
+    public function user(bool $withPassword = false): ?string
+    {
+        if ($withPassword) {
+            return $this->uri->getUserInfo();
+        }
+
+        $userInfo = $this->uri->getUserInfo();
+
+        if (is_null($userInfo)) {
+            return null;
+        }
+
+        return str_contains($userInfo, ':')
+            ? Str::before($userInfo, ':')
+            : $userInfo;
+    }
+
+    /**
+     * Get the password from the URI.
+     */
+    public function password(): ?string
+    {
+        $userInfo = $this->uri->getUserInfo();
+
+        return ! is_null($userInfo) ? Str::after($userInfo, ':') : null;
+    }
+
+    /**
+     * Get the URI's host.
+     */
+    public function host(): ?string
+    {
+        return $this->uri->getHost();
+    }
+
+    /**
+     * Get the URI's port.
+     */
+    public function port(): ?int
+    {
+        return $this->uri->getPort();
+    }
+
+    /**
+     * Get the URI's path.
+     *
+     * Empty or missing paths are returned as a single "/".
+     */
+    public function path(): ?string
+    {
+        $path = trim((string) $this->uri->getPath(), '/');
+
+        return $path === '' ? '/' : $path;
+    }
+
+    /**
+     * Get the URI's query string.
+     */
+    public function query(): UriQueryString
+    {
+        return new UriQueryString($this);
+    }
+
+    /**
+     * Get the URI's fragment.
+     */
+    public function fragment(): ?string
+    {
+        return $this->uri->getFragment();
+    }
+
+    /**
+     * Specify the scheme of the URI.
+     */
+    public function withScheme(Stringable|string $scheme): static
+    {
+        return new static($this->uri->withScheme($scheme));
+    }
+
+    /**
+     * Specify the user and password for the URI.
+     */
+    public function withUser(Stringable|string|null $user, #[SensitiveParameter] Stringable|string|null $password = null): static
+    {
+        return new static($this->uri->withUserInfo($user, $password));
+    }
+
+    /**
+     * Specify the host of the URI.
+     */
+    public function withHost(Stringable|string $host): static
+    {
+        return new static($this->uri->withHost($host));
+    }
+
+    /**
+     * Specify the port of the URI.
+     */
+    public function withPort(int|null $port): static
+    {
+        return new static($this->uri->withPort($port));
+    }
+
+    /**
+     * Specify the path of the URI.
+     */
+    public function withPath(Stringable|string $path): static
+    {
+        return new static($this->uri->withPath(Str::start((string) $path, '/')));
+    }
+
+    /**
+     * Merge new query parameters into the URI.
+     */
+    public function withQuery(Stringable|array|string $query, bool $merge = true): static
+    {
+        [$newQuery, $currentQuery] = [[], []];
+
+        if ($query instanceof Stringable || is_string($query)) {
+            parse_str($query, (string) $newQuery);
+        } else {
+            $newQuery = $query;
+        }
+
+        foreach ($newQuery as $key => $parameter) {
+            if ($parameter instanceof UrlRoutable) {
+                $newQuery[$key] = $parameter->getRouteKey();
+            }
+        }
+
+        if ($merge) {
+            parse_str($this->uri->getQuery(), $currentQuery);
+
+            $newQuery = array_merge($currentQuery, $newQuery);
+        }
+
+        return new static($this->uri->withQuery(Arr::query($newQuery)));
+    }
+
+    /**
+     * Specify new query parameters for the URI.
+     */
+    public function replaceQuery(Stringable|array|string $query)
+    {
+        return $this->withQuery($query, merge: false);
+    }
+
+    /**
+     * Specify the fragment of the URI.
+     */
+    public function withFragment(string $fragment): static
+    {
+        return new static($this->uri->withFragment($fragment));
+    }
+
+    /**
+     * Get the underlying URI instance.
+     */
+    public function getUri(): UriInterface
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return (string) $this;
+    }
+
+    /**
+     * Get the string representation of the URI.
+     */
+    public function __toString(): string
+    {
+        return $this->uri->toString();
+    }
+}

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -5,6 +5,8 @@ namespace Illuminate\Support;
 use Closure;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Tappable;
 use League\Uri\Contracts\UriInterface;
@@ -12,7 +14,7 @@ use League\Uri\Uri as LeagueUri;
 use SensitiveParameter;
 use Stringable;
 
-class Uri implements Htmlable
+class Uri implements Htmlable, Responsable
 {
     use Conditionable, Tappable;
 
@@ -264,6 +266,51 @@ class Uri implements Htmlable
     }
 
     /**
+     * Create a redirect HTTP response for the given URI.
+     */
+    public function redirect(int $status = 302, array $headers = []): RedirectResponse
+    {
+        return new RedirectResponse((string) $this, $status, $headers);
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return new RedirectResponse((string) $this);
+    }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return (string) $this;
+    }
+
+    /**
+     * Get the string representation of the URI.
+     */
+    public function value(): string
+    {
+        return (string) $this;
+    }
+
+    /**
+     * Determine if the URI is currently an empty string.
+     */
+    public function isEmpty(): bool
+    {
+        return trim((string) $this) === '';
+    }
+
+    /**
      * Set the URL generator resolver.
      */
     public static function setUrlGeneratorResolver(Closure $urlGeneratorResolver): void
@@ -277,16 +324,6 @@ class Uri implements Htmlable
     public function getUri(): UriInterface
     {
         return $this->uri;
-    }
-
-    /**
-     * Get content as a string of HTML.
-     *
-     * @return string
-     */
-    public function toHtml()
-    {
-        return (string) $this;
     }
 
     /**

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -81,7 +81,11 @@ class UriQueryString implements Arrayable
      */
     public function toArray()
     {
-        parse_str($this->uri->getUri()->getQuery(), $currentQuery);
+        if (is_null($query = $this->uri->getUri()->getQuery())) {
+            return [];
+        }
+
+        parse_str($query, $currentQuery);
 
         return $currentQuery;
     }

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\InteractsWithData;
+use League\Uri\QueryString;
 
 class UriQueryString implements Arrayable
 {
@@ -81,13 +82,7 @@ class UriQueryString implements Arrayable
      */
     public function toArray()
     {
-        if (is_null($query = $this->uri->getUri()->getQuery())) {
-            return [];
-        }
-
-        parse_str($query, $currentQuery);
-
-        return $currentQuery;
+        return QueryString::extract($this->value());
     }
 
     /**

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\InteractsWithData;
+
+class UriQueryString implements Arrayable
+{
+    use InteractsWithData;
+
+    /**
+     * Create a new URI query string instance.
+     */
+    public function __construct(Uri $uri)
+    {
+        $this->uri = $uri;
+    }
+
+    /**
+     * Retrieve all data from the instance.
+     *
+     * @param  array|mixed|null  $keys
+     * @return array
+     */
+    public function all($keys = null)
+    {
+        $query = $this->toArray();
+
+        if (! $keys) {
+            return $query;
+        }
+
+        $results = [];
+
+        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
+            Arr::set($results, $key, Arr::get($query, $key));
+        }
+
+        return $results;
+    }
+
+    /**
+     * Retrieve data from the instance.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected function data($key = null, $default = null)
+    {
+        return $this->get($key, $default);
+    }
+
+    /**
+     * Get a query string parameter.
+     */
+    public function get(?string $key = null, mixed $default = null): mixed
+    {
+        return data_get($this->toArray(), $key, $default);
+    }
+
+    /**
+     * Get the URL decoded version of the query string.
+     */
+    public function decode(): string
+    {
+        return rawurldecode((string) $this);
+    }
+
+    /**
+     * Convert the query string into an array.
+     */
+    public function toArray()
+    {
+        parse_str($this->uri->getUri()->getQuery(), $currentQuery);
+
+        return $currentQuery;
+    }
+
+    /**
+     * Get the string representation of the query string.
+     */
+    public function __toString(): string
+    {
+        return (string) $this->uri->getUri()->getQuery();
+    }
+}

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -12,9 +12,9 @@ class UriQueryString implements Arrayable
     /**
      * Create a new URI query string instance.
      */
-    public function __construct(Uri $uri)
+    public function __construct(protected Uri $uri)
     {
-        $this->uri = $uri;
+        //
     }
 
     /**

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -69,6 +69,14 @@ class UriQueryString implements Arrayable
     }
 
     /**
+     * Get the string representation of the query string.
+     */
+    public function value(): string
+    {
+        return (string) $this;
+    }
+
+    /**
      * Convert the query string into an array.
      */
     public function toArray()

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -50,7 +50,7 @@
         "illuminate/filesystem": "Required to use the Composer class (^11.0).",
         "laravel/serializable-closure": "Required to use the once function (^1.3).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.0.2).",
-        "league/uri": "Required to use the Uri class (^7.4).",
+        "league/uri": "Required to use the Uri class (^7.5.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
         "symfony/process": "Required to use the Composer class (^7.0).",
         "symfony/uid": "Required to use Str::ulid() (^7.0).",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -47,11 +47,12 @@
         }
     },
     "suggest": {
-        "illuminate/filesystem": "Required to use the composer class (^11.0).",
+        "illuminate/filesystem": "Required to use the Composer class (^11.0).",
         "laravel/serializable-closure": "Required to use the once function (^1.3).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.0.2).",
+        "league/uri": "Required to use the Uri class (^7.4).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
-        "symfony/process": "Required to use the composer class (^7.0).",
+        "symfony/process": "Required to use the Composer class (^7.0).",
         "symfony/uid": "Required to use Str::ulid() (^7.0).",
         "symfony/var-dumper": "Required to use the dd function (^7.0).",
         "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.6.1)."

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -111,4 +111,12 @@ class SupportUriTest extends TestCase
 
         $this->assertEquals(['tag' => ['foo', 'bar']], $uri->pushOntoQuery('tag', 'bar')->query()->all());
     }
+
+    public function test_query_strings_with_dots_can_be_replaced_or_merged_consistently()
+    {
+        $uri = Uri::of('https://dot.test/?foo.bar=baz');
+
+        $this->assertEquals('foo.bar=baz&foo[bar]=zab', $uri->withQuery(['foo.bar' => 'zab'])->query()->decode());
+        $this->assertEquals('foo[bar]=zab', $uri->replaceQuery(['foo.bar' => 'zab'])->query()->decode());
+    }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -53,7 +53,7 @@ class SupportUriTest extends TestCase
                         'foo' => [
                             9 => 'bar',
                         ],
-                    ]
+                    ],
                 ],
             ],
             'flag_value' => '',

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -34,7 +34,7 @@ class SupportUriTest extends TestCase
 
     public function test_complicated_query_string_parsing()
     {
-        $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&flag_value');
+        $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value');
 
         $this->assertEquals([
             'key_1' => 'value',
@@ -56,10 +56,11 @@ class SupportUriTest extends TestCase
                     ],
                 ],
             ],
+            'key.6' => 'value',
             'flag_value' => '',
         ], $uri->query()->all());
 
-        $this->assertEquals('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&flag_value', $uri->query()->decode());
+        $this->assertEquals('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value', $uri->query()->decode());
     }
 
     public function test_uri_building()

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -119,4 +119,11 @@ class SupportUriTest extends TestCase
         $this->assertEquals('foo.bar=baz&foo[bar]=zab', $uri->withQuery(['foo.bar' => 'zab'])->query()->decode());
         $this->assertEquals('foo[bar]=zab', $uri->replaceQuery(['foo.bar' => 'zab'])->query()->decode());
     }
+
+    public function test_decoding_the_entire_uri()
+    {
+        $uri = Uri::of('https://laravel.com/docs/11.x/installation')->withQuery(['tags' => ['first', 'second']]);
+
+        $this->assertEquals('https://laravel.com/docs/11.x/installation?tags[0]=first&tags[1]=second', $uri->decode());
+    }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Uri;
+use PHPUnit\Framework\TestCase;
+
+class SupportUriTest extends TestCase
+{
+    public function test_basic_uri_interactions()
+    {
+        $uri = Uri::of($originalUri = 'https://laravel.com/docs/installation');
+
+        $this->assertEquals('https', $uri->scheme());
+        $this->assertNull($uri->user());
+        $this->assertNull($uri->password());
+        $this->assertEquals('laravel.com', $uri->host());
+        $this->assertNull($uri->port());
+        $this->assertEquals('docs/installation', $uri->path());
+        $this->assertEquals([], $uri->query()->toArray());
+        $this->assertEquals('', (string) $uri->query());
+        $this->assertEquals('', $uri->query()->decode());
+        $this->assertNull($uri->fragment());
+        $this->assertEquals($originalUri, (string) $uri);
+
+        $uri = Uri::of('https://taylor:password@laravel.com/docs/installation?version=1#hello');
+
+        $this->assertEquals('taylor', $uri->user());
+        $this->assertEquals('password', $uri->password());
+        $this->assertEquals('hello', $uri->fragment());
+        $this->assertEquals(['version' => 1], $uri->query()->all());
+        $this->assertEquals(1, $uri->query()->integer('version'));
+    }
+
+    public function test_complicated_query_string_parsing()
+    {
+        $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&flag_value');
+
+        $this->assertEquals([
+            'key_1' => 'value',
+            'key_2' => [
+                'sub_field' => 'value',
+            ],
+            'key_3' => [
+                'value',
+            ],
+            'key_4' => [
+                9 => 'value',
+            ],
+            'key_5' => [
+                [
+                    [
+                        'foo' => [
+                            9 => 'bar',
+                        ],
+                    ]
+                ],
+            ],
+            'flag_value' => '',
+        ], $uri->query()->all());
+
+        $this->assertEquals('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&flag_value', $uri->query()->decode());
+    }
+
+    public function test_uri_building()
+    {
+        $uri = Uri::of();
+
+        $uri = $uri->withHost('laravel.com')
+            ->withScheme('https')
+            ->withUser('taylor', 'password')
+            ->withPath('/docs/installation')
+            ->withPort(80)
+            ->withQuery(['version' => 1])
+            ->withFragment('hello');
+
+        $this->assertEquals('https://taylor:password@laravel.com:80/docs/installation?version=1#hello', (string) $uri);
+    }
+
+    public function test_complicated_query_string_manipulation()
+    {
+        $uri = Uri::of('https://laravel.com');
+
+        $uri = $uri->withQuery([
+            'name' => 'Taylor',
+            'age' => 38,
+            'role' => [
+                'title' => 'Developer',
+                'focus' => 'PHP',
+            ],
+            'tags' => [
+                'person',
+                'employee',
+            ],
+            'flag' => '',
+        ])->withoutQuery(['name']);
+
+        $this->assertEquals('age=38&role[title]=Developer&role[focus]=PHP&tags[0]=person&tags[1]=employee&flag=', $uri->query()->decode());
+        $this->assertEquals('name=Taylor', $uri->replaceQuery(['name' => 'Taylor'])->query()->decode());
+
+        // Push onto multi-value and missing items...
+        $uri = Uri::of('https://laravel.com?tags[]=foo');
+
+        $this->assertEquals(['tags' => ['foo', 'bar']], $uri->pushOntoQuery('tags', 'bar')->query()->all());
+        $this->assertEquals(['tags' => ['foo', 'bar', 'baz']], $uri->pushOntoQuery('tags', ['bar', 'baz'])->query()->all());
+        $this->assertEquals(['tags' => ['foo'], 'names' => ['Taylor']], $uri->pushOntoQuery('names', 'Taylor')->query()->all());
+
+        // Push onto single value item...
+        $uri = Uri::of('https://laravel.com?tag=foo');
+
+        $this->assertEquals(['tag' => ['foo', 'bar']], $uri->pushOntoQuery('tag', 'bar')->query()->all());
+    }
+}


### PR DESCRIPTION
URI parsing and mutation powered by `league/uri`.

```php
$uri = Uri::of('https://laravel.com')
    ->withQuery(['name' => 'Taylor'])
    ->withPath('/docs/installation')
    ->withFragment('hello-world');

$uri->scheme();
$uri->host();
$uri->user();
$uri->password();
$uri->path();
$uri->port();
$uri->query()->all();
$uri->query()->has('name');
$uri->query()->missing('name');
$uri->query()->decode();

// And more...

return (string) $uri;
```

URI instances can be retrieved from the current request, as well as created from URLs and names routes for the current application:

```php
$uri = $request->uri();

$uri = Uri::to('/something')->withQuery(...);

$uri = Uri::route('named-route', ['user' => $user]);
```

URIs can even be returned directly from routes to generate a redirect to that location:

```php
return Uri::route('named-route', ['user' => $user])->withQuery(['name' => 'Taylor']);
```