### PR TITLE
[11.x] Ignore health endpoint when in maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -213,7 +213,7 @@ class ApplicationBuilder
 
             if (is_string($health)) {
                 PreventRequestsDuringMaintenance::except($health);
-                
+
                 Route::get($health, function () {
                     $exception = null;
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Events\DiagnosingHealth;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as AppEventServiceProvider;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as AppRouteServiceProvider;
 use Illuminate\Support\Collection;
@@ -211,6 +212,8 @@ class ApplicationBuilder
             }
 
             if (is_string($health)) {
+                PreventRequestsDuringMaintenance::except($health);
+                
                 Route::get($health, function () {
                     $exception = null;
 


### PR DESCRIPTION
Currently if you use any liveliness or readiness checks in your app such as with Kubernetes, if you put the app into maintenance mode, it clobbers the health endpoint and starts returning 503 response, which triggers the infra to spin up new containers in an attempt to resolve the unhealthy containers... This we do not want to happen.

This PR puts the health endpoint into the exception list for preventing requests during maintenance.
