### PR TITLE
set schema to smtps if MAIL_ENCRYPTION === tls

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -194,7 +194,9 @@ class MailManager implements FactoryContract
         $scheme = $config['scheme'] ?? null;
 
         if (! $scheme) {
-            $scheme = ($config['port'] == 465) ? 'smtps' : 'smtp';
+            $scheme = ! empty($config['encryption']) && $config['encryption'] === 'tls'
+                ? 'smtps'
+                : 'smtp';
         }
 
         $transport = $factory->create(new Dsn(


### PR DESCRIPTION
This fixes the problem with the missing scheme in the config [this Pull ](https://github.com/laravel/framework/pull/53585)only added the validation but never added the config option


