### PR TITLE
Add static function to Application class to get bootstrap instance

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -246,6 +246,22 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Get the application from the bootstrap file.
+     *
+     * @param  string  $bootstrapPath
+     * @return static
+     */
+    public static function fromBootstrap(string $bootstrapPath)
+    {
+        $application = (require_once $bootstrapPath);
+
+        return match (true) {
+            ($application instanceof static) => $application,
+            default => null,
+        };
+    }
+
+    /**
      * Infer the application's base directory from the environment.
      *
      * @return string

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Foundation\Configuration\ApplicationBuilder configure(string|null $basePath = null)
+ * @method static \Illuminate\Foundation\Application fromBootstrap(string $bootstrapPath)
  * @method static string inferBasePath()
  * @method static string version()
  * @method static void bootstrapWith(string[] $bootstrappers)


### PR DESCRIPTION
Whenever I look at the `artisan` or `public/index.php` files, I kind of find them ugly to watch, and I think there improvements to make there. For example, getting the bootstrapped application.

Adding the `fromBootstrap` function will change the `public/index.php` code from...
```php
// Bootstrap Laravel and handle the request...
(require_once __DIR__.'/../bootstrap/app.php')
    ->handleRequest(Request::capture());
```
...to:
```php
// Bootstrap Laravel and handle the request...
Application::fromBootstrap(__DIR__.'/../bootstrap/app.php')
    ->handleRequest(Request::capture());
```

In the future, the `fromBootstrap` may even be modified to a form where `$bootstrapPath` is optional.