### PR TITLE
[12.x] Add `hasMorePages()` to `CursorPaginator` contract

### DIFF
--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -98,6 +98,13 @@ interface CursorPaginator
     public function hasPages();
 
     /**
+     * Determine if there are more items in the data source.
+     *
+     * @return bool
+     */
+    public function hasMorePages();
+
+    /**
      * Get the base path for paginator generated URLs.
      *
      * @return string|null


### PR DESCRIPTION
All the `cursorPaginate()` methods in different implementations return the `CursorPaginator` contract, like this one:

https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Query/Builder.php#L3222

```php
/**
 * @return \Illuminate\Contracts\Pagination\CursorPaginator
 */
public function cursorPaginate($perPage = 15, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
```

However, unlike the regular [Paginator](https://github.com/laravel/framework/blob/master/src/Illuminate/Contracts/Pagination/Paginator.php#L98) contract, the `CursorPaginator` does not include the `hasMorePages()` method.