### PR TITLE
[11.x] Add `Str::extract`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -435,21 +435,21 @@ class Str
     {
         $placeholders = static::matchAll('/\{([^{}]+)}/', $pattern);
 
-        $pattern = static::replace(
-            ['\*', '\{', '\}'],
-            ['*', '{', '}'],
-            preg_quote($pattern, '/')
-        );
+        $pattern = preg_quote($pattern, '/');
 
         foreach ($placeholders as $placeholder) {
             $pattern = static::replace(
-                '{'.$placeholder.'}',
-                '(?<'.$placeholder.'>.*?)',
+                preg_quote('{'.$placeholder.'}', '/'),
+                '(?<'.$placeholder.'>[^\/]+?)',
                 $pattern,
             );
         }
 
-        $pattern = static::replace('*', '.*', $pattern);
+        $pattern = static::replace(
+            ['\*', '\{', '\}'],
+            ['.*?', '{', '}'],
+            $pattern
+        );
 
         if (preg_match("/^$pattern$/i", $haystack, $matches)) {
             return array_intersect_key($matches, $placeholders->flip()->all());

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -425,6 +425,40 @@ class Str
     }
 
     /**
+     * Extract values from the haystack using the given template pattern.
+     *
+     * @param string $haystack
+     * @param string $pattern
+     * @return array
+     */
+    public static function extract($haystack, $pattern)
+    {
+        $pattern = static::replace(
+            ["\*", "\{", "\}"], ["*", "{", "}"],
+            preg_quote($pattern, "/")
+        );
+
+        $placeholders = static::matchAll("/\{(.*?)}/", $pattern);
+
+        foreach ($placeholders as $placeholder) {
+            $pattern = static::replace(
+                ["{" . $placeholder . "}"],
+                "(?<" . $placeholder . ">[^\/]+)",
+                $pattern,
+                false,
+            );
+        }
+
+        $pattern = static::replace("*", ".*", $pattern);
+
+        if (preg_match("/$pattern/i", $haystack, $matches)) {
+            return array_intersect_key($matches, $placeholders->flip()->all());
+        }
+
+        return [];
+    }
+
+    /**
      * Cap a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -442,10 +442,9 @@ class Str
 
         foreach ($placeholders as $placeholder) {
             $pattern = static::replace(
-                ["{" . $placeholder . "}"],
-                "(?<" . $placeholder . ">[^\/]+)",
+                "{".$placeholder."}",
+                "(?<".$placeholder.">[^\/]+)",
                 $pattern,
-                false,
             );
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -427,28 +427,28 @@ class Str
     /**
      * Extract values from the haystack using the given template pattern.
      *
-     * @param string $haystack
-     * @param string $pattern
+     * @param  string  $haystack
+     * @param  string  $pattern
      * @return array
      */
     public static function extract($haystack, $pattern)
     {
         $pattern = static::replace(
-            ["\*", "\{", "\}"], ["*", "{", "}"],
-            preg_quote($pattern, "/")
+            ['\*', '\{', '\}'], ['*', '{', '}'],
+            preg_quote($pattern, '/')
         );
 
         $placeholders = static::matchAll("/\{(.*?)}/", $pattern);
 
         foreach ($placeholders as $placeholder) {
             $pattern = static::replace(
-                "{".$placeholder."}",
-                "(?<".$placeholder.">[^\/]+)",
+                '{'.$placeholder.'}',
+                '(?<'.$placeholder.'>[^\/]+)',
                 $pattern,
             );
         }
 
-        $pattern = static::replace("*", ".*", $pattern);
+        $pattern = static::replace('*', '.*', $pattern);
 
         if (preg_match("/^$pattern$/i", $haystack, $matches)) {
             return array_intersect_key($matches, $placeholders->flip()->all());

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -444,7 +444,7 @@ class Str
         foreach ($placeholders as $placeholder) {
             $pattern = static::replace(
                 '{'.$placeholder.'}',
-                '(?<'.$placeholder.'>[^\/]+)',
+                '(?<'.$placeholder.'>.*?)',
                 $pattern,
             );
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -433,12 +433,13 @@ class Str
      */
     public static function extract($haystack, $pattern)
     {
+        $placeholders = static::matchAll('/\{([^{}]+)}/', $pattern);
+
         $pattern = static::replace(
-            ['\*', '\{', '\}'], ['*', '{', '}'],
+            ['\*', '\{', '\}'],
+            ['*', '{', '}'],
             preg_quote($pattern, '/')
         );
-
-        $placeholders = static::matchAll("/\{(.*?)}/", $pattern);
 
         foreach ($placeholders as $placeholder) {
             $pattern = static::replace(

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -451,7 +451,7 @@ class Str
 
         $pattern = static::replace("*", ".*", $pattern);
 
-        if (preg_match("/$pattern/i", $haystack, $matches)) {
+        if (preg_match("/^$pattern$/i", $haystack, $matches)) {
             return array_intersect_key($matches, $placeholders->flip()->all());
         }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -303,7 +303,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function extract($pattern)
     {
-        return Str::extract($pattern, $this->value);
+        return Str::extract($this->value, $pattern);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -296,7 +296,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Extract values from the haystack using the given template pattern.
+     * Extract values in the string matching the given template pattern.
      *
      * @param  string  $pattern
      * @return array

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -298,7 +298,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Extract values from the haystack using the given template pattern.
      *
-     * @param string $pattern
+     * @param  string  $pattern
      * @return array
      */
     public function extract($pattern)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -296,6 +296,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Extract values from the haystack using the given template pattern.
+     *
+     * @param string $pattern
+     * @return array
+     */
+    public function extract($pattern)
+    {
+        return Str::extract($pattern, $this->value);
+    }
+
+    /**
      * Explode the string into a collection.
      *
      * @param  string  $delimiter

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -231,33 +231,34 @@ class SupportStrTest extends TestCase
         // Extraction with wildcard
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}*posts/{post_id}'));
+        $this->assertSame(['user_id' => '1?', 'post_id' => '2-'], Str::extract('/users/1?/posts/2-', '/users/{user_id}/posts/{post_id}'));
+        $this->assertSame(['user_id' => '1_a', 'post_id' => '2.b'], Str::extract('/users/1_a/posts/2.b', '/users/{user_id}/posts/{post_id}'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments', '/users/{user_id}/posts/{post_id}/*'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('https://foo.com/users/1/posts/2/comments', '*users/{user_id}/posts/{post_id}/*'));
 
-        // Extraction with different characters
-        $this->assertSame(['user_id' => '1?', 'post_id' => '2-'], Str::extract('/users/1?/posts/2-', '/users/{user_id}/posts/{post_id}'));
-        $this->assertSame(['user_id' => '1_a', 'post_id' => '2.b'], Str::extract('/users/1_a/posts/2.b', '/users/{user_id}/posts/{post_id}'));
-
         // Extraction with multiple wildcards
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments/3', '/users/{user_id}/posts/{post_id}/*'));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '/users/{user_id}/posts/{post_id}*/comments/{comment_id}*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments/3', '*/users/{user_id}/posts/{post_id}/*'));
         $this->assertSame(['user_id' => '1', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '*users/{user_id}/*/comments/{comment_id}*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '/users/{user_id}/posts/{post_id}*/comments/{comment_id}*'));
 
-        // Extraction with numbers and special characters in the pattern
+        // Extraction with numbers and sequences in the pattern
+        $this->assertSame(['id' => '123'], Str::extract('ID: 123, ID: 456', 'ID: {id},*'));
+        $this->assertSame(['param' => 'with.dots'], Str::extract('?param=with.dots&another=value', '?param={param}&*'));
         $this->assertSame(['file_name' => '123-abc'], Str::extract('/files/123-abc.pdf', '/files/{file_name}.pdf'));
         $this->assertSame(['file_name' => '123-abc'], Str::extract('/user/home/files/123-abc.pdf', '*/{file_name}.pdf'));
+        $this->assertSame(['file_name' => 'my_file_(1).txt'], Str::extract('/path/to/my_file_(1).txt', '/path/to/{file_name}'));
         $this->assertSame(['product_id' => 'abc-123', 'category' => 'electronics'], Str::extract('/products/abc-123/electronics', '/products/{product_id}/{category}'));
-
-        //  Extraction with UUIDs
         $this->assertSame(['uuid' => 'a1b2c3d4-e5f6-7890-1234-567890abcdef'], Str::extract('/users/a1b2c3d4-e5f6-7890-1234-567890abcdef/profile', '/users/{uuid}/profile'));
+        //  Extraction with UUIDs
 
         // Edge cases
         $this->assertSame(['foo' => '{bar}'], Str::extract('{bar}', '{foo}'));
         $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{\{foo}\}*'));
-        $this->assertSame(['foo' => '{bar}'], Str::extract('foo bar {{bar}}', '* {{foo}}'));
-        $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '*\{foo}/*'));
+        $this->assertSame(['foo' => '{bar}'], Str::extract('foo bar* {{bar}}', '* {{foo}}'));
+        $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|*}', '*\{foo}/*'));
         $this->assertSame(['foo' => '{{bar}}'], Str::extract('foo bar {{{bar}}}', '* {{foo}}'));
         $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '{(|\*&!@$/\{foo}/|}'));
+        $this->assertSame(['foo' => '{bar}'], Str::extract('Example: \\{{bar}\\}', 'Example: \\{{foo}\\}'));
 
         $this->assertSame([], Str::extract('/users/1/posts/2', '')); // Empty pattern
         $this->assertSame([], Str::extract('', '/users/{user_id}/posts/{post_id}')); // Empty haystack

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -249,16 +249,16 @@ class SupportStrTest extends TestCase
         $this->assertSame(['file_name' => 'my_file_(1).txt'], Str::extract('/path/to/my_file_(1).txt', '/path/to/{file_name}'));
         $this->assertSame(['product_id' => 'abc-123', 'category' => 'electronics'], Str::extract('/products/abc-123/electronics', '/products/{product_id}/{category}'));
         $this->assertSame(['uuid' => 'a1b2c3d4-e5f6-7890-1234-567890abcdef'], Str::extract('/users/a1b2c3d4-e5f6-7890-1234-567890abcdef/profile', '/users/{uuid}/profile'));
-        //  Extraction with UUIDs
 
         // Edge cases
         $this->assertSame(['foo' => '{bar}'], Str::extract('{bar}', '{foo}'));
         $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{\{foo}\}*'));
         $this->assertSame(['foo' => '{bar}'], Str::extract('foo bar* {{bar}}', '* {{foo}}'));
-        $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|*}', '*\{foo}/*'));
+        $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|*}', '*/\{foo}/*'));
         $this->assertSame(['foo' => '{{bar}}'], Str::extract('foo bar {{{bar}}}', '* {{foo}}'));
         $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '{(|\*&!@$/\{foo}/|}'));
         $this->assertSame(['foo' => '{bar}'], Str::extract('Example: \\{{bar}\\}', 'Example: \\{{foo}\\}'));
+        $this->assertSame(['first' => '131415*\\', 'second' => '\\d+d'], Str::extract('123/131415*\\/\\d+d/7\\8\\9/101112', '*/{first}/{second}/*'));
 
         $this->assertSame([], Str::extract('/users/1/posts/2', '')); // Empty pattern
         $this->assertSame([], Str::extract('', '/users/{user_id}/posts/{post_id}')); // Empty haystack

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -220,27 +220,27 @@ class SupportStrTest extends TestCase
     public function testStrExtract()
     {
         // Basic extraction
-        $this->assertSame(['last_4' => '5000'], Str::extract("4242-4242-4242-5000", "*-*-*-{last_4}"));
-        $this->assertSame(['area_code' => '800'], Str::extract("Phone Number: 1-(800)-555-5555", "*1-({area_code})-*"));
+        $this->assertSame(['last_4' => '5000'], Str::extract('4242-4242-4242-5000', '*-*-*-{last_4}'));
+        $this->assertSame(['area_code' => '800'], Str::extract('Phone Number: 1-(800)-555-5555', '*1-({area_code})-*'));
         $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com.', '* at {email}.'));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}"));
-        $this->assertSame(['day' => '1st', 'month' => 'January'], Str::extract("My birthday is on the 1st of January", "My birthday is on the {day} of {month}"));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));
+        $this->assertSame(['day' => '1st', 'month' => 'January'], Str::extract('My birthday is on the 1st of January', 'My birthday is on the {day} of {month}'));
         $this->assertSame(['street' => '123 Main St', 'city' => 'Anytown', 'region' =>'CA'], Str::extract('The address is 123 Main St, Anytown, CA.', '*address is {street}, {city}, {region}.'));
 
         // Extraction with wildcard
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}"));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}*/posts/{post_id}"));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2/comments", "/users/{user_id}/posts/{post_id}*"));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("https://foo.com/users/1/posts/2/comments", "*users/{user_id}/posts/{post_id}*"));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}*/posts/{post_id}'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments', '/users/{user_id}/posts/{post_id}*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('https://foo.com/users/1/posts/2/comments', '*users/{user_id}/posts/{post_id}*'));
 
         // Extraction with different characters
         $this->assertSame(['user_id' => '1?', 'post_id' => '2-'], Str::extract('/users/1?/posts/2-', '/users/{user_id}/posts/{post_id}'));
         $this->assertSame(['user_id' => '1_a', 'post_id' => '2.b'], Str::extract('/users/1_a/posts/2.b', '/users/{user_id}/posts/{post_id}'));
 
         // Extraction with multiple wildcards
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2/comments/3", "/users/{user_id}/posts/{post_id}*"));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2', 'comment_id' => '3'], Str::extract("/users/1/posts/2/comments/3/replies/4", "/users/{user_id}/posts/{post_id}*/comments/{comment_id}*"));
-        $this->assertSame(['user_id' => '1', 'comment_id' => '3'], Str::extract("/users/1/posts/2/comments/3/replies/4", "*users/{user_id}/*/comments/{comment_id}*"));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments/3', '/users/{user_id}/posts/{post_id}*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '/users/{user_id}/posts/{post_id}*/comments/{comment_id}*'));
+        $this->assertSame(['user_id' => '1', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '*users/{user_id}/*/comments/{comment_id}*'));
 
         // Extraction with numbers and special characters in the pattern
         $this->assertSame(['file_id' => '123-abc'], Str::extract('/files/123-abc.pdf', '/files/{file_id}.pdf'));
