### PR TITLE
[11.x] Support Single and Multi-Selection for Publishing Stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -141,7 +141,7 @@ class StubPublishCommand extends Command
             ->only(
                 multisearch(
                     'Which stubs would you like to publish?',
-                    options: fn ($search) => collect($stubs)
+                    options: fn ($search) => collect($commonStubs)
                         ->filter(fn ($to) => str_contains($to, $search))
                         ->mapWithKeys(fn ($to, $from) => [
                             $from => $this->forHumans($to),

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -123,18 +123,18 @@ class StubPublishCommand extends Command
 
         $commonStubs = collect($stubs)
             ->filter(fn ($to, $from) => Str::contains($from, [
-                    'model',
-                    'controller',
-                    'migration',
-                    'seeder',
-                    'factory',
-                    'test',
-                    'pest',
-                    'resource',
-                    'notification',
-                    'mail',
-                    'job',
-                ]))
+                'model',
+                'controller',
+                'migration',
+                'seeder',
+                'factory',
+                'test',
+                'pest',
+                'resource',
+                'notification',
+                'mail',
+                'job',
+            ]))
             ->all();
 
         return collect($commonStubs)
@@ -144,7 +144,7 @@ class StubPublishCommand extends Command
                     options: fn ($search) => collect($stubs)
                         ->filter(fn ($to) => str_contains($to, $search))
                         ->mapWithKeys(fn ($to, $from) => [
-                            $from => $this->forHumans($to)
+                            $from => $this->forHumans($to),
                         ])
                         ->sort()
                         ->all(),
@@ -171,7 +171,7 @@ class StubPublishCommand extends Command
         if ($parts->count() <= 1) {
             return $parts->first();
         }
-        
+
         // Set the second segment as the prefix and join the remaining segments.
         return $parts
             ->splice(1, 1)

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Events\PublishingStubs;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\multisearch;
@@ -134,7 +134,7 @@ class StubPublishCommand extends Command
     /**
      * Get a human-readable name for the given stub.
      */
-    private function forHumans(string $stub): string 
+    private function forHumans(string $stub): string
     {
         $parts = Str::of($stub)
             ->beforeLast('.stub')

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -122,9 +122,9 @@ class StubPublishCommand extends Command
 
         return collect($stubs)->only(multisearch(
             'Which stubs would you like to publish?',
-            options: fn($search) => collect($stubs)
-                ->filter(fn($to) => str_contains($to, $search))
-                ->map(fn($to) => $to)
+            options: fn ($search) => collect($stubs)
+                ->filter(fn ($to) => str_contains($to, $search))
+                ->map(fn ($to) => $to)
                 ->all(),
             scroll: 10,
         ))->all();


### PR DESCRIPTION
This PR adds support for single and multi-selection using Laravel Prompts in the `stub:publish` artisan command.


https://github.com/user-attachments/assets/ae4325f1-35b2-454b-9840-ad1f7755f4ed

The `stub:publish` command currently publishes all customizable stubs, which now includes 52 stubs. With this change, it adds flexibility for developers who only need to customize a few specific stubs.

- You can now choose which stubs to publish directly from a selection menu, making it easier to target just the stubs you need.

- `--all` Option: If you prefer to publish everything, the `--all` flag skips the menu and works just like it does today.


## Examples:

### Interactive Mode:
Simply run:

```bash
php artisan stub:publish
```

and select one or more stubs from the list:
![image](https://github.com/user-attachments/assets/2eaed011-5e2f-4c3d-90a7-309255a40e95)

End Result:

![image](https://github.com/user-attachments/assets/a9ec0a55-721b-40a5-8859-563d80991990)

### Publish All:
Use the --all flag to publish everything at once:

```bash
php artisan stub:publish --all
```

![image](https://github.com/user-attachments/assets/6cf717e3-502d-46b7-9daf-f13c0b3981b0)

