### PR TITLE
[11.x] Add `Number::duration()` for converting seconds to a duration string

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -301,11 +301,11 @@ class Number
      */
     public static function duration(int|float $seconds)
     {
-        $duration = $seconds;
+        $duration = (int) $seconds;
 
         $hours = intdiv($duration, 3600);
         $minutes = intdiv($duration % 3600, 60);
-        $seconds = $duration % 60;
+        $seconds = ((int) $duration) % 60;
 
         if ($hours > 0) {
             return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -301,7 +301,7 @@ class Number
      */
     public static function duration(int|float $seconds)
     {
-        $duration = (int) $seconds;
+        $duration = (int) abs($seconds);
 
         $hours = intdiv($duration, 3600);
         $minutes = intdiv($duration % 3600, 60);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -294,6 +294,27 @@ class Number
     }
 
     /**
+     * Convert the given number to its formatted duration equivalent.
+     *
+     * @param  int|float  $seconds
+     * @return string
+     */
+    public static function duration(int|float $seconds)
+    {
+        $duration = $seconds;
+
+        $hours = intdiv($duration, 3600);
+        $minutes = intdiv($duration % 3600, 60);
+        $seconds = $duration % 60;
+
+        if ($hours > 0) {
+            return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
+        } else {
+            return sprintf('%02d:%02d', $minutes, $seconds);
+        }
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -305,7 +305,7 @@ class Number
 
         $hours = intdiv($duration, 3600);
         $minutes = intdiv($duration % 3600, 60);
-        $seconds = ((int) $duration) % 60;
+        $seconds = $duration % 60;
 
         if ($hours > 0) {
             return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -322,4 +322,16 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    public function testDuration()
+    {
+        $this->assertSame('00:00', Number::duration(0));
+        $this->assertSame('00:00', Number::duration(-0));
+        $this->assertSame('00:00', Number::duration(0.1));
+        $this->assertSame('00:05', Number::duration(5));
+        $this->assertSame('05:00', Number::duration(300));
+        $this->assertSame('59:59', Number::duration(3599));
+        $this->assertSame('01:00:00', Number::duration(3600));
+        $this->assertSame('8760:00:00', Number::duration(3.1536e+7));
+    }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -332,6 +332,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('05:00', Number::duration(300));
         $this->assertSame('59:59', Number::duration(3599));
         $this->assertSame('01:00:00', Number::duration(3600));
+        $this->assertSame('01:00:00', Number::duration(-3600));
         $this->assertSame('8760:00:00', Number::duration(3.1536e+7));
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -326,7 +326,6 @@ class SupportNumberTest extends TestCase
     public function testDuration()
     {
         $this->assertSame('00:00', Number::duration(0));
-        $this->assertSame('00:00', Number::duration(-0));
         $this->assertSame('00:00', Number::duration(0.1));
         $this->assertSame('00:05', Number::duration(5));
         $this->assertSame('05:00', Number::duration(300));


### PR DESCRIPTION
> [!NOTE]
> Eh, not every PR can be a winner 😄. Maybe someone else will be able to pick it back up and improve on it in the future. But, if you do find it useful and would like to use it, [here's a quick macro you can plop in to make that dream a reality](https://gist.github.com/jj15asmr/3b8efc20bc5ce61580fa23cf16fc0c8f#file-numberdurationmacro-php).

This PR adds a `duration()` method to the `Illuminate\Support\Number` helper class which converts a given number of seconds to a human-readable string in the `HH:MM:SS` format. This would, for example, be useful in displaying the length of a video/audio file (as was my case) or the time it took a user to complete an activity.

---

### Usage Example

```php
use Illuminate\Support\Number;

$duration = Number::duration(300); 

// 05:00

$duration = Number::duration(3600);

// 01:00:00
```

---

### Implementation Notes

- The argument accepted by the `duration()` method is named `$seconds`, which is to aid in self-documentation and conformance with the other methods in the `Number` class. Because its name could cause some confusion when performing the calculation within the method, it is immediately reassigned as `$duration`.
- If a negative value of seconds is passed in, it will be converted to a positive representation.

---

If this PR is merged in, then I would also be happy to make one to the docs.

Thanks for reviewing and happy holidays!