### PR TITLE
[11.x] Add pingOnSuccessIf & pingOnFailureIf to Schedule handling

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -532,7 +532,7 @@ class Event
     }
 
     /**
-     * Register a callback to ping a given URL if the operation succeeds if the given condition is true.
+     * Register a callback to ping a given URL if the operation succeeds and if the given condition is true.
      *
      * @param  bool  $value
      * @param  string  $url
@@ -555,7 +555,7 @@ class Event
     }
 
     /**
-     * Register a callback to ping a given URL if the operation fails if the given condition is true.
+     * Register a callback to ping a given URL if the operation fails and if the given condition is true.
      *
      * @param  bool  $value
      * @param  string  $url

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -532,6 +532,19 @@ class Event
     }
 
     /**
+     * Register a callback to ping a given URL if the operation succeeds if the given condition is true.
+     *
+     * @param  bool  $value
+     * @param  string  $url
+     * @return $this
+     */
+    public function pingOnSuccessIf($value, $url)
+    {
+        return $value ? $this->onSuccess($this->pingCallback($url)) : $this;
+    }
+
+
+    /**
      * Register a callback to ping a given URL if the operation fails.
      *
      * @param  string  $url
@@ -540,6 +553,18 @@ class Event
     public function pingOnFailure($url)
     {
         return $this->onFailure($this->pingCallback($url));
+    }
+
+    /**
+     * Register a callback to ping a given URL if the operation fails if the given condition is true.
+     *
+     * @param  bool  $value
+     * @param  string  $url
+     * @return $this
+     */
+    public function pingOnFailureIf($value, $url)
+    {
+        return $value ? $this->onFailure($this->pingCallback($url)) : $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -543,7 +543,6 @@ class Event
         return $value ? $this->onSuccess($this->pingCallback($url)) : $this;
     }
 
-
     /**
      * Register a callback to ping a given URL if the operation fails.
      *


### PR DESCRIPTION
Currently `pingBeforeIf()` exists. Which can be used like this:
```php
Schedule::command('backup:run')->hourly()
    ->pingBefore((bool) config('services.ohdear.tasks.backup:run', false), config('services.ohdear.tasks.backup:run') . '/starting')
```

This PR proposes adding the same functionality to the `pingOnSuccess` and the `pingOnFailure` methods. (https://laravel.com/docs/11.x/scheduling#pinging-urls)

This makes it possible to write the following code:
```php
$pingBackupRun = (bool) config('services.ohdear.tasks.backup:run', false);
$pingBackupRunUrl = config('services.ohdear.tasks.backup:run');

Schedule::command('backup:run')->hourly()
    ->pingBeforeIf($pingBackupRun, $pingBackupRunUrl . '/starting')
    ->pingOnSuccessIf($pingBackupRun, $pingBackupRunUrl . '/finished')
    ->pingOnFailureIf($pingBackupRun, $pingBackupRunUrl . '/failed');
```

This is my first PR to the laravel/framework repo. Let me know if I did something wrong :)