@@ -253,7 +253,7 @@ class SupportStrTest extends TestCase
         $this->assertSame([], Str::extract('/users/1/posts/2', '')); // Empty pattern
         $this->assertSame([], Str::extract('', '/users/{user_id}/posts/{post_id}')); // Empty haystack
         $this->assertSame([], Str::extract('/users/1/posts', '/users/{user_id}/posts/{post_id}')); // Missing segment in haystack
-        $this->assertSame([], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}/comments/{comment_id}")); // Missing segment
+        $this->assertSame([], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}/comments/{comment_id}')); // Missing segment
     }
 
     public function testStrExcerpt()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -224,7 +224,6 @@ class SupportStrTest extends TestCase
         $this->assertSame(['area_code' => '800'], Str::extract("Phone Number: 1-(800)-555-5555", "*1-({area_code})-*"));
         $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com.', '* at {email}.'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}"));
-
         $this->assertSame(['day' => '1st', 'month' => 'January'], Str::extract("My birthday is on the 1st of January", "My birthday is on the {day} of {month}"));
         $this->assertSame(['street' => '123 Main St', 'city' => 'Anytown', 'region' =>'CA'], Str::extract('The address is 123 Main St, Anytown, CA.', '*address is {street}, {city}, {region}.'));
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -225,7 +225,7 @@ class SupportStrTest extends TestCase
         $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com.', '* at {email}.'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));
         $this->assertSame(['day' => '1st', 'month' => 'January'], Str::extract('My birthday is on the 1st of January', 'My birthday is on the {day} of {month}'));
