### PR TITLE
[11.x] Make `Exceptions@dontTruncateRequestExceptions()` fluent

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -223,5 +223,7 @@ class Exceptions
     public function dontTruncateRequestExceptions()
     {
         RequestException::dontTruncate();
+
+        return $this;
     }
 }


### PR DESCRIPTION
Looks like this was maybe missed in @stevebauman's PR https://github.com/laravel/framework/pull/53734