### PR TITLE
Use options from AWS S3 disk config if none are passed to temporary url methods

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -76,6 +76,11 @@ class AwsS3V3Adapter extends FilesystemAdapter
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {
+        // Use the default options from the filesystems disk config if none are provided.
+        if (empty($options)) {
+            $options = $this->config['options'] ?? [];
+        }
+
         $command = $this->client->getCommand('GetObject', array_merge([
             'Bucket' => $this->config['bucket'],
             'Key' => $this->prefixer->prefixPath($path),
@@ -105,6 +110,11 @@ class AwsS3V3Adapter extends FilesystemAdapter
      */
     public function temporaryUploadUrl($path, $expiration, array $options = [])
     {
+        // Use the default options from the filesystems disk config if none are provided.
+        if (empty($options)) {
+            $options = $this->config['options'] ?? [];
+        }
+
         $command = $this->client->getCommand('PutObject', array_merge([
             'Bucket' => $this->config['bucket'],
             'Key' => $this->prefixer->prefixPath($path),


### PR DESCRIPTION
### Summary
This PR updates the `temporaryUrl` and `temporaryUploadUrl` methods in the `AwsS3V3Adapter` class to use the default options specified in the Laravel `filesystems.php` configuration file for disk. This ensures that any additional options defined in the configuration, such as `ServerSideEncryption`, `ACL`, `CacheControl`, etc., are automatically applied to all calls to these methods if no options are explicitly passed as the third argument.

### Reason
If there is a common `options` setting we want a disk to inherit, it is important that all calls to temporaryUrl or temporaryUploadUrl use these base configuration `options` by default. In the same file, we use the bucket from the config, yet the options from the same config are currently **being ignored**. This change makes it so that the framework respects its own configuration file.

### Backwards compatibility
It should be discussed whether this is considered a breaking change - it would affect behavior on temporary url method calls that do not pass any options - they would start using the `options` from the disk config. In my opinion, if developers have set options on a disk configuration, they set them so that they can be used when calling these 2 methods (amongst other `Storage` facade methods).

This is why I opened the PR against `master` for now.