-        $this->assertSame(['street' => '123 Main St', 'city' => 'Anytown', 'region' =>'CA'], Str::extract('The address is 123 Main St, Anytown, CA.', '*address is {street}, {city}, {region}.'));
+        $this->assertSame(['street' => '123 Main St', 'city' => 'Anytown', 'region' => 'CA'], Str::extract('The address is 123 Main St, Anytown, CA.', '*address is {street}, {city}, {region}.'));
 
         // Extraction with wildcard
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -220,9 +220,11 @@ class SupportStrTest extends TestCase
     public function testStrExtract()
     {
         // Basic extraction
+        $this->assertSame(['last_4' => '5000'], Str::extract("4242-4242-4242-5000", "*-*-*-{last_4}"));
         $this->assertSame(['area_code' => '800'], Str::extract("Phone Number: 1-(800)-555-5555", "*1-({area_code})-*"));
         $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com.', '* at {email}.'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}"));
+
         $this->assertSame(['day' => '1st', 'month' => 'January'], Str::extract("My birthday is on the 1st of January", "My birthday is on the {day} of {month}"));
         $this->assertSame(['street' => '123 Main St', 'city' => 'Anytown', 'region' =>'CA'], Str::extract('The address is 123 Main St, Anytown, CA.', '*address is {street}, {city}, {region}.'));
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -251,7 +251,7 @@ class SupportStrTest extends TestCase
         $this->assertSame(['uuid' => 'a1b2c3d4-e5f6-7890-1234-567890abcdef'], Str::extract('/users/a1b2c3d4-e5f6-7890-1234-567890abcdef/profile', '/users/{uuid}/profile'));
 
         // Edge cases
-        // $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{foo}\\}'));
+        // $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{foo}\\}')); //  ['foo' => '}'],
 
         $this->assertSame(['foo' => '{bar}'], Str::extract('{bar}', '{foo}'));
         $this->assertSame(['foo' => '{bar}'], Str::extract('foo bar {{bar}}', '* {{foo}}'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -244,19 +244,19 @@ class SupportStrTest extends TestCase
         $this->assertSame(['user_id' => '1', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '*users/{user_id}/*/comments/{comment_id}*'));
 
         // Extraction with numbers and special characters in the pattern
-        $this->assertSame(['file_id' => '123-abc'], Str::extract('/files/123-abc.pdf', '/files/{file_id}.pdf'));
+        $this->assertSame(['file_name' => '123-abc'], Str::extract('/files/123-abc.pdf', '/files/{file_name}.pdf'));
+        $this->assertSame(['file_name' => '123-abc'], Str::extract('/user/home/files/123-abc.pdf', '*/{file_name}.pdf'));
         $this->assertSame(['product_id' => 'abc-123', 'category' => 'electronics'], Str::extract('/products/abc-123/electronics', '/products/{product_id}/{category}'));
 
         //  Extraction with UUIDs
         $this->assertSame(['uuid' => 'a1b2c3d4-e5f6-7890-1234-567890abcdef'], Str::extract('/users/a1b2c3d4-e5f6-7890-1234-567890abcdef/profile', '/users/{uuid}/profile'));
 
         // Edge cases
-        // $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{foo}\\}')); //  ['foo' => '}'],
-
         $this->assertSame(['foo' => '{bar}'], Str::extract('{bar}', '{foo}'));
+        $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{\{foo}\}*'));
         $this->assertSame(['foo' => '{bar}'], Str::extract('foo bar {{bar}}', '* {{foo}}'));
-        $this->assertSame(['foo' => '{{bar}}'], Str::extract('foo bar {{{bar}}}', '* {{foo}}'));
         $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '*\{foo}/*'));
+        $this->assertSame(['foo' => '{{bar}}'], Str::extract('foo bar {{{bar}}}', '* {{foo}}'));
         $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '{(|\*&!@$/\{foo}/|}'));
 
         $this->assertSame([], Str::extract('/users/1/posts/2', '')); // Empty pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -221,6 +221,7 @@ class SupportStrTest extends TestCase
     {
         // Basic extraction
         $this->assertSame(['last_4' => '5000'], Str::extract('4242-4242-4242-5000', '*-*-*-{last_4}'));
+        $this->assertSame(['last_4' => '{5000}'], Str::extract('4242-4242-4242-{5000}', '*-*-*-{last_4}'));
         $this->assertSame(['area_code' => '800'], Str::extract('Phone Number: 1-(800)-555-5555', '*1-({area_code})-*'));
         $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com.', '* at {email}.'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));
@@ -229,16 +230,16 @@ class SupportStrTest extends TestCase
 
         // Extraction with wildcard
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}/posts/{post_id}'));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}*/posts/{post_id}'));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments', '/users/{user_id}/posts/{post_id}*'));
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('https://foo.com/users/1/posts/2/comments', '*users/{user_id}/posts/{post_id}*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2', '/users/{user_id}*posts/{post_id}'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments', '/users/{user_id}/posts/{post_id}/*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('https://foo.com/users/1/posts/2/comments', '*users/{user_id}/posts/{post_id}/*'));
 
         // Extraction with different characters
         $this->assertSame(['user_id' => '1?', 'post_id' => '2-'], Str::extract('/users/1?/posts/2-', '/users/{user_id}/posts/{post_id}'));
         $this->assertSame(['user_id' => '1_a', 'post_id' => '2.b'], Str::extract('/users/1_a/posts/2.b', '/users/{user_id}/posts/{post_id}'));
 
         // Extraction with multiple wildcards
-        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments/3', '/users/{user_id}/posts/{post_id}*'));
+        $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract('/users/1/posts/2/comments/3', '/users/{user_id}/posts/{post_id}/*'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '/users/{user_id}/posts/{post_id}*/comments/{comment_id}*'));
         $this->assertSame(['user_id' => '1', 'comment_id' => '3'], Str::extract('/users/1/posts/2/comments/3/replies/4', '*users/{user_id}/*/comments/{comment_id}*'));
 
@@ -250,6 +251,14 @@ class SupportStrTest extends TestCase
         $this->assertSame(['uuid' => 'a1b2c3d4-e5f6-7890-1234-567890abcdef'], Str::extract('/users/a1b2c3d4-e5f6-7890-1234-567890abcdef/profile', '/users/{uuid}/profile'));
 
         // Edge cases
+        // $this->assertSame(['foo' => '{bar}'], Str::extract('{\\{bar}\\}', '*{foo}\\}'));
+
+        $this->assertSame(['foo' => '{bar}'], Str::extract('{bar}', '{foo}'));
+        $this->assertSame(['foo' => '{bar}'], Str::extract('foo bar {{bar}}', '* {{foo}}'));
+        $this->assertSame(['foo' => '{{bar}}'], Str::extract('foo bar {{{bar}}}', '* {{foo}}'));
+        $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '*\{foo}/*'));
+        $this->assertSame(['foo' => 'bar'], Str::extract('{(|\*&!@$/\bar/|}', '{(|\*&!@$/\{foo}/|}'));
+
         $this->assertSame([], Str::extract('/users/1/posts/2', '')); // Empty pattern
         $this->assertSame([], Str::extract('', '/users/{user_id}/posts/{post_id}')); // Empty haystack
         $this->assertSame([], Str::extract('/users/1/posts', '/users/{user_id}/posts/{post_id}')); // Missing segment in haystack

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -221,10 +221,10 @@ class SupportStrTest extends TestCase
     {
         // Basic extraction
         $this->assertSame(['area_code' => '800'], Str::extract("Phone Number: 1-(800)-555-5555", "*1-({area_code})-*"));
+        $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com.', '* at {email}.'));
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}"));
         $this->assertSame(['day' => '1st', 'month' => 'January'], Str::extract("My birthday is on the 1st of January", "My birthday is on the {day} of {month}"));
         $this->assertSame(['street' => '123 Main St', 'city' => 'Anytown', 'region' =>'CA'], Str::extract('The address is 123 Main St, Anytown, CA.', '*address is {street}, {city}, {region}.'));
