### PR TITLE
Tap fluent chainable

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -54,9 +54,7 @@ class AuthorizationException extends Exception
      */
     public function setResponse($response)
     {
-        $this->response = $response;
-
-        return $this;
+        return tap($this, fn () => $this->response = $response);
     }
 
     /**
@@ -67,9 +65,7 @@ class AuthorizationException extends Exception
      */
     public function withStatus($status)
     {
-        $this->status = $status;
-
-        return $this;
+        return tap($this, fn () => $this->status = $status);
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -291,9 +291,7 @@ class Gate implements GateContract
      */
     public function policy($class, $policy)
     {
-        $this->policies[$class] = $policy;
-
-        return $this;
+        return tap($this, fn () => $this->policies[$class] = $policy);
     }
 
     /**
@@ -304,9 +302,7 @@ class Gate implements GateContract
      */
     public function before(callable $callback)
     {
-        $this->beforeCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->beforeCallbacks[] = $callback);
     }
 
     /**
@@ -317,9 +313,7 @@ class Gate implements GateContract
      */
     public function after(callable $callback)
     {
-        $this->afterCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->afterCallbacks[] = $callback);
     }
 
     /**
@@ -716,9 +710,7 @@ class Gate implements GateContract
      */
     public function guessPolicyNamesUsing(callable $callback)
     {
-        $this->guessPolicyNamesUsingCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->guessPolicyNamesUsingCallback = $callback);
     }
 
     /**
@@ -883,9 +875,7 @@ class Gate implements GateContract
      */
     public function defaultDenialResponse(Response $response)
     {
-        $this->defaultDenialResponse = $response;
-
-        return $this;
+        return tap($this, fn () => $this->defaultDenialResponse = $response);
     }
 
     /**
@@ -896,8 +886,6 @@ class Gate implements GateContract
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 }

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -165,9 +165,7 @@ class Response implements Arrayable, Stringable
      */
     public function withStatus($status)
     {
-        $this->status = $status;
-
-        return $this;
+        return tap($this, fn () => $this->status = $status);
     }
 
     /**

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -261,9 +261,7 @@ class AuthManager implements FactoryContract
      */
     public function resolveUsersUsing(Closure $userResolver)
     {
-        $this->userResolver = $userResolver;
-
-        return $this;
+        return tap($this, fn () => $this->userResolver = $userResolver);
     }
 
     /**
@@ -275,9 +273,7 @@ class AuthManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback);
     }
 
     /**
@@ -289,9 +285,7 @@ class AuthManager implements FactoryContract
      */
     public function provider($name, Closure $callback)
     {
-        $this->customProviderCreators[$name] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->customProviderCreators[$name] = $callback);
     }
 
     /**
@@ -311,9 +305,7 @@ class AuthManager implements FactoryContract
      */
     public function forgetGuards()
     {
-        $this->guards = [];
-
-        return $this;
+        return tap($this, fn() => $this->guards = []);
     }
 
     /**
@@ -324,9 +316,7 @@ class AuthManager implements FactoryContract
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn() => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -305,7 +305,7 @@ class AuthManager implements FactoryContract
      */
     public function forgetGuards()
     {
-        return tap($this, fn() => $this->guards = []);
+        return tap($this, fn () => $this->guards = []);
     }
 
     /**
@@ -316,7 +316,7 @@ class AuthManager implements FactoryContract
      */
     public function setApplication($app)
     {
-        return tap($this, fn() => $this->app = $app);
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -227,9 +227,7 @@ class EloquentUserProvider implements UserProvider
      */
     public function setHasher(HasherContract $hasher)
     {
-        $this->hasher = $hasher;
-
-        return $this;
+        return tap($this, fn () => $this->hasher = $hasher);
     }
 
     /**
@@ -250,9 +248,7 @@ class EloquentUserProvider implements UserProvider
      */
     public function setModel($model)
     {
-        $this->model = $model;
-
-        return $this;
+        return tap($this, fn () => $this->model = $model);
     }
 
     /**
@@ -273,8 +269,6 @@ class EloquentUserProvider implements UserProvider
      */
     public function withQuery($queryCallback = null)
     {
-        $this->queryCallback = $queryCallback;
-
-        return $this;
+        return tap($this, fn () => $this->queryCallback = $queryCallback);
     }
 }

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -86,9 +86,7 @@ trait GuardHelpers
      */
     public function setUser(AuthenticatableContract $user)
     {
-        $this->user = $user;
-
-        return $this;
+        return tap($this, fn () => $this->user = $user);
     }
 
     /**
@@ -98,9 +96,7 @@ trait GuardHelpers
      */
     public function forgetUser()
     {
-        $this->user = null;
-
-        return $this;
+        return tap($this, fn () => $this->user = null);
     }
 
     /**

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -80,8 +80,6 @@ class RequestGuard implements Guard
      */
     public function setRequest(Request $request)
     {
-        $this->request = $request;
-
-        return $this;
+        return tap($this, fn () => $this->request = $request);
     }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -864,9 +864,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function setRememberDuration($minutes)
     {
-        $this->rememberDuration = $minutes;
-
-        return $this;
+        return tap($this, fn () => $this->rememberDuration = $minutes);
     }
 
     /**
@@ -972,9 +970,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function setRequest(Request $request)
     {
-        $this->request = $request;
-
-        return $this;
+        return tap($this, fn () => $this->request = $request);
     }
 
     /**

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -143,8 +143,6 @@ class TokenGuard implements Guard
      */
     public function setRequest(Request $request)
     {
-        $this->request = $request;
-
-        return $this;
+        return tap($this, fn () => $this->request = $request);
     }
 }

