### PR TITLE
Add merge method to config repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -227,6 +227,22 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Merge items into an array configuration value.
+     *
+     * @param  string  $key
+     * @param  array  $value
+     * @return void
+     */
+    public function merge($key, array $value)
+    {
+        $array = $this->get($key, []);
+
+        $array = array_merge($array, $value);
+
+        $this->set($key, $array);
+    }
+
+    /**
      * Get all of the configuration items for the application.
      *
      * @return array

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -214,6 +214,18 @@ class RepositoryTest extends TestCase
         $this->assertSame(['xxx'], $this->repository->get('new_key'));
     }
 
+    public function testMerge()
+    {
+        $this->assertSame('xxx', $this->repository->get('associate.x'));
+        $this->assertSame('yyy', $this->repository->get('associate.y'));
+        $this->repository->merge('associate', ['z' => 'zzz']);
+        $this->assertSame('xxx', $this->repository->get('associate.x'));
+        $this->assertSame('yyy', $this->repository->get('associate.y'));
+        $this->assertSame('zzz', $this->repository->get('associate.z'));
+
+        $this->assertCount(3, $this->repository->get('associate'));
+    }
+
     public function testAll()
     {
         $this->assertSame($this->config, $this->repository->all());


### PR DESCRIPTION
This PR adds a merge method to the config repository. It's essentially the same as the push method, but allows you to add items to associative arrays not just numeric arrays.

```php
Config::merge('package.items', ['new_item' => 'foo']);
```

```php
Config::get('package.items'); // ['old_item' => 'bar', 'new_item' => 'foo']
```

### Edit:

I guess you can just use `set` with the full key... I'm actually merging multiple items into an existing list, so this simplifies things a bit in that situation, but no worries if you close this! :-)