### PR TITLE
[11.x] more consistent and readable chaining

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -73,9 +73,9 @@ class Authorize
             return [];
         }
 
-        return (new Collection($models))->map(function ($model) use ($request) {
-            return $model instanceof Model ? $model : $this->getModel($request, $model);
-        })->all();
+        return (new Collection($models))
+            ->map(fn ($model) => $model instanceof Model ? $model : $this->getModel($request, $model))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -146,9 +146,9 @@ class Repository implements ArrayAccess, CacheContract
             return is_string($key) ? $key : $value;
         })->values()->all());
 
-        return (new Collection($values))->map(function ($value, $key) use ($keys) {
-            return $this->handleManyResult($keys, $key, $value);
-        })->all();
+        return (new Collection($values))
+            ->map(fn ($value, $key) => $this->handleManyResult($keys, $key, $value))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -18,9 +18,9 @@ trait RetrievesMultipleKeys
     {
         $return = [];
 
-        $keys = (new Collection($keys))->mapWithKeys(function ($value, $key) {
-            return [is_string($key) ? $key : $value => is_string($key) ? $value : null];
-        })->all();
+        $keys = (new Collection($keys))
+            ->mapWithKeys(fn ($value, $key) => [is_string($key) ? $key : $value => is_string($key) ? $value : null])
+            ->all();
 
         foreach ($keys as $key => $default) {
             /** @phpstan-ignore arguments.count (some clients don't accept a default) */

--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -96,14 +96,16 @@ trait CallsCommands
      */
     protected function context()
     {
-        return (new Collection($this->option()))->only([
-            'ansi',
-            'no-ansi',
-            'no-interaction',
-            'quiet',
-            'verbose',
-        ])->filter()->mapWithKeys(function ($value, $key) {
-            return ["--{$key}" => $value];
-        })->all();
+        return (new Collection($this->option()))
+            ->only([
+                'ansi',
+                'no-ansi',
+                'no-interaction',
+                'quiet',
+                'verbose',
+            ])
+            ->filter()
+            ->mapWithKeys(fn ($value, $key) => ["--{$key}" => $value])
+            ->all();
     }
 }

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -157,9 +157,9 @@ class PruneCommand extends Command
     protected function getPath()
     {
         if (! empty($path = $this->option('path'))) {
-            return (new Collection($path))->map(function ($path) {
-                return base_path($path);
-            })->all();
+            return (new Collection($path))
+                ->map(fn ($path) => base_path($path))
+                ->all();
         }
 
         return app_path('Models');

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -78,9 +78,9 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
                 ? ($this->model->broadcastOn($this->event) ?: [])
                 : $this->channels;
 
-        return (new BaseCollection($channels))->map(function ($channel) {
-            return $channel instanceof Model ? new PrivateChannel($channel) : $channel;
-        })->all();
+        return (new BaseCollection($channels))
+            ->map(fn ($channel) => $channel instanceof Model ? new PrivateChannel($channel) : $channel)
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1942,9 +1942,9 @@ trait HasAttributes
             );
         }
 
