### PR TITLE
[11.x] Add ability to transform `Http\Client\Response` into `Fluent`

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http\Client;
 use ArrayAccess;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
 use Stringable;
@@ -106,6 +107,17 @@ class Response implements ArrayAccess, Stringable
     public function collect($key = null)
     {
         return new Collection($this->json($key));
+    }
+
+    /**
+     * Get the JSON decoded body of the response as a fluent object.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Fluent
+     */
+    public function fluent($key = null)
+    {
+        return new Fluent((array) $this->json($key));
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -402,6 +402,21 @@ class HttpClientTest extends TestCase
         $this->assertEquals(collect(), $response->collect('missing_key'));
     }
 
+    public function testResponseCanBeReturnedAsFluent()
+    {
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api');
+
+        $this->assertInstanceOf(Fluent::class, $response->fluent());
+        $this->assertEquals(fluent(['result' => ['foo' => 'bar']]), $response->fluent());
+        $this->assertEquals(fluent(['foo' => 'bar']), $response->fluent('result'));
+        $this->assertEquals(fluent(['bar']), $response->fluent('result.foo'));
+        $this->assertEquals(fluent([]), $response->fluent('missing_key'));
+    }
+
     public function testSendRequestBodyAsJsonByDefault()
     {
         $body = '{"test":"phpunit"}';


### PR DESCRIPTION
This PR adds a `fluent` method on the `Http\Client\Response` class to be able to transform response data into a `Fluent` instance:

```php
$fluent = Http::get('https://api.example.com/products/1')->fluent();

$fluent->float('price'); // 420.69
$fluent->collect('colors'); // Collection(['red', 'blue'])
$fluent->boolean('on_sale'); // true
$fluent->integer('current_stock'); // 69
```