### PR TITLE
[11.x] Add ability to customize or disable `Http\Client\RequestException` message truncation

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Configuration;
 
 use Closure;
 use Illuminate\Foundation\Exceptions\Handler;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
 
 class Exceptions
@@ -199,5 +200,28 @@ class Exceptions
         $this->handler->stopIgnoring($class);
 
         return $this;
+    }
+
+    /**
+     * Set the truncation length for request exception messages.
+     *
+     * @param  int  $length
+     * @return $this
+     */
+    public function truncateRequestExceptionsAt(int $length)
+    {
+        RequestException::truncateAt($length);
+
+        return $this;
+    }
+
+    /**
+     * Disable truncation of request exception messages.
+     *
+     * @return $this
+     */
+    public function dontTruncateRequestExceptions()
+    {
+        RequestException::dontTruncate();
     }
 }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -34,7 +34,7 @@ class RequestException extends HttpClientException
     }
 
     /**
-     * Enable truncation of the exception message.
+     * Enable truncation of request exception messages.
      *
      * @return void
      */
@@ -44,24 +44,24 @@ class RequestException extends HttpClientException
     }
 
     /**
-     * Disable truncation of the exception message.
+     * Set the truncation length for request exception messages.
+     *
+     * @param  int  $length
+     * @return void
+     */
+    public static function truncateAt(int $length)
+    {
+        static::$truncateAt = $length;
+    }
+
+    /**
+     * Disable truncation of request exception messages.
      *
      * @return void
      */
     public static function dontTruncate()
     {
         static::$truncateAt = false;
-    }
-
-    /**
-     * Set the truncation length for the exception message.
-     *
-     * @param  int  $length
-     * @return void
-     */
-    public static function truncateAt($length)
-    {
-        static::$truncateAt = $length;
     }
 
     /**

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -14,6 +14,13 @@ class RequestException extends HttpClientException
     public $response;
 
     /**
+     * The truncation length for the exception message.
+     *
+     * @var int|false
+     */
+    public static $truncateAt = 120;
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Illuminate\Http\Client\Response  $response
@@ -27,6 +34,37 @@ class RequestException extends HttpClientException
     }
 
     /**
+     * Enable truncation of the exception message.
+     *
+     * @return void
+     */
+    public static function truncate()
+    {
+        static::$truncateAt = 120;
+    }
+
+    /**
+     * Disable truncation of the exception message.
+     *
+     * @return void
+     */
+    public static function dontTruncate()
+    {
+        static::$truncateAt = false;
+    }
+
+    /**
+     * Set the truncation length for the exception message.
+     *
+     * @param  int  $length
+     * @return void
+     */
+    public static function truncateAt($length)
+    {
+        static::$truncateAt = $length;
+    }
+
+    /**
      * Prepare the exception message.
      *
      * @param  \Illuminate\Http\Client\Response  $response
@@ -36,7 +74,9 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = Message::bodySummary($response->toPsrResponse());
+        $summary = static::$truncateAt
+            ? Message::bodySummary($response->toPsrResponse(), static::$truncateAt)
+            : Message::toString($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -51,6 +51,8 @@ class HttpClientTest extends TestCase
         parent::setUp();
 
         $this->factory = new Factory;
+
+        RequestException::truncate();
     }
 
     protected function tearDown(): void
@@ -1230,6 +1232,43 @@ class HttpClientTest extends TestCase
     {
         $this->expectException(RequestException::class);
         $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our sup (truncated...)');
+
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+
+        throw new RequestException(new Response($response));
+    }
+
+    public function testRequestExceptionWithoutTruncatedSummary()
+    {
+        RequestException::dontTruncate();
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit');
+
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+
+        throw new RequestException(new Response($response));
+    }
+
+
+    public function testRequestExceptionWithCustomTruncatedSummary()
+    {
+        RequestException::truncateAt(60);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be compl (truncated...)');
 
         $error = [
             'error' => [

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1261,8 +1261,7 @@ class HttpClientTest extends TestCase
 
         throw new RequestException(new Response($response));
     }
-
-
+    
     public function testRequestExceptionWithCustomTruncatedSummary()
     {
         RequestException::truncateAt(60);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1261,7 +1261,7 @@ class HttpClientTest extends TestCase
 
         throw new RequestException(new Response($response));
     }
-    
+
     public function testRequestExceptionWithCustomTruncatedSummary()
     {
         RequestException::truncateAt(60);


### PR DESCRIPTION
## Problem

The exception message on `Http\Client\RequestException` is always truncated, leading to useful debugging information being cropped out. For example:

```
Illuminate\Http\Client\RequestException
HTTP request returned status code 422:
{"error":{"code":422,"message":"The Request can not be completed because the provided request contains invalid data. Key at 'cus (truncated...)
```

Unfortunately due to the above truncation, I'm not given enough information in production to debug this. Instead, I have to replicate the HTTP request on the server somehow and try/catch manually (via tinker or some other mechanism) to see the rest. Depending on how complex the HTTP request is and where it was sent in the application, this can be really hard to replicate and debug.

## Description

This PR gives developers the option to globally alter the truncation behaviour on `Http\Client\RequestException` messages.

I initially assumed that this behaviour was built into PHP, but after getting hit with HTTP errors in production and this causing a lot of grief for me in debugging, I dug in and found that luckily this is changeable.

You can see complaints of this truncation causing grief for others here as well: https://github.com/guzzle/guzzle/issues/2185

## Usage

Truncation behaviour is controlled with a static variable on the `RequestException` class.

It can be altered by calling `RequestException::dontTrucate()` or `RequestException::truncateAt($length)`:

> I can move this to the `Http\Client\Factory` where `$preventStrayRequests` is if you'd prefer.

```php
// bootstrap/app.php

use Illuminate\Http\Client\RequestException;

return Application::configure(basePath: dirname(__DIR__))
    // ...
    ->withExceptions(function (Exceptions $exceptions) {
        RequestException::dontTruncate();

        // Or ...

        RequestException::truncateAt(260);
    })->create();
```

If this method of customizing the exception isn't appealing, let me know. I'd love to be able to simply make the customization this exception easier for developers (and me) to save the hair I have left haha.

Let me know your thoughts -- thanks for your time!