-        return (new Collection($this->original))->mapWithKeys(function ($value, $key) {
-            return [$key => $this->transformModelValue($key, $value)];
-        })->all();
+        return (new Collection($this->original))
+            ->mapWithKeys(fn ($value, $key) => [$key => $this->transformModelValue($key, $value)])
+            ->all();
     }
 
     /**
@@ -2315,17 +2315,14 @@ trait HasAttributes
 
         $class = $reflection->getName();
 
-        static::$getAttributeMutatorCache[$class] =
-            (new Collection($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance)))
-                    ->mapWithKeys(function ($match) {
-                        return [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true];
-                    })->all();
+        static::$getAttributeMutatorCache[$class] = (new Collection($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance)))
+            ->mapWithKeys(fn ($match) => [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true])
+            ->all();
 
         static::$mutatorCache[$class] = (new Collection(static::getMutatorMethods($class)))
-                ->merge($attributeMutatorMethods)
-                ->map(function ($match) {
-                    return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
-                })->all();
+            ->merge($attributeMutatorMethods)
+            ->map(fn ($match) => lcfirst(static::$snakeAttributes ? Str::snake($match) : $match))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -600,9 +600,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function qualifyColumns($columns)
     {
-        return (new BaseCollection($columns))->map(function ($column) {
-            return $this->qualifyColumn($column);
-        })->all();
+        return (new BaseCollection($columns))
+            ->map(fn ($column) => $this->qualifyColumn($column))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -616,9 +616,9 @@ trait InteractsWithPivotTable
         }
 
         if ($value instanceof BaseCollection || is_array($value)) {
-            return (new BaseCollection($value))->map(function ($item) {
-                return $item instanceof Model ? $item->{$this->relatedKey} : $item;
-            })->all();
+            return (new BaseCollection($value))
+                ->map(fn ($item) => $item instanceof Model ? $item->{$this->relatedKey} : $item)
+                ->all();
         }
 
         return (array) $value;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3949,9 +3949,9 @@ class Builder implements BuilderContract
 
         $bindings = $this->cleanBindings(array_merge(
             Arr::flatten($values, 1),
-            (new Collection($update))->reject(function ($value, $key) {
-                return is_int($key);
-            })->all()
+            (new Collection($update))
+                ->reject(fn ($value, $key) => is_int($key))
+                ->all()
         ));
 
         return $this->connection->affectingStatement(

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -250,9 +250,9 @@ class Grammar extends BaseGrammar
      */
     protected function compileWheresToArray($query)
     {
-        return (new Collection($query->wheres))->map(function ($where) use ($query) {
-            return $where['boolean'].' '.$this->{"where{$where['type']}"}($query, $where);
-        })->all();
+        return (new Collection($query->wheres))
+            ->map(fn ($where) => $where['boolean'].' '.$this->{"where{$where['type']}"}($query, $where))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -444,11 +444,10 @@ class MySqlGrammar extends Grammar
      */
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
-        $values = (new Collection($values))->reject(function ($value, $column) {
-            return $this->isJsonSelector($column) && is_bool($value);
-        })->map(function ($value) {
-            return is_array($value) ? json_encode($value) : $value;
-        })->all();
+        $values = (new Collection($values))
+            ->reject(fn ($value, $column) => $this->isJsonSelector($column) && is_bool($value))
+            ->map(fn ($value) => is_array($value) ? json_encode($value) : $value)
+            ->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -493,9 +493,9 @@ class PostgresGrammar extends Grammar
             // When using Postgres, updates with joins list the joined tables in the from
             // clause, which is different than other systems like MySQL. Here, we will
             // compile out the tables that are joined and add them to a from clause.
-            $froms = (new Collection($query->joins))->map(function ($join) {
-                return $this->wrapTable($join->table);
-            })->all();
+            $froms = (new Collection($query->joins))
+                ->map(fn ($join) => $this->wrapTable($join->table))
+                ->all();
 
             if (count($froms) > 0) {
                 $from = ' from '.implode(', ', $froms);
@@ -566,11 +566,13 @@ class PostgresGrammar extends Grammar
      */
     public function prepareBindingsForUpdateFrom(array $bindings, array $values)
     {
-        $values = (new Collection($values))->map(function ($value, $column) {
-            return is_array($value) || ($this->isJsonSelector($column) && ! $this->isExpression($value))
-                ? json_encode($value)
-                : $value;
-        })->all();
+        $values = (new Collection($values))
+            ->map(function ($value, $column) {
+                return is_array($value) || ($this->isJsonSelector($column) && ! $this->isExpression($value))
+                    ? json_encode($value)
+                    : $value;
+            })
+            ->all();
 
         $bindingsWithoutWhere = Arr::except($bindings, ['select', 'where']);
 
@@ -734,13 +736,15 @@ class PostgresGrammar extends Grammar
     {
         $quote = func_num_args() === 2 ? func_get_arg(1) : "'";
 
-        return (new Collection($path))->map(function ($attribute) {
-            return $this->parseJsonPathArrayKeys($attribute);
-        })->collapse()->map(function ($attribute) use ($quote) {
-            return filter_var($attribute, FILTER_VALIDATE_INT) !== false
-                        ? $attribute
-                        : $quote.$attribute.$quote;
-        })->all();
+        return (new Collection($path))
+            ->map(fn ($attribute) => $this->parseJsonPathArrayKeys($attribute))
+            ->collapse()
+            ->map(function ($attribute) use ($quote) {
+                return filter_var($attribute, FILTER_VALIDATE_INT) !== false
+                    ? $attribute
+                    : $quote.$attribute.$quote;
+            })
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -386,11 +386,11 @@ class SQLiteGrammar extends Grammar
     {
         $groups = $this->groupJsonColumnsForUpdate($values);
 
-        $values = (new Collection($values))->reject(function ($value, $key) {
-            return $this->isJsonSelector($key);
-        })->merge($groups)->map(function ($value) {
-            return is_array($value) ? json_encode($value) : $value;
-        })->all();
+        $values = (new Collection($values))
+            ->reject(fn ($value, $key) => $this->isJsonSelector($key))
+            ->merge($groups)
+            ->map(fn ($value) => is_array($value) ? json_encode($value) : $value)
+            ->all();
 
         $cleanBindings = Arr::except($bindings, 'select');
 

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -45,10 +45,9 @@ class SqliteSchemaState extends SchemaState
             //
         ]));
 
-        $migrations = (new Collection(preg_split("/\r\n|\n|\r/", $process->getOutput())))->filter(function ($line) {
-            return preg_match('/^\s*(--|INSERT\s)/iu', $line) === 1 &&
-                   strlen($line) > 0;
-        })->all();
+        $migrations = (new Collection(preg_split("/\r\n|\n|\r/", $process->getOutput())))
+            ->filter(fn ($line) => preg_match('/^\s*(--|INSERT\s)/iu', $line) === 1 && strlen($line) > 0)
+            ->all();
 
         $this->files->append($path, implode(PHP_EOL, $migrations).PHP_EOL);
     }

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -119,9 +119,9 @@ class QueuedClosure
             dispatch(new CallQueuedListener(InvokeQueuedClosure::class, 'handle', [
                 'closure' => new SerializableClosure($this->closure),
                 'arguments' => $arguments,
-                'catch' => (new Collection($this->catchCallbacks))->map(function ($callback) {
-                    return new SerializableClosure($callback);
-                })->all(),
+                'catch' => (new Collection($this->catchCallbacks))
+                    ->map(fn ($callback) => new SerializableClosure($callback))
+                    ->all(),
             ]))->onConnection($this->connection)->onQueue($this->queue)->delay($this->delay);
         };
     }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -513,9 +513,9 @@ class Kernel implements KernelContract
     public function bootstrapWithoutBootingProviders()
     {
         $this->app->bootstrapWith(
-            (new Collection($this->bootstrappers()))->reject(function ($bootstrapper) {
-                return $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class;
-            })->all()
+            (new Collection($this->bootstrappers()))
+                ->reject(fn ($bootstrapper) => $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class)
+                ->all()
         );
     }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -448,9 +448,8 @@ class Factory
             return true;
         };
 
