### PR TITLE
[11.x] Add string support to Matching->whereContains()

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -157,6 +157,18 @@ trait Matching
      */
     public function whereContains(string $key, $expected)
     {
+        if (is_string($expected)) {
+            PHPUnit::assertTrue(
+                str_contains($key, $expected),
+                sprintf(
+                    'Property [%s] does not contain string [%s].',
+                    $key,
+                    $expected
+                )
+            );
+            return $this;
+        }
+
         $actual = new Collection(
             $this->prop($key) ?? $this->prop()
         );

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -580,6 +580,23 @@ class AssertTest extends TestCase
         $assert->where('bar', BackedEnum::test_empty);
     }
 
+    public function testAssertWhereContainsStringFailsWithEmptyValue()
+    {
+        $assert = AssertableJson::fromArray([]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain string [b].');
+
+        $assert->whereContains('foo', 'b');
+    }
+
+    public function testAssertWhereContainsStringWithExistingValue()
+    {
+        $assert = AssertableJson::fromArray([]);
+
+        $assert->whereContains('foo', 'f');
+    }
+
     public function testAssertWhereContainsFailsWithEmptyValue()
     {
         $assert = AssertableJson::fromArray([]);


### PR DESCRIPTION
Currently, whereContains works only checking if a string is within an array. 

However, it would be very useful to also support string contains comparison.