### PR TITLE
[URI] Enhance URI class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
-        "league/uri": "^7.4",
+        "league/uri": "^7.5.1",
         "monolog/monolog": "^3.0",
         "nesbot/carbon": "^2.72.2|^3.4",
         "nunomaduro/termwind": "^2.0",

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -24,6 +24,11 @@ class Uri implements Htmlable, Responsable
     protected static ?Closure $urlGeneratorResolver = null;
 
     /**
+     * The URI instance.
+     */
+    protected UriInterface $uri;
+
+    /**
      * Create a new parsed URI instance.
      */
     public function __construct(UriInterface|Stringable|string $uri = '')
@@ -75,19 +80,9 @@ class Uri implements Htmlable, Responsable
      */
     public function user(bool $withPassword = false): ?string
     {
-        if ($withPassword) {
-            return $this->uri->getUserInfo();
-        }
-
-        $userInfo = $this->uri->getUserInfo();
-
-        if (is_null($userInfo)) {
-            return null;
-        }
-
-        return str_contains($userInfo, ':')
-            ? Str::before($userInfo, ':')
-            : $userInfo;
+        return $withPassword
+            ? $this->uri->getUserInfo()
+            : $this->uri->getUsername();
     }
 
     /**
@@ -95,9 +90,7 @@ class Uri implements Htmlable, Responsable
      */
     public function password(): ?string
     {
-        $userInfo = $this->uri->getUserInfo();
-
-        return ! is_null($userInfo) ? Str::after($userInfo, ':') : null;
+        return $this->uri->getPassword();
     }
 
     /**
@@ -272,7 +265,7 @@ class Uri implements Htmlable, Responsable
      */
     public function redirect(int $status = 302, array $headers = []): RedirectResponse
     {
-        return new RedirectResponse((string) $this, $status, $headers);
+        return new RedirectResponse($this->value(), $status, $headers);
     }
 
     /**
@@ -283,7 +276,7 @@ class Uri implements Htmlable, Responsable
      */
     public function toResponse($request)
     {
-        return new RedirectResponse((string) $this);
+        return new RedirectResponse($this->value());
     }
 
     /**
@@ -293,7 +286,7 @@ class Uri implements Htmlable, Responsable
      */
     public function toHtml()
     {
-        return (string) $this;
+        return $this->value();
     }
 
     /**
@@ -309,7 +302,7 @@ class Uri implements Htmlable, Responsable
      */
     public function isEmpty(): bool
     {
-        return trim((string) $this) === '';
+        return trim($this->value()) === '';
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -19,14 +19,14 @@ class Uri implements Htmlable, Responsable
     use Conditionable, Tappable;
 
     /**
-     * The URL generator resolver.
-     */
-    protected static ?Closure $urlGeneratorResolver = null;
-
-    /**
      * The URI instance.
      */
     protected UriInterface $uri;
+
+    /**
+     * The URL generator resolver.
+     */
+    protected static ?Closure $urlGeneratorResolver = null;
 
     /**
      * Create a new parsed URI instance.

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\InteractsWithData;
+use League\Uri\QueryString;
 
 class UriQueryString implements Arrayable
 {
@@ -81,13 +82,7 @@ class UriQueryString implements Arrayable
      */
     public function toArray()
     {
-        if (is_null($query = $this->uri->getUri()->getQuery())) {
-            return [];
-        }
-
-        parse_str($query, $currentQuery);
-
-        return $currentQuery;
+        return QueryString::extract($this->value());
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -50,7 +50,7 @@
         "illuminate/filesystem": "Required to use the Composer class (^11.0).",
         "laravel/serializable-closure": "Required to use the once function (^1.3).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.0.2).",
-        "league/uri": "Required to use the Uri class (^7.4).",
+        "league/uri": "Required to use the Uri class (^7.5.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
         "symfony/process": "Required to use the Composer class (^7.0).",
         "symfony/uid": "Required to use Str::ulid() (^7.0).",

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -34,7 +34,7 @@ class SupportUriTest extends TestCase
 
     public function test_complicated_query_string_parsing()
     {
-        $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&flag_value');
+        $uri = Uri::of('https://example.com/users?key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value');
 
         $this->assertEquals([
             'key_1' => 'value',
@@ -56,10 +56,11 @@ class SupportUriTest extends TestCase
                     ],
                 ],
             ],
+            'key.6' => 'value',
             'flag_value' => '',
         ], $uri->query()->all());
 
-        $this->assertEquals('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&flag_value', $uri->query()->decode());
+        $this->assertEquals('key_1=value&key_2[sub_field]=value&key_3[]=value&key_4[9]=value&key_5[][][foo][9]=bar&key.6=value&flag_value', $uri->query()->decode());
     }
 
     public function test_uri_building()


### PR DESCRIPTION
Related to #53731
Related to thephpleague/uri-src#146

* New `league/uri` version 7.5.1 has been released:
    *  Use newly introduced `getUsername()` and `getPassword()` methods on the `Uri` class, instead of manually extracting these values.
* Use `League\Uri\QueryString` class for parsing URI's query string instead of using `parse_str` function:
    * Fix [name mangling](https://www.php.net/parse_str#:~:text=Because%20variables%20in%20PHP%20can%27t%20have%20dots%20and%20spaces%20in%20their%20names%2C%20those%20are%20converted%20to%20underscores.%20Same%20applies%20to%20naming%20of%20respective%20key%20names%20in%20case%20of%20using%20this%20function%20with%20result%20parameter.) issue of `parse_str` method.
    * Add a test to make sure the parsing works without mangling the results.
* Fix a [deprecation](https://github.com/laravel/framework/pull/53731#discussion_r1866780095).