-        $this->assertSame(['email' => 'john.doe@example.com'], Str::extract('Contact us at john.doe@example.com for more information', 'Contact us at {email} for more information'));
 
         // Extraction with wildcard
         $this->assertSame(['user_id' => '1', 'post_id' => '2'], Str::extract("/users/1/posts/2", "/users/{user_id}/posts/{post_id}"));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -613,6 +613,11 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('Malmö')->endsWith('mo'));
     }
 
+    public function testExtract()
+    {
+        $this->assertSame(['name' => 'John'], $this->stringable('Hello John')->extract('Hello {name}'));
+    }
+
     public function testExcerpt()
     {
         $this->assertSame('...is a beautiful morn...', (string) $this->stringable('This is a beautiful morning')->excerpt('beautiful', ['radius' => 5]));


### PR DESCRIPTION
### Description

This PR adds a `Str::extract` method to be able to retrieve pieces of text using a template string.

On various projects I've had to use different regex patterns to extract pieces of information. Such as ID's from URL's, information from comments, area codes from phone numbers, etc. A built-in way to extract this kind of data from known formats would have been a big time saver, and also help those who don't want to dive into their own regex to be able to do so.

### Usage

```php
use Illuminate\Support\Str;

// ['last_4' => '5000']
Str::extract(
    '4242-4242-4242-5000', 
    '*-*-*-{last_4}'
);

// ['area_code' => '800']
Str::extract(
    'Phone Number: 1-(800)-555-5555', 
    '*1-({area_code})-*'
);

// ['email' => 'john.doe@example.com']
Str::extract(
    'Contact us at john.doe@example.com.', 
    '* at {email}.'
);

// ['user_id' => '1', 'post_id' => '2']
Str::extract(
    '/users/1/posts/2/comments', 
    '/users/{user_id}/posts/{post_id}/*'
);

// ['day' => '1st', 'month' => 'January']
Str::extract(
    'My birthday is on the 1st of January', 
    'My birthday is on the {day} of {month}'
);

// ['street' => '123 Main St', 'city' => 'Anytown', 'region' => 'CA']
Str::extract(
    'The address is 123 Main St, Anytown, CA.', 
    '*address is {street}, {city}, {region}.'
);
```