### PR TITLE
[11.x] switch `Collection::make()` for `new Collection()`

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -154,7 +154,7 @@ class PusherBroadcaster extends Broadcaster
 
         $parameters = $socket !== null ? ['socket_id' => $socket] : [];
 
-        $channels = Collection::make($this->formatChannels($channels));
+        $channels = new Collection($this->formatChannels($channels));
 
         try {
             $channels->chunk(100)->each(function ($channels) use ($event, $payload, $parameters) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -489,7 +489,7 @@ class Arr
      */
     public static function keyBy($array, $keyBy)
     {
-        return Collection::make($array)->keyBy($keyBy)->all();
+        return (new Collection($array))->keyBy($keyBy)->all();
     }
 
     /**
@@ -816,7 +816,7 @@ class Arr
      */
     public static function sort($array, $callback = null)
     {
-        return Collection::make($array)->sortBy($callback)->all();
+        return (new Collection($array))->sortBy($callback)->all();
     }
 
     /**
@@ -828,7 +828,7 @@ class Arr
      */
     public static function sortDesc($array, $callback = null)
     {
-        return Collection::make($array)->sortByDesc($callback)->all();
+        return (new Collection($array))->sortByDesc($callback)->all();
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1752,7 +1752,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         $iterables = func_get_args();
 
         return new static(function () use ($iterables) {
-            $iterators = Collection::make($iterables)->map(function ($iterable) {
+            $iterators = (new Collection($iterables))->map(function ($iterable) {
                 return $this->makeIterator($iterable);
             })->prepend($this->getIterator());
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -794,7 +794,7 @@ trait EnumeratesValues
      */
     public function pipeThrough($callbacks)
     {
-        return Collection::make($callbacks)->reduce(
+        return (new Collection($callbacks))->reduce(
             fn ($carry, $callback) => $callback($carry),
             $this,
         );

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -80,7 +80,7 @@ trait BuildsQueries
      */
     public function chunkMap(callable $callback, $count = 1000)
     {
-        $collection = Collection::make();
+        $collection = new Collection;
 
         $this->chunk($count, function ($items) use ($collection, $callback) {
             $items->each(function ($item) use ($collection, $callback) {

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -99,7 +99,7 @@ class StatusCommand extends BaseCommand
      */
     protected function getStatusFor(array $ran, array $batches)
     {
-        return Collection::make($this->getAllMigrationFiles())
+        return (new Collection($this->getAllMigrationFiles()))
                     ->map(function ($migration) use ($ran, $batches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -96,7 +96,7 @@ class MorphTo extends BelongsTo
     #[\Override]
     public function addEagerConstraints(array $models)
     {
-        $this->buildDictionary($this->models = Collection::make($models));
+        $this->buildDictionary($this->models = new Collection($models));
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -134,7 +134,7 @@ class Migrator
      */
     protected function pendingMigrations($files, $ran)
     {
-        return Collection::make($files)
+        return (new Collection($files))
             ->reject(fn ($file) => in_array($this->getMigrationName($file), $ran))
             ->values()
             ->all();
@@ -536,7 +536,7 @@ class Migrator
      */
     public function getMigrationFiles($paths)
     {
-        return Collection::make($paths)
+        return (new Collection($paths))
             ->flatMap(fn ($path) => str_ends_with($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php'))
             ->filter()
             ->values()

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2872,7 +2872,7 @@ class Builder implements BuilderContract
      */
     protected function removeExistingOrdersFor($column)
     {
-        return Collection::make($this->orders)
+        return (new Collection($this->orders))
                     ->reject(function ($order) use ($column) {
                         return isset($order['column'])
                                ? $order['column'] === $column : false;

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -836,7 +836,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function registerConfiguredProviders()
     {
-        $providers = Collection::make($this->make('config')->get('app.providers'))
+        $providers = (new Collection($this->make('config')->get('app.providers')))
                         ->partition(fn ($provider) => str_starts_with($provider, 'Illuminate\\'));
 
         $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -381,10 +381,10 @@ class DocsCommand extends Command
             return;
         }
 
-        $binary = Collection::make(match ($this->systemOsFamily) {
+        $binary = (new Collection(match ($this->systemOsFamily) {
             'Darwin' => ['open'],
             'Linux' => ['xdg-open', 'wslview'],
-        })->first(fn ($binary) => (new ExecutableFinder)->find($binary) !== null);
+        }))->first(fn ($binary) => (new ExecutableFinder)->find($binary) !== null);
 
         if ($binary === null) {
             $this->components->warn('Unable to open the URL on your system. You will need to open it yourself or create a custom opener for your system.');
@@ -475,7 +475,7 @@ class DocsCommand extends Command
      */
     protected function searchQuery()
     {
-        return Collection::make($_SERVER['argv'])->skip(3)->implode(' ');
+        return (new Collection($_SERVER['argv']))->skip(3)->implode(' ');
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -87,7 +87,7 @@ class BladeMapper
             $exception = $previous;
         }
 
-        $trace = Collection::make($exception->getTrace())
+        $trace = (new Collection($exception->getTrace()))
             ->map(function ($frame) {
                 if ($originalPath = $this->findCompiledView((string) Arr::get($frame, 'file', ''))) {
                     $frame['file'] = $originalPath;

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -67,7 +67,7 @@ class Inspiring
      */
     public static function quotes()
     {
-        return Collection::make([
+        return new Collection([
             'Act only according to that maxim whereby you can, at the same time, will that it should become a universal law. - Immanuel Kant',
             'An unexamined life is not worth living. - Socrates',
             'Be present above all else. - Naval Ravikant',

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -405,7 +405,7 @@ class Vite implements Htmlable
                 ]);
 
                 foreach ($manifest[$import]['css'] ?? [] as $css) {
-                    $partialManifest = Collection::make($manifest)->where('file', $css);
+                    $partialManifest = (new Collection($manifest))->where('file', $css);
 
                     $preloads->push([
                         $partialManifest->keys()->first(),
@@ -431,7 +431,7 @@ class Vite implements Htmlable
             ));
 
             foreach ($chunk['css'] ?? [] as $css) {
-                $partialManifest = Collection::make($manifest)->where('file', $css);
+                $partialManifest = (new Collection($manifest))->where('file', $css);
 
                 $preloads->push([
                     $partialManifest->keys()->first(),
@@ -624,7 +624,7 @@ class Vite implements Htmlable
         }
 
         $this->preloadedAssets[$url] = $this->parseAttributes(
-            Collection::make($attributes)->forget('href')->all()
+            (new Collection($attributes))->forget('href')->all()
         );
 
         return '<link '.implode(' ', $this->parseAttributes($attributes)).' />';
@@ -811,7 +811,7 @@ class Vite implements Htmlable
      */
     protected function parseAttributes($attributes)
     {
-        return Collection::make($attributes)
+        return (new Collection($attributes))
             ->reject(fn ($value, $key) => in_array($value, [false, null], true))
             ->flatMap(fn ($value, $key) => $value === true ? [$key] : [$key => $value])
             ->map(fn ($value, $key) => is_int($key) ? $value : $key.'="'.$value.'"')

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -105,7 +105,7 @@ class Response implements ArrayAccess, Stringable
      */
     public function collect($key = null)
     {
-        return Collection::make($this->json($key));
+        return new Collection($this->json($key));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -18,7 +18,7 @@ trait CanBePrecognitive
             return $rules;
         }
 
-        return Collection::make($rules)
+        return (new Collection($rules))
             ->only(explode(',', $this->header('Precognition-Validate-Only')))
             ->all();
     }

--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -19,7 +19,7 @@ class AddLinkHeadersForPreloadedAssets
     {
         return tap($next($request), function ($response) {
             if ($response instanceof Response && Vite::preloadedAssets() !== []) {
-                $response->header('Link', Collection::make(Vite::preloadedAssets())
+                $response->header('Link', (new Collection(Vite::preloadedAssets()))
                     ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
                     ->join(', '), false);
             }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1046,7 +1046,7 @@ class Mailable implements MailableContract, Renderable
 
         $attachments = $this->attachments();
 
-        return Collection::make(is_object($attachments) ? [$attachments] : $attachments)
+        return (new Collection(is_object($attachments) ? [$attachments] : $attachments))
                 ->map(fn ($attached) => $attached instanceof Attachable ? $attached->toMailAttachment() : $attached)
                 ->contains(fn ($attached) => $attached->isEquivalent($attachment, $options));
     }
@@ -1766,7 +1766,7 @@ class Mailable implements MailableContract, Renderable
 
         $attachments = $this->attachments();
 
-        Collection::make(is_object($attachments) ? [$attachments] : $attachments)
+        (new Collection(is_object($attachments) ? [$attachments] : $attachments))
             ->each(function ($attachment) {
                 $this->attach($attachment);
             });

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -64,7 +64,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
      */
     protected function setItems($items)
     {
-        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->items = $items instanceof Collection ? $items : new Collection($items);
 
         $this->hasMore = $this->items->count() > $this->perPage;
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -62,7 +62,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->lastPage = max((int) ceil($total / $perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
-        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->items = $items instanceof Collection ? $items : new Collection($items);
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -77,7 +77,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     protected function setItems($items)
     {
-        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->items = $items instanceof Collection ? $items : new Collection($items);
 
         $this->hasMore = $this->items->count() > $this->perPage;
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -63,7 +63,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         parent::__construct($app);
 
         $this->jobsToFake = Collection::wrap($jobsToFake);
-        $this->jobsToBeQueued = Collection::make();
+        $this->jobsToBeQueued = new Collection;
         $this->queue = $queue;
     }
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -26,7 +26,7 @@ trait Matching
 
         if ($expected instanceof Closure) {
             PHPUnit::assertTrue(
-                $expected(is_array($actual) ? Collection::make($actual) : $actual),
+                $expected(is_array($actual) ? new Collection($actual) : $actual),
                 sprintf('Property [%s] was marked as invalid using a closure.', $this->dotPath($key))
             );
 
@@ -64,7 +64,7 @@ trait Matching
 
         if ($expected instanceof Closure) {
             PHPUnit::assertFalse(
-                $expected(is_array($actual) ? Collection::make($actual) : $actual),
+                $expected(is_array($actual) ? new Collection($actual) : $actual),
                 sprintf('Property [%s] was marked as invalid using a closure.', $this->dotPath($key))
             );
 
@@ -157,11 +157,11 @@ trait Matching
      */
     public function whereContains(string $key, $expected)
     {
-        $actual = Collection::make(
+        $actual = new Collection(
             $this->prop($key) ?? $this->prop()
         );
 
-        $missing = Collection::make($expected)
+        $missing = (new Collection($expected))
             ->map(fn ($search) => enum_value($search))
             ->reject(function ($search) use ($key, $actual) {
                 if ($actual->containsStrict($key, $search)) {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1083,7 +1083,7 @@ class TestResponse implements ArrayAccess
      */
     public function collect($key = null)
     {
-        return Collection::make($this->json($key));
+        return new Collection($this->json($key));
     }
 
     /**


### PR DESCRIPTION
`make()` is essentially just a static alias to the constructor. it performs no logic.

removing the middleman to simplify the call stack.

continuation of #53726

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