-        return (new Collection($this->recorded))->filter(function ($pair) use ($callback) {
-            return $callback($pair[0], $pair[1]);
-        });
+        return (new Collection($this->recorded))
+            ->filter(fn ($pair) => $callback($pair[0], $pair[1]));
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1008,9 +1008,10 @@ class PendingRequest
      */
     protected function parseMultipartBodyFormat(array $data)
     {
-        return (new Collection($data))->map(function ($value, $key) {
-            return is_array($value) ? $value : ['name' => $key, 'contents' => $value];
-        })->values()->all();
+        return (new Collection($data))
+            ->map(fn ($value, $key) => is_array($value) ? $value : ['name' => $key, 'contents' => $value])
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -363,9 +363,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function mergeIfMissing(array $input)
     {
-        return $this->merge((new Collection($input))->filter(function ($value, $key) {
-            return $this->missing($key);
-        })->toArray());
+        return $this->merge((new Collection($input))
+            ->filter(fn ($value, $key) => $this->missing($key))
+            ->toArray()
+        );
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1080,9 +1080,9 @@ class Mailable implements MailableContract, Renderable
             'path' => $path,
             'name' => $name ?? basename($path),
             'options' => $options,
-        ])->unique(function ($file) {
-            return $file['name'].$file['disk'].$file['path'];
-        })->all();
+        ])
+            ->unique(fn ($file) => $file['name'].$file['disk'].$file['path'])
+            ->all();
 
         return $this;
     }
