### PR TITLE
[11.x]  Optimize `TrimStrings` middleware 

### DIFF
--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -243,7 +243,7 @@ class TrimStringsTest extends TestCase
 
         $middleware = new TrimStringsWithExceptAttribute;
 
-        $middleware->handle($request, function ($req) use($text) {
+        $middleware->handle($request, function ($req) use ($text) {
             $this->assertSame($text, $req->title);
             $this->assertSame($text, $req->about);
             $this->assertSame(Str::trim($text), $req->summary); // Assert that the summary is trimmed


### PR DESCRIPTION
This PR improves how we handle excluded attributes and perform lookups. Before, we were doing array merges in every `transform()` call:

```php
protected function transform($key, $value)
{
    $except = array_merge($this->except, static::$neverTrim);
```

So, this version introduces a `$exceptCache` created once per request.

This version also changed the  `$neverTrim` from `O(n)` (`in_array($key, $except, true)`), to a hashmap `O(1)` lookups using `isset($except[$key])`.

Finally, now we're doing an early return if the value isn't string (fast path):

```php
protected function transform($key, $value)
{
    if (! is_string($value) || $this->shouldSkip($key, $this->exceptCache)) {
```

Since this is a heavily used middleware, I believe these improvements are a good call.

