### PR TITLE
[11.x] Improves `Collection` support for enums using `firstWhere()` and `value()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,6 +132,7 @@
     },
     "autoload": {
         "files": [
+            "src/Illuminate/Collections/functions.php",
             "src/Illuminate/Collections/helpers.php",
             "src/Illuminate/Events/functions.php",
             "src/Illuminate/Filesystem/functions.php",

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -19,6 +19,8 @@ use UnexpectedValueException;
 use UnitEnum;
 use WeakMap;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @template TKey of array-key
  *
@@ -1092,10 +1094,15 @@ trait EnumeratesValues
         }
 
         return function ($item) use ($key, $operator, $value) {
-            $retrieved = data_get($item, $key);
+            $retrieved = enum_value(data_get($item, $key));
+            $value = enum_value($value);
 
             $strings = array_filter([$retrieved, $value], function ($value) {
-                return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
+                return match (true) {
+                    is_string($value) => true,
+                    $value instanceof \Stringable => true,
+                    default => false,
+                };
             });
 
             if (count($strings) < 2 && count(array_filter([$retrieved, $value], 'is_object')) == 1) {

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -24,6 +24,7 @@
             "Illuminate\\Support\\": ""
         },
         "files": [
+            "functions.php",
             "helpers.php"
         ]
     },

--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Support;
+
+if (! function_exists('Illuminate\Support\enum_value')) {
+    /**
+     * Return a scalar value for the given value that might be an enum.
+     *
+     * @internal
+     *
+     * @template TValue
+     * @template TDefault
+     *
+     * @param  TValue  $value
+     * @param  TDefault|callable(TValue): TDefault  $default
+     * @return ($value is empty ? TDefault : mixed)
+     */
+    function enum_value($value, $default = null)
+    {
+        return transform($value, fn ($value) => match (true) {
+            $value instanceof \BackedEnum => $value->value,
+            $value instanceof \UnitEnum => $value->name,
+
+            default => $value,
+        }, $default ?? $value);
+    }
+}

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -28,30 +28,6 @@ if (! function_exists('Illuminate\Support\defer')) {
     }
 }
 
-if (! function_exists('Illuminate\Support\enum_value')) {
-    /**
-     * Return a scalar value for the given value that might be an enum.
-     *
-     * @internal
-     *
-     * @template TValue
-     * @template TDefault
-     *
-     * @param  TValue  $value
-     * @param  TDefault|callable(TValue): TDefault  $default
-     * @return ($value is empty ? TDefault : mixed)
-     */
-    function enum_value($value, $default = null)
-    {
-        return transform($value, fn ($value) => match (true) {
-            $value instanceof \BackedEnum => $value->value,
-            $value instanceof \UnitEnum => $value->name,
-
-            default => $value,
-        }, $default ?? $value);
-    }
-}
-
 if (! function_exists('Illuminate\Support\php_binary')) {
     /**
      * Determine the PHP Binary.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -258,6 +258,20 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testFirstWhereUsingEnum($collection)
+    {
+        $data = new $collection([
+            ['id' => 1, 'name' => StaffEnum::Taylor],
+            ['id' => 2, 'name' => StaffEnum::Joe],
+            ['id' => 3, 'name' => StaffEnum::James],
+        ]);
+
+        $this->assertSame(1, $data->firstWhere('name', 'Taylor')['id']);
+        $this->assertSame(2, $data->firstWhere('name', StaffEnum::Joe)['id']);
+        $this->assertSame(3, $data->firstWhere('name', StaffEnum::James)['id']);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testLastReturnsLastItemInCollection($collection)
     {
         $c = new $collection(['foo', 'bar']);
@@ -1128,6 +1142,15 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['value' => 'foo'], $c->value('pivot'));
         $this->assertEquals('foo', $c->value('pivot.value'));
         $this->assertEquals('bar', $c->where('id', 2)->value('pivot.value'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testValueUsingEnum($collection)
+    {
+        $c = new $collection([['id' => 1, 'name' => StaffEnum::Taylor], ['id' => 2, 'name' => StaffEnum::Joe]]);
+
+        $this->assertSame(StaffEnum::Taylor, $c->value('name'));
+        $this->assertEquals(StaffEnum::Joe, $c->where('id', 2)->value('name'));
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -5736,4 +5759,10 @@ class TestCollectionMapIntoObject
 class TestCollectionSubclass extends Collection
 {
     //
+}
+
+enum StaffEnum {
+    case Taylor;
+    case Joe;
+    case James;
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5761,7 +5761,8 @@ class TestCollectionSubclass extends Collection
     //
 }
 
-enum StaffEnum {
+enum StaffEnum
+{
     case Taylor;
     case Joe;
     case James;


### PR DESCRIPTION
Fixes #53676

* Moved `enum_value()` namespaced function to `illuminate/collections` 
* Update code to check for instanceof `\Stringable` instead of object with `__toString()` method. https://www.php.net/manual/en/class.stringable.php 