### PR TITLE
[11.x] Make mailables tappable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionClass;
@@ -29,7 +30,7 @@ use Symfony\Component\Mime\Address;
 
 class Mailable implements MailableContract, Renderable
 {
-    use Conditionable, ForwardsCalls, Localizable, Macroable {
+    use Conditionable, ForwardsCalls, Localizable, Tappable, Macroable {
         __call as macroCall;
     }
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -24,13 +24,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsRecipientsCorrectly()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new WelcomeMailableStub;
         $mailable->to('taylor@laravel.com');
@@ -114,13 +108,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsCcRecipientsCorrectly()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new WelcomeMailableStub;
         $mailable->cc('taylor@laravel.com');
@@ -211,13 +199,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsBccRecipientsCorrectly()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new WelcomeMailableStub;
         $mailable->bcc('taylor@laravel.com');
@@ -308,13 +290,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsReplyToCorrectly()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new WelcomeMailableStub;
         $mailable->replyTo('taylor@laravel.com');
@@ -394,13 +370,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsFromCorrectly()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new WelcomeMailableStub;
         $mailable->from('taylor@laravel.com');
@@ -630,13 +600,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableMetadataGetsSent()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $view = m::mock(Factory::class);
 
@@ -671,13 +635,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableTagGetsSent()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $view = m::mock(Factory::class);
 
@@ -829,13 +787,7 @@ class MailMailableTest extends TestCase
 
     public function testHasAttachmentWithEnvelopeAttachments()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
         $mailable = new class extends Mailable
         {
             public function envelope()
@@ -1034,13 +986,7 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasAttachment()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new class() extends Mailable
         {
@@ -1070,13 +1016,7 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasAttachedData()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new class() extends Mailable
         {
@@ -1134,13 +1074,7 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasSubject()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new class() extends Mailable
         {
@@ -1194,13 +1128,7 @@ class MailMailableTest extends TestCase
 
     public function testMailableAttributesInBuild()
     {
-        Container::getInstance()->instance('mailer', new class
-        {
-            public function render()
-            {
-                //
-            }
-        });
+        $this->stubMailer();
 
         $mailable = new class() extends Mailable
         {
@@ -1226,6 +1154,32 @@ class MailMailableTest extends TestCase
         $mailable->assertHasMetadata('origin', 'test-suite');
         $mailable->assertHasMetadata('user_id', 1);
         $mailable->assertHasSubject('test subject');
+    }
+
+    public function testMailablesCanBeTapped()
+    {
+        $this->stubMailer();
+
+        $mail = new WelcomeMailableStub;
+
+        $mail->tap(fn ($mailable) => $mailable->to('taylor@laravel.com', 'Taylor Otwell'));
+        $mail->tap(fn ($mailable) => $mailable->subject('Test Subject!'));
+
+        $mail->tap(function ($mailable) {
+            $mailable->assertTo('taylor@laravel.com')
+                ->assertHasSubject('Test Subject!');
+        });
+    }
+
+    protected function stubMailer()
+    {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
     }
 }
 


### PR DESCRIPTION
I have been enjoying using the `tap` method from the `Illuminate\Testing\TestResponse` class, when I got a little logics around assertions.

The `Illuminate\Mail\Mailable` class contains assertion methods. It would be nice to also make it tappable.

I have the following real-life example from my organization:

```php
use App\Mails\OrderCompleted;
use App\Models\Customer;
use App\Models\Order;

public function test_emails_containing_correct_addresses(country $countryCode)
{
    $order = Order::factory()
        ->for(Customer::factory()->create(['country' => $countryCode]))
        ->create();

    $mail = new OrderCompleted($order);

    $mail->assertHasSubject('Your Order Has Been Fulfilled!');

    match (true) {
        $countryCode === 'AU' => $mail->assertSeeInHtml('64 Barker Street REDMOND WA 6327'),
        $countryCode === 'US' => $mail->assertSeeInHtml('2142 Doctors Drive, Burbank, CA 91505'),
        $order->customer->is_from_europe => $mail->assertSeeInHtml('Gerrit van der Veenstraat 1 1077 DX  Amsterdam'),
    };
}
```

As a global business, we want to display correct branch address in our emails depending on the customer's location.

I would prefer to do all assertions in one go:

```php
$mail->assertHasSubject('Your Order Has Been Fulfilled!')
    ->tap(function ($mailable) use ($countryCode, $order) {
        match (true) {
            $countryCode === 'AU' => $mailable->assertSeeInHtml('64 Barker Street REDMOND WA 6327'),
            $countryCode === 'US' => $mailable->assertSeeInHtml('2142 Doctors Drive, Burbank, CA 91505'),
            $order->customer->is_from_europe => $mailable->assertSeeInHtml('Gerrit van der Veenstraat 1 1077 DX Amsterdam'),
        };
    });
```