### PR TITLE
[11.x] Fix the RateLimiter issue when using dynamic keys

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -85,7 +85,9 @@ class RateLimiter
 
             foreach ($result as $limit) {
                 if ($duplicates->contains($limit->key)) {
-                    $limit->key = $limit->fallbackKey();
+                    $limit->key = empty($limit->key)
+                        ? $limit->fallbackKey()
+                        : $limit->key.':'.$limit->fallbackKey();
                 }
             }
 

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -85,9 +85,7 @@ class RateLimiter
 
             foreach ($result as $limit) {
                 if ($duplicates->contains($limit->key)) {
-                    $limit->key = empty($limit->key)
-                        ? $limit->fallbackKey()
-                        : $limit->key.':'.$limit->fallbackKey();
+                    $limit->key = $limit->fallbackKey();
                 }
             }
 

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -150,7 +150,7 @@ class Limit
      */
     public function fallbackKey()
     {
-        $prefix = $this->key ? '' : "{$this->key}:";
+        $prefix = $this->key ? "{$this->key}:" : '';
 
         return "{$prefix}attempts:{$this->maxAttempts}:decay:{$this->decaySeconds}";
     }

--- a/tests/Cache/RateLimiterTest.php
+++ b/tests/Cache/RateLimiterTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -37,6 +39,33 @@ class RateLimiterTest extends TestCase
         $limiterClosure = $rateLimiter->limiter($name);
 
         $this->assertNotNull($limiterClosure);
+    }
+
+    public function testShouldUseOriginKeyAsPrefixWhenMultipleLimiterWithSameKey()
+    {
+        $rateLimiter = new RateLimiter(new Repository(new ArrayStore));
+
+        $rateLimiter->for('user_limiter', fn (string $userId) => [
+            Limit::perSecond(3)->by($userId),
+            Limit::perMinute(5)->by($userId),
+        ]);
+
+        $userId1 = '123';
+        $userId2 = '456';
+
+        $limiterForUser1 = $rateLimiter->limiter('user_limiter')($userId1);
+        $limiterForUser2 = $rateLimiter->limiter('user_limiter')($userId2);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->assertFalse($rateLimiter->tooManyAttempts($limiterForUser1[0]->key, $limiterForUser1[0]->maxAttempts));
+            $this->assertFalse($rateLimiter->tooManyAttempts($limiterForUser2[0]->key, $limiterForUser2[0]->maxAttempts));
+
+            $rateLimiter->hit($limiterForUser1[0]->key, $limiterForUser1[0]->decaySeconds);
+            $rateLimiter->hit($limiterForUser2[0]->key, $limiterForUser2[0]->decaySeconds);
+        }
+
+        $this->assertNotSame($limiterForUser1[0]->key, $limiterForUser2[0]->key);
+        $this->assertNotSame($limiterForUser1[1]->key, $limiterForUser2[1]->key);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In Laravel [v11.29.0](https://github.com/laravel/framework/compare/v11.28.1...v11.29.0), a new modification was introduced to the `RateLimiter` via [PR #53177](https://github.com/laravel/framework/pull/53177), which provides a fallback key when no unique key is specified. However, this mechanism can cause issues in scenarios where the key is determined dynamically using a closure.

For example, when implementing rate limiting based on dynamic `userId` values:

```php
$rateLimiter->for('user_limiter', fn (string $userId) => [
    Limit::perSecond(3)->by($userId),
    Limit::perMinute(5)->by($userId),
]);

$userId1 = '123';
$userId2 = '456';

$limiterForUser1 = $rateLimiter->limiter('user_limiter')($userId1);
$limiterForUser2 = $rateLimiter->limiter('user_limiter')($userId2);
```

In version 11.29.0, the `Limit::by($userId)` method is ignored, and the fallback key is used instead, causing rate limiting records for different `userId` values to interfere with each other.

This fix ensures that if the original limit has a recorded key, it uses the original key as a prefix. For more details, please refer to the PR.