### PR TITLE
[11.x] HasMiddlewareHooks trait - Adds job middleware before, after, onFail Hooks

### DIFF
--- a/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
+++ b/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Middleware;
 
-
 trait HasMiddlewareHooks
 {
     /**

--- a/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
+++ b/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
@@ -6,8 +6,6 @@ use Illuminate\Support\Traits\ForwardsCalls;
 
 trait HasMiddlewareHooks
 {
-    use ForwardsCalls;
-
     /**
      * The wrapper we are creating for this middleware.
      */
@@ -17,10 +15,12 @@ trait HasMiddlewareHooks
      * Adds a hook to the middleware and returns a wrapped middleware instance.
      * The hook should accept the job instance as its only argument.
      * Supported hooks are `before`, `after`, and `onFail`.
+     *
+     * @throws \BadMethodCallException
      */
     public function addHook(string $hookType, callable $hook): WrappedMiddleware
     {
-        return $this->forwardCallTo($this->getHookWrapper(), $hookType, [$hook]);
+        return $this->getHookWrapper()->$hookType($hook);
     }
 
     /**
@@ -69,5 +69,21 @@ trait HasMiddlewareHooks
     public function onPass(callable $callback): WrappedMiddleware
     {
         return $this->addHook('after', $callback);
+    }
+
+    /**
+     * When condition is evaluated as false, the middleware will be skipped.
+     */
+    public function skipUnless(callable|bool $condition): WrappedMiddleware
+    {
+        return $this->getHookWrapper()->skipUnless($condition);
+    }
+
+    /**
+     * When condition is evaluated as true, the middleware will be skipped.
+     */
+    public function skipWhen(callable|bool $condition): WrappedMiddleware
+    {
+        return $this->getHookWrapper()->skipWhen($condition);
     }
 }

--- a/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
+++ b/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Illuminate\Support\Traits\ForwardsCalls;
+
+trait HasMiddlewareHooks
+{
+    use ForwardsCalls;
+    protected mixed $hookWrapper = null;
+
+    public function addHook(string $hookType, callable $hook): WrappedMiddleware
+    {
+        return $this->forwardCallTo($this->getHookWrapper(), $hookType, [$hook]);
+    }
+
+    protected function getHookWrapper(): WrappedMiddleware
+    {
+        if (! $this->hookWrapper) {
+            $this->hookWrapper = new WrappedMiddleware($this);
+        }
+
+        return $this->hookWrapper;
+    }
+
+    public function before(callable $callback): WrappedMiddleware
+    {
+        return $this->addHook('before', $callback);
+    }
+
+    public function after(callable $callback): WrappedMiddleware
+    {
+        return $this->addHook('after', $callback);
+    }
+
+    public function onFail(callable $callback): WrappedMiddleware
+    {
+        return $this->addHook('onFail', $callback);
+    }
+
+    public function onPass(callable $callback): WrappedMiddleware
+    {
+        return $this->addHook('after', $callback);
+    }
+}

--- a/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
+++ b/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Middleware;
 
