### PR TITLE
Update CSRF token method docblock to reflect nullable return type

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -101,7 +101,7 @@ interface Session
     /**
      * Get the CSRF token value.
      *
-     * @return string
+     * @return string|null
      */
     public function token();
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -712,7 +712,7 @@ class Store implements Session
     /**
      * Get the CSRF token value.
      *
-     * @return string
+     * @return string|null
      */
     public function token()
     {

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -55,7 +55,7 @@ namespace Illuminate\Support\Facades;
  * @method static void setId(string|null $id)
  * @method static bool isValidId(string|null $id)
  * @method static void setExists(bool $value)
- * @method static string token()
+ * @method static string|null token()
  * @method static void regenerateToken()
  * @method static string|null previousUrl()
  * @method static void setPreviousUrl(string $url)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `token()` method can return null in certain cases, but this wasn't reflected in the PHPDoc. Updated the `@return` tag from `string` to `string|null` to accurately document the method's return type and help with static analysis.

