### PR TITLE
[11.x] Include the initial value in the return types of `reduce()`

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -846,7 +846,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
-     * @return TReduceReturnType
+     * @return TReduceInitial|TReduceReturnType
      */
     public function reduce(callable $callback, $initial = null);
 


### PR DESCRIPTION
When a collection is empty, the `reduce()` method returns the initial value (either the value specified as second argument, or `null` otherwise). Therefore, the type of the initial values needs to be among the possible return types.
