### PR TITLE
Using throw config of filesystem disks when faking

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -96,8 +96,8 @@ class Storage extends Facade
      */
     public static function fake($disk = null, array $config = [])
     {
-        $disk   = $disk ?: static::$app['config']->get('filesystems.default');
-        $root   = storage_path('framework/testing/disks/' . $disk);
+        $disk = $disk ?: static::$app['config']->get('filesystems.default');
+        $root = self::getRootPath($disk);
         $config = self::assembleConfig($disk, $config, $root);
 
         if ($token = ParallelTesting::token()) {
@@ -112,21 +112,21 @@ class Storage extends Facade
         );
 
         return tap($fake)->buildTemporaryUrlsUsing(function ($path, $expiration) {
-            return URL::to($path . '?expiration=' . $expiration->getTimestamp());
+            return URL::to($path.'?expiration='.$expiration->getTimestamp());
         });
     }
 
     /**
      * Replace the given disk with a persistent local testing disk.
      *
-     * @param string|null $disk
-     * @param array       $config
+     * @param  string|null $disk
+     * @param  array       $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public static function persistentFake($disk = null, array $config = [])
     {
-        $disk   = $disk ?: static::$app['config']->get('filesystems.default');
-        $config = self::assembleConfig($disk, $config, storage_path('framework/testing/disks/' . $disk));
+        $disk = $disk ?: static::$app['config']->get('filesystems.default');
+        $config = self::assembleConfig($disk, $config, self::getRootPath($disk));
 
         static::set(
             $disk,
@@ -149,7 +149,13 @@ class Storage extends Facade
     private static function assembleConfig(string $disk, array $configOverWrite, string $rootPath): array
     {
         $originalConfig = static::$app['config']["filesystems.disks.{$disk}"] ?? [];
-        $throw          = $originalConfig['throw'] ?? false;
+        $throw = $originalConfig['throw'] ?? false;
+
         return array_merge(['throw' => $throw], $configOverWrite, ['root' => $rootPath]);
+    }
+
+    private static function getRootPath(string $disk): string
+    {
+        return storage_path('framework/testing/disks/'.$disk);
     }
 }

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -147,7 +147,7 @@ class Storage extends Facade
     }
 
     /**
-     * Assemble the configuration of the given disk
+     * Assemble the configuration of the given disk.
      *
      * @param  string  $disk
      * @param  array  $configOverWrite
@@ -163,7 +163,7 @@ class Storage extends Facade
     }
 
     /**
-     * Get the root path of the given disk
+     * Get the root path of the given disk.
      *
      * @param  string  $disk
      * @return string

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -146,6 +146,14 @@ class Storage extends Facade
         return 'filesystem';
     }
 
+    /**
+     * Assemble the configuration of the given disk
+     *
+     * @param  string  $disk
+     * @param  array  $configOverWrite
+     * @param  string  $rootPath
+     * @return array
+     */
     private static function assembleConfig(string $disk, array $configOverWrite, string $rootPath): array
     {
         $originalConfig = static::$app['config']["filesystems.disks.{$disk}"] ?? [];
@@ -154,6 +162,12 @@ class Storage extends Facade
         return array_merge(['throw' => $throw], $configOverWrite, ['root' => $rootPath]);
     }
 
+    /**
+     * Get the root path of the given disk
+     *
+     * @param  string  $disk
+     * @return string
+     */
     private static function getRootPath(string $disk): string
     {
         return storage_path('framework/testing/disks/'.$disk);

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -119,8 +119,8 @@ class Storage extends Facade
     /**
      * Replace the given disk with a persistent local testing disk.
      *
-     * @param  string|null $disk
-     * @param  array $config
+     * @param  string|null  $disk
+     * @param  array  $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public static function persistentFake($disk = null, array $config = [])

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -120,7 +120,7 @@ class Storage extends Facade
      * Replace the given disk with a persistent local testing disk.
      *
      * @param  string|null $disk
-     * @param  array       $config
+     * @param  array $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public static function persistentFake($disk = null, array $config = [])

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToReadFile;
+use Orchestra\Testbench\TestCase;
+
+class StorageFacadeTest extends TestCase
+{
+    public function testFake_whenDiskNotConfigured_doesNotThrowExceptionOnError()
+    {
+        $result = Storage::fake('test')->get('nonExistentFile');
+
+        $this->assertNull($result);
+    }
+
+    public function testFake_whenThrowSetToDisk_throwsExceptionOnError()
+    {
+        Config::set('filesystems.disks.test', ['throw' => true]);
+
+        $this->expectException(UnableToReadFile::class);
+        Storage::fake('test')->get('nonExistentFile');
+    }
+
+    public function testFake_whenThrowOverwritten_usesOverwrite()
+    {
+        Config::set('filesystems.disks.test', ['throw' => true]);
+
+        $result = Storage::fake('test', ['throw' => false])->get('nonExistentFile');
+        $this->assertNull($result);
+    }
+
+    public function testPersistentFake_whenDiskNotConfigured_doesNotThrowExceptionOnError()
+    {
+        $result = Storage::persistentFake('test')->get('nonExistentFile');
+
+        $this->assertNull($result);
+    }
+
+    public function testPersistentFake_whenThrowSetToDisk_throwsExceptionOnError()
+    {
+        Config::set('filesystems.disks.test', ['throw' => true]);
+
+        $this->expectException(UnableToReadFile::class);
+        Storage::persistentFake('test')->get('nonExistentFile');
+    }
+
+    public function testPersistentFake_whenThrowOverwritten_usesOverwrite()
+    {
+        Config::set('filesystems.disks.test', ['throw' => true]);
+
+        $result = Storage::persistentFake('test', ['throw' => false])->get('nonExistentFile');
+        $this->assertNull($result);
+    }
+}
+

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -55,4 +55,3 @@ class StorageFacadeTest extends TestCase
         $this->assertNull($result);
     }
 }
-


### PR DESCRIPTION
### Problem  
When production code initializes a storage instance, it relies on the filesystem configuration, which includes a crucial setting called `throw`. Enabling `throw` removes the need for additional checks in the code to verify whether file operations succeeded, as the exceptions themselves provide that information. Moreover, production code often depends heavily on the exceptions thrown.  

However, the `Storage::fake()` method, by default, creates a storage instance where errors do not trigger exceptions. To align the test environment with production behavior, you must explicitly set the `throw` configuration to `true` each time. Forgetting to do so can lead to issues, including false positives in tests.  

With this update, the Storage faker will now respect the configuration to set the `throw` value, though it can still be manually overridden.  

### Behavior Before the Change  
- `throw` always defaulted to `false`, regardless of the configuration.  
- `throw` could be set to `true` via the `$config` parameter.  

### Behavior After the Change  
- `throw` defaults to `false` if not specified in the configuration.  
- If present, the `throw` setting is retrieved from the configuration.  
- `throw` can still be explicitly set to `true` via the `$config` parameter. 