### PR TITLE
[12.x] modernize `DatabaseTokenRepository` and make consistent with `CacheTokenRepository`

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -11,72 +11,16 @@ use Illuminate\Support\Str;
 class DatabaseTokenRepository implements TokenRepositoryInterface
 {
     /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\ConnectionInterface
-     */
-    protected $connection;
-
-    /**
-     * The Hasher implementation.
-     *
-     * @var \Illuminate\Contracts\Hashing\Hasher
-     */
-    protected $hasher;
-
-    /**
-     * The token database table.
-     *
-     * @var string
-     */
-    protected $table;
-
-    /**
-     * The hashing key.
-     *
-     * @var string
-     */
-    protected $hashKey;
-
-    /**
-     * The number of seconds a token should last.
-     *
-     * @var int
-     */
-    protected $expires;
-
-    /**
-     * Minimum number of seconds before re-redefining the token.
-     *
-     * @var int
-     */
-    protected $throttle;
-
-    /**
      * Create a new token repository instance.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
-     * @param  string  $table
-     * @param  string  $hashKey
-     * @param  int  $expires
-     * @param  int  $throttle
-     * @return void
      */
     public function __construct(
-        ConnectionInterface $connection,
-        HasherContract $hasher,
-        $table,
-        $hashKey,
-        $expires = 60,
-        $throttle = 60,
+        protected ConnectionInterface $connection,
+        protected HasherContract $hasher,
+        protected string $table,
+        protected string $hashKey,
+        protected int $expires = 3600,
+        protected int $throttle = 60,
     ) {
-        $this->table = $table;
-        $this->hasher = $hasher;
-        $this->hashKey = $hashKey;
-        $this->expires = $expires * 60;
-        $this->connection = $connection;
-        $this->throttle = $throttle;
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -104,8 +104,8 @@ class PasswordBrokerManager implements FactoryContract
             $this->app['hash'],
             $config['table'],
             $key,
-            $config['expire'],
-            $config['throttle'] ?? 0
+            ($config['expire'] ?? 60) * 60,
+            $config['throttle'] ?? 0,
         );
     }
 


### PR DESCRIPTION
- use promoted properties
- require the `expires` property to be passed in as seconds, rather than taking it as minutes and converting it. shift responsibility to calling code.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
