### PR TITLE
[12.x] Change the default for scheduled command `emailOutput()` to only send email if output exists

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -386,7 +386,7 @@ class Event
      *
      * @throws \LogicException
      */
-    public function emailOutputTo($addresses, $onlyIfOutputExists = false)
+    public function emailOutputTo($addresses, $onlyIfOutputExists = true)
     {
         $this->ensureOutputIsBeingCaptured();
 
@@ -447,7 +447,7 @@ class Event
      * @param  bool  $onlyIfOutputExists
      * @return void
      */
-    protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = false)
+    protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = true)
     {
         $text = is_file($this->output) ? file_get_contents($this->output) : '';
 


### PR DESCRIPTION
I found it quite confusing that this was the default for the last 8 yrs. When calling [`emailOutputTo()`](https://laravel.com/docs/11.x/scheduling#task-output) on a scheduled command, one would expect that if there is no output, there is no email. I couldn't find a use case for the default behavior (who likes to receive empty emails? and if they are used for monitoring the task runs, there are better ways for it!), assuming it was just kept like this for compatibility reasons.

As this is a bc break, I marked it as `12.x`.