### PR TITLE
[11.x] Remove usage of `compact()` in Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -297,7 +297,7 @@ class Container implements ArrayAccess, ContainerContract
             $concrete = $this->getClosure($abstract, $concrete);
         }
 
-        $this->bindings[$abstract] = compact('concrete', 'shared');
+        $this->bindings[$abstract] = ['concrete' => $concrete, 'shared' => $shared];
 
         // If the abstract type was already resolved in this container we'll fire the
         // rebound listener so that any objects which have already gotten resolved


### PR DESCRIPTION
This removes the only `compact()` function call in `Container` and replaces it with a direct array, saving a function call.