--- a/src/Illuminate/Broadcasting/AnonymousEvent.php
+++ b/src/Illuminate/Broadcasting/AnonymousEvent.php
@@ -52,9 +52,7 @@ class AnonymousEvent implements ShouldBroadcast
      */
     public function via(string $connection): static
     {
-        $this->connection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->connection = $connection);
     }
 
     /**
@@ -62,9 +60,7 @@ class AnonymousEvent implements ShouldBroadcast
      */
     public function as(string $name): static
     {
-        $this->name = $name;
-
-        return $this;
+        return tap($this, fn () => $this->name = $name);
     }
 
     /**
@@ -86,9 +82,7 @@ class AnonymousEvent implements ShouldBroadcast
      */
     public function toOthers(): static
     {
-        $this->includeCurrentUser = false;
-
-        return $this;
+        return tap($this, fn () => $this->includeCurrentUser = false);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -471,9 +471,7 @@ class BroadcastManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback);
     }
 
     /**
@@ -494,9 +492,7 @@ class BroadcastManager implements FactoryContract
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**
@@ -506,9 +502,7 @@ class BroadcastManager implements FactoryContract
      */
     public function forgetDrivers()
     {
-        $this->drivers = [];
-
-        return $this;
+        return tap($this, fn () => $this->drivers = []);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/InteractsWithSockets.php
+++ b/src/Illuminate/Broadcasting/InteractsWithSockets.php
@@ -20,9 +20,7 @@ trait InteractsWithSockets
      */
     public function dontBroadcastToCurrentUser()
     {
-        $this->socket = Broadcast::socket();
-
-        return $this;
+        return tap($this, fn () => $this->socket = Broadcast::socket());
     }
 
     /**
@@ -32,8 +30,6 @@ trait InteractsWithSockets
      */
     public function broadcastToEveryone()
     {
-        $this->socket = null;
-
-        return $this;
+        return tap($this, fn () => $this->socket = null);
     }
 }

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -59,9 +59,7 @@ trait Batchable
      */
     public function withBatchId(string $batchId)
     {
-        $this->batchId = $batchId;
-
-        return $this;
+        return tap($this, fn () => $this->batchId = $batchId);
     }
 
     /**

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -266,9 +266,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function pipeThrough(array $pipes)
     {
-        $this->pipes = $pipes;
-
-        return $this;
+        return tap($this, fn () => $this->pipes = $pipes);
     }
 
     /**
@@ -279,8 +277,6 @@ class Dispatcher implements QueueingDispatcher
      */
     public function map(array $map)
     {
-        $this->handlers = array_merge($this->handlers, $map);
-
-        return $this;
+        return tap($this, fn () => $this->handlers = array_merge($this->handlers, $map));
     }
 }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -209,9 +209,7 @@ class PendingBatch
      */
     public function allowFailures($allowFailures = true)
     {
-        $this->options['allowFailures'] = $allowFailures;
-
-        return $this;
+        return tap($this, fn () => $this->options['allowFailures'] = $allowFailures);
     }
 
     /**
@@ -232,9 +230,7 @@ class PendingBatch
      */
     public function name(string $name)
     {
-        $this->name = $name;
-
-        return $this;
+        return tap($this, fn () => $this->name = $name);
     }
 
     /**
@@ -245,9 +241,7 @@ class PendingBatch
      */
     public function onConnection(string $connection)
     {
-        $this->options['connection'] = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->options['connection'] = $connection);
     }
 
     /**
@@ -268,9 +262,7 @@ class PendingBatch
      */
     public function onQueue($queue)
     {
-        $this->options['queue'] = enum_value($queue);
-
-        return $this;
+        return tap($this, fn () => $this->options['queue'] = enum_value($queue));
     }
 
     /**
@@ -292,9 +284,7 @@ class PendingBatch
      */
     public function withOption(string $key, $value)
     {
-        $this->options[$key] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->options[$key] = $value);
     }
 
     /**

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -84,9 +84,7 @@ trait Queueable
      */
     public function onConnection($connection)
     {
-        $this->connection = enum_value($connection);
-
-        return $this;
+        return tap($this, fn () => $this->connection = enum_value($connection));
     }
 
     /**
@@ -97,9 +95,7 @@ trait Queueable
      */
     public function onQueue($queue)
     {
-        $this->queue = enum_value($queue);
-
-        return $this;
+        return tap($this, fn () => $this->queue = enum_value($queue));
     }
 
     /**
@@ -142,9 +138,7 @@ trait Queueable
      */
     public function delay($delay)
     {
-        $this->delay = $delay;
-
-        return $this;
+        return tap($this, fn () => $this->delay = $delay);
     }
 
     /**
@@ -154,9 +148,7 @@ trait Queueable
      */
     public function withoutDelay()
     {
-        $this->delay = 0;
-
-        return $this;
+        return tap($this, fn () => $this->delay = 0);
     }
 
     /**
@@ -166,9 +158,7 @@ trait Queueable
      */
     public function afterCommit()
     {
-        $this->afterCommit = true;
-
-        return $this;
+        return tap($this, fn () => $this->afterCommit = true);
     }
 
     /**
@@ -178,9 +168,7 @@ trait Queueable
      */
     public function beforeCommit()
     {
-        $this->afterCommit = false;
-
-        return $this;
+        return tap($this, fn () => $this->afterCommit = false);
     }
 
     /**
@@ -191,9 +179,7 @@ trait Queueable
      */
     public function through($middleware)
     {
-        $this->middleware = Arr::wrap($middleware);
-
-        return $this;
+        return tap($this, fn () => $this->middleware = Arr::wrap($middleware));
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -423,9 +423,7 @@ class CacheManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback->bindTo($this, $this));
     }
 
     /**
@@ -436,9 +434,7 @@ class CacheManager implements FactoryContract
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -451,9 +451,7 @@ class DatabaseStore implements LockProvider, Store
      */
     public function setLockConnection($connection)
     {
-        $this->lockConnection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->lockConnection = $connection);
     }
 
     /**

--- a/src/Illuminate/Cache/Events/CacheEvent.php
+++ b/src/Illuminate/Cache/Events/CacheEvent.php
@@ -48,8 +48,6 @@ abstract class CacheEvent
      */
     public function setTags($tags)
     {
-        $this->tags = $tags;
-
-        return $this;
+        return tap($this, fn () => $this->tags = $tags);
     }
 }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -392,9 +392,7 @@ class FileStore implements Store, LockProvider
      */
     public function setDirectory($directory)
     {
-        $this->directory = $directory;
-
-        return $this;
+        return tap($this, fn () => $this->directory = $directory);
     }
 
     /**
@@ -405,9 +403,7 @@ class FileStore implements Store, LockProvider
      */
     public function setLockDirectory($lockDirectory)
     {
-        $this->lockDirectory = $lockDirectory;
-
-        return $this;
+        return tap($this, fn () => $this->lockDirectory = $lockDirectory);
     }
 
     /**

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -176,8 +176,6 @@ abstract class Lock implements LockContract
      */
     public function betweenBlockedAttemptsSleepFor($milliseconds)
     {
-        $this->sleepMilliseconds = $milliseconds;
-
-        return $this;
+        return tap($this, fn () => $this->sleepMilliseconds = $milliseconds);
     }
 }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -125,9 +125,7 @@ class Limit
      */
     public function by($key)
     {
-        $this->key = $key;
-
-        return $this;
+        return tap($this, fn () => $this->key = $key);
     }
 
     /**
@@ -138,9 +136,7 @@ class Limit
      */
     public function response(callable $callback)
     {
-        $this->responseCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->responseCallback = $callback);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -364,9 +364,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function setLockConnection($connection)
     {
-        $this->lockConnection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->lockConnection = $connection);
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -671,9 +671,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function setDefaultCacheTime($seconds)
     {
-        $this->default = $seconds;
-
-        return $this;
+        return tap($this, fn () => $this->default = $seconds);
     }
 
     /**
@@ -694,9 +692,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function setStore($store)
     {
-        $this->store = $store;
-
-        return $this;
+        return tap($this, fn () => $this->store = $store);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1010,9 +1010,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function prepend($value, $key = null)
     {
-        $this->items = Arr::prepend($this->items, ...func_get_args());
-
-        return $this;
+        return tap($this, fn () => $this->items = Arr::prepend($this->items, ...func_get_args()));
     }
 
     /**
@@ -1038,9 +1036,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function unshift(...$values)
     {
-        array_unshift($this->items, ...$values);
-
-        return $this;
+        return tap($this, fn () => array_unshift($this->items, ...$values));
     }
 
     /**
@@ -1086,9 +1082,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function put($key, $value)
     {
-        $this->offsetSet($key, $value);
-
-        return $this;
+        return tap($this)->offsetSet($key, $value);
     }
 
     /**
@@ -1715,9 +1709,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function transform(callable $callback)
     {
-        $this->items = $this->map($callback)->all();
-
-        return $this;
+        return tap($this, fn () => $this->items = $this->map($callback)->all());
     }
 
     /**
@@ -1849,9 +1841,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function add($item)
     {
-        $this->items[] = $item;
-
-        return $this;
+        return tap($this, fn () => $this->items[] = $item);
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -240,9 +240,7 @@ trait EnumeratesValues
      */
     public function dump(...$args)
     {
-        dump($this->all(), ...$args);
-
-        return $this;
+        return tap($this, fn () => dump($this->all(), ...$args));
     }
 
     /**
@@ -888,9 +886,7 @@ trait EnumeratesValues
      */
     public function tap(callable $callback)
     {
-        $callback($this);
-
-        return $this;
+        return tap($this, $callback(...));
     }
 
     /**
@@ -1008,9 +1004,7 @@ trait EnumeratesValues
      */
     public function escapeWhenCastingToString($escape = true)
     {
-        $this->escapeWhenCastingToString = $escape;
-
-        return $this;
+        return tap($this, fn () => $this->escapeWhenCastingToString = $escape);
     }
 
     /**

--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -51,9 +51,7 @@ class HigherOrderWhenProxy
      */
     public function condition($condition)
     {
-        [$this->condition, $this->hasCondition] = [$condition, true];
-
-        return $this;
+        return tap($this, fn () => [$this->condition, $this->hasCondition] = [$condition, true]);
     }
 
     /**
@@ -63,9 +61,7 @@ class HigherOrderWhenProxy
      */
     public function negateConditionOnCapture()
     {
-        $this->negateConditionOnCapture = true;
-
-        return $this;
+        return tap($this, fn () => $this->negateConditionOnCapture = true);
     }
 
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -277,9 +277,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function setContainerCommandLoader()
     {
-        $this->setCommandLoader(new ContainerCommandLoader($this->laravel, $this->commandMap));
-
-        return $this;
+        return tap($this, fn () => $this->setCommandLoader(new ContainerCommandLoader($this->laravel, $this->commandMap)));
     }
 
     /**

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -123,9 +123,7 @@ class CacheCommandMutex implements CommandMutex
      */
     public function useStore($store)
     {
-        $this->store = $store;
-
-        return $this;
+        return tap($this, fn () => $this->store = $store);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -299,9 +299,7 @@ class Command extends SymfonyCommand
     #[\Override]
     public function setHidden(bool $hidden = true): static
     {
-        parent::setHidden($this->hidden = $hidden);
-
-        return $this;
+        return tap($this, fn () => parent::setHidden($this->hidden = $hidden));
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -386,9 +386,7 @@ trait InteractsWithIO
      */
     public function newLine($count = 1)
     {
-        $this->output->newLine($count);
-
-        return $this;
+        return tap($this, fn () => $this->output->newLine($count));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -107,8 +107,6 @@ class CacheEventMutex implements EventMutex, CacheAware
      */
     public function useStore($store)
     {
-        $this->store = $store;
-
-        return $this;
+        return tap($this, fn () => $this->store = $store);
     }
 }

--- a/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
@@ -68,8 +68,6 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
      */
     public function useStore($store)
     {
-        $this->store = $store;
-
-        return $this;
+        return tap($this, fn () => $this->store = $store);
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -345,9 +345,7 @@ class Event
      */
     public function storeOutput()
     {
-        $this->ensureOutputIsBeingCaptured();
-
-        return $this;
+        return tap($this, fn () => $this->ensureOutputIsBeingCaptured());
     }
 
     /**
@@ -586,9 +584,7 @@ class Event
      */
     public function before(Closure $callback)
     {
-        $this->beforeCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->beforeCallbacks[] = $callback);
     }
 
     /**
@@ -769,9 +765,7 @@ class Event
      */
     public function preventOverlapsUsing(EventMutex $mutex)
     {
-        $this->mutex = $mutex;
-
-        return $this;
+        return tap($this, fn () => $this->mutex = $mutex);
     }
 
     /**
@@ -798,9 +792,7 @@ class Event
      */
     public function createMutexNameUsing(Closure|string $mutexName)
     {
-        $this->mutexNameResolver = is_string($mutexName) ? fn () => $mutexName : $mutexName;
-
-        return $this;
+        return tap($this, fn () => $this->mutexNameResolver = is_string($mutexName) ? fn () => $mutexName : $mutexName);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -164,7 +164,7 @@ trait ManagesAttributes
      */
     public function runInBackground()
     {
-        return tap($this, fn () => $this->runInBackground = true;
+        return tap($this, fn () => $this->runInBackground = true);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -104,7 +104,7 @@ trait ManagesAttributes
      * @return $this
      */
     public function user($user)
-    {        
+    {
         return tap($this, fn () => $this->user = $user);
     }
 

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -104,10 +104,8 @@ trait ManagesAttributes
      * @return $this
      */
     public function user($user)
-    {
-        $this->user = $user;
-
-        return $this;
+    {        
+        return tap($this, fn () => $this->user = $user);
     }
 
     /**
@@ -118,9 +116,7 @@ trait ManagesAttributes
      */
     public function environments($environments)
     {
-        $this->environments = is_array($environments) ? $environments : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->environments = is_array($environments) ? $environments : func_get_args());
     }
 
     /**
@@ -130,9 +126,7 @@ trait ManagesAttributes
      */
     public function evenInMaintenanceMode()
     {
-        $this->evenInMaintenanceMode = true;
-
-        return $this;
+        return tap($this, fn () => $this->evenInMaintenanceMode = true);
     }
 
     /**
@@ -160,9 +154,7 @@ trait ManagesAttributes
      */
     public function onOneServer()
     {
-        $this->onOneServer = true;
-
-        return $this;
+        return tap($this, fn () => $this->onOneServer = true);
     }
 
     /**
@@ -172,9 +164,7 @@ trait ManagesAttributes
      */
     public function runInBackground()
     {
-        $this->runInBackground = true;
-
-        return $this;
+        return tap($this, fn () => $this->runInBackground = true;
     }
 
     /**
@@ -226,8 +216,6 @@ trait ManagesAttributes
      */
     public function description($description)
     {
-        $this->description = $description;
-
-        return $this;
+        return tap($this, fn () => $this->description = $description);
     }
 }

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -15,9 +15,7 @@ trait ManagesFrequencies
      */
     public function cron($expression)
     {
-        $this->expression = $expression;
-
-        return $this;
+        return tap($this, fn () => $this->expression = $expression);
     }
 
     /**
@@ -644,9 +642,7 @@ trait ManagesFrequencies
      */
     public function timezone($timezone)
     {
-        $this->timezone = $timezone;
-
-        return $this;
+        return tap($this, fn () => $this->timezone = $timezone);
     }
 
     /**

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -49,9 +49,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function needs($abstract)
     {
-        $this->needs = $abstract;
-
-        return $this;
+        return tap($this, fn () => $this->needs = $abstract);
     }
 
     /**

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -66,8 +66,6 @@ class ModelIdentifier
      */
     public function useCollectionClass(?string $collectionClass)
     {
-        $this->collectionClass = $collectionClass;
-
-        return $this;
+        return tap($this, fn () => $this->collectionClass = $collectionClass);
     }
 }

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -213,9 +213,7 @@ class CookieJar implements JarContract
      */
     public function setDefaultPathAndDomain($path, $domain, $secure = false, $sameSite = null)
     {
-        [$this->path, $this->domain, $this->secure, $this->sameSite] = [$path, $domain, $secure, $sameSite];
-
-        return $this;
+        return tap($this, fn () => [$this->path, $this->domain, $this->secure, $this->sameSite] = [$path, $domain, $secure, $sameSite]);
     }
 
     /**
@@ -235,8 +233,6 @@ class CookieJar implements JarContract
      */
     public function flushQueuedCookies()
     {
-        $this->queued = [];
-
-        return $this;
+        return tap($this, fn () => $this->queued = []);
     }
 }

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -150,9 +150,7 @@ class Manager
      */
     public function setFetchMode($fetchMode)
     {
-        $this->container['config']['database.fetch'] = $fetchMode;
-
-        return $this;
+        return tap($this, fn () => $this->container['config']['database.fetch'] = $fetchMode);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -572,8 +572,6 @@ trait BuildsQueries
      */
     public function tap($callback)
     {
-        $callback($this);
-
-        return $this;
+        return tap($this, $callback(...));
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1028,9 +1028,7 @@ class Connection implements ConnectionInterface
      */
     public function beforeStartingTransaction(Closure $callback)
     {
-        $this->beforeStartingTransaction[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->beforeStartingTransaction[] = $callback);
     }
 
     /**
@@ -1041,9 +1039,7 @@ class Connection implements ConnectionInterface
      */
     public function beforeExecuting(Closure $callback)
     {
-        $this->beforeExecutingCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->beforeExecutingCallbacks[] = $callback);
     }
 
     /**
@@ -1192,9 +1188,7 @@ class Connection implements ConnectionInterface
      */
     public function setRecordModificationState(bool $value)
     {
-        $this->recordsModified = $value;
-
-        return $this;
+        return tap($this, fn () => $this->recordsModified = $value);
     }
 
     /**
@@ -1215,9 +1209,7 @@ class Connection implements ConnectionInterface
      */
     public function useWriteConnectionWhenReading($value = true)
     {
-        $this->readOnWriteConnection = $value;
-
-        return $this;
+        return tap($this, fn () => $this->readOnWriteConnection = $value);
     }
 
     /**
@@ -1300,9 +1292,7 @@ class Connection implements ConnectionInterface
      */
     public function setReadPdo($pdo)
     {
-        $this->readPdo = $pdo;
-
-        return $this;
+        return tap($this, fn () => $this->readPdo = $pdo);
     }
 
     /**
@@ -1313,9 +1303,7 @@ class Connection implements ConnectionInterface
      */
     public function setReconnector(callable $reconnector)
     {
-        $this->reconnector = $reconnector;
-
-        return $this;
+        return tap($this, fn () => $this->reconnector = $reconnector);
     }
 
     /**
@@ -1387,9 +1375,7 @@ class Connection implements ConnectionInterface
      */
     public function setQueryGrammar(Query\Grammars\Grammar $grammar)
     {
-        $this->queryGrammar = $grammar;
-
-        return $this;
+        return tap($this, fn () => $this->queryGrammar = $grammar);
     }
 
     /**
@@ -1410,9 +1396,7 @@ class Connection implements ConnectionInterface
      */
     public function setSchemaGrammar(Schema\Grammars\Grammar $grammar)
     {
-        $this->schemaGrammar = $grammar;
-
-        return $this;
+        return tap($this, fn () => $this->schemaGrammar = $grammar);
     }
 
     /**
@@ -1433,9 +1417,7 @@ class Connection implements ConnectionInterface
      */
     public function setPostProcessor(Processor $processor)
     {
-        $this->postProcessor = $processor;
-
-        return $this;
+        return tap($this, fn () => $this->postProcessor = $processor);
     }
 
     /**
@@ -1456,9 +1438,7 @@ class Connection implements ConnectionInterface
      */
     public function setEventDispatcher(Dispatcher $events)
     {
-        $this->events = $events;
-
-        return $this;
+        return tap($this, fn () => $this->events = $events);
     }
 
     /**
@@ -1479,9 +1459,7 @@ class Connection implements ConnectionInterface
      */
     public function setTransactionManager($manager)
     {
-        $this->transactionsManager = $manager;
-
-        return $this;
+        return tap($this, fn () => $this->transactionsManager = $manager);
     }
 
     /**
@@ -1588,9 +1566,7 @@ class Connection implements ConnectionInterface
      */
     public function setDatabaseName($database)
     {
-        $this->database = $database;
-
-        return $this;
+        return tap($this, fn () => $this->database = $database);
     }
 
     /**
@@ -1601,9 +1577,7 @@ class Connection implements ConnectionInterface
      */
     public function setReadWriteType($readWriteType)
     {
-        $this->readWriteType = $readWriteType;
-
-        return $this;
+        return tap($this, fn () => $this->readWriteType = $readWriteType);
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -452,9 +452,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -117,9 +117,7 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
      */
     public function onChannels(array $channels)
     {
-        $this->channels = $channels;
-
-        return $this;
+        return tap($this, fn () => $this->channels = $channels);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2042,7 +2042,9 @@ class Builder implements BuilderContract
             return $this->toBase()->{$method}(...$parameters);
         }
 
-        return tap($this)->forwardCallTo($this->query, $method, $parameters);
+        $this->forwardCallTo($this->query, $method, $parameters);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2042,9 +2042,7 @@ class Builder implements BuilderContract
             return $this->toBase()->{$method}(...$parameters);
         }
 
-        $this->forwardCallTo($this->query, $method, $parameters);
-
-        return $this;
+        return tap($this)->forwardCallTo($this->query, $method, $parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -882,9 +882,7 @@ class Builder implements BuilderContract
      */
     public function afterQuery(Closure $callback)
     {
-        $this->afterQueryCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->afterQueryCallbacks[] = $callback);
     }
 
     /**
@@ -1774,9 +1772,7 @@ class Builder implements BuilderContract
      */
     public function withCasts($casts)
     {
-        $this->model->mergeCasts($casts);
-
-        return $this;
+        return tap($this, fn () => $this->model->mergeCasts($casts));
     }
 
     /**
@@ -1824,9 +1820,7 @@ class Builder implements BuilderContract
      */
     public function setQuery($query)
     {
-        $this->query = $query;
-
-        return $this;
+        return tap($this, fn () => $this->query = $query);
     }
 
     /**
@@ -1857,9 +1851,7 @@ class Builder implements BuilderContract
      */
     public function setEagerLoads(array $eagerLoad)
     {
-        $this->eagerLoad = $eagerLoad;
-
-        return $this;
+        return tap($this, fn () => $this->eagerLoad = $eagerLoad);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -86,9 +86,7 @@ class Attribute
      */
     public function withoutObjectCaching()
     {
-        $this->withObjectCaching = false;
-
-        return $this;
+        return tap($this, fn () => $this->withObjectCaching = false);
     }
 
     /**
@@ -98,8 +96,6 @@ class Attribute
      */
     public function shouldCache()
     {
-        $this->withCaching = true;
-
-        return $this;
+        return tap($this, fn () => $this->withCaching = true);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -289,12 +289,11 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function loadMorph($relation, $relations)
     {
-        $this->pluck($relation)
+        return tap($this)
+            ->pluck($relation)
             ->filter()
             ->groupBy(fn ($model) => get_class($model))
             ->each(fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
-
-        return $this;
     }
 
     /**
@@ -306,12 +305,11 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function loadMorphCount($relation, $relations)
     {
-        $this->pluck($relation)
+        return tap($this)
+            ->pluck($relation)
             ->filter()
             ->groupBy(fn ($model) => get_class($model))
             ->each(fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -50,9 +50,7 @@ trait GuardsAttributes
      */
     public function fillable(array $fillable)
     {
-        $this->fillable = $fillable;
-
-        return $this;
+        return tap($this, fn () => $this->fillable = $fillable);
     }
 
     /**
@@ -63,9 +61,7 @@ trait GuardsAttributes
      */
     public function mergeFillable(array $fillable)
     {
-        $this->fillable = array_values(array_unique(array_merge($this->fillable, $fillable)));
-
-        return $this;
+        return tap($this, fn () => $this->fillable = array_values(array_unique(array_merge($this->fillable, $fillable))));
     }
 
     /**
@@ -88,9 +84,7 @@ trait GuardsAttributes
      */
     public function guard(array $guarded)
     {
-        $this->guarded = $guarded;
-
-        return $this;
+        return tap($this, fn () => $this->guarded = $guarded);
     }
 
     /**
@@ -101,9 +95,7 @@ trait GuardsAttributes
      */
     public function mergeGuarded(array $guarded)
     {
-        $this->guarded = array_values(array_unique(array_merge($this->guarded, $guarded)));
-
-        return $this;
+        return tap($this, fn () => $this->guarded = array_values(array_unique(array_merge($this->guarded, $guarded))));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1583,9 +1583,7 @@ trait HasAttributes
      */
     public function setDateFormat($format)
     {
-        $this->dateFormat = $format;
-
-        return $this;
+        return tap($this, fn () => $this->dateFormat = $format);
     }
 
     /**
@@ -1983,9 +1981,7 @@ trait HasAttributes
      */
     public function syncOriginal()
     {
-        $this->original = $this->getAttributes();
-
-        return $this;
+        return tap($this, fn () => $this->original = $this->getAttributes());
     }
 
     /**
@@ -2025,9 +2021,7 @@ trait HasAttributes
      */
     public function syncChanges()
     {
-        $this->changes = $this->getDirty();
-
-        return $this;
+        return tap($this, fn () => $this->changes = $this->getDirty());
     }
 
     /**
@@ -2061,9 +2055,7 @@ trait HasAttributes
      */
     public function discardChanges()
     {
-        [$this->attributes, $this->changes] = [$this->original, []];
-
-        return $this;
+        return tap($this, fn () => [$this->attributes, $this->changes] = [$this->original, []]);
     }
 
     /**
@@ -2273,9 +2265,7 @@ trait HasAttributes
      */
     public function setAppends(array $appends)
     {
-        $this->appends = $appends;
-
-        return $this;
+        return tap($this, fn () => $this->appends = $appends);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -148,9 +148,7 @@ trait HasEvents
      */
     public function setObservableEvents(array $observables)
     {
-        $this->observables = $observables;
-
-        return $this;
+        return tap($this, fn () => $this->observables = $observables);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -915,9 +915,7 @@ trait HasRelationships
      */
     public function setRelation($relation, $value)
     {
-        $this->relations[$relation] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->relations[$relation] = $value);
     }
 
     /**
@@ -928,9 +926,7 @@ trait HasRelationships
      */
     public function unsetRelation($relation)
     {
-        unset($this->relations[$relation]);
-
-        return $this;
+        return tap($this, fn () => unset($this->relations[$relation]));
     }
 
     /**
@@ -941,9 +937,7 @@ trait HasRelationships
      */
     public function setRelations(array $relations)
     {
-        $this->relations = $relations;
-
-        return $this;
+        return tap($this, fn () => $this->relations = $relations);
     }
 
     /**
@@ -965,9 +959,7 @@ trait HasRelationships
      */
     public function unsetRelations()
     {
-        $this->relations = [];
-
-        return $this;
+        return tap($this, fn () => $this->relations = []);
     }
 
     /**
@@ -988,8 +980,6 @@ trait HasRelationships
      */
     public function setTouchedRelations(array $touches)
     {
-        $this->touches = $touches;
-
-        return $this;
+        return tap($this, fn () => $this->touches = $touches);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -926,7 +926,9 @@ trait HasRelationships
      */
     public function unsetRelation($relation)
     {
-        return tap($this, fn () => unset($this->relations[$relation]));
+        unset($this->relations[$relation]);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -86,9 +86,7 @@ trait HasTimestamps
      */
     public function setCreatedAt($value)
     {
-        $this->{$this->getCreatedAtColumn()} = $value;
-
-        return $this;
+        return tap($this, fn () => $this->{$this->getCreatedAtColumn()} = $value);
     }
 
     /**
@@ -99,9 +97,7 @@ trait HasTimestamps
      */
     public function setUpdatedAt($value)
     {
-        $this->{$this->getUpdatedAtColumn()} = $value;
-
-        return $this;
+        return tap($this, fn () => $this->{$this->getUpdatedAtColumn()} = $value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -36,9 +36,7 @@ trait HidesAttributes
      */
     public function setHidden(array $hidden)
     {
-        $this->hidden = $hidden;
-
-        return $this;
+        return tap($this, fn () => $this->hidden = $hidden);
     }
 
     /**
@@ -59,9 +57,7 @@ trait HidesAttributes
      */
     public function setVisible(array $visible)
     {
-        $this->visible = $visible;
-
-        return $this;
+        return tap($this, fn () => $this->visible = $visible);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -68,8 +68,6 @@ class Relationship
      */
     public function recycle($recycle)
     {
-        $this->factory = $this->factory->recycle($recycle);
-
-        return $this;
+        return tap($this, fn () => $this->factory = $this->factory->recycle($recycle));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1734,9 +1734,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true));
         })->keys()->all());
 
-        $this->syncOriginal();
-
-        return $this;
+        return tap($this)->syncOriginal();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -770,9 +770,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function loadAggregate($relations, $column, $function = null)
     {
-        $this->newCollection([$this])->loadAggregate($relations, $column, $function);
-
-        return $this;
+        return tap($this, fn () => $this->newCollection([$this])->loadAggregate($relations, $column, $function));
     }
 
     /**
@@ -1834,9 +1832,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function setConnection($name)
     {
-        $this->connection = $name;
-
-        return $this;
+        return tap($this, fn () => $this->connection = $name);
     }
 
     /**
@@ -1899,9 +1895,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function setTable($table)
     {
-        $this->table = $table;
-
-        return $this;
+        return tap($this, fn () => $this->table = $table);
     }
 
     /**
@@ -1922,9 +1916,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function setKeyName($key)
     {
-        $this->primaryKey = $key;
-
-        return $this;
+        return tap($this, fn () => $this->primaryKey = $key);
     }
 
     /**
@@ -1955,9 +1947,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function setKeyType($type)
     {
-        $this->keyType = $type;
-
-        return $this;
+        return tap($this, fn () => $this->keyType = $type);
     }
 
     /**
@@ -1978,9 +1968,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function setIncrementing($value)
     {
-        $this->incrementing = $value;
-
-        return $this;
+        return tap($this, fn () => $this->incrementing = $value);
     }
 
     /**
@@ -2193,9 +2181,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function setPerPage($perPage)
     {
-        $this->perPage = $perPage;
-
-        return $this;
+        return tap($this, fn () => $this->perPage = $perPage);
     }
 
     /**
@@ -2399,9 +2385,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function escapeWhenCastingToString($escape = true)
     {
-        $this->escapeWhenCastingToString = $escape;
-
-        return $this;
+        return tap($this, fn () => $this->escapeWhenCastingToString = $escape);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -331,9 +331,7 @@ class BelongsToMany extends Relation
      */
     public function using($class)
     {
-        $this->using = $class;
-
-        return $this;
+        return tap($this, fn () => $this->using = $class);
     }
 
     /**
@@ -344,9 +342,7 @@ class BelongsToMany extends Relation
      */
     public function as($accessor)
     {
-        $this->accessor = $accessor;
-
-        return $this;
+        return tap($this, fn () => $this->accessor = $accessor);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -229,9 +229,7 @@ trait AsPivot
      */
     public function setRelatedModel(?Model $related = null)
     {
-        $this->pivotRelated = $related;
-
-        return $this;
+        return tap($this, fn () => $this->pivotRelated = $related);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsDefaultModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsDefaultModels.php
@@ -31,9 +31,7 @@ trait SupportsDefaultModels
      */
     public function withDefault($callback = true)
     {
-        $this->withDefault = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->withDefault = $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -150,8 +150,6 @@ trait SupportsInverseRelations
      */
     public function withoutChaperone()
     {
-        $this->inverseRelationship = null;
-
-        return $this;
+        return tap($this, fn () => $this->inverseRelationship = null);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -155,9 +155,7 @@ abstract class HasOneOrManyThrough extends Relation
      */
     public function withTrashedParents()
     {
-        $this->query->withoutGlobalScope('SoftDeletableHasManyThrough');
-
-        return $this;
+        return tap($this, fn () => $this->query->withoutGlobalScope('SoftDeletableHasManyThrough'));
     }
 
     /** @inheritDoc */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -92,9 +92,7 @@ class MorphPivot extends Pivot
      */
     public function setMorphType($morphType)
     {
-        $this->morphType = $morphType;
-
-        return $this;
+        return tap($this, fn () => $this->morphType = $morphType);
     }
 
     /**
@@ -105,9 +103,7 @@ class MorphPivot extends Pivot
      */
     public function setMorphClass($morphClass)
     {
-        $this->morphClass = $morphClass;
-
-        return $this;
+        return tap($this, fn () => $this->morphClass = $morphClass);
     }
 
     /**

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -296,9 +296,7 @@ abstract class Grammar
      */
     public function setTablePrefix($prefix)
     {
-        $this->tablePrefix = $prefix;
-
-        return $this;
+        return tap($this, fn () => $this->tablePrefix = $prefix);
     }
 
     /**
@@ -309,8 +307,6 @@ abstract class Grammar
      */
     public function setConnection($connection)
     {
-        $this->connection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->connection = $connection);
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -719,9 +719,7 @@ class Migrator
      */
     public function setOutput(OutputInterface $output)
     {
-        $this->output = $output;
-
-        return $this;
+        return tap($this, fn () => $this->output = $output);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -494,9 +494,7 @@ class Builder implements BuilderContract
      */
     public function useIndex($index)
     {
-        $this->indexHint = new IndexHint('hint', $index);
-
-        return $this;
+        return tap($this, fn () => $this->indexHint = new IndexHint('hint', $index));
     }
 
     /**
@@ -507,9 +505,7 @@ class Builder implements BuilderContract
      */
     public function forceIndex($index)
     {
-        $this->indexHint = new IndexHint('force', $index);
-
-        return $this;
+        return tap($this, fn () => $this->indexHint = new IndexHint('force', $index));
     }
 
     /**
@@ -520,9 +516,7 @@ class Builder implements BuilderContract
      */
     public function ignoreIndex($index)
     {
-        $this->indexHint = new IndexHint('ignore', $index);
-
-        return $this;
+        return tap($this, fn () => $this->indexHint = new IndexHint('ignore', $index));
     }
 
     /**
@@ -2955,9 +2949,7 @@ class Builder implements BuilderContract
      */
     public function beforeQuery(callable $callback)
     {
-        $this->beforeQueryCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->beforeQueryCallbacks[] = $callback);
     }
 
     /**
@@ -2982,9 +2974,7 @@ class Builder implements BuilderContract
      */
     public function afterQuery(Closure $callback)
     {
-        $this->afterQueryCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->afterQueryCallbacks[] = $callback);
     }
 
     /**
@@ -4229,9 +4219,7 @@ class Builder implements BuilderContract
      */
     public function mergeBindings(self $query)
     {
-        $this->bindings = array_merge_recursive($this->bindings, $query->bindings);
-
-        return $this;
+        return tap($this, fn () => $this->bindings = array_merge_recursive($this->bindings, $query->bindings));
     }
 
     /**
@@ -4309,9 +4297,7 @@ class Builder implements BuilderContract
      */
     public function useWritePdo()
     {
-        $this->useWritePdo = true;
-
-        return $this;
+        return tap($this, fn () => $this->useWritePdo = true);
     }
 
     /**
@@ -4392,9 +4378,7 @@ class Builder implements BuilderContract
      */
     public function dumpRawSql()
     {
-        dump($this->toRawSql());
-
-        return $this;
+        return tap($this, fn () => dump($this->toRawSql()));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -353,9 +353,7 @@ class Builder implements BuilderContract
     {
         $this->from = new Expression($expression);
 
-        $this->addBinding($bindings, 'from');
-
-        return $this;
+        return tap($this)->addBinding($bindings, 'from');
     }
 
     /**
@@ -1101,9 +1099,7 @@ class Builder implements BuilderContract
     {
         $this->wheres[] = ['type' => 'raw', 'sql' => $sql, 'boolean' => $boolean];
 
-        $this->addBinding((array) $bindings, 'where');
-
-        return $this;
+        return tap($this)->addBinding((array) $bindings, 'where');
     }
 
     /**
@@ -1138,9 +1134,7 @@ class Builder implements BuilderContract
             $value = $this->grammar->prepareWhereLikeBinding($value, $caseSensitive);
         }
 
-        $this->addBinding($value);
-
-        return $this;
+        return tap($this)->addBinding($value);
     }
 
     /**
@@ -1223,9 +1217,7 @@ class Builder implements BuilderContract
         // Finally, we'll add a binding for each value unless that value is an expression
         // in which case we will just skip over it since it will be the query as a raw
         // string and not as a parameterized place-holder to be replaced by the PDO.
-        $this->addBinding($this->cleanBindings($values), 'where');
-
-        return $this;
+        return tap($this)->addBinding($this->cleanBindings($values), 'where');
     }
 
     /**
@@ -1391,9 +1383,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 
-        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');
-
-        return $this;
+        return tap($this)->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');
     }
 
     /**
@@ -1838,9 +1828,7 @@ class Builder implements BuilderContract
             'type', 'column', 'operator', 'query', 'boolean'
         );
 
-        $this->addBinding($query->getBindings(), 'where');
-
-        return $this;
+        return tap($this)->addBinding($query->getBindings(), 'where');
     }
 
     /**
@@ -1916,9 +1904,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'query', 'boolean');
 
-        $this->addBinding($query->getBindings(), 'where');
-
-        return $this;
+        return tap($this)->addBinding($query->getBindings(), 'where');
     }
 
     /**
@@ -1942,9 +1928,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'columns', 'operator', 'values', 'boolean');
 
-        $this->addBinding($this->cleanBindings($values));
-
-        return $this;
+        return tap($this)->addBinding($this->cleanBindings($values));
     }
 
     /**
@@ -2257,9 +2241,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'columns', 'value', 'options', 'boolean');
 
-        $this->addBinding($value);
-
-        return $this;
+        return tap($this)->addBinding($value);
     }
 
     /**
@@ -2404,9 +2386,7 @@ class Builder implements BuilderContract
     {
         $this->groups[] = new Expression($sql);
 
-        $this->addBinding($bindings, 'groupBy');
-
-        return $this;
+        return tap($this)->addBinding($bindings, 'groupBy');
     }
 
     /**
@@ -2584,9 +2564,7 @@ class Builder implements BuilderContract
 
         $this->havings[] = compact('type', 'column', 'values', 'boolean', 'not');
 
-        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'having');
-
-        return $this;
+        return tap($this)->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'having');
     }
 
     /**
@@ -2603,9 +2581,7 @@ class Builder implements BuilderContract
 
         $this->havings[] = compact('type', 'sql', 'boolean');
 
-        $this->addBinding($bindings, 'having');
-
-        return $this;
+        tap($this)->addBinding($bindings, 'having');
     }
 
     /**
@@ -2710,9 +2686,7 @@ class Builder implements BuilderContract
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = compact('type', 'sql');
 
-        $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
-
-        return $this;
+        return tap($this)->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
     }
 
     /**
@@ -2888,9 +2862,7 @@ class Builder implements BuilderContract
 
         $this->unions[] = compact('query', 'all');
 
-        $this->addBinding($query->getBindings(), 'union');
-
-        return $this;
+        return tap($this)->addBinding($query->getBindings(), 'union');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -602,9 +602,7 @@ class Builder
      */
     public function setConnection(Connection $connection)
     {
-        $this->connection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->connection = $connection);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -122,9 +122,7 @@ abstract class SchemaState
      */
     public function withMigrationTable(string $table)
     {
-        $this->migrationTable = $table;
-
-        return $this;
+        return tap($this, fn () => $this->migrationTable = $table);
     }
 
     /**
@@ -135,8 +133,6 @@ abstract class SchemaState
      */
     public function handleOutputUsing(callable $output)
     {
-        $this->output = $output;
-
-        return $this;
+        return tap($this, fn () => $this->output = $output);
     }
 }

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -148,9 +148,7 @@ abstract class Seeder
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 
     /**
@@ -161,9 +159,7 @@ abstract class Seeder
      */
     public function setCommand(Command $command)
     {
-        $this->command = $command;
-
-        return $this;
+        return tap($this, fn () => $this->command = $command);
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -738,9 +738,7 @@ class Dispatcher implements DispatcherContract
      */
     public function setQueueResolver(callable $resolver)
     {
-        $this->queueResolver = $resolver;
-
-        return $this;
+        return tap($this, fn () => $this->queueResolver = $resolver);
     }
 
     /**
@@ -761,9 +759,7 @@ class Dispatcher implements DispatcherContract
      */
     public function setTransactionManagerResolver(callable $resolver)
     {
-        $this->transactionManagerResolver = $resolver;
-
-        return $this;
+        return tap($this, fn () => $this->transactionManagerResolver = $resolver);
     }
 
     /**

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -64,9 +64,7 @@ class QueuedClosure
      */
     public function onConnection($connection)
     {
-        $this->connection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->connection = $connection);
     }
 
     /**
@@ -77,9 +75,7 @@ class QueuedClosure
      */
     public function onQueue($queue)
     {
-        $this->queue = enum_value($queue);
-
-        return $this;
+        return tap($this, fn () => $this->queue = enum_value($queue));
     }
 
     /**
@@ -90,9 +86,7 @@ class QueuedClosure
      */
     public function delay($delay)
     {
-        $this->delay = $delay;
-
-        return $this;
+        return tap($this, fn () => $this->delay = $delay);
     }
 
     /**
@@ -103,9 +97,7 @@ class QueuedClosure
      */
     public function catch(Closure $closure)
     {
-        $this->catchCallbacks[] = $closure;
-
-        return $this;
+        return tap($this, fn () => $this->catchCallbacks[] = $closure);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -343,9 +343,7 @@ class FilesystemManager implements FactoryContract
      */
     public function set($name, $disk)
     {
-        $this->disks[$name] = $disk;
-
-        return $this;
+        return tap($this, fn () => $this->disks[$name] = $disk);
     }
 
     /**
@@ -416,9 +414,7 @@ class FilesystemManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback);
     }
 
     /**
@@ -429,9 +425,7 @@ class FilesystemManager implements FactoryContract
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -81,9 +81,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
      */
     public function diskName(string $disk)
     {
-        $this->disk = $disk;
-
-        return $this;
+        return tap($this, fn () => $this->disk = $disk);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -545,7 +545,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->langPath = $path;
 
-        return tap($this)->$this->instance('path.lang', $path);
+        return tap($this)->instance('path.lang', $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -376,7 +376,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->basePath = rtrim($basePath, '\/');
 
-        return tap($this)->bindPathsInContainer();
+        $this->bindPathsInContainer();
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -376,9 +376,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->basePath = rtrim($basePath, '\/');
 
-        $this->bindPathsInContainer();
-
-        return $this;
+        return tap($this)->bindPathsInContainer();
     }
 
     /**
@@ -430,9 +428,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->appPath = $path;
 
-        $this->instance('path', $path);
-
-        return $this;
+        return tap($this)->instance('path', $path);
     }
 
     /**
@@ -477,9 +473,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->bootstrapPath = $path;
 
-        $this->instance('path.bootstrap', $path);
-
-        return $this;
+        return tap($this)->instance('path.bootstrap', $path);
     }
 
     /**
@@ -503,9 +497,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->configPath = $path;
 
-        $this->instance('path.config', $path);
-
-        return $this;
+        return tap($this)->instance('path.config', $path);
     }
 
     /**
@@ -529,9 +521,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->databasePath = $path;
 
-        $this->instance('path.database', $path);
-
-        return $this;
+        return tap($this)->instance('path.database', $path);
     }
 
     /**
@@ -555,9 +545,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->langPath = $path;
 
-        $this->instance('path.lang', $path);
-
-        return $this;
+        return tap($this)->$this->instance('path.lang', $path);
     }
 
     /**
@@ -581,9 +569,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->publicPath = $path;
 
-        $this->instance('path.public', $path);
-
-        return $this;
+        return tap($this)->instance('path.public', $path);
     }
 
     /**
@@ -615,9 +601,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->storagePath = $path;
 
-        $this->instance('path.storage', $path);
-
-        return $this;
+        return tap($this)->instance('path.storage', $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -676,9 +676,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function useEnvironmentPath($path)
     {
-        $this->environmentPath = $path;
-
-        return $this;
+        return tap($this, fn () => $this->environmentPath = $path);
     }
 
     /**
@@ -689,9 +687,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function loadEnvironmentFrom($file)
     {
-        $this->environmentFile = $file;
-
-        return $this;
+        return tap($this, fn () => $this->environmentFile = $file);
     }
 
     /**
@@ -1229,9 +1225,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function dontMergeFrameworkConfiguration()
     {
-        $this->mergeFrameworkConfiguration = false;
-
-        return $this;
+        return tap($this, fn () => $this->mergeFrameworkConfiguration = false);
     }
 
     /**
@@ -1351,9 +1345,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function addAbsoluteCachePathPrefix($prefix)
     {
-        $this->absoluteCachePathPrefixes[] = $prefix;
-
-        return $this;
+        return tap($this, fn () => $this->absoluteCachePathPrefixes[] = $prefix);
     }
 
     /**
@@ -1404,9 +1396,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function terminating($callback)
     {
-        $this->terminatingCallbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->terminatingCallbacks[] = $callback);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -77,9 +77,7 @@ class PendingChain
      */
     public function onConnection($connection)
     {
-        $this->connection = $connection;
-
-        return $this;
+        return tap($this, fn () => $this->connection = $connection);
     }
 
     /**
@@ -90,9 +88,7 @@ class PendingChain
      */
     public function onQueue($queue)
     {
-        $this->queue = enum_value($queue);
-
-        return $this;
+        return tap($this, fn () => $this->queue = enum_value($queue));
     }
 
     /**
@@ -103,9 +99,7 @@ class PendingChain
      */
     public function delay($delay)
     {
-        $this->delay = $delay;
-
-        return $this;
+        return tap($this, fn () => $this->delay = $delay);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingClosureDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingClosureDispatch.php
@@ -14,8 +14,6 @@ class PendingClosureDispatch extends PendingDispatch
      */
     public function catch(Closure $callback)
     {
-        $this->job->onFailure($callback);
-
-        return $this;
+        return tap($this, fn () => $this->job->onFailure($callback));
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -43,9 +43,7 @@ class PendingDispatch
      */
     public function onConnection($connection)
     {
-        $this->job->onConnection($connection);
-
-        return $this;
+        return tap($this, fn () => $this->job->onConnection($connection));
     }
 
     /**
@@ -56,9 +54,7 @@ class PendingDispatch
      */
     public function onQueue($queue)
     {
-        $this->job->onQueue($queue);
-
-        return $this;
+        return tap($this, fn () => $this->job->onQueue($queue));
     }
 
     /**
@@ -69,9 +65,7 @@ class PendingDispatch
      */
     public function allOnConnection($connection)
     {
-        $this->job->allOnConnection($connection);
-
-        return $this;
+        return tap($this, fn () => $this->job->allOnConnection($connection));
     }
 
     /**
@@ -82,9 +76,7 @@ class PendingDispatch
      */
     public function allOnQueue($queue)
     {
-        $this->job->allOnQueue($queue);
-
-        return $this;
+        return tap($this, fn () => $this->job->allOnQueue($queue));
     }
 
     /**
@@ -95,9 +87,7 @@ class PendingDispatch
      */
     public function delay($delay)
     {
-        $this->job->delay($delay);
-
-        return $this;
+        return tap($this, fn () => $this->job->delay($delay));
     }
 
     /**
@@ -107,9 +97,7 @@ class PendingDispatch
      */
     public function withoutDelay()
     {
-        $this->job->withoutDelay();
-
-        return $this;
+        return tap($this, fn () => $this->job->withoutDelay());
     }
 
     /**
@@ -119,9 +107,7 @@ class PendingDispatch
      */
     public function afterCommit()
     {
-        $this->job->afterCommit();
-
-        return $this;
+        return tap($this, fn () => $this->job->afterCommit());
     }
 
     /**
@@ -131,9 +117,7 @@ class PendingDispatch
      */
     public function beforeCommit()
     {
-        $this->job->beforeCommit();
-
-        return $this;
+        return tap($this, fn () => $this->job->beforeCommit());
     }
 
     /**
@@ -144,9 +128,7 @@ class PendingDispatch
      */
     public function chain($chain)
     {
-        $this->job->chain($chain);
-
-        return $this;
+        return tap($this, fn () => $this->job->chain($chain));
     }
 
     /**
@@ -156,9 +138,7 @@ class PendingDispatch
      */
     public function afterResponse()
     {
-        $this->afterResponse = true;
-
-        return $this;
+        return tap($this, fn () => $this->afterResponse = true);
     }
 
     /**
@@ -185,9 +165,7 @@ class PendingDispatch
      */
     public function __call($method, $parameters)
     {
-        $this->job->{$method}(...$parameters);
-
-        return $this;
+        return tap($this, fn () => $this->job->{$method}(...$parameters));
     }
 
     /**

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -428,7 +428,7 @@ class ApplicationBuilder
      * @return $this
      */
     public function booting(callable $callback)
-    {        
+    {
         return tap($this, fn () => $this->app->booting($callback));
     }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -350,9 +350,7 @@ class ApplicationBuilder
      */
     public function withSchedule(callable $callback)
     {
-        Artisan::starting(fn () => $callback($this->app->make(Schedule::class)));
-
-        return $this;
+        return tap($this, fn () => Artisan::starting(fn () => $callback($this->app->make(Schedule::class))));
     }
 
     /**
@@ -420,9 +418,7 @@ class ApplicationBuilder
      */
     public function registered(callable $callback)
     {
-        $this->app->registered($callback);
-
-        return $this;
+        return tap($this, fn () => $this->app->registered($callback));
     }
 
     /**
@@ -432,10 +428,8 @@ class ApplicationBuilder
      * @return $this
      */
     public function booting(callable $callback)
-    {
-        $this->app->booting($callback);
-
-        return $this;
+    {        
+        return tap($this, fn () => $this->app->booting($callback));
     }
 
     /**
@@ -446,9 +440,7 @@ class ApplicationBuilder
      */
     public function booted(callable $callback)
     {
-        $this->app->booted($callback);
-
-        return $this;
+        return tap($this, fn () => $this->app->booted($callback));
     }
 
     /**

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -48,9 +48,7 @@ class Exceptions
      */
     public function render(callable $using)
     {
-        $this->handler->renderable($using);
-
-        return $this;
+        return tap($this, fn () => $this->handler->renderable($using));
     }
 
     /**
@@ -61,9 +59,7 @@ class Exceptions
      */
     public function renderable(callable $renderUsing)
     {
-        $this->handler->renderable($renderUsing);
-
-        return $this;
+        return tap($this, fn () => $this->handler->renderable($renderUsing));
     }
 
     /**
@@ -74,9 +70,7 @@ class Exceptions
      */
     public function respond(callable $using)
     {
-        $this->handler->respondUsing($using);
-
-        return $this;
+        return tap($this, fn () => $this->handler->respondUsing($using));
     }
 
     /**
@@ -87,9 +81,7 @@ class Exceptions
      */
     public function throttle(callable $throttleUsing)
     {
-        $this->handler->throttleUsing($throttleUsing);
-
-        return $this;
+        return tap($this, fn () => $this->handler->throttleUsing($throttleUsing));
     }
 
     /**
@@ -103,9 +95,7 @@ class Exceptions
      */
     public function map($from, $to = null)
     {
-        $this->handler->map($from, $to);
-
-        return $this;
+        return tap($this, fn () => $this->handler->map($from, $to));
     }
 
     /**
@@ -117,9 +107,7 @@ class Exceptions
      */
     public function level(string $type, string $level)
     {
-        $this->handler->level($type, $level);
-
-        return $this;
+        return tap($this, fn () => $this->handler->level($type, $level));
     }
 
     /**
@@ -130,9 +118,7 @@ class Exceptions
      */
     public function context(Closure $contextCallback)
     {
-        $this->handler->buildContextUsing($contextCallback);
-
-        return $this;
+        return tap($this, fn () => $this->handler->buildContextUsing($contextCallback));
     }
 
     /**
@@ -157,9 +143,7 @@ class Exceptions
      */
     public function dontReportDuplicates()
     {
-        $this->handler->dontReportDuplicates();
-
-        return $this;
+        return tap($this, fn () => $this->handler->dontReportDuplicates());
     }
 
     /**
@@ -170,9 +154,7 @@ class Exceptions
      */
     public function dontFlash(array|string $attributes)
     {
-        $this->handler->dontFlash($attributes);
-
-        return $this;
+        return tap($this, fn () => $this->handler->dontFlash($attributes));
     }
 
     /**
@@ -183,9 +165,7 @@ class Exceptions
      */
     public function shouldRenderJsonWhen(callable $callback)
     {
-        $this->handler->shouldRenderJsonWhen($callback);
-
-        return $this;
+        return tap($this, fn () => $this->handler->shouldRenderJsonWhen($callback));
     }
 
     /**
@@ -196,8 +176,6 @@ class Exceptions
      */
     public function stopIgnoring(array|string $class)
     {
-        $this->handler->stopIgnoring($class);
-
-        return $this;
+        return tap($this, fn () => $this->handler->stopIgnoring($class));
     }
 }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -217,9 +217,7 @@ class Middleware
      */
     public function replace(string $search, string $replace)
     {
-        $this->replacements[$search] = $replace;
-
-        return $this;
+        return tap($this, fn () => $this->replacements[$search] = $replace);
     }
 
     /**
@@ -230,9 +228,7 @@ class Middleware
      */
     public function use(array $middleware)
     {
-        $this->global = $middleware;
-
-        return $this;
+        return tap($this, fn () => $this->global = $middleware);
     }
 
     /**
@@ -244,9 +240,7 @@ class Middleware
      */
     public function group(string $group, array $middleware)
     {
-        $this->groups[$group] = $middleware;
-
-        return $this;
+        return tap($this, fn () => $this->groups[$group] = $middleware);
     }
 
     /**
@@ -310,9 +304,7 @@ class Middleware
      */
     public function replaceInGroup(string $group, string $search, string $replace)
     {
-        $this->groupReplacements[$group][$search] = $replace;
-
-        return $this;
+        return tap($this, fn () => $this->groupReplacements[$group][$search] = $replace);
     }
 
     /**
@@ -384,9 +376,7 @@ class Middleware
      */
     public function pages(array $middleware)
     {
-        $this->pageMiddleware = $middleware;
-
-        return $this;
+        return tap($this, fn () => $this->pageMiddleware = $middleware);
     }
 
     /**
@@ -397,9 +387,7 @@ class Middleware
      */
     public function alias(array $aliases)
     {
-        $this->customAliases = $aliases;
-
-        return $this;
+        return tap($this, fn () => $this->customAliases = $aliases);
     }
 
     /**
@@ -410,9 +398,7 @@ class Middleware
      */
     public function priority(array $priority)
     {
-        $this->priority = $priority;
-
-        return $this;
+        return tap($this, fn () => $this->priority = $priority);
     }
 
     /**
@@ -424,9 +410,7 @@ class Middleware
      */
     public function prependToPriorityList($before, $prepend)
     {
-        $this->prependPriority[$prepend] = $before;
-
-        return $this;
+        return tap($this, fn () => $this->prependPriority[$prepend] = $before);
     }
 
     /**
@@ -438,9 +422,7 @@ class Middleware
      */
     public function appendToPriorityList($after, $append)
     {
-        $this->appendPriority[$append] = $after;
-
-        return $this;
+        return tap($this, fn () => $this->appendPriority[$append] = $after);
     }
 
     /**
@@ -584,9 +566,7 @@ class Middleware
      */
     public function encryptCookies(array $except = [])
     {
-        EncryptCookies::except($except);
-
-        return $this;
+        return tap($this, fn () => EncryptCookies::except($except));
     }
 
     /**
@@ -597,9 +577,7 @@ class Middleware
      */
     public function validateCsrfTokens(array $except = [])
     {
-        ValidateCsrfToken::except($except);
-
-        return $this;
+        return tap($this, fn () => ValidateCsrfToken::except($except));
     }
 
     /**
@@ -610,9 +588,7 @@ class Middleware
      */
     public function validateSignatures(array $except = [])
     {
-        ValidateSignature::except($except);
-
-        return $this;
+        return tap($this, fn () => ValidateSignature::except($except));
     }
 
     /**
@@ -623,9 +599,7 @@ class Middleware
      */
     public function convertEmptyStringsToNull(array $except = [])
     {
-        (new Collection($except))->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
-
-        return $this;
+        return tap($this, fn () => (new Collection($except))->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback)));
     }
 
     /**
@@ -691,9 +665,7 @@ class Middleware
      */
     public function preventRequestsDuringMaintenance(array $except = [])
     {
-        PreventRequestsDuringMaintenance::except($except);
-
-        return $this;
+        return tap($this, fn () => PreventRequestsDuringMaintenance::except($except));
     }
 
     /**
@@ -703,9 +675,7 @@ class Middleware
      */
     public function statefulApi()
     {
-        $this->statefulApi = true;
-
-        return $this;
+        return tap($this, fn () => $this->statefulApi = true);
     }
 
     /**
@@ -733,9 +703,7 @@ class Middleware
      */
     public function throttleWithRedis()
     {
-        $this->throttleWithRedis = true;
-
-        return $this;
+        return tap($this, fn () => $this->throttleWithRedis = true);
     }
 
     /**
@@ -745,9 +713,7 @@ class Middleware
      */
     public function authenticateSessions()
     {
-        $this->authenticatedSessions = true;
-
-        return $this;
+        return tap($this, fn () => $this->authenticatedSessions = true);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -89,9 +89,7 @@ class ClosureCommand extends Command
      */
     public function describe($description)
     {
-        $this->setDescription($description);
-
-        return $this;
+        return tap($this, fn () => $this->setDescription($description));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -496,9 +496,7 @@ class DocsCommand extends Command
      */
     public function setVersion($version)
     {
-        $this->version = $version;
-
-        return $this;
+        return tap($this, fn () => $this->version = $version);
     }
 
     /**
@@ -509,9 +507,7 @@ class DocsCommand extends Command
      */
     public function setUrlOpener($opener)
     {
-        $this->urlOpener = $opener;
-
-        return $this;
+        return tap($this, fn () => $this->urlOpener = $opener);
     }
 
     /**
@@ -522,8 +518,6 @@ class DocsCommand extends Command
      */
     public function setSystemOsFamily($family)
     {
-        $this->systemOsFamily = $family;
-
-        return $this;
+        return tap($this, fn () => $this->systemOsFamily = $family);
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -569,9 +569,7 @@ class Kernel implements KernelContract
      */
     public function addCommands(array $commands)
     {
-        $this->commands = array_values(array_unique(array_merge($this->commands, $commands)));
-
-        return $this;
+        return tap($this, fn () => $this->commands = array_values(array_unique(array_merge($this->commands, $commands))));
     }
 
     /**
@@ -582,9 +580,7 @@ class Kernel implements KernelContract
      */
     public function addCommandPaths(array $paths)
     {
-        $this->commandPaths = array_values(array_unique(array_merge($this->commandPaths, $paths)));
-
-        return $this;
+        return tap($this, fn () => $this->commandPaths = array_values(array_unique(array_merge($this->commandPaths, $paths))));
     }
 
     /**
@@ -595,9 +591,7 @@ class Kernel implements KernelContract
      */
     public function addCommandRoutePaths(array $paths)
     {
-        $this->commandRoutePaths = array_values(array_unique(array_merge($this->commandRoutePaths, $paths)));
-
-        return $this;
+        return tap($this, fn () => $this->commandRoutePaths = array_values(array_unique(array_merge($this->commandRoutePaths, $paths))));
     }
 
     /**

--- a/src/Illuminate/Foundation/Events/PublishingStubs.php
+++ b/src/Illuminate/Foundation/Events/PublishingStubs.php
@@ -33,8 +33,6 @@ class PublishingStubs
      */
     public function add(string $path, string $name)
     {
-        $this->stubs[$path] = $name;
-
-        return $this;
+        return tap($this, fn () => $this->stubs[$path] = $name);
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -318,9 +318,7 @@ class Handler implements ExceptionHandlerContract
      */
     public function level($type, $level)
     {
-        $this->levels[$type] = $level;
-
-        return $this;
+        return tap($this, fn () => $this->levels[$type] = $level);
     }
 
     /**
@@ -550,9 +548,7 @@ class Handler implements ExceptionHandlerContract
      */
     public function buildContextUsing(Closure $contextCallback)
     {
-        $this->contextCallbacks[] = $contextCallback;
-
-        return $this;
+        return tap($this, fn () => $this->contextCallbacks[] = $contextCallback);
     }
 
     /**
@@ -617,9 +613,7 @@ class Handler implements ExceptionHandlerContract
      */
     public function respondUsing($callback)
     {
-        $this->finalizeResponseCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->finalizeResponseCallback = $callback);
     }
 
     /**
@@ -788,9 +782,7 @@ class Handler implements ExceptionHandlerContract
      */
     public function shouldRenderJsonWhen($callback)
     {
-        $this->shouldRenderJsonWhenCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->shouldRenderJsonWhenCallback = $callback);
     }
 
     /**
@@ -1033,9 +1025,7 @@ class Handler implements ExceptionHandlerContract
      */
     public function dontReportDuplicates()
     {
-        $this->withoutDuplicates = true;
-
-        return $this;
+        return tap($this, fn () => $this->withoutDuplicates = true);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
@@ -75,8 +75,6 @@ class ReportableHandler
      */
     public function stop()
     {
-        $this->shouldStop = true;
-
-        return $this;
+        return tap($this, fn () => $this->shouldStop = true);
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -273,9 +273,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function setValidator(Validator $validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 
     /**
@@ -286,9 +284,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function setRedirector(Redirector $redirector)
     {
-        $this->redirector = $redirector;
-
-        return $this;
+        return tap($this, fn () => $this->redirector = $redirector);
     }
 
     /**
@@ -299,8 +295,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 }

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -695,8 +695,6 @@ class Kernel implements KernelContract
      */
     public function setApplication(Application $app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -84,9 +84,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function routes(Closure $routesCallback)
     {
-        $this->loadRoutesUsing = $routesCallback;
-
-        return $this;
+        return tap($this, fn () => $this->loadRoutesUsing = $routesCallback);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -46,9 +46,7 @@ trait InteractsWithAuthentication
      */
     public function assertAuthenticated($guard = null)
     {
-        $this->assertTrue($this->isAuthenticated($guard), 'The user is not authenticated');
-
-        return $this;
+        return tap($this)->assertTrue($this->isAuthenticated($guard), 'The user is not authenticated');
     }
 
     /**
@@ -59,9 +57,7 @@ trait InteractsWithAuthentication
      */
     public function assertGuest($guard = null)
     {
-        $this->assertFalse($this->isAuthenticated($guard), 'The user is authenticated');
-
-        return $this;
+        return tap($this)->assertFalse($this->isAuthenticated($guard), 'The user is authenticated');
     }
 
     /**
@@ -110,11 +106,9 @@ trait InteractsWithAuthentication
      */
     public function assertCredentials(array $credentials, $guard = null)
     {
-        $this->assertTrue(
+        return tap($this)->assertTrue(
             $this->hasCredentials($credentials, $guard), 'The given credentials are invalid.'
         );
-
-        return $this;
     }
 
     /**
@@ -126,11 +120,9 @@ trait InteractsWithAuthentication
      */
     public function assertInvalidCredentials(array $credentials, $guard = null)
     {
-        $this->assertFalse(
+        return tap($this)->assertFalse(
             $this->hasCredentials($credentials, $guard), 'The given credentials are valid.'
         );
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -103,9 +103,7 @@ trait InteractsWithContainer
      */
     protected function forgetMock($abstract)
     {
-        $this->app->forgetInstance($abstract);
-
-        return $this;
+        return tap($this, fn () => $this->app->forgetInstance($abstract));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -76,11 +76,9 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseCount($table, int $count, $connection = null)
     {
-        $this->assertThat(
+        return tap($this)->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), $count)
         );
-
-        return $this;
     }
 
     /**
@@ -92,11 +90,9 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseEmpty($table, $connection = null)
     {
-        $this->assertThat(
+        return tap($this)->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), 0)
         );
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
@@ -12,9 +12,7 @@ trait InteractsWithSession
      */
     public function withSession(array $data)
     {
-        $this->session($data);
-
-        return $this;
+        return tap($this, fn () => $this->session($data));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -76,8 +76,6 @@ trait InteractsWithViews
      */
     protected function withViewErrors(array $errors, $key = 'default')
     {
-        ViewFacade::share('errors', (new ViewErrorBag)->put($key, new MessageBag($errors)));
-
-        return $this;
+        return tap($this, fn () => ViewFacade::share('errors', (new ViewErrorBag)->put($key, new MessageBag($errors))));
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -96,7 +96,9 @@ trait MakesHttpRequests
      */
     public function withoutHeader(string $name)
     {
-        return tap($this, fn () => unset($this->defaultHeaders[$name]));
+        unset($this->defaultHeaders[$name]);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -73,9 +73,7 @@ trait MakesHttpRequests
      */
     public function withHeaders(array $headers)
     {
-        $this->defaultHeaders = array_merge($this->defaultHeaders, $headers);
-
-        return $this;
+        return tap($this, fn () => $this->defaultHeaders = array_merge($this->defaultHeaders, $headers));
     }
 
     /**
@@ -87,9 +85,7 @@ trait MakesHttpRequests
      */
     public function withHeader(string $name, string $value)
     {
-        $this->defaultHeaders[$name] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->defaultHeaders[$name] = $value);
     }
 
     /**
@@ -100,9 +96,7 @@ trait MakesHttpRequests
      */
     public function withoutHeader(string $name)
     {
-        unset($this->defaultHeaders[$name]);
-
-        return $this;
+        return tap($this, fn () => unset($this->defaultHeaders[$name]));
     }
 
     /**
@@ -161,9 +155,7 @@ trait MakesHttpRequests
      */
     public function flushHeaders()
     {
-        $this->defaultHeaders = [];
-
-        return $this;
+        return tap($this, fn () => $this->defaultHeaders = []);
     }
 
     /**
@@ -174,9 +166,7 @@ trait MakesHttpRequests
      */
     public function withServerVariables(array $server)
     {
-        $this->serverVariables = $server;
-
-        return $this;
+        return tap($this, fn () => $this->serverVariables = $server);
     }
 
     /**
@@ -235,9 +225,7 @@ trait MakesHttpRequests
      */
     public function withCookies(array $cookies)
     {
-        $this->defaultCookies = array_merge($this->defaultCookies, $cookies);
-
-        return $this;
+        return tap($this, fn () => $this->defaultCookies = array_merge($this->defaultCookies, $cookies));
     }
 
     /**
@@ -249,9 +237,7 @@ trait MakesHttpRequests
      */
     public function withCookie(string $name, string $value)
     {
-        $this->defaultCookies[$name] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->defaultCookies[$name] = $value);
     }
 
     /**
@@ -262,9 +248,7 @@ trait MakesHttpRequests
      */
     public function withUnencryptedCookies(array $cookies)
     {
-        $this->unencryptedCookies = array_merge($this->unencryptedCookies, $cookies);
-
-        return $this;
+        return tap($this, fn () => $this->unencryptedCookies = array_merge($this->unencryptedCookies, $cookies));
     }
 
     /**
@@ -276,9 +260,7 @@ trait MakesHttpRequests
      */
     public function withUnencryptedCookie(string $name, string $value)
     {
-        $this->unencryptedCookies[$name] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->unencryptedCookies[$name] = $value);
     }
 
     /**
@@ -288,9 +270,7 @@ trait MakesHttpRequests
      */
     public function followingRedirects()
     {
-        $this->followRedirects = true;
-
-        return $this;
+        return tap($this, fn () => $this->followRedirects = true);
     }
 
     /**
@@ -300,9 +280,7 @@ trait MakesHttpRequests
      */
     public function withCredentials()
     {
-        $this->withCredentials = true;
-
-        return $this;
+        return tap($this, fn () => $this->withCredentials = true);
     }
 
     /**
@@ -312,9 +290,7 @@ trait MakesHttpRequests
      */
     public function disableCookieEncryption()
     {
-        $this->encryptCookies = false;
-
-        return $this;
+        return tap($this, fn () => $this->encryptCookies = false);
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -157,9 +157,7 @@ class Vite implements Htmlable
      */
     public function useIntegrityKey($key)
     {
-        $this->integrityKey = $key;
-
-        return $this;
+        return tap($this, fn () => $this->integrityKey = $key);
     }
 
     /**
@@ -170,9 +168,7 @@ class Vite implements Htmlable
      */
     public function withEntryPoints($entryPoints)
     {
-        $this->entryPoints = $entryPoints;
-
-        return $this;
+        return tap($this, fn () => $this->entryPoints = $entryPoints);
     }
 
     /**
@@ -197,9 +193,7 @@ class Vite implements Htmlable
      */
     public function useManifestFilename($filename)
     {
-        $this->manifestFilename = $filename;
-
-        return $this;
+        return tap($this, fn () => $this->manifestFilename = $filename);
     }
 
     /**
@@ -210,9 +204,7 @@ class Vite implements Htmlable
      */
     public function createAssetPathsUsing($resolver)
     {
-        $this->assetPathResolver = $resolver;
-
-        return $this;
+        return tap($this, fn () => $this->assetPathResolver = $resolver);
     }
 
     /**
@@ -233,9 +225,7 @@ class Vite implements Htmlable
      */
     public function useHotFile($path)
     {
-        $this->hotFile = $path;
-
-        return $this;
+        return tap($this, fn () => $this->hotFile = $path);
     }
 
     /**
@@ -246,9 +236,7 @@ class Vite implements Htmlable
      */
     public function useBuildDirectory($path)
     {
-        $this->buildDirectory = $path;
-
-        return $this;
+        return tap($this, fn () => $this->buildDirectory = $path);
     }
 
     /**

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -180,9 +180,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     public function setMemory(int $memory)
     {
-        $this->memory = $memory;
-
-        return $this;
+        return tap($this, fn () => $this->memory = $memory);
     }
 
     /**
@@ -193,9 +191,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     public function setTime(int $time)
     {
-        $this->time = $time;
-
-        return $this;
+        return tap($this, fn () => $this->time = $time);
     }
 
     /**
@@ -206,9 +202,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     public function setThreads(int $threads)
     {
-        $this->threads = $threads;
-
-        return $this;
+        return tap($this, fn () => $this->threads = $threads);
     }
 
     /**

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -142,9 +142,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      */
     public function setRounds($rounds)
     {
-        $this->rounds = (int) $rounds;
-
-        return $this;
+        return tap($this, fn () => $this->rounds = (int) $rounds);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -101,9 +101,7 @@ class Factory
      */
     public function globalMiddleware($middleware)
     {
-        $this->globalMiddleware[] = $middleware;
-
-        return $this;
+        return tap($this, fn () => $this->globalMiddleware[] = $middleware);
     }
 
     /**
@@ -114,9 +112,7 @@ class Factory
      */
     public function globalRequestMiddleware($middleware)
     {
-        $this->globalMiddleware[] = Middleware::mapRequest($middleware);
-
-        return $this;
+        return tap($this, fn () => $this->globalMiddleware[] = Middleware::mapRequest($middleware));
     }
 
     /**
@@ -127,9 +123,7 @@ class Factory
      */
     public function globalResponseMiddleware($middleware)
     {
-        $this->globalMiddleware[] = Middleware::mapResponse($middleware);
-
-        return $this;
+        return tap($this, fn () => $this->globalMiddleware[] = Middleware::mapResponse($middleware));
     }
 
     /**
@@ -140,9 +134,7 @@ class Factory
      */
     public function globalOptions($options)
     {
-        $this->globalOptions = $options;
-
-        return $this;
+        return tap($this, fn () => $this->globalOptions = $options);
     }
 
     /**
@@ -292,9 +284,7 @@ class Factory
      */
     public function preventStrayRequests($prevent = true)
     {
-        $this->preventStrayRequests = $prevent;
-
-        return $this;
+        return tap($this, fn () => $this->preventStrayRequests = $prevent);
     }
 
     /**
@@ -324,9 +314,7 @@ class Factory
      */
     protected function record()
     {
-        $this->recording = true;
-
-        return $this;
+        return tap($this, fn () => $this->recording = true);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -252,9 +252,7 @@ class PendingRequest
      */
     public function baseUrl(string $url)
     {
-        $this->baseUrl = $url;
-
-        return $this;
+        return tap($this, fn () => $this->baseUrl = $url);
     }
 
     /**
@@ -372,9 +370,7 @@ class PendingRequest
      */
     public function contentType(string $contentType)
     {
-        $this->options['headers']['Content-Type'] = $contentType;
-
-        return $this;
+        return tap($this, fn () => $this->options['headers']['Content-Type'] = $contentType);
     }
 
     /**
@@ -433,9 +429,7 @@ class PendingRequest
      */
     public function replaceHeaders(array $headers)
     {
-        $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers);
-
-        return $this;
+        return tap($this, fn () => $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers));
     }
 
     /**
@@ -641,9 +635,7 @@ class PendingRequest
      */
     public function withMiddleware(callable $middleware)
     {
-        $this->middleware->push($middleware);
-
-        return $this;
+        return tap($this, fn () => $this->middleware->push($middleware));
     }
 
     /**
@@ -654,9 +646,7 @@ class PendingRequest
      */
     public function withRequestMiddleware(callable $middleware)
     {
-        $this->middleware->push(Middleware::mapRequest($middleware));
-
-        return $this;
+        return tap($this, fn () => $this->middleware->push(Middleware::mapRequest($middleware)));
     }
 
     /**
@@ -667,9 +657,7 @@ class PendingRequest
      */
     public function withResponseMiddleware(callable $middleware)
     {
-        $this->middleware->push(Middleware::mapResponse($middleware));
-
-        return $this;
+        return tap($this, fn () => $this->middleware->push(Middleware::mapResponse($middleware)));
     }
 
     /**
@@ -693,9 +681,7 @@ class PendingRequest
      */
     public function throw(?callable $callback = null)
     {
-        $this->throwCallback = $callback ?: fn () => null;
-
-        return $this;
+        return tap($this, fn () => $this->throwCallback = $callback ?: fn () => null);
     }
 
     /**
@@ -1430,9 +1416,7 @@ class PendingRequest
      */
     public function stub($callback)
     {
-        $this->stubCallbacks = new Collection($callback);
-
-        return $this;
+        return tap($this, fn () => $this->stubCallbacks = new Collection($callback));
     }
 
     /**
@@ -1443,9 +1427,7 @@ class PendingRequest
      */
     public function preventStrayRequests($prevent = true)
     {
-        $this->preventStrayRequests = $prevent;
-
-        return $this;
+        return tap($this, fn () => $this->preventStrayRequests = $prevent);
     }
 
     /**
@@ -1456,9 +1438,7 @@ class PendingRequest
      */
     public function async(bool $async = true)
     {
-        $this->async = $async;
-
-        return $this;
+        return tap($this, fn () => $this->async = $async);
     }
 
     /**
@@ -1520,9 +1500,7 @@ class PendingRequest
      */
     public function setClient(Client $client)
     {
-        $this->client = $client;
-
-        return $this;
+        return tap($this, fn () => $this->client = $client);
     }
 
     /**
@@ -1533,9 +1511,7 @@ class PendingRequest
      */
     public function setHandler($handler)
     {
-        $this->handler = $handler;
-
-        return $this;
+        return tap($this, fn () => $this->handler = $handler);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -240,9 +240,7 @@ class Request implements ArrayAccess
      */
     public function withData(array $data)
     {
-        $this->data = $data;
-
-        return $this;
+        return tap($this, fn () => $this->data = $data);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -263,9 +263,7 @@ class Response implements ArrayAccess, Stringable
      */
     public function close()
     {
-        $this->response->getBody()->close();
-
-        return $this;
+        return tap($this, fn () => $this->response->getBody()->close());
     }
 
     /**

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -109,9 +109,7 @@ class ResponseSequence
      */
     public function pushResponse($response)
     {
-        $this->responses[] = $response;
-
-        return $this;
+        return tap($this, fn () => $this->responses[] = $response);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -350,9 +350,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function merge(array $input)
     {
-        $this->getInputSource()->add($input);
-
-        return $this;
+        return tap($this, fn () => $this->getInputSource()->add($input));
     }
 
     /**
@@ -376,9 +374,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function replace(array $input)
     {
-        $this->getInputSource()->replace($input);
-
-        return $this;
+        return tap($this, fn () => $this->getInputSource()->replace($input));
     }
 
     /**
@@ -657,9 +653,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function setJson($json)
     {
-        $this->json = $json;
-
-        return $this;
+        return tap($this, fn () => $this->json = $json);
     }
 
     /**
@@ -682,9 +676,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function setUserResolver(Closure $callback)
     {
-        $this->userResolver = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->userResolver = $callback);
     }
 
     /**
@@ -707,9 +699,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function setRouteResolver(Closure $callback)
     {
-        $this->routeResolver = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->routeResolver = $callback);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -173,9 +173,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function additional(array $data)
     {
-        $this->additional = $data;
-
-        return $this;
+        return tap($this, fn () => $this->additional = $data);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -61,9 +61,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      */
     public function preserveQuery()
     {
-        $this->preserveAllQueryParameters = true;
-
-        return $this;
+        return tap($this, fn () => $this->preserveAllQueryParameters = true);
     }
 
     /**

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -74,9 +74,7 @@ trait ResponseTrait
      */
     public function header($key, $values, $replace = true)
     {
-        $this->headers->set($key, $values, $replace);
-
-        return $this;
+        return tap($this, fn () => $this->headers->set($key, $values, $replace));
     }
 
     /**
@@ -163,9 +161,7 @@ trait ResponseTrait
      */
     public function withException(Throwable $e)
     {
-        $this->exception = $e;
-
-        return $this;
+        return tap($this, fn () => $this->exception = $e);
     }
 
     /**

--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -97,9 +97,7 @@ class File extends UploadedFile
      */
     public function size($kilobytes)
     {
-        $this->sizeToReport = $kilobytes * 1024;
-
-        return $this;
+        return tap($this, fn () => $this->sizeToReport = $kilobytes * 1024);
     }
 
     /**
@@ -120,9 +118,7 @@ class File extends UploadedFile
      */
     public function mimeType($mimeType)
     {
-        $this->mimeTypeToReport = $mimeType;
-
-        return $this;
+        return tap($this, fn () => $this->mimeTypeToReport = $mimeType);
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -443,9 +443,7 @@ class Repository
      */
     public function dehydrating($callback)
     {
-        $this->events->listen(fn (Dehydrating $event) => $callback($event->context));
-
-        return $this;
+        return tap($this, fn () => $this->events->listen(fn (Dehydrating $event) => $callback($event->context)));
     }
 
     /**
@@ -456,9 +454,7 @@ class Repository
      */
     public function hydrated($callback)
     {
-        $this->events->listen(fn (Hydrated $event) => $callback($event->context));
-
-        return $this;
+        return tap($this, fn () => $this->events->listen(fn (Hydrated $event) => $callback($event->context)));
     }
 
     /**
@@ -469,9 +465,7 @@ class Repository
      */
     public function handleUnserializeExceptionsUsing($callback)
     {
-        static::$handleUnserializeExceptionsUsing = $callback;
-
-        return $this;
+        return tap($this, fn () => static::$handleUnserializeExceptionsUsing = $callback);
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -544,9 +544,7 @@ class LogManager implements LoggerInterface
      */
     public function flushSharedContext()
     {
-        $this->sharedContext = [];
-
-        return $this;
+        return tap($this, fn () => $this->sharedContext = []);
     }
 
     /**
@@ -600,9 +598,7 @@ class LogManager implements LoggerInterface
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback->bindTo($this, $this));
     }
 
     /**
@@ -775,9 +771,7 @@ class LogManager implements LoggerInterface
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -197,9 +197,7 @@ class Logger implements LoggerInterface
      */
     public function withContext(array $context = [])
     {
-        $this->context = array_merge($this->context, $context);
-
-        return $this;
+        return tap($this, fn () => $this->context = array_merge($this->context, $context));
     }
 
     /**
@@ -209,9 +207,7 @@ class Logger implements LoggerInterface
      */
     public function withoutContext()
     {
-        $this->context = [];
-
-        return $this;
+        return tap($this, fn () => $this->context = []);
     }
 
     /**

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -121,9 +121,7 @@ class Attachment
      */
     public function as($name)
     {
-        $this->as = $name;
-
-        return $this;
+        return tap($this, fn () => $this->as = $name);
     }
 
     /**
@@ -134,9 +132,7 @@ class Attachment
      */
     public function withMime($mime)
     {
-        $this->mime = $mime;
-
-        return $this;
+        return tap($this, fn () => $this->mime = $mime);
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -570,9 +570,7 @@ class MailManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback);
     }
 
     /**
@@ -593,9 +591,7 @@ class MailManager implements FactoryContract
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**
@@ -605,9 +601,7 @@ class MailManager implements FactoryContract
      */
     public function forgetMailers()
     {
-        $this->mailers = [];
-
-        return $this;
+        return tap($this, fn () => $this->mailers = []);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1157,9 +1157,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function tag($value)
     {
-        return tap($this, fn () => array_push($this->tags, $value)(;
-
-        return $this);
+        return tap($this, fn () => array_push($this->tags, $value));
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -567,9 +567,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
-
-        return $this;
+        return tap($this, fn () => $this->locale = $locale);
     }
 
     /**
@@ -854,9 +852,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function subject($subject)
     {
-        $this->subject = $subject;
-
-        return $this;
+        return tap($this, fn () => $this->subject = $subject);
     }
 
     /**
@@ -909,9 +905,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function html($html)
     {
-        $this->html = $html;
-
-        return $this;
+        return tap($this, fn () => $this->html = $html);
     }
 
     /**
@@ -1163,9 +1157,9 @@ class Mailable implements MailableContract, Renderable
      */
     public function tag($value)
     {
-        array_push($this->tags, $value);
+        return tap($this, fn () => array_push($this->tags, $value)(;
 
-        return $this;
+        return $this);
     }
 
     /**
@@ -1189,9 +1183,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function metadata($key, $value)
     {
-        $this->metadata[$key] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->metadata[$key] = $value);
     }
 
     /**
@@ -1780,9 +1772,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function mailer($mailer)
     {
-        $this->mailer = $mailer;
-
-        return $this;
+        return tap($this, fn () => $this->mailer = $mailer);
     }
 
     /**
@@ -1793,9 +1783,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function withSymfonyMessage($callback)
     {
-        $this->callbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->callbacks[] = $callback);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -82,9 +82,7 @@ class Content
      */
     public function view(string $view)
     {
-        $this->view = $view;
-
-        return $this;
+        return tap($this, fn () => $this->view = $view);
     }
 
     /**
@@ -106,9 +104,7 @@ class Content
      */
     public function text(string $view)
     {
-        $this->text = $view;
-
-        return $this;
+        return tap($this, fn () => $this->text = $view);
     }
 
     /**
@@ -119,9 +115,7 @@ class Content
      */
     public function markdown(string $view)
     {
-        $this->markdown = $view;
-
-        return $this;
+        return tap($this, fn () => $this->markdown = $view);
     }
 
     /**
@@ -132,9 +126,7 @@ class Content
      */
     public function htmlString(string $html)
     {
-        $this->htmlString = $html;
-
-        return $this;
+        return tap($this, fn () => $this->htmlString = $html);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -125,9 +125,7 @@ class Envelope
      */
     public function from(Address|string $address, $name = null)
     {
-        $this->from = is_string($address) ? new Address($address, $name) : $address;
-
-        return $this;
+        return tap($this, fn () => $this->from = is_string($address) ? new Address($address, $name) : $address);
     }
 
     /**
@@ -202,9 +200,7 @@ class Envelope
      */
     public function subject(string $subject)
     {
-        $this->subject = $subject;
-
-        return $this;
+        return tap($this, fn () => $this->subject = $subject);
     }
 
     /**
@@ -215,9 +211,7 @@ class Envelope
      */
     public function tags(array $tags)
     {
-        $this->tags = array_merge($this->tags, $tags);
-
-        return $this;
+        return tap($this, fn () => $this->tags = array_merge($this->tags, $tags));
     }
 
     /**
@@ -228,9 +222,7 @@ class Envelope
      */
     public function tag(string $tag)
     {
-        $this->tags[] = $tag;
-
-        return $this;
+        return tap($this, fn () => $this->tags[] = $tag);
     }
 
     /**
@@ -242,9 +234,7 @@ class Envelope
      */
     public function metadata(string $key, string|int $value)
     {
-        $this->metadata[$key] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->metadata[$key] = $value);
     }
 
     /**
@@ -255,9 +245,7 @@ class Envelope
      */
     public function using(Closure $callback)
     {
-        $this->using[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->using[] = $callback);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -56,9 +56,7 @@ class Headers
      */
     public function messageId(string $messageId)
     {
-        $this->messageId = $messageId;
-
-        return $this;
+        return tap($this, fn () => $this->messageId = $messageId);
     }
 
     /**
@@ -69,9 +67,7 @@ class Headers
      */
     public function references(array $references)
     {
-        $this->references = array_merge($this->references, $references);
-
-        return $this;
+        return tap($this, fn () => $this->references = array_merge($this->references, $references));
     }
 
     /**
@@ -82,9 +78,7 @@ class Headers
      */
     public function text(array $text)
     {
-        $this->text = array_merge($this->text, $text);
-
-        return $this;
+        return tap($this, fn () => $this->text = array_merge($this->text, $text));
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -659,8 +659,6 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function setQueue(QueueContract $queue)
     {
-        $this->queue = $queue;
-
-        return $this;
+        return tap($this, fn () => $this->queue = $queue);
     }
 }

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -172,9 +172,7 @@ class Markdown
      */
     public function theme($theme)
     {
-        $this->theme = $theme;
-
-        return $this;
+        return tap($this, fn () => $this->theme = $theme);
     }
 
     /**

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -85,9 +85,7 @@ class Message
      */
     public function returnPath($address)
     {
-        $this->message->returnPath($address);
-
-        return $this;
+        return tap($this, fn () => $this->message->returnPath($address));
     }
 
     /**
@@ -275,9 +273,7 @@ class Message
      */
     public function subject($subject)
     {
-        $this->message->subject($subject);
-
-        return $this;
+        return tap($this, fn () => $this->message->subject($subject));
     }
 
     /**
@@ -288,9 +284,7 @@ class Message
      */
     public function priority($level)
     {
-        $this->message->priority($level);
-
-        return $this;
+        return tap($this, fn () => $this->message->priority($level));
     }
 
     /**
@@ -325,9 +319,7 @@ class Message
      */
     public function attachData($data, $name, array $options = [])
     {
-        $this->message->attach($data, $name, $options['mime'] ?? null);
-
-        return $this;
+        return tap($this, fn () => $this->message->attach($data, $name, $options['mime'] ?? null));
     }
 
     /**

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -65,9 +65,7 @@ class PendingMail
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
-
-        return $this;
+        return tap($this, fn () => $this->locale = $locale);
     }
 
     /**
@@ -95,9 +93,7 @@ class PendingMail
      */
     public function cc($users)
     {
-        $this->cc = $users;
-
-        return $this;
+        return tap($this, fn () => $this->cc = $users);
     }
 
     /**
@@ -108,9 +104,7 @@ class PendingMail
      */
     public function bcc($users)
     {
-        $this->bcc = $users;
-
-        return $this;
+        return tap($this, fn () => $this->bcc = $users);
     }
 
     /**

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -155,8 +155,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
-
-        return $this;
+        return tap($this, fn () => $this->locale = $locale);
     }
 }

--- a/src/Illuminate/Notifications/Messages/BroadcastMessage.php
+++ b/src/Illuminate/Notifications/Messages/BroadcastMessage.php
@@ -34,8 +34,6 @@ class BroadcastMessage
      */
     public function data($data)
     {
-        $this->data = $data;
-
-        return $this;
+        return tap($this, fn () => $this->data = $data);
     }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -170,9 +170,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function template($template)
     {
-        $this->markdown = $template;
-
-        return $this;
+        return tap($this, fn () => $this->markdown = $template);
     }
 
     /**
@@ -183,9 +181,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function theme($theme)
     {
-        $this->theme = $theme;
-
-        return $this;
+        return tap($this, fn () => $this->theme = $theme);
     }
 
     /**
@@ -197,9 +193,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function from($address, $name = null)
     {
-        $this->from = [$address, $name];
-
-        return $this;
+        return tap($this, fn () => $this->from = [$address, $name]);
     }
 
     /**
@@ -307,9 +301,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function attachData($data, $name, array $options = [])
     {
-        $this->rawAttachments[] = compact('data', 'name', 'options');
-
-        return $this;
+        return tap($this, fn () => $this->rawAttachments[] = compact('data', 'name', 'options'));
     }
 
     /**
@@ -320,9 +312,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function tag($value)
     {
-        array_push($this->tags, $value);
-
-        return $this;
+        return tap($this, fn () => array_push($this->tags, $value));
     }
 
     /**
@@ -334,9 +324,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function metadata($key, $value)
     {
-        $this->metadata[$key] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->metadata[$key] = $value);
     }
 
     /**
@@ -349,9 +337,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function priority($level)
     {
-        $this->priority = $level;
-
-        return $this;
+        return tap($this, fn () => $this->priority = $level);
     }
 
     /**
@@ -415,8 +401,6 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function withSymfonyMessage($callback)
     {
-        $this->callbacks[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->callbacks[] = $callback);
     }
 }

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -77,9 +77,7 @@ class SimpleMessage
      */
     public function success()
     {
-        $this->level = 'success';
-
-        return $this;
+        return tap($this, fn () => $this->level = 'success');
     }
 
     /**
@@ -89,9 +87,7 @@ class SimpleMessage
      */
     public function error()
     {
-        $this->level = 'error';
-
-        return $this;
+        return tap($this, fn () => $this->level = 'error');
     }
 
     /**
@@ -102,9 +98,7 @@ class SimpleMessage
      */
     public function level($level)
     {
-        $this->level = $level;
-
-        return $this;
+        return tap($this, fn () => $this->level = $level);
     }
 
     /**
@@ -115,9 +109,7 @@ class SimpleMessage
      */
     public function subject($subject)
     {
-        $this->subject = $subject;
-
-        return $this;
+        return tap($this, fn () => $this->subject = $subject);
     }
 
     /**
@@ -128,9 +120,7 @@ class SimpleMessage
      */
     public function greeting($greeting)
     {
-        $this->greeting = $greeting;
-
-        return $this;
+        return tap($this, fn () => $this->greeting = $greeting);
     }
 
     /**
@@ -141,9 +131,7 @@ class SimpleMessage
      */
     public function salutation($salutation)
     {
-        $this->salutation = $salutation;
-
-        return $this;
+        return tap($this, fn () => $this->salutation = $salutation);
     }
 
     /**
@@ -265,9 +253,7 @@ class SimpleMessage
      */
     public function mailer($mailer)
     {
-        $this->mailer = $mailer;
-
-        return $this;
+        return tap($this, fn () => $this->mailer = $mailer);
     }
 
     /**

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -40,8 +40,6 @@ class Notification
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
-
-        return $this;
+        return tap($this, fn () => $this->locale = $locale);
     }
 }

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -370,9 +370,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function loadMorph($relation, $relations)
     {
-        $this->getCollection()->loadMorph($relation, $relations);
-
-        return $this;
+        return tap($this, fn () => $this->getCollection()->loadMorph($relation, $relations));
     }
 
     /**
@@ -384,9 +382,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function loadMorphCount($relation, $relations)
     {
-        $this->getCollection()->loadMorphCount($relation, $relations);
-
-        return $this;
+        return tap($this, fn () => $this->getCollection()->loadMorphCount($relation, $relations));
     }
 
     /**
@@ -407,9 +403,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function through(callable $callback)
     {
-        $this->items->transform($callback);
-
-        return $this;
+        return tap($this, fn () => $this->items->transform($callback));
     }
 
     /**
@@ -450,9 +444,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function setCursorName($name)
     {
-        $this->cursorName = $name;
-
-        return $this;
+        return tap($this, fn () => $this->cursorName = $name);
     }
 
     /**
@@ -474,9 +466,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function setPath($path)
     {
-        $this->path = $path;
-
-        return $this;
+        return tap($this, fn () => $this->path = $path);
     }
 
     /**
@@ -583,9 +573,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function setCollection(Collection $collection)
     {
-        $this->items = $collection;
-
-        return $this;
+        return tap($this, fn () => $this->items = $collection);
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -292,9 +292,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function loadMorph($relation, $relations)
     {
-        $this->getCollection()->loadMorph($relation, $relations);
-
-        return $this;
+        return tap($this, fn () => $this->getCollection()->loadMorph($relation, $relations));
     }
 
     /**
@@ -306,9 +304,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function loadMorphCount($relation, $relations)
     {
-        $this->getCollection()->loadMorphCount($relation, $relations);
-
-        return $this;
+        return tap($this, fn () => $this->getCollection()->loadMorphCount($relation, $relations));
     }
 
     /**
@@ -349,9 +345,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function through(callable $callback)
     {
-        $this->items->transform($callback);
-
-        return $this;
+        return tap($this, fn () => $this->items->transform($callback));
     }
 
     /**
@@ -422,9 +416,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function setPageName($name)
     {
-        $this->pageName = $name;
-
-        return $this;
+        return tap($this, fn () => $this->pageName = $name);
     }
 
     /**
@@ -446,9 +438,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function setPath($path)
     {
-        $this->path = $path;
-
-        return $this;
+        return tap($this, fn () => $this->path = $path);
     }
 
     /**
@@ -459,9 +449,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function onEachSide($count)
     {
-        $this->onEachSide = $count;
-
-        return $this;
+        return tap($this, fn () => $this->onEachSide = $count);
     }
 
     /**
@@ -708,9 +696,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function setCollection(Collection $collection)
     {
-        $this->items = $collection;
-
-        return $this;
+        return tap($this, fn () => $this->items = $collection);
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -130,9 +130,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     public function hasMorePagesWhen($hasMore = true)
     {
-        $this->hasMore = $hasMore;
-
-        return $this;
+        return tap($this, fn () => $this->hasMore = $hasMore);
     }
 
     /**

--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -90,8 +90,6 @@ class Hub implements HubContract
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -60,9 +60,7 @@ class Pipeline implements PipelineContract
      */
     public function send($passable)
     {
-        $this->passable = $passable;
-
-        return $this;
+        return tap($this, fn () => $this->passable = $passable);
     }
 
     /**
@@ -73,9 +71,7 @@ class Pipeline implements PipelineContract
      */
     public function through($pipes)
     {
-        $this->pipes = is_array($pipes) ? $pipes : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->pipes = is_array($pipes) ? $pipes : func_get_args());
     }
 
     /**
@@ -86,9 +82,7 @@ class Pipeline implements PipelineContract
      */
     public function pipe($pipes)
     {
-        array_push($this->pipes, ...(is_array($pipes) ? $pipes : func_get_args()));
-
-        return $this;
+        return tap($this, fn () => array_push($this->pipes, ...(is_array($pipes) ? $pipes : func_get_args())));
     }
 
     /**
@@ -99,9 +93,7 @@ class Pipeline implements PipelineContract
      */
     public function via($method)
     {
-        $this->method = $method;
-
-        return $this;
+        return tap($this, fn () => $this->method = $method);
     }
 
     /**
@@ -242,9 +234,7 @@ class Pipeline implements PipelineContract
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 
     /**

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -146,9 +146,7 @@ class Factory
      */
     public function record(PendingProcess $process, ProcessResultContract $result)
     {
-        $this->recorded[] = [$process, $result];
-
-        return $this;
+        return tap($this, fn () => $this->recorded[] = [$process, $result]);
     }
 
     /**
@@ -159,9 +157,7 @@ class Factory
      */
     public function preventStrayProcesses(bool $prevent = true)
     {
-        $this->preventStrayProcesses = $prevent;
-
-        return $this;
+        return tap($this, fn () => $this->preventStrayProcesses = $prevent);
     }
 
     /**

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -295,8 +295,6 @@ class FakeInvokedProcess implements InvokedProcessContract
      */
     public function withOutputHandler(?callable $outputHandler)
     {
-        $this->outputHandler = $outputHandler;
-
-        return $this;
+        return tap($this, fn () => $this->outputHandler = $outputHandler);
     }
 }

--- a/src/Illuminate/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Process/FakeProcessDescription.php
@@ -43,9 +43,7 @@ class FakeProcessDescription
      */
     public function id(int $processId)
     {
-        $this->processId = $processId;
-
-        return $this;
+        return tap($this, fn () => $this->processId = $processId);
     }
 
     /**
@@ -138,9 +136,7 @@ class FakeProcessDescription
      */
     public function exitCode(int $exitCode)
     {
-        $this->exitCode = $exitCode;
-
-        return $this;
+        return tap($this, fn () => $this->exitCode = $exitCode);
     }
 
     /**
@@ -162,9 +158,7 @@ class FakeProcessDescription
      */
     public function runsFor(int $iterations)
     {
-        $this->runIterations = $iterations;
-
-        return $this;
+        return tap($this, fn () => $this->runIterations = $iterations);
     }
 
     /**

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -45,9 +45,7 @@ class InvokedProcess implements InvokedProcessContract
      */
     public function signal(int $signal)
     {
-        $this->process->signal($signal);
-
-        return $this;
+        return tap($this, fn () => $this->process->signal($signal));
     }
 
     /**

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -112,9 +112,7 @@ class PendingProcess
      */
     public function command(array|string $command)
     {
-        $this->command = $command;
-
-        return $this;
+        return tap($this, fn () => $this->command = $command);
     }
 
     /**
@@ -125,9 +123,7 @@ class PendingProcess
      */
     public function path(string $path)
     {
-        $this->path = $path;
-
-        return $this;
+        return tap($this, fn () => $this->path = $path);
     }
 
     /**
@@ -138,9 +134,7 @@ class PendingProcess
      */
     public function timeout(int $timeout)
     {
-        $this->timeout = $timeout;
-
-        return $this;
+        return tap($this, fn () => $this->timeout = $timeout);
     }
 
     /**
@@ -151,9 +145,7 @@ class PendingProcess
      */
     public function idleTimeout(int $timeout)
     {
-        $this->idleTimeout = $timeout;
-
-        return $this;
+        return tap($this, fn () => $this->idleTimeout = $timeout);
     }
 
     /**
@@ -163,9 +155,7 @@ class PendingProcess
      */
     public function forever()
     {
-        $this->timeout = null;
-
-        return $this;
+        return tap($this, fn () => $this->timeout = null);
     }
 
     /**
@@ -176,9 +166,7 @@ class PendingProcess
      */
     public function env(array $environment)
     {
-        $this->environment = $environment;
-
-        return $this;
+        return tap($this, fn () => $this->environment = $environment);
     }
 
     /**
@@ -189,9 +177,7 @@ class PendingProcess
      */
     public function input($input)
     {
-        $this->input = $input;
-
-        return $this;
+        return tap($this, fn () => $this->input = $input);
     }
 
     /**
@@ -201,9 +187,7 @@ class PendingProcess
      */
     public function quietly()
     {
-        $this->quietly = true;
-
-        return $this;
+        return tap($this, fn () => $this->quietly = true);
     }
 
     /**
@@ -214,9 +198,7 @@ class PendingProcess
      */
     public function tty(bool $tty = true)
     {
-        $this->tty = $tty;
-
-        return $this;
+        return tap($this, fn () => $this->tty = $tty);
     }
 
     /**
@@ -227,9 +209,7 @@ class PendingProcess
      */
     public function options(array $options)
     {
-        $this->options = $options;
-
-        return $this;
+        return tap($this, fn () => $this->options = $options);
     }
 
     /**
@@ -337,9 +317,7 @@ class PendingProcess
      */
     public function withFakeHandlers(array $fakeHandlers)
     {
-        $this->fakeHandlers = $fakeHandlers;
-
-        return $this;
+        return tap($this, fn () => $this->fakeHandlers = $fakeHandlers);
     }
 
     /**

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -89,9 +89,7 @@ trait InteractsWithQueue
      */
     public function withFakeQueueInteractions()
     {
-        $this->job = new FakeJob;
-
-        return $this;
+        return tap($this, fn () => $this->job = new FakeJob);
     }
 
     /**
@@ -229,8 +227,6 @@ trait InteractsWithQueue
      */
     public function setJob(JobContract $job)
     {
-        $this->job = $job;
-
-        return $this;
+        return tap($this, fn () => $this->job = $job);
     }
 }

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -108,9 +108,7 @@ class RateLimited
      */
     public function dontRelease()
     {
-        $this->shouldRelease = false;
-
-        return $this;
+        return tap($this, fn () => $this->shouldRelease = false);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -126,9 +126,7 @@ class ThrottlesExceptions
      */
     public function when(callable $callback)
     {
-        $this->whenCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->whenCallback = $callback);
     }
 
     /**
@@ -139,9 +137,7 @@ class ThrottlesExceptions
      */
     public function withPrefix(string $prefix)
     {
-        $this->prefix = $prefix;
-
-        return $this;
+        return tap($this, fn () => $this->prefix = $prefix);
     }
 
     /**
@@ -152,9 +148,7 @@ class ThrottlesExceptions
      */
     public function backoff($backoff)
     {
-        $this->retryAfterMinutes = $backoff;
-
-        return $this;
+        return tap($this, fn () => $this->retryAfterMinutes = $backoff);
     }
 
     /**
@@ -182,9 +176,7 @@ class ThrottlesExceptions
      */
     public function by($key)
     {
-        $this->key = $key;
-
-        return $this;
+        return tap($this, fn () => $this->key = $key);
     }
 
     /**
@@ -194,9 +186,7 @@ class ThrottlesExceptions
      */
     public function byJob()
     {
-        $this->byJob = true;
-
-        return $this;
+        return tap($this, fn () => $this->byJob = true);
     }
 
     /**
@@ -207,9 +197,7 @@ class ThrottlesExceptions
      */
     public function report(?callable $callback = null)
     {
-        $this->reportCallback = $callback ?? fn () => true;
-
-        return $this;
+        return tap($this, fn () => $this->reportCallback = $callback ?? fn () => true);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -92,9 +92,7 @@ class WithoutOverlapping
      */
     public function releaseAfter($releaseAfter)
     {
-        $this->releaseAfter = $releaseAfter;
-
-        return $this;
+        return tap($this, fn () => $this->releaseAfter = $releaseAfter);
     }
 
     /**
@@ -104,9 +102,7 @@ class WithoutOverlapping
      */
     public function dontRelease()
     {
-        $this->releaseAfter = null;
-
-        return $this;
+        return tap($this, fn () => $this->releaseAfter = null);
     }
 
     /**
@@ -117,9 +113,7 @@ class WithoutOverlapping
      */
     public function expireAfter($expiresAfter)
     {
-        $this->expiresAfter = $this->secondsUntil($expiresAfter);
-
-        return $this;
+        return tap($this, fn () => $this->expiresAfter = $this->secondsUntil($expiresAfter));
     }
 
     /**
@@ -130,9 +124,7 @@ class WithoutOverlapping
      */
     public function withPrefix(string $prefix)
     {
-        $this->prefix = $prefix;
-
-        return $this;
+        return tap($this, fn () => $this->prefix = $prefix);
     }
 
     /**
@@ -142,9 +134,7 @@ class WithoutOverlapping
      */
     public function shared()
     {
-        $this->shareKey = true;
-
-        return $this;
+        return tap($this, fn () => $this->shareKey = true);
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -417,9 +417,7 @@ abstract class Queue
      */
     public function setConnectionName($name)
     {
-        $this->connectionName = $name;
-
-        return $this;
+        return tap($this, fn () => $this->connectionName = $name);
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -827,9 +827,7 @@ class Worker
      */
     public function setCache(CacheContract $cache)
     {
-        $this->cache = $cache;
-
-        return $this;
+        return tap($this, fn () => $this->cache = $cache);
     }
 
     /**
@@ -840,9 +838,7 @@ class Worker
      */
     public function setName($name)
     {
-        $this->name = $name;
-
-        return $this;
+        return tap($this, fn () => $this->name = $name);
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -177,9 +177,7 @@ abstract class Connection
      */
     public function setName($name)
     {
-        $this->name = $name;
-
-        return $this;
+        return tap($this, fn () => $this->name = $name);
     }
 
     /**

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
@@ -72,9 +72,7 @@ class ConcurrencyLimiterBuilder
      */
     public function limit($maxLocks)
     {
-        $this->maxLocks = $maxLocks;
-
-        return $this;
+        return tap($this, fn () => $this->maxLocks = $maxLocks);
     }
 
     /**
@@ -85,9 +83,7 @@ class ConcurrencyLimiterBuilder
      */
     public function releaseAfter($releaseAfter)
     {
-        $this->releaseAfter = $this->secondsUntil($releaseAfter);
-
-        return $this;
+        return tap($this, fn () => $this->releaseAfter = $this->secondsUntil($releaseAfter));
     }
 
     /**
@@ -98,9 +94,7 @@ class ConcurrencyLimiterBuilder
      */
     public function block($timeout)
     {
-        $this->timeout = $timeout;
-
-        return $this;
+        return tap($this, fn () => $this->timeout = $timeout);
     }
 
     /**
@@ -111,9 +105,7 @@ class ConcurrencyLimiterBuilder
      */
     public function sleep($sleep)
     {
-        $this->sleep = $sleep;
-
-        return $this;
+        return tap($this, fn () => $this->sleep = $sleep);
     }
 
     /**

--- a/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
@@ -72,9 +72,7 @@ class DurationLimiterBuilder
      */
     public function allow($maxLocks)
     {
-        $this->maxLocks = $maxLocks;
-
-        return $this;
+        return tap($this, fn () => $this->maxLocks = $maxLocks);
     }
 
     /**
@@ -85,9 +83,7 @@ class DurationLimiterBuilder
      */
     public function every($decay)
     {
-        $this->decay = $this->secondsUntil($decay);
-
-        return $this;
+        return tap($this, fn () => $this->decay = $this->secondsUntil($decay));
     }
 
     /**
@@ -98,9 +94,7 @@ class DurationLimiterBuilder
      */
     public function block($timeout)
     {
-        $this->timeout = $timeout;
-
-        return $this;
+        return tap($this, fn () => $this->timeout = $timeout);
     }
 
     /**
@@ -111,9 +105,7 @@ class DurationLimiterBuilder
      */
     public function sleep($sleep)
     {
-        $this->sleep = $sleep;
-
-        return $this;
+        return tap($this, fn () => $this->sleep = $sleep);
     }
 
     /**

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -259,9 +259,7 @@ class RedisManager implements Factory
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback->bindTo($this, $this);
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback->bindTo($this, $this));
     }
 
     /**

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -310,9 +310,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function setRouter(Router $router)
     {
-        $this->router = $router;
-
-        return $this;
+        return tap($this, fn () => $this->router = $router);
     }
 
     /**
@@ -323,8 +321,6 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 }

--- a/src/Illuminate/Routing/ControllerMiddlewareOptions.php
+++ b/src/Illuminate/Routing/ControllerMiddlewareOptions.php
@@ -30,9 +30,7 @@ class ControllerMiddlewareOptions
      */
     public function only($methods)
     {
-        $this->options['only'] = is_array($methods) ? $methods : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->options['only'] = is_array($methods) ? $methods : func_get_args());
     }
 
     /**
@@ -43,8 +41,6 @@ class ControllerMiddlewareOptions
      */
     public function except($methods)
     {
-        $this->options['except'] = is_array($methods) ? $methods : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->options['except'] = is_array($methods) ? $methods : func_get_args());
     }
 }

--- a/src/Illuminate/Routing/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Middleware.php
@@ -25,9 +25,7 @@ class Middleware
      */
     public function only(array|string $only)
     {
-        $this->only = Arr::wrap($only);
-
-        return $this;
+        return tap($this, fn () => $this->only = Arr::wrap($only));
     }
 
     /**
@@ -38,8 +36,6 @@ class Middleware
      */
     public function except(array|string $except)
     {
-        $this->except = Arr::wrap($except);
-
-        return $this;
+        return tap($this, fn () => $this->except = Arr::wrap($except));
     }
 }

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -69,9 +69,7 @@ class PendingResourceRegistration
      */
     public function only($methods)
     {
-        $this->options['only'] = is_array($methods) ? $methods : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->options['only'] = is_array($methods) ? $methods : func_get_args());
     }
 
     /**
@@ -82,9 +80,7 @@ class PendingResourceRegistration
      */
     public function except($methods)
     {
-        $this->options['except'] = is_array($methods) ? $methods : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->options['except'] = is_array($methods) ? $methods : func_get_args());
     }
 
     /**
@@ -95,9 +91,7 @@ class PendingResourceRegistration
      */
     public function names($names)
     {
-        $this->options['names'] = $names;
-
-        return $this;
+        return tap($this, fn () => $this->options['names'] = $names);
     }
 
     /**
@@ -109,9 +103,7 @@ class PendingResourceRegistration
      */
     public function name($method, $name)
     {
-        $this->options['names'][$method] = $name;
-
-        return $this;
+        return tap($this, fn () => $this->options['names'][$method] = $name);
     }
 
     /**
@@ -122,9 +114,7 @@ class PendingResourceRegistration
      */
     public function parameters($parameters)
     {
-        $this->options['parameters'] = $parameters;
-
-        return $this;
+        return tap($this, fn () => $this->options['parameters'] = $parameters);
     }
 
     /**
@@ -136,9 +126,7 @@ class PendingResourceRegistration
      */
     public function parameter($previous, $new)
     {
-        $this->options['parameters'][$previous] = $new;
-
-        return $this;
+        return tap($this, fn () => $this->options['parameters'][$previous] = $new);
     }
 
     /**
@@ -183,9 +171,7 @@ class PendingResourceRegistration
      */
     public function where($wheres)
     {
-        $this->options['wheres'] = $wheres;
-
-        return $this;
+        return tap($this, fn () => $this->options['wheres'] = $wheres);
     }
 
     /**
@@ -196,9 +182,7 @@ class PendingResourceRegistration
      */
     public function shallow($shallow = true)
     {
-        $this->options['shallow'] = $shallow;
-
-        return $this;
+        return tap($this, fn () => $this->options['shallow'] = $shallow);
     }
 
     /**
@@ -209,9 +193,7 @@ class PendingResourceRegistration
      */
     public function missing($callback)
     {
-        $this->options['missing'] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->options['missing'] = $callback);
     }
 
     /**
@@ -222,9 +204,7 @@ class PendingResourceRegistration
      */
     public function scoped(array $fields = [])
     {
-        $this->options['bindingFields'] = $fields;
-
-        return $this;
+        return tap($this, fn () => $this->options['bindingFields'] = $fields);
     }
 
     /**
@@ -235,9 +215,7 @@ class PendingResourceRegistration
      */
     public function withTrashed(array $methods = [])
     {
-        $this->options['trashed'] = $methods;
-
-        return $this;
+        return tap($this, fn () => $this->options['trashed'] = $methods);
     }
 
     /**

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -69,9 +69,7 @@ class PendingSingletonResourceRegistration
      */
     public function only($methods)
     {
-        $this->options['only'] = is_array($methods) ? $methods : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->options['only'] = is_array($methods) ? $methods : func_get_args());
     }
 
     /**
@@ -82,9 +80,7 @@ class PendingSingletonResourceRegistration
      */
     public function except($methods)
     {
-        $this->options['except'] = is_array($methods) ? $methods : func_get_args();
-
-        return $this;
+        return tap($this, fn () => $this->options['except'] = is_array($methods) ? $methods : func_get_args());
     }
 
     /**
@@ -94,9 +90,7 @@ class PendingSingletonResourceRegistration
      */
     public function creatable()
     {
-        $this->options['creatable'] = true;
-
-        return $this;
+        return tap($this, fn () => $this->options['creatable'] = true);
     }
 
     /**
@@ -106,9 +100,7 @@ class PendingSingletonResourceRegistration
      */
     public function destroyable()
     {
-        $this->options['destroyable'] = true;
-
-        return $this;
+        return tap($this, fn () => $this->options['destroyable'] = true);
     }
 
     /**
@@ -119,9 +111,7 @@ class PendingSingletonResourceRegistration
      */
     public function names($names)
     {
-        $this->options['names'] = $names;
-
-        return $this;
+        return tap($this, fn () => $this->options['names'] = $names);
     }
 
     /**
@@ -133,9 +123,7 @@ class PendingSingletonResourceRegistration
      */
     public function name($method, $name)
     {
-        $this->options['names'][$method] = $name;
-
-        return $this;
+        return tap($this, fn () => $this->options['names'][$method] = $name);
     }
 
     /**
@@ -146,9 +134,7 @@ class PendingSingletonResourceRegistration
      */
     public function parameters($parameters)
     {
-        $this->options['parameters'] = $parameters;
-
-        return $this;
+        return tap($this, fn () => $this->options['parameters'] = $parameters);
     }
 
     /**
@@ -160,9 +146,7 @@ class PendingSingletonResourceRegistration
      */
     public function parameter($previous, $new)
     {
-        $this->options['parameters'][$previous] = $new;
-
-        return $this;
+        return tap($this, fn () => $this->options['parameters'][$previous] = $new);
     }
 
     /**
@@ -207,9 +191,7 @@ class PendingSingletonResourceRegistration
      */
     public function where($wheres)
     {
-        $this->options['wheres'] = $wheres;
-
-        return $this;
+        return tap($this, fn () => $this->options['wheres'] = $wheres);
     }
 
     /**

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -256,8 +256,6 @@ class Redirector
      */
     public function setIntendedUrl($url)
     {
-        $this->session->put('url.intended', $url);
-
-        return $this;
+        return tap($this, fn () => $this->session->put('url.intended', $url));
     }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -575,9 +575,7 @@ class Route
      */
     public function setBindingFields(array $bindingFields)
     {
-        $this->bindingFields = $bindingFields;
-
-        return $this;
+        return tap($this, fn () => $this->bindingFields = $bindingFields);
     }
 
     /**
@@ -605,9 +603,7 @@ class Route
      */
     public function withTrashed($withTrashed = true)
     {
-        $this->withTrashedBindings = $withTrashed;
-
-        return $this;
+        return tap($this, fn () => $this->withTrashedBindings = $withTrashed);
     }
 
     /**
@@ -629,9 +625,7 @@ class Route
      */
     public function defaults($key, $value)
     {
-        $this->defaults[$key] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->defaults[$key] = $value);
     }
 
     /**
@@ -642,9 +636,7 @@ class Route
      */
     public function setDefaults(array $defaults)
     {
-        $this->defaults = $defaults;
-
-        return $this;
+        return tap($this, fn () => $this->defaults = $defaults);
     }
 
     /**
@@ -697,9 +689,7 @@ class Route
      */
     public function fallback()
     {
-        $this->isFallback = true;
-
-        return $this;
+        return tap($this, fn () => $this->isFallback = true);
     }
 
     /**
@@ -710,9 +700,7 @@ class Route
      */
     public function setFallback($isFallback)
     {
-        $this->isFallback = $isFallback;
-
-        return $this;
+        return tap($this, fn () => $this->isFallback = $isFallback);
     }
 
     /**
@@ -853,9 +841,7 @@ class Route
      */
     public function setUri($uri)
     {
-        $this->uri = $this->parseUri($uri);
-
-        return $this;
+        return tap($this, fn () => $this->uri = $this->parseUri($uri));
     }
 
     /**
@@ -1032,9 +1018,7 @@ class Route
      */
     public function missing($missing)
     {
-        $this->action['missing'] = $missing;
-
-        return $this;
+        return tap($this, fn () => $this->action['missing'] = $missing);
     }
 
     /**
@@ -1181,9 +1165,7 @@ class Route
      */
     public function scopeBindings()
     {
-        $this->action['scope_bindings'] = true;
-
-        return $this;
+        return tap($this, fn () => $this->action['scope_bindings'] = true);
     }
 
     /**
@@ -1193,9 +1175,7 @@ class Route
      */
     public function withoutScopedBindings()
     {
-        $this->action['scope_bindings'] = false;
-
-        return $this;
+        return tap($this, fn () => $this->action['scope_bindings'] = false);
     }
 
     /**
@@ -1341,9 +1321,7 @@ class Route
      */
     public function setRouter(Router $router)
     {
-        $this->router = $router;
-
-        return $this;
+        return tap($this, fn () => $this->router = $router);
     }
 
     /**
@@ -1354,9 +1332,7 @@ class Route
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -196,9 +196,7 @@ class RouteRegistrar
      */
     public function group($callback)
     {
-        $this->router->group($this->attributes, $callback);
-
-        return $this;
+        return tap($this, fn () => $this->router->group($this->attributes, $callback));
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -973,9 +973,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function substituteImplicitBindingsUsing($callback)
     {
-        $this->implicitBindingCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->implicitBindingCallback = $callback);
     }
 
     /**
@@ -1023,9 +1021,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function aliasMiddleware($name, $class)
     {
-        $this->middleware[$name] = $class;
-
-        return $this;
+        return tap($this, fn () => $this->middleware[$name] = $class);
     }
 
     /**
@@ -1058,9 +1054,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function middlewareGroup($name, array $middleware)
     {
-        $this->middlewareGroups[$name] = $middleware;
-
-        return $this;
+        return tap($this, fn () => $this->middlewareGroups[$name] = $middleware);
     }
 
     /**
@@ -1136,9 +1130,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function flushMiddlewareGroups()
     {
-        $this->middlewareGroups = [];
-
-        return $this;
+        return tap($this, fn () => $this->middlewareGroups = []);
     }
 
     /**
@@ -1475,9 +1467,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -763,9 +763,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatHostUsing(Closure $callback)
     {
-        $this->formatHostUsing = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->formatHostUsing = $callback);
     }
 
     /**
@@ -776,9 +774,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatPathUsing(Closure $callback)
     {
-        $this->formatPathUsing = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->formatPathUsing = $callback);
     }
 
     /**
@@ -833,9 +829,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function setRoutes(RouteCollectionInterface $routes)
     {
-        $this->routes = $routes;
-
-        return $this;
+        return tap($this, fn () => $this->routes = $routes);
     }
 
     /**
@@ -858,9 +852,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function setSessionResolver(callable $sessionResolver)
     {
-        $this->sessionResolver = $sessionResolver;
-
-        return $this;
+        return tap($this, fn () => $this->sessionResolver = $sessionResolver);
     }
 
     /**
@@ -871,9 +863,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function setKeyResolver(callable $keyResolver)
     {
-        $this->keyResolver = $keyResolver;
-
-        return $this;
+        return tap($this, fn () => $this->keyResolver = $keyResolver);
     }
 
     /**
@@ -895,9 +885,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function resolveMissingNamedRoutesUsing(callable $missingNamedRouteResolver)
     {
-        $this->missingNamedRouteResolver = $missingNamedRouteResolver;
-
-        return $this;
+        return tap($this, fn () => $this->missingNamedRouteResolver = $missingNamedRouteResolver);
     }
 
     /**
@@ -918,8 +906,6 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function setRootControllerNamespace($rootNamespace)
     {
-        $this->rootNamespace = $rootNamespace;
-
-        return $this;
+        return tap($this, fn () => $this->rootNamespace = $rootNamespace);
     }
 }

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -299,9 +299,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     public function setContainer($container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 
     /**
@@ -312,8 +310,6 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     public function setExists($value)
     {
-        $this->exists = $value;
-
-        return $this;
+        return tap($this, fn () => $this->exists = $value);
     }
 }

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -226,9 +226,7 @@ class Composer
      */
     public function setWorkingPath($path)
     {
-        $this->workingPath = realpath($path);
-
-        return $this;
+        return tap($this, fn () => $this->workingPath = realpath($path));
     }
 
     /**

--- a/src/Illuminate/Support/Defer/DeferredCallback.php
+++ b/src/Illuminate/Support/Defer/DeferredCallback.php
@@ -25,9 +25,7 @@ class DeferredCallback
      */
     public function name(string $name): self
     {
-        $this->name = $name;
-
-        return $this;
+        return tap($this, fn () => $this->name = $name);
     }
 
     /**
@@ -38,9 +36,7 @@ class DeferredCallback
      */
     public function always(bool $always = true): self
     {
-        $this->always = $always;
-
-        return $this;
+        return tap($this, fn () => $this->always = $always);
     }
 
     /**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -213,9 +213,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
-        $this->attributes[$method] = count($parameters) > 0 ? reset($parameters) : true;
-
-        return $this;
+        return tap($this, fn () => $this->attributes[$method] = count($parameters) > 0 ? reset($parameters) : true);
     }
 
     /**

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -79,9 +79,7 @@ class Lottery
      */
     public function winner($callback)
     {
-        $this->winner = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->winner = $callback);
     }
 
     /**
@@ -92,9 +90,7 @@ class Lottery
      */
     public function loser($callback)
     {
-        $this->loser = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->loser = $callback);
     }
 
     /**

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -129,9 +129,7 @@ abstract class Manager
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$driver] = $callback);
     }
 
     /**
@@ -162,9 +160,7 @@ abstract class Manager
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 
     /**
@@ -174,9 +170,7 @@ abstract class Manager
      */
     public function forgetDrivers()
     {
-        $this->drivers = [];
-
-        return $this;
+        return tap($this, fn () => $this->drivers = []);
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -272,9 +272,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      */
     public function forget($key)
     {
-        unset($this->messages[$key]);
-
-        return $this;
+        return tap($this, fn () => unset($this->messages[$key]));
     }
 
     /**
@@ -359,9 +357,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      */
     public function setFormat($format = ':message')
     {
-        $this->format = $format;
-
-        return $this;
+        return tap($this, fn () => $this->format = $format);
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -272,7 +272,9 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      */
     public function forget($key)
     {
-        return tap($this, fn () => unset($this->messages[$key]));
+        unset($this->messages[$key]);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -196,9 +196,7 @@ abstract class MultipleInstanceManager
      */
     public function extend($name, Closure $callback)
     {
-        $this->customCreators[$name] = $callback->bindTo($this, $this);
-
-        return $this;
+        return tap($this, fn () => $this->customCreators[$name] = $callback->bindTo($this, $this));
     }
 
     /**
@@ -209,9 +207,7 @@ abstract class MultipleInstanceManager
      */
     public function setApplication($app)
     {
-        $this->app = $app;
-
-        return $this;
+        return tap($this, fn () => $this->app = $app);
     }
 
     /**

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -168,9 +168,7 @@ class Sleep
      */
     public function minutes()
     {
-        $this->duration->add('minutes', $this->pullPending());
-
-        return $this;
+        return tap($this, fn () => $this->duration->add('minutes', $this->pullPending()));
     }
 
     /**
@@ -190,9 +188,7 @@ class Sleep
      */
     public function seconds()
     {
-        $this->duration->add('seconds', $this->pullPending());
-
-        return $this;
+        return tap($this, fn () => $this->duration->add('seconds', $this->pullPending()));
     }
 
     /**
@@ -212,9 +208,7 @@ class Sleep
      */
     public function milliseconds()
     {
-        $this->duration->add('milliseconds', $this->pullPending());
-
-        return $this;
+        return tap($this, fn () => $this->duration->add('milliseconds', $this->pullPending()));
     }
 
     /**
@@ -234,9 +228,7 @@ class Sleep
      */
     public function microseconds()
     {
-        $this->duration->add('microseconds', $this->pullPending());
-
-        return $this;
+        return tap($this, fn () => $this->duration->add('microseconds', $this->pullPending()));
     }
 
     /**
@@ -257,9 +249,7 @@ class Sleep
      */
     public function and($duration)
     {
-        $this->pending = $duration;
-
-        return $this;
+        return tap($this, fn () => $this->pending = $duration);
     }
 
     /**
@@ -270,9 +260,7 @@ class Sleep
      */
     public function while(Closure $callback)
     {
-        $this->while = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->while = $callback);
     }
 
     /**
@@ -492,9 +480,7 @@ class Sleep
      */
     protected function shouldNotSleep()
     {
-        $this->shouldSleep = false;
-
-        return $this;
+        return tap($this, fn () => $this->shouldSleep = false);
     }
 
     /**
@@ -505,9 +491,7 @@ class Sleep
      */
     public function when($condition)
     {
-        $this->shouldSleep = (bool) value($condition, $this);
-
-        return $this;
+        return tap($this, fn () => $this->shouldSleep = (bool) value($condition, $this));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1322,9 +1322,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function dump(...$args)
     {
-        dump($this->value, ...$args);
-
-        return $this;
+        return tap($this, fn () => dump($this->value, ...$args));
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -103,9 +103,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function except($jobsToDispatch)
     {
-        $this->jobsToDispatch = array_merge($this->jobsToDispatch, Arr::wrap($jobsToDispatch));
-
-        return $this;
+        return tap($this, fn () => $this->jobsToDispatch = array_merge($this->jobsToDispatch, Arr::wrap($jobsToDispatch)));
     }
 
     /**
@@ -814,9 +812,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function serializeAndRestore(bool $serializeAndRestore = true)
     {
-        $this->serializeAndRestore = $serializeAndRestore;
-
-        return $this;
+        return tap($this, fn () => $this->serializeAndRestore = $serializeAndRestore);
     }
 
     /**
@@ -849,9 +845,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function pipeThrough(array $pipes)
     {
-        $this->dispatcher->pipeThrough($pipes);
-
-        return $this;
+        return tap($this, fn () => $this->dispatcher->pipeThrough($pipes));
     }
 
     /**
@@ -884,9 +878,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function map(array $map)
     {
-        $this->dispatcher->map($map);
-
-        return $this;
+        return tap($this, fn () => $this->dispatcher->map($map));
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -228,9 +228,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     public function throwOnReport()
     {
-        $this->throwOnReport = true;
-
-        return $this;
+        return tap($this, fn () => $this->throwOnReport = true);
     }
 
     /**
@@ -257,9 +255,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     public function setHandler(ExceptionHandler $handler)
     {
-        $this->handler = $handler;
-
-        return $this;
+        return tap($this, fn () => $this->handler = $handler);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -416,9 +416,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function mailer($name = null)
     {
-        $this->currentMailer = $name;
-
-        return $this;
+        return tap($this, fn () => $this->currentMailer = $name);
     }
 
     /**
@@ -572,9 +570,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function forgetMailers()
     {
-        $this->currentMailer = null;
-
-        return $this;
+        return tap($this, fn () => $this->currentMailer = null);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -360,9 +360,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
-
-        return $this;
+        return tap($this, fn () => $this->locale = $locale);
     }
 
     /**
@@ -373,9 +371,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     public function serializeAndRestore(bool $serializeAndRestore = true)
     {
-        $this->serializeAndRestore = $serializeAndRestore;
-
-        return $this;
+        return tap($this, fn () => $this->serializeAndRestore = $serializeAndRestore);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -75,9 +75,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function except($jobsToBeQueued)
     {
-        $this->jobsToBeQueued = Collection::wrap($jobsToBeQueued)->merge($this->jobsToBeQueued);
-
-        return $this;
+        return tap($this, fn () => $this->jobsToBeQueued = Collection::wrap($jobsToBeQueued)->merge($this->jobsToBeQueued));
     }
 
     /**
@@ -524,9 +522,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function serializeAndRestore(bool $serializeAndRestore = true)
     {
-        $this->serializeAndRestore = $serializeAndRestore;
-
-        return $this;
+        return tap($this, fn () => $this->serializeAndRestore = $serializeAndRestore);
     }
 
     /**

--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -56,9 +56,7 @@ class Timebox
      */
     public function returnEarly()
     {
-        $this->earlyReturn = true;
-
-        return $this;
+        return tap($this, fn () => $this->earlyReturn = true);
     }
 
     /**
@@ -68,9 +66,7 @@ class Timebox
      */
     public function dontReturnEarly()
     {
-        $this->earlyReturn = false;
-
-        return $this;
+        return tap($this, fn () => $this->earlyReturn = false);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/Dumpable.php
+++ b/src/Illuminate/Support/Traits/Dumpable.php
@@ -23,8 +23,6 @@ trait Dumpable
      */
     public function dump(...$args)
     {
-        dump($this, ...$args);
-
-        return $this;
+        return tap($this, fn () => dump($this, ...$args));
     }
 }

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -59,9 +59,7 @@ class ViewErrorBag implements Countable, Stringable
      */
     public function put($key, MessageBagContract $bag)
     {
-        $this->bags[$key] = $bag;
-
-        return $this;
+        return tap($this, fn () => $this->bags[$key] = $bag);
     }
 
     /**

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -222,7 +222,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertMissingPath($path)
     {
-        return tap($this, fn () => PHPUnit::assertFalse(Arr::has($this->json(), $path)))
+        return tap($this, fn () => PHPUnit::assertFalse(Arr::has($this->json(), $path)));
 
     /**
      * Assert that the expected value and type exists at the given path in the response.

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -222,10 +222,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertMissingPath($path)
     {
-        PHPUnit::assertFalse(Arr::has($this->json(), $path));
-
-        return $this;
-    }
+        return tap($this, fn () => PHPUnit::assertFalse(Arr::has($this->json(), $path)))
 
     /**
      * Assert that the expected value and type exists at the given path in the response.
@@ -254,9 +251,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertPathCanonicalizing($path, $expect)
     {
-        PHPUnit::assertEqualsCanonicalizing($expect, $this->json($path));
-
-        return $this;
+        return tap($this, fn () => PHPUnit::assertEqualsCanonicalizing($expect, $this->json($path)));
     }
 
     /**

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -223,6 +223,7 @@ class AssertableJsonString implements ArrayAccess, Countable
     public function assertMissingPath($path)
     {
         return tap($this, fn () => PHPUnit::assertFalse(Arr::has($this->json(), $path)));
+    }
 
     /**
      * Assert that the expected value and type exists at the given path in the response.

--- a/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
@@ -16,9 +16,7 @@ trait Debugging
      */
     public function dump(?string $prop = null): self
     {
-        dump($this->prop($prop));
-
-        return $this;
+        return tap($this, fn () => dump($this->prop($prop)));
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
@@ -52,9 +52,7 @@ trait Interaction
      */
     public function etc(): self
     {
-        $this->interacted = array_keys($this->prop());
-
-        return $this;
+        return tap($this, fn () => $this->interacted = array_keys($this->prop()));
     }
 
     /**

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -99,9 +99,7 @@ class PendingCommand
      */
     public function expectsQuestion($question, $answer)
     {
-        $this->test->expectedQuestions[] = [$question, $answer];
-
-        return $this;
+        return tap($this, fn () => $this->test->expectedQuestions[] = [$question, $answer]);
     }
 
     /**
@@ -197,9 +195,7 @@ class PendingCommand
      */
     public function expectsOutputToContain($string)
     {
-        $this->test->expectedOutputSubstrings[] = $string;
-
-        return $this;
+        return tap($this, fn () => $this->test->expectedOutputSubstrings[] = $string);
     }
 
     /**
@@ -210,9 +206,7 @@ class PendingCommand
      */
     public function doesntExpectOutputToContain($string)
     {
-        $this->test->unexpectedOutputSubstrings[$string] = false;
-
-        return $this;
+        return tap($this, fn () => $this->test->unexpectedOutputSubstrings[$string] = false);
     }
 
     /**
@@ -256,9 +250,7 @@ class PendingCommand
      */
     public function assertExitCode($exitCode)
     {
-        $this->expectedExitCode = $exitCode;
-
-        return $this;
+        return tap($this, fn () => $this->expectedExitCode = $exitCode);
     }
 
     /**
@@ -269,9 +261,7 @@ class PendingCommand
      */
     public function assertNotExitCode($exitCode)
     {
-        $this->unexpectedExitCode = $exitCode;
-
-        return $this;
+        return tap($this, fn () => $this->unexpectedExitCode = $exitCode);
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -386,9 +386,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertPlainCookie($cookieName, $value = null)
     {
-        $this->assertCookie($cookieName, $value, false);
-
-        return $this;
+        return tap($this)->assertCookie($cookieName, $value, false);
     }
 
     /**
@@ -527,9 +525,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertContent($value)
     {
-        PHPUnit::withResponse($this)->assertSame($value, $this->content());
-
-        return $this;
+        return tap($this, fn () => PHPUnit::withResponse($this)->assertSame($value, $this->content()));
     }
 
     /**
@@ -540,9 +536,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertStreamedContent($value)
     {
-        PHPUnit::withResponse($this)->assertSame($value, $this->streamedContent());
-
-        return $this;
+        return tap($this, fn () => PHPUnit::withResponse($this)->assertSame($value, $this->streamedContent()));
     }
 
     /**
@@ -740,9 +734,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonPath($path, $expect)
     {
-        $this->decodeResponseJson()->assertPath($path, $expect);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertPath($path, $expect));
     }
 
     /**
@@ -754,9 +746,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonPathCanonicalizing($path, array $expect)
     {
-        $this->decodeResponseJson()->assertPathCanonicalizing($path, $expect);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertPathCanonicalizing($path, $expect));
     }
 
     /**
@@ -767,9 +757,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertExactJson(array $data)
     {
-        $this->decodeResponseJson()->assertExact($data);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertExact($data));
     }
 
     /**
@@ -780,9 +768,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertSimilarJson(array $data)
     {
-        $this->decodeResponseJson()->assertSimilar($data);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertSimilar($data));
     }
 
     /**
@@ -793,9 +779,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonFragment(array $data)
     {
-        $this->decodeResponseJson()->assertFragment($data);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertFragment($data));
     }
 
     /**
@@ -807,9 +791,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonMissing(array $data, $exact = false)
     {
-        $this->decodeResponseJson()->assertMissing($data, $exact);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertMissing($data, $exact));
     }
 
     /**
@@ -820,9 +802,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonMissingExact(array $data)
     {
-        $this->decodeResponseJson()->assertMissingExact($data);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertMissingExact($data));
     }
 
     /**
@@ -833,9 +813,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonMissingPath(string $path)
     {
-        $this->decodeResponseJson()->assertMissingPath($path);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertMissingPath($path));
     }
 
     /**
@@ -847,9 +825,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonStructure(?array $structure = null, $responseData = null)
     {
-        $this->decodeResponseJson()->assertStructure($structure, $responseData);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertStructure($structure, $responseData));
     }
 
     /**
@@ -861,9 +837,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertExactJsonStructure(?array $structure = null, $responseData = null)
     {
-        $this->decodeResponseJson()->assertStructure($structure, $responseData, true);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertStructure($structure, $responseData, true));
     }
 
     /**
@@ -875,9 +849,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonCount(int $count, $key = null)
     {
-        $this->decodeResponseJson()->assertCount($count, $key);
-
-        return $this;
+        return tap($this, fn () => $this->decodeResponseJson()->assertCount($count, $key));
     }
 
     /**
@@ -1589,9 +1561,7 @@ class TestResponse implements ArrayAccess
      */
     public function dumpHeaders()
     {
-        dump($this->headers->all());
-
-        return $this;
+        return tap($this, fn () => dump($this->headers->all()));
     }
 
     /**
@@ -1650,9 +1620,7 @@ class TestResponse implements ArrayAccess
      */
     public function withExceptions(Collection $exceptions)
     {
-        $this->exceptions = $exceptions;
-
-        return $this;
+        return tap($this, fn () => $this->exceptions = $exceptions);
     }
 
     /**

--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -49,9 +49,7 @@ class PotentiallyTranslatedString implements Stringable
      */
     public function translate($replace = [], $locale = null)
     {
-        $this->translation = $this->translator->get($this->string, $replace, $locale);
-
-        return $this;
+        return tap($this, fn () => $this->translation = $this->translator->get($this->string, $replace, $locale));
     }
 
     /**
@@ -64,9 +62,7 @@ class PotentiallyTranslatedString implements Stringable
      */
     public function translateChoice($number, array $replace = [], $locale = null)
     {
-        $this->translation = $this->translator->choice($this->string, $number, $replace, $locale);
-
-        return $this;
+        return tap($this, fn () => $this->translation = $this->translator->choice($this->string, $number, $replace, $locale));
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -387,9 +387,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function handleMissingKeysUsing(?callable $callback)
     {
-        $this->missingTranslationKeyCallback = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->missingTranslationKeyCallback = $callback);
     }
 
     /**

--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -87,8 +87,6 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
      */
     public function setValidator($validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 }

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -328,8 +328,6 @@ class Factory implements FactoryContract
      */
     public function setContainer(Container $container)
     {
-        $this->container = $container;
-
-        return $this;
+        return tap($this, fn () => $this->container = $container);
     }
 }

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -136,9 +136,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
      */
     public function setData($data)
     {
-        $this->data = $data;
-
-        return $this;
+        return tap($this, fn () => $this->data = $data);
     }
 
     /**
@@ -149,8 +147,6 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
      */
     public function setValidator($validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 }

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -79,8 +79,6 @@ class Can implements Rule, ValidatorAwareRule
      */
     public function setValidator($validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 }

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -184,9 +184,7 @@ trait DatabaseRule
      */
     public function withoutTrashed($deletedAtColumn = 'deleted_at')
     {
-        $this->whereNull($deletedAtColumn);
-
-        return $this;
+        return tap($this)->whereNull($deletedAtColumn);
     }
 
     /**
@@ -197,9 +195,7 @@ trait DatabaseRule
      */
     public function onlyTrashed($deletedAtColumn = 'deleted_at')
     {
-        $this->whereNotNull($deletedAtColumn);
-
-        return $this;
+        return tap($this)->whereNotNull($deletedAtColumn);
     }
 
     /**
@@ -210,9 +206,7 @@ trait DatabaseRule
      */
     public function using(Closure $callback)
     {
-        $this->using[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->using[] = $callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -35,9 +35,7 @@ class Dimensions implements Stringable
      */
     public function width($value)
     {
-        $this->constraints['width'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['width'] = $value);
     }
 
     /**
@@ -48,9 +46,7 @@ class Dimensions implements Stringable
      */
     public function height($value)
     {
-        $this->constraints['height'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['height'] = $value);
     }
 
     /**
@@ -61,9 +57,7 @@ class Dimensions implements Stringable
      */
     public function minWidth($value)
     {
-        $this->constraints['min_width'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['min_width'] = $value);
     }
 
     /**
@@ -74,9 +68,7 @@ class Dimensions implements Stringable
      */
     public function minHeight($value)
     {
-        $this->constraints['min_height'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['min_height'] = $value);
     }
 
     /**
@@ -87,9 +79,7 @@ class Dimensions implements Stringable
      */
     public function maxWidth($value)
     {
-        $this->constraints['max_width'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['max_width'] = $value);
     }
 
     /**
@@ -100,9 +90,7 @@ class Dimensions implements Stringable
      */
     public function maxHeight($value)
     {
-        $this->constraints['max_height'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['max_height'] = $value);
     }
 
     /**
@@ -113,9 +101,7 @@ class Dimensions implements Stringable
      */
     public function ratio($value)
     {
-        $this->constraints['ratio'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['ratio'] = $value);
     }
 
     /**
@@ -126,9 +112,7 @@ class Dimensions implements Stringable
      */
     public function minRatio($value)
     {
-        $this->constraints['min_ratio'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['min_ratio'] = $value);
     }
 
     /**
@@ -139,9 +123,7 @@ class Dimensions implements Stringable
      */
     public function maxRatio($value)
     {
-        $this->constraints['max_ratio'] = $value;
-
-        return $this;
+        return tap($this, fn () => $this->constraints['max_ratio'] = $value);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -86,9 +86,7 @@ class Enum implements Rule, ValidatorAwareRule
      */
     public function only($values)
     {
-        $this->only = $values instanceof Arrayable ? $values->toArray() : Arr::wrap($values);
-
-        return $this;
+        return tap($this, fn () => $this->only = $values instanceof Arrayable ? $values->toArray() : Arr::wrap($values));
     }
 
     /**
@@ -99,9 +97,7 @@ class Enum implements Rule, ValidatorAwareRule
      */
     public function except($values)
     {
-        $this->except = $values instanceof Arrayable ? $values->toArray() : Arr::wrap($values);
-
-        return $this;
+        return tap($this, fn () => $this->except = $values instanceof Arrayable ? $values->toArray() : Arr::wrap($values));
     }
 
     /**
@@ -141,8 +137,6 @@ class Enum implements Rule, ValidatorAwareRule
      */
     public function setValidator($validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 }

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -144,9 +144,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function extensions($extensions)
     {
-        $this->allowedExtensions = (array) $extensions;
-
-        return $this;
+        return tap($this, fn () => $this->allowedExtensions = (array) $extensions);
     }
 
     /**
@@ -186,9 +184,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function min($size)
     {
-        $this->minimumFileSize = $this->toKilobytes($size);
-
-        return $this;
+        return tap($this, fn () => $this->minimumFileSize = $this->toKilobytes($size));
     }
 
     /**
@@ -199,9 +195,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function max($size)
     {
-        $this->maximumFileSize = $this->toKilobytes($size);
-
-        return $this;
+        return tap($this, fn () => $this->maximumFileSize = $this->toKilobytes($size));
     }
 
     /**
@@ -235,9 +229,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function rules($rules)
     {
-        $this->customRules = array_merge($this->customRules, Arr::wrap($rules));
-
-        return $this;
+        return tap($this, fn () => $this->customRules = array_merge($this->customRules, Arr::wrap($rules)));
     }
 
     /**
@@ -357,9 +349,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function setValidator($validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 
     /**
@@ -370,8 +360,6 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function setData($data)
     {
-        $this->data = $data;
-
-        return $this;
+        return tap($this, fn () => $this->data = $data);
     }
 }

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -21,8 +21,6 @@ class ImageFile extends File
      */
     public function dimensions($dimensions)
     {
-        $this->rules($dimensions);
-
-        return $this;
+        return tap($this, fn () => $this->rules($dimensions));
     }
 }

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -181,9 +181,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function setValidator($validator)
     {
-        $this->validator = $validator;
-
-        return $this;
+        return tap($this, fn () => $this->validator = $validator);
     }
 
     /**
@@ -194,9 +192,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function setData($data)
     {
-        $this->data = $data;
-
-        return $this;
+        return tap($this, fn () => $this->data = $data);
     }
 
     /**
@@ -218,9 +214,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function max($size)
     {
-        $this->max = $size;
-
-        return $this;
+        return tap($this, fn () => $this->max = $size);
     }
 
     /**
@@ -245,9 +239,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function mixedCase()
     {
-        $this->mixedCase = true;
-
-        return $this;
+        return tap($this, fn () => $this->mixedCase = true);
     }
 
     /**
@@ -257,9 +249,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function letters()
     {
-        $this->letters = true;
-
-        return $this;
+        return tap($this, fn () => $this->letters = true);
     }
 
     /**
@@ -269,9 +259,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function numbers()
     {
-        $this->numbers = true;
-
-        return $this;
+        return tap($this, fn () => $this->numbers = true);
     }
 
     /**
@@ -281,9 +269,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function symbols()
     {
-        $this->symbols = true;
-
-        return $this;
+        return tap($this, fn () => $this->symbols = true);
     }
 
     /**
@@ -294,9 +280,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function rules($rules)
     {
-        $this->customRules = Arr::wrap($rules);
-
-        return $this;
+        return tap($this, fn () => $this->customRules = Arr::wrap($rules));
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -120,9 +120,7 @@ class ValidationException extends Exception
      */
     public function status($status)
     {
-        $this->status = $status;
-
-        return $this;
+        return tap($this, fn () => $this->status = $status);
     }
 
     /**
@@ -133,9 +131,7 @@ class ValidationException extends Exception
      */
     public function errorBag($errorBag)
     {
-        $this->errorBag = $errorBag;
-
-        return $this;
+        return tap($this, fn () => $this->errorBag = $errorBag);
     }
 
     /**
@@ -146,9 +142,7 @@ class ValidationException extends Exception
      */
     public function redirectTo($url)
     {
-        $this->redirectTo = $url;
-
-        return $this;
+        return tap($this, fn () => $this->redirectTo = $url);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1140,9 +1140,7 @@ class Validator implements ValidatorContract
     {
         $this->data = $this->parseData($data);
 
-        $this->setRules($this->initialRules);
-
-        return $this;
+        return tap($this)->setRules($this->initialRules);
     }
 
     /**
@@ -1208,9 +1206,7 @@ class Validator implements ValidatorContract
 
         $this->rules = [];
 
-        $this->addRules($rules);
-
-        return $this;
+        return tap($this)->addRules($rules);
     }
 
     /**
@@ -1290,9 +1286,7 @@ class Validator implements ValidatorContract
      */
     public function stopOnFirstFailure($stopOnFirstFailure = true)
     {
-        $this->stopOnFirstFailure = $stopOnFirstFailure;
-
-        return $this;
+        return tap($this, fn () => $this->stopOnFirstFailure = $stopOnFirstFailure);
     }
 
     /**
@@ -1419,9 +1413,7 @@ class Validator implements ValidatorContract
      */
     public function setCustomMessages(array $messages)
     {
-        $this->customMessages = array_merge($this->customMessages, $messages);
-
-        return $this;
+        return tap($this, fn () => $this->customMessages = array_merge($this->customMessages, $messages));
     }
 
     /**
@@ -1432,9 +1424,7 @@ class Validator implements ValidatorContract
      */
     public function setAttributeNames(array $attributes)
     {
-        $this->customAttributes = $attributes;
-
-        return $this;
+        return tap($this, fn () => $this->customAttributes = $attributes);
     }
 
     /**
@@ -1445,9 +1435,7 @@ class Validator implements ValidatorContract
      */
     public function addCustomAttributes(array $attributes)
     {
-        $this->customAttributes = array_merge($this->customAttributes, $attributes);
-
-        return $this;
+        return tap($this, fn () => $this->customAttributes = array_merge($this->customAttributes, $attributes));
     }
 
     /**
@@ -1458,9 +1446,7 @@ class Validator implements ValidatorContract
      */
     public function setImplicitAttributesFormatter(?callable $formatter = null)
     {
-        $this->implicitAttributesFormatter = $formatter;
-
-        return $this;
+        return tap($this, fn () => $this->implicitAttributesFormatter = $formatter);
     }
 
     /**
@@ -1471,9 +1457,7 @@ class Validator implements ValidatorContract
      */
     public function setValueNames(array $values)
     {
-        $this->customValues = $values;
-
-        return $this;
+        return tap($this, fn () => $this->customValues = $values);
     }
 
     /**
@@ -1484,9 +1468,7 @@ class Validator implements ValidatorContract
      */
     public function addCustomValues(array $customValues)
     {
-        $this->customValues = array_merge($this->customValues, $customValues);
-
-        return $this;
+        return tap($this, fn () => $this->customValues = array_merge($this->customValues, $customValues));
     }
 
     /**
@@ -1571,9 +1553,7 @@ class Validator implements ValidatorContract
      */
     public function ensureExponentWithinAllowedRangeUsing($callback)
     {
-        $this->ensureExponentWithinAllowedRangeUsing = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->ensureExponentWithinAllowedRangeUsing = $callback);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -986,9 +986,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function prepareStringsForCompilationUsing(callable $callback)
     {
-        $this->prepareStringsForCompilationUsing[] = $callback;
-
-        return $this;
+        return tap($this, fn () => $this->prepareStringsForCompilationUsing[] = $callback);
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -357,9 +357,7 @@ abstract class Component
      */
     public function withName($name)
     {
-        $this->componentName = $name;
-
-        return $this;
+        return tap($this, fn () => $this->componentName = $name);
     }
 
     /**

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -44,9 +44,7 @@ class ComponentSlot implements Htmlable, Stringable
      */
     public function withAttributes(array $attributes)
     {
-        $this->attributes = new ComponentAttributeBag($attributes);
-
-        return $this;
+        return tap($this, fn () => $this->attributes = new ComponentAttributeBag($attributes));
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -444,9 +444,7 @@ class Factory implements FactoryContract
      */
     public function addNamespace($namespace, $hints)
     {
-        $this->finder->addNamespace($namespace, $hints);
-
-        return $this;
+        return tap($this, fn () => $this->finder->addNamespace($namespace, $hints));
     }
 
     /**
@@ -458,9 +456,7 @@ class Factory implements FactoryContract
      */
     public function prependNamespace($namespace, $hints)
     {
-        $this->finder->prependNamespace($namespace, $hints);
-
-        return $this;
+        return tap($this, fn () => $this->finder->prependNamespace($namespace, $hints));
     }
 
     /**
@@ -472,9 +468,7 @@ class Factory implements FactoryContract
      */
     public function replaceNamespace($namespace, $hints)
     {
-        $this->finder->replaceNamespace($namespace, $hints);
-
-        return $this;
+        return tap($this, fn () => $this->finder->replaceNamespace($namespace, $hints));
     }
 
     /**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -285,9 +285,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function setPaths($paths)
     {
-        $this->paths = $paths;
-
-        return $this;
+        return tap($this, fn () => $this->paths = $paths);
     }
 
     /**


### PR DESCRIPTION
Refactor chainable/fluent class methods to use `tap()` where possible

This doesn't require new tests as the existing tests not failing should prove that there are no side-effects outside of the changed methods

## Rules
* Only methods that `return $this` and **one** additional line will be reduced to a one-liner (since additional lines could not be transformed into an arrow function. Using normal functions would nullify the line reduction benefit. Only using the last line before the `return $this` would look inconsistent)
    * These are mostly setters
    ```diff
    public function setA($a)
    {
    - $this->a = $a;
    - 
    - return $this;
    + return tap($this, fn () => $this->a = $a);
    }
    ```
* When the last operation before the `return $this` in a method is a method call on `$this`, the higher-order tap is used instead
* In two cases, this could be further optimizes by passing a first-class callable as the second argument