-use Illuminate\Support\Traits\ForwardsCalls;
 
 trait HasMiddlewareHooks
 {

--- a/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
+++ b/src/Illuminate/Queue/Middleware/HasMiddlewareHooks.php
@@ -7,13 +7,25 @@ use Illuminate\Support\Traits\ForwardsCalls;
 trait HasMiddlewareHooks
 {
     use ForwardsCalls;
-    protected mixed $hookWrapper = null;
 
+    /**
+     * The wrapper we are creating for this middleware.
+     */
+    protected ?WrappedMiddleware $hookWrapper = null;
+
+    /**
+     * Adds a hook to the middleware and returns a wrapped middleware instance.
+     * The hook should accept the job instance as its only argument.
+     * Supported hooks are `before`, `after`, and `onFail`.
+     */
     public function addHook(string $hookType, callable $hook): WrappedMiddleware
     {
         return $this->forwardCallTo($this->getHookWrapper(), $hookType, [$hook]);
     }
 
+    /**
+     * Initializes and returns the middleware wrapper.
+     */
     protected function getHookWrapper(): WrappedMiddleware
     {
         if (! $this->hookWrapper) {
@@ -23,21 +35,37 @@ trait HasMiddlewareHooks
         return $this->hookWrapper;
     }
 
+    /**
+     * Registers a callback to be executed before the middleware is handled.
+     * If the callback returns false or releases or fails the job, the middleware will be aborted.
+     * The callback should accept the job instance as its only argument.
+     */
     public function before(callable $callback): WrappedMiddleware
     {
         return $this->addHook('before', $callback);
     }
 
+    /**
+     * Registers a callback to be executed after the middleware is handled, but before `$next` is called.
+     * The callback should accept the job instance as its only argument.
+     */
     public function after(callable $callback): WrappedMiddleware
     {
         return $this->addHook('after', $callback);
     }
 
+    /**
+     * Registers a callback to be executed if the middleware does not call `$next` and fails.
+     * The callback should accept the job instance as its only argument.
+     */
     public function onFail(callable $callback): WrappedMiddleware
     {
         return $this->addHook('onFail', $callback);
     }
 
+    /**
+     * Same as `after`, just a more semantic name.
+     */
     public function onPass(callable $callback): WrappedMiddleware
     {
         return $this->addHook('after', $callback);

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -12,6 +12,8 @@ use function Illuminate\Support\enum_value;
 
 class RateLimited
 {
+    use HasMiddlewareHooks;
+
     /**
      * The rate limiter instance.
      *

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -8,6 +8,8 @@ use Throwable;
 
 class ThrottlesExceptions
 {
+    use HasMiddlewareHooks;
+
     /**
      * The developer specified key that the rate limiter should use.
      *

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -8,7 +8,7 @@ use Illuminate\Support\InteractsWithTime;
 
 class WithoutOverlapping
 {
-    use InteractsWithTime;
+    use HasMiddlewareHooks, InteractsWithTime;
 
     /**
      * The job's unique key used for preventing overlaps.

--- a/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
+++ b/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+class WrappedMiddleware
+{
+    protected mixed $beforeMiddleware = null;
+
+    protected mixed $afterMiddleware = null;
+
+    protected mixed $onFail = null;
+
+    protected bool $middlewarePassed = false;
+
+    public function __construct(
+        protected object $middleware,
+    ) {}
+
+    public function handle($job, $next): void
+    {
+        if (
+            $this->beforeMiddleware &&
+            (
+                call_user_func($this->beforeMiddleware, $job) === false ||
+                $job->job->isReleased() ||
+                $job->job->hasFailed()
+            )
+        ) {
+            return;
+        }
+
+        $next = function ($job) use ($next) {
+            $this->middlewarePassed = true;
+
+            if ($this->afterMiddleware) {
+                call_user_func($this->afterMiddleware, $job);
+            }
+
+            $next($job);
+        };
+
+        $this->middleware->handle($job, $next);
+
+        if (! $this->middlewarePassed && $this->onFail) {
+            call_user_func($this->onFail, $job);
+        }
+    }
+
+    public function before(callable $before): object
+    {
+        $this->beforeMiddleware = $before;
+
+        return $this;
+    }
+
+    public function after(callable $after): object
+    {
+        $this->afterMiddleware = $after;
+
+        return $this;
+    }
+
+    public function onFail(callable $callback): object
+    {
+        $this->onFail = $callback;
+
+        return $this;
+    }
+
+    public function onPass(callable $callback): object
+    {
+        $this->after($callback);
+
+        return $this;
+    }
+
+    public function addHook(string $hookType, callable $hook): object
+    {
+        return $this->$hookType($hook);
+    }
+}

--- a/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
+++ b/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
@@ -4,20 +4,48 @@ namespace Illuminate\Queue\Middleware;
 
 class WrappedMiddleware
 {
+    /**
+     * The callback that is executed before the middleware is handled.
+     *
+     * @var callable|null
+     */
     protected mixed $beforeMiddleware = null;
 
+    /**
+     * The callback that is executed after the middleware is handled successfully (before `$next` is called).
+     *
+     * @var callable|null
+     */
     protected mixed $afterMiddleware = null;
 
+    /**
+     * The callback that is executed if the middleware does not call `$next` and fails.
+     *
+     * @var callable|null
+     */
     protected mixed $onFail = null;
 
+    /**
+     * Indicates if the middleware has passed.
+     */
     protected bool $middlewarePassed = false;
 
+    /**
+     * @var object $middleware The initialized middleware instance.
+     */
     public function __construct(
         protected object $middleware,
     ) {
     }
 
-    public function handle($job, $next): void
+    /**
+     * Handles the job by wrapping the initial middleware and executing the before and after callbacks
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
     {
         if (
             $this->beforeMiddleware &&
@@ -47,6 +75,11 @@ class WrappedMiddleware
         }
     }
 
+    /**
+     * Registers a callback to be executed before the middleware is handled.
+     * If the callback returns false or releases or fails the job, the middleware will be aborted.
+     * The callback should accept the job instance as its only argument.
+     */
     public function before(callable $before): object
     {
         $this->beforeMiddleware = $before;
@@ -54,6 +87,10 @@ class WrappedMiddleware
         return $this;
     }
 
+    /**
+     * Registers a callback to be executed after the middleware is handled, but before `$next` is called.
+     * The callback should accept the job instance as its only argument.
+     */
     public function after(callable $after): object
     {
         $this->afterMiddleware = $after;
@@ -61,6 +98,10 @@ class WrappedMiddleware
         return $this;
     }
 
+    /**
+     * Registers a callback to be executed if the middleware does not call `$next` and fails.
+     * The callback should accept the job instance as its only argument.
+     */
     public function onFail(callable $callback): object
     {
         $this->onFail = $callback;
@@ -68,6 +109,9 @@ class WrappedMiddleware
         return $this;
     }
 
+    /**
+     * Same as `after`, just a more semantic name.
+     */
     public function onPass(callable $callback): object
     {
         $this->after($callback);
@@ -75,6 +119,11 @@ class WrappedMiddleware
         return $this;
     }
 
+    /**
+     * Adds a hook to the middleware and returns a wrapped middleware instance.
+     * The hook should accept the job instance as its only argument.
+     * Supported hooks are `before`, `after`, and `onFail`.
+     */
     public function addHook(string $hookType, callable $hook): object
     {
         return $this->$hookType($hook);

--- a/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
+++ b/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
@@ -14,7 +14,8 @@ class WrappedMiddleware
 
     public function __construct(
         protected object $middleware,
-    ) {}
+    ) {
+    }
 
     public function handle($job, $next): void
     {

--- a/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
+++ b/src/Illuminate/Queue/Middleware/WrappedMiddleware.php
@@ -33,7 +33,7 @@ class WrappedMiddleware
     protected bool $skip = false;
 
     /**
-     * @var object $middleware The initialized middleware instance.
+     * @var object The initialized middleware instance.
      */
     public function __construct(
         protected object $middleware,
@@ -41,7 +41,7 @@ class WrappedMiddleware
     }
 
     /**
-     * Handles the job by wrapping the initial middleware and executing the before and after callbacks
+     * Handles the job by wrapping the initial middleware and executing the before and after callbacks.
      *
      * @param  mixed  $job
      * @param  callable  $next
@@ -129,6 +129,4 @@ class WrappedMiddleware
 
         throw new \BadMethodCallException("Method {$method} does not exist.");
     }
-
-
 }

--- a/tests/Integration/Queue/WrappedMiddlewareTest.php
+++ b/tests/Integration/Queue/WrappedMiddlewareTest.php
@@ -193,6 +193,7 @@ class WrappedMiddlewareTest extends TestCase
         $class::$calls = [];
         $class::$before = function ($job) {
             $job::$calls[] = 'before';
+
             return false;
         };
         $class::$after = fn ($job) => $job::$calls[] = 'after';

--- a/tests/Integration/Queue/WrappedMiddlewareTest.php
+++ b/tests/Integration/Queue/WrappedMiddlewareTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WrappedMiddleware;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class WrappedMiddlewareTest extends TestCase
+{
+    public function testBeforeAndAfterCalled()
+    {
+        $job = new WrappedMiddlewareTestJob();
+
+        $this->assertJobRanSuccessfully($job);
+        $this->assertContains('before', $job::$calls);
+        $this->assertContains('middlewareBefore', $job::$calls);
+        $this->assertContains('middlewareAfter', $job::$calls);
+        $this->assertContains('after', $job::$calls);
+        $this->assertNotContains('onFail', $job::$calls);
+        $this->assertSame(['before', 'middlewareBefore', 'after', 'jobHandle', 'middlewareAfter'], $job::$calls);
+    }
+
+    public function testBeforeCalledWhenMiddlewareReleases()
+    {
+        $job = new WrappedMiddlewareTestJob();
+
+        $this->assertReleasedInMiddleware($job);
+        $this->assertContains('before', $job::$calls);
+        $this->assertContains('middlewareBefore', $job::$calls);
+        $this->assertNotContains('middlewareAfter', $job::$calls);
+        $this->assertNotContains('after', $job::$calls);
+        $this->assertContains('onFail', $job::$calls);
+        $this->assertSame(['before', 'middlewareBefore', 'onFail'], $job::$calls);
+    }
+
+    public function testBeforeAndAfterCalledWhenJobReleases()
+    {
+        $job = new WrappedMiddlewareTestJob();
+
+        $this->assertReleasedInJob($job);
+        $this->assertContains('before', $job::$calls);
+        $this->assertContains('middlewareBefore', $job::$calls);
+        $this->assertContains('middlewareAfter', $job::$calls);
+        $this->assertContains('after', $job::$calls);
+        $this->assertNotContains('onFail', $job::$calls);
+        $this->assertSame(['before', 'middlewareBefore', 'after', 'jobHandle', 'middlewareAfter'], $job::$calls);
+    }
+
+    public function testBeforeCalledWhenMiddlewareFails()
+    {
+        $job = new WrappedMiddlewareTestJob();
+
+        $this->assertFailedInMiddleware($job);
+        $this->assertContains('before', $job::$calls);
+        $this->assertContains('middlewareBefore', $job::$calls);
+        $this->assertNotContains('middlewareAfter', $job::$calls);
+        $this->assertNotContains('after', $job::$calls);
+        $this->assertContains('onFail', $job::$calls);
+        $this->assertSame(['before', 'middlewareBefore', 'onFail'], $job::$calls);
+    }
+
+    public function testBeforeMethodCanShortCircuitMiddleware()
+    {
+        $job = new WrappedMiddlewareTestJob();
+
+        $this->assertMiddlewareSkipped($job);
+        $this->assertContains('before', $job::$calls);
+        $this->assertNotContains('middlewareBefore', $job::$calls);
+        $this->assertNotContains('middlewareAfter', $job::$calls);
+        $this->assertNotContains('after', $job::$calls);
+        $this->assertNotContains('onFail', $job::$calls);
+        $this->assertSame(['before'], $job::$calls);
+    }
+
+    protected function assertJobRanSuccessfully($class)
+    {
+        $class::$calls = [];
+        $class::$before = fn ($job) => $job::$calls[] = 'before';
+        $class::$after = fn ($job) => $job::$calls[] = 'after';
+        $class::$onFail = fn ($job) => $job::$calls[] = 'onFail';
+        $class::$shouldRelease = false;
+        $class::$middlewareToUse = DefaultMiddlewareToBeWrapped::class;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertContains('jobHandle', $class::$calls);
+    }
+
+    protected function assertReleasedInMiddleware($class)
+    {
+        $class::$calls = [];
+        $class::$before = fn ($job) => $job::$calls[] = 'before';
+        $class::$after = fn ($job) => $job::$calls[] = 'after';
+        $class::$onFail = fn ($job) => $job::$calls[] = 'onFail';
+        $class::$shouldRelease = false;
+        $class::$middlewareToUse = ReleaseMiddleware::class;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('release')->once();
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertNotContains('jobHandle', $class::$calls);
+    }
+
+    protected function assertReleasedInJob($class)
+    {
+        $class::$calls = [];
+        $class::$before = fn ($job) => $job::$calls[] = 'before';
+        $class::$after = fn ($job) => $job::$calls[] = 'after';
+        $class::$onFail = fn ($job) => $job::$calls[] = 'onFail';
+        $class::$shouldRelease = true;
+        $class::$middlewareToUse = DefaultMiddlewareToBeWrapped::class;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('release')->once();
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertContains('jobHandle', $class::$calls);
+    }
+
+    protected function assertFailedInMiddleware($class)
+    {
+        $class::$calls = [];
+        $class::$before = fn ($job) => $job::$calls[] = 'before';
+        $class::$after = fn ($job) => $job::$calls[] = 'after';
+        $class::$onFail = fn ($job) => $job::$calls[] = 'onFail';
+        $class::$shouldRelease = false;
+        $class::$middlewareToUse = FailureMiddleware::class;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('fail')->once();
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('hasFailed')->andReturn(true);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertNotContains('jobHandle', $class::$calls);
+    }
+
+    protected function assertMiddlewareSkipped($class)
+    {
+        $class::$calls = [];
+        $class::$before = function ($job) {
+            $job::$calls[] = 'before';
+            return false;
+        };
+        $class::$after = fn ($job) => $job::$calls[] = 'after';
+        $class::$onFail = fn ($job) => $job::$calls[] = 'onFail';
+        $class::$shouldRelease = false;
+        $class::$middlewareToUse = DefaultMiddlewareToBeWrapped::class;
+
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+        $job->shouldNotReceive('release');
+        $job->shouldNotReceive('fail');
+
+        $job->shouldReceive('hasFailed')->once()->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
+        $job->shouldReceive('delete')->once();
+        $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertNotContains('jobHandle', $class::$calls);
+    }
+}
+
+class DefaultMiddlewareToBeWrapped
+{
+    public function handle($job, $next): void
+    {
+        $job::$calls[] = 'middlewareBefore';
+
+        $next($job);
+
+        $job::$calls[] = 'middlewareAfter';
+    }
+}
+
+class ReleaseMiddleware
+{
+    public function handle($job, $next): void
+    {
+        $job::$calls[] = 'middlewareBefore';
+
+        $job->release(1);
+    }
+}
+
+class FailureMiddleware
+{
+    public function handle($job, $next): void
+    {
+        $job::$calls[] = 'middlewareBefore';
+
+        $job->fail(new \Exception('Failed'));
+    }
+}
+
+class WrappedMiddlewareTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $calls = [];
+
+    public static $before;
+
+    public static $after;
+
+    public static $onFail;
+
+    public static $middlewareToUse = DefaultMiddlewareToBeWrapped::class;
+
+    public static $shouldRelease = false;
+
+    public function handle()
+    {
+        self::$calls[] = 'jobHandle';
+
+        if (self::$shouldRelease) {
+            $this->release(1);
+        }
+    }
+
+    public function middleware(): array
+    {
+        return [
+            (new WrappedMiddleware(new self::$middlewareToUse))
+                ->before(self::$before)
+                ->after(self::$after)
+                ->onFail(self::$onFail),
+        ];
+    }
+}

--- a/tests/Queue/HasMiddlewareHooksTest.php
+++ b/tests/Queue/HasMiddlewareHooksTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use BadMethodCallException;
+use Illuminate\Queue\Middleware\HasMiddlewareHooks;
+use Illuminate\Queue\Middleware\WrappedMiddleware;
+use PHPUnit\Framework\TestCase;
+
+class HasMiddlewareHooksTest extends TestCase
+{
+    public function testCreatesAndReturnsWrappedMiddleware()
+    {
+        $getMiddleware = function () {
+            return new class {
+                use HasMiddlewareHooks;
+
+                public function handle($job, $next)
+                {
+                    $next($job);
+                }
+            };
+        };
+
+        $this->assertNotInstanceOf(WrappedMiddleware::class, $getMiddleware());
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->before(fn($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->after(fn($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->onFail(fn($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->addHook('before', fn($job) => true));
+    }
+
+    public function testThrowsExceptionWhenHookIsNotSupported()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $middleware = new class {
+            use HasMiddlewareHooks;
+
+            public function handle($job, $next)
+            {
+                $next($job);
+            }
+        };
+
+        $middleware->addHook('unsupported', fn($job) => true);
+    }
+
+    public function testChainedMethodsReturnSameInstance()
+    {
+        $middleware = new class {
+            use HasMiddlewareHooks;
+
+            public function handle($job, $next)
+            {
+                $next($job);
+            }
+        };
+
+        $beforeInstance = $middleware->before(fn($job) => true);
+        $afterInstance = $middleware->after(fn($job) => true);
+        $onFailInstance = $middleware->onFail(fn($job) => true);
+
+        $this->assertSame($beforeInstance, $afterInstance);
+        $this->assertSame($beforeInstance, $onFailInstance);
+    }
+}

--- a/tests/Queue/HasMiddlewareHooksTest.php
+++ b/tests/Queue/HasMiddlewareHooksTest.php
@@ -12,7 +12,8 @@ class HasMiddlewareHooksTest extends TestCase
     public function testCreatesAndReturnsWrappedMiddleware()
     {
         $getMiddleware = function () {
-            return new class {
+            return new class
+            {
                 use HasMiddlewareHooks;
 
                 public function handle($job, $next)
@@ -23,17 +24,18 @@ class HasMiddlewareHooksTest extends TestCase
         };
 
         $this->assertNotInstanceOf(WrappedMiddleware::class, $getMiddleware());
-        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->before(fn($job) => true));
-        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->after(fn($job) => true));
-        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->onFail(fn($job) => true));
-        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->addHook('before', fn($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->before(fn ($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->after(fn ($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->onFail(fn ($job) => true));
+        $this->assertInstanceOf(WrappedMiddleware::class, $getMiddleware()->addHook('before', fn ($job) => true));
     }
 
     public function testThrowsExceptionWhenHookIsNotSupported()
     {
         $this->expectException(BadMethodCallException::class);
 
-        $middleware = new class {
+        $middleware = new class
+        {
             use HasMiddlewareHooks;
 
             public function handle($job, $next)
@@ -42,12 +44,13 @@ class HasMiddlewareHooksTest extends TestCase
             }
         };
 
-        $middleware->addHook('unsupported', fn($job) => true);
+        $middleware->addHook('unsupported', fn ($job) => true);
     }
 
     public function testChainedMethodsReturnSameInstance()
     {
-        $middleware = new class {
+        $middleware = new class
+        {
             use HasMiddlewareHooks;
 
             public function handle($job, $next)
@@ -56,9 +59,9 @@ class HasMiddlewareHooksTest extends TestCase
             }
         };
 
-        $beforeInstance = $middleware->before(fn($job) => true);
-        $afterInstance = $middleware->after(fn($job) => true);
-        $onFailInstance = $middleware->onFail(fn($job) => true);
+        $beforeInstance = $middleware->before(fn ($job) => true);
+        $afterInstance = $middleware->after(fn ($job) => true);
+        $onFailInstance = $middleware->onFail(fn ($job) => true);
 
         $this->assertSame($beforeInstance, $afterInstance);
         $this->assertSame($beforeInstance, $onFailInstance);


### PR DESCRIPTION
This PR provides a trait that allows for hooks into existing job middleware at the point of failure or success with a simple api. It allows for modification of the Job itself before the middleware is executed, after it is successful (before `$next($job)` is called, or if it failed (failed or released). Not only does this allow for modifications, but also provides the needed ability to determine _which_ middleware released/failed the job, allowing for enhanced monitoring and better job handling. It also provides the ability to skip the middleware if a condition is met.

### Example Usage:

```php
public function middleware(): array
{
    return [
        (new MyMiddleware)
            ->before(fn ($job) => Log::info('Job entering MyMiddleware', compact('job')))
            ->after(fn ($job) => Log::info('Job passed MyMiddleware. $next($job) will be called.', compact('job')))
            ->onFail(fn ($job) => Log::info('Job did not pass MyMiddleware. $next($job) will not be called.', [
                'job' => $job,
                'isReleased' => $job->job->isReleased(),
                'hasFailed' => $job->job->hasFailed(),
            ]))
            ->skipWhen($this->someCondition),
    ];
}
```

### Background and usage:
This came about when trying to (1) diagnose and report which middleware was releasing jobs and (2) then trying to modify the job if it was released for a specific reason. 

Some of the jobs were leveraging several middlewares, including RateLimited and WithoutOverlapping. When the jobs would release, there is no easy way to figure out why it was released unless we extended every middleware we were using and write a wrapper for the `handle()` method.

The thought occurred that it would be much simpler to handle these random scenarios with something like: `(new RateLimitedWithRedis('rate-limiter'))->onFail(fn ($job) => $job->failReason = 'Rate Limiting')`"

### Quick example showcasing the issue:
```php
// normal middlewares
class LoggerMiddleware
{
    public function handle($job, $next)
    {
        $next($job);

        if ($job->job->isReleased() || $job->job->hasFailed()) {
                Log::info('Job failed or released... but why?', ['job' => $job]);
        }
    }
}
class MiddlewareA
{
    public function handle($job, $next)
    {
        if (rand(0, 1)) {
            $next($job);
        } else {
            $job->release(5);
        }
    }
}

class MiddlewareB
{
    public function handle($job, $next)
    {
        if (rand(0, 1)) {
            $next($job);
        } else {
            $job->release(5);
        }
    }
}

// normal job
class Job implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable;
    
    public function middleware()
    {
        return [new LoggerMiddleware, new MiddlewareA, new MiddlewareB];
    }
    
    public function handle()
    {
        dump('handled');
    }
}
```

When `Job::dispatch()` is called, there is a 50% chance it passes `MiddlewareA`, and if it passes, another 50% chance it passes `MiddlewareB`. As it stands, there is no way to know whether it was `MiddlewareA` or `MiddlewareB` or the job handle itself that called `release()`.

The current solution is to extend the middleware, but that doesn't feel right, especially when different jobs might want to do different things with the same middleware.


### Order of operations:
```php

class MiddlewareA
{
    use HasMiddlewareHooks;

    public function handle($job, $next)
    {
        Log::info('MiddlewareA initialized');
        
        if (rand(0, 1)) {
            $next($job);
        } else {
            $job->release(5);
        }

        $job->status = 'MiddlewareA finished';
    }
}

class MiddlewareB
{
    use HasMiddlewareHooks;

    public function handle($job, $next)
    {
        Log::info('MiddlewareB initialized');
        
        if (rand(0, 1)) {
            $next($job);
        } else {
            $job->release(5);
        }

        $job->status = 'MiddlewareB finished';
    }
}

// normal job
class Job implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable;
    
    public function middleware()
    {
        return [
            (new MiddlewareA)
                ->before(fn ($job) => Log::info('MiddlewareA before'))
                ->after(fn ($job) => Log::info('MiddlewareA after'))
                ->onFail(fn ($job) => Log::info('MiddlewareA failed')),
            (new MiddlewareB)
                ->before(fn ($job) => Log::info('MiddlewareB before'))
                ->after(fn ($job) => Log::info('MiddlewareB after'))
                ->onFail(fn ($job) => Log::info('MiddlewareB failed')),
        ];
    }
    
    public function handle()
    {
        Log::info('Job Handled');
    }
}
```

#### Logs when both middlewares pass:
```
MiddlewareA before
MiddlewareA initialized
MiddlewareA passed
MiddlewareB before
MiddlewareB initialized
MiddlewareB passed
JobHandled
MiddlewareB finished
MiddlewareA finished
```

#### Logs when MiddlewareA fails:
```
MiddlewareA before
MiddlewareA initialized
MiddlewareA failed
MiddlewareA finished
```

#### Logs when MiddlewareB fails:
```
MiddlewareA before
MiddlewareA initialized
MiddlewareA passed
MiddlewareB before
MiddlewareB initialized
MiddlewareB failed
MiddlewareB finished
MiddlewareA finished
```

### Additional Notes

If the `before()` hook releases the job, fails the job, or returns `false`, the middleware is aborted before it is ever executed. Using the example above, and changing MiddlewareA's `before()` to: `before(fn ($job) => false)`, the logs would only show:
```
MiddlewareA before
```

The `skipWhen` or `skipUnless` will skip the `handle()` of the middleware and simply call `$next($job)`, but it will not skip initialization of the middleware. So queries and modifications in the `__construct()` would still be executed.