@@ -1130,10 +1130,9 @@ class Mailable implements MailableContract, Renderable
     public function attachData($data, $name, array $options = [])
     {
         $this->rawAttachments = (new Collection($this->rawAttachments))
-                ->push(compact('data', 'name', 'options'))
-                ->unique(function ($file) {
-                    return $file['name'].$file['data'];
-                })->all();
+            ->push(compact('data', 'name', 'options'))
+            ->unique(fn ($file) => $file['name'].$file['data'])
+            ->all();
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -111,9 +111,9 @@ class Envelope
      */
     protected function normalizeAddresses($addresses)
     {
-        return (new Collection($addresses))->map(function ($address) {
-            return is_string($address) ? new Address($address) : $address;
-        })->all();
+        return (new Collection($addresses))
+            ->map(fn ($address) => is_string($address) ? new Address($address) : $address)
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -94,8 +94,8 @@ class Headers
      */
     public function referencesString(): string
     {
-        return (new Collection($this->references))->map(function ($messageId) {
-            return Str::finish(Str::start($messageId, '<'), '>');
-        })->implode(' ');
+        return (new Collection($this->references))
+            ->map(fn ($messageId) => Str::finish(Str::start($messageId, '<'), '>'))
+            ->implode(' ');
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -72,9 +72,9 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return [new PrivateChannel($channels)];
         }
 
-        return (new Collection($channels))->map(function ($channel) {
-            return new PrivateChannel($channel);
-        })->all();
+        return (new Collection($channels))
+            ->map(fn ($channel) => new PrivateChannel($channel))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -159,9 +159,9 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function getUrlRange($start, $end)
     {
-        return (new Collection(range($start, $end)))->mapWithKeys(function ($page) {
-            return [$page => $this->url($page)];
-        })->all();
+        return (new Collection(range($start, $end)))
+            ->mapWithKeys(fn ($page) => [$page => $this->url($page)])
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -56,9 +56,10 @@ class ListFailedCommand extends Command
     {
         $failed = $this->laravel['queue.failer']->all();
 
-        return (new Collection($failed))->map(function ($failed) {
-            return $this->parseFailedJob((array) $failed);
-        })->filter()->all();
+        return (new Collection($failed))
+            ->map(fn ($failed) => $this->parseFailedJob((array) $failed))
+            ->filter()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -216,10 +216,8 @@ abstract class Queue
         }
 
         return (new Collection(Arr::wrap($backoff)))
-            ->map(function ($backoff) {
-                return $backoff instanceof DateTimeInterface
-                                ? $this->secondsUntil($backoff) : $backoff;
-            })->implode(',');
+            ->map(fn ($backoff) => $backoff instanceof DateTimeInterface ? $this->secondsUntil($backoff) : $backoff)
+            ->implode(',');
     }
 
     /**

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -91,9 +91,9 @@ trait SerializesAndRestoresModelIdentifiers
         $collectionClass = get_class($collection);
 
         return new $collectionClass(
-            (new Collection($value->id))->map(function ($id) use ($collection) {
-                return $collection[$id] ?? null;
-            })->filter()
+            (new Collection($value->id))
+                ->map(fn ($id) => $collection[$id] ?? null)
+                ->filter()
         );
     }
 

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -224,14 +224,11 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     protected function getMessagesForWildcardKey($key, $format)
     {
         return (new Collection($this->messages))
-                ->filter(function ($messages, $messageKey) use ($key) {
-                    return Str::is($key, $messageKey);
-                })
-                ->map(function ($messages, $messageKey) use ($format) {
-                    return $this->transform(
-                        $messages, $this->checkFormat($format), $messageKey
-                    );
-                })->all();
+            ->filter(fn ($messages, $messageKey) => Str::is($key, $messageKey))
+            ->map(function ($messages, $messageKey) use ($format) {
+                return $this->transform($messages, $this->checkFormat($format), $messageKey);
+            })
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -330,9 +330,9 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function fail($messages)
     {
-        $messages = (new Collection(Arr::wrap($messages)))->map(function ($message) {
-            return $this->validator->getTranslator()->get($message);
-        })->all();
+        $messages = (new Collection(Arr::wrap($messages)))
+            ->map(fn ($message) => $this->validator->getTranslator()->get($message))
+            ->all();
 
         $this->messages = array_merge($this->messages, $messages);
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -488,9 +488,9 @@ class ComponentTagCompiler
                     ? (new Collection($constructor->getParameters()))->map->getName()->all()
                     : [];
 
-        return (new Collection($attributes))->partition(function ($value, $key) use ($parameterNames) {
-            return in_array(Str::camel($key), $parameterNames);
-        })->all();
+        return (new Collection($attributes))
+            ->partition(fn ($value, $key) => in_array(Str::camel($key), $parameterNames))
+            ->all();
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -238,15 +238,10 @@ abstract class Component
             $reflection = new ReflectionClass($this);
 
             static::$propertyCache[$class] = (new Collection($reflection->getProperties(ReflectionProperty::IS_PUBLIC)))
-                ->reject(function (ReflectionProperty $property) {
-                    return $property->isStatic();
-                })
-                ->reject(function (ReflectionProperty $property) {
-                    return $this->shouldIgnore($property->getName());
-                })
-                ->map(function (ReflectionProperty $property) {
-                    return $property->getName();
-                })->all();
+                ->reject(fn (ReflectionProperty $property) => $property->isStatic())
+                ->reject(fn (ReflectionProperty $property) => $this->shouldIgnore($property->getName()))
+                ->map(fn (ReflectionProperty $property) => $property->getName())
+                ->all();
         }
 
         $values = [];
@@ -271,12 +266,8 @@ abstract class Component
             $reflection = new ReflectionClass($this);
 
             static::$methodCache[$class] = (new Collection($reflection->getMethods(ReflectionMethod::IS_PUBLIC)))
-                ->reject(function (ReflectionMethod $method) {
-                    return $this->shouldIgnore($method->getName());
-                })
-                ->map(function (ReflectionMethod $method) {
-                    return $method->getName();
-                });
+                ->reject(fn (ReflectionMethod $method) => $this->shouldIgnore($method->getName()))
+                ->map(fn (ReflectionMethod $method) => $method->getName());
         }
 
         $values = [];
@@ -442,7 +433,8 @@ abstract class Component
             }
 
             static::$ignoredParameterNames[static::class] = (new Collection($constructor->getParameters()))
-                ->map->getName()
+                ->map
+                ->getName()
                 ->all();
         }
 

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -107,9 +107,9 @@ EOF;
      */
     protected function compileBindings(array $bindings)
     {
-        return (new Collection($bindings))->map(function ($key) {
-            return ':'.$key.'="$'.Str::camel(str_replace([':', '.'], ' ', $key)).'"';
-        })->implode(' ');
+        return (new Collection($bindings))
+            ->map(fn ($key) => ':'.$key.'="$'.Str::camel(str_replace([':', '.'], ' ', $key)).'"')
+            ->implode(' ');
     }
 
     /**
@@ -120,9 +120,10 @@ EOF;
      */
     protected function compileSlots(array $slots)
     {
-        return (new Collection($slots))->map(function ($slot, $name) {
-            return $name === '__default' ? null : '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>';
-        })->filter()->implode(PHP_EOL);
+        return (new Collection($slots))
+            ->map(fn ($slot, $name) => $name === '__default' ? null : '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>')
+            ->filter()
+            ->implode(PHP_EOL);
     }
 
     /**


### PR DESCRIPTION
my goal with this commit is to make multiline chaining more consistent and readable. obviously there can be a subjective component to things like this, so I'll do my best to layout why I think these changes are objectively good.

I have limited this first proof-of-concept commit to chaining on new `Collection`s, as they are a good simple example.

what did I change:

- convert closures to arrow functions for very simple expressions
- always begin the start of a chained method (`->`) on a new line
- use a single indent from the first line on new lines

why I think this is better:

- readability is better by not having multiple methods on a single line. no more hunting for the closing parentheses
- each line serves a single grokable purpose. the first line instantiates the new `Collection` with some data. each following line runs an operation on that `Collection`
- significantly improved GIT diffs. changes you see in the diff are more likely to be isolated to the purpose of the change
- the single indent still gives us good alignment, without the pitfalls of trying to line it up with some arbitrary character or pattern in the starting line. it's very easy to apply consistently across many scenarios.

---

if this PR is accepted I will look into more places to apply this consistently, and into automation we can use for these rules as we move forward.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
