### PR TITLE
Add method to Dispatchable Trait for Immediate Job ID Retrieval

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -88,6 +88,17 @@ trait Dispatchable
     }
 
     /**
+     * Dispatch a command and return the result.
+     *
+     * @param  mixed  ...$arguments
+     * @return mixed
+     */
+    public static function dispatchAndGetResponse(...$arguments)
+    {
+        return app(Dispatcher::class)->dispatchToQueue(new static(...$arguments));
+    }
+
+    /**
      * Set the jobs that should run if this job is successful.
      *
      * @param  array  $chain


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


# Summary

This pull request introduces a new dispatchAndGetResponse() method to the Dispatchable trait in the Laravel framework. This method allows Jobs to be dispatched and immediately receive the Job ID without waiting for the PendingDispatch destructor. By providing the Job ID instantly upon dispatch, developers can more easily handle and monitor Jobs, enhancing the overall usability and observability of the Job dispatching process.

Additional Context:
Currently, when a Dispatchable job class is dispatched, the return value is an instance of PendingDispatch. This PendingDispatch is not executed until it is destructed, which means the Job ID cannot be received as a response immediately upon dispatching. This behavior can hinder the ability to monitor and manage Jobs effectively. (Reference: [PendingDispatch Source Code](https://github.com/laravel/framework/blob/36b09b725936a43403f78cf46820d8ade3101633/src/Illuminate/Foundation/Bus/PendingDispatch.php#L205))

# Details

New Functionality: Added dispatchAndGetResponse() method to the Dispatchable trait.
Implementation: The method dispatches the Job to the queue using dispatchToQueue internally and returns the Job ID immediately.
Usage: Accessible from Job classes, enabling developers to retrieve the Job ID right after dispatching.

# Testing

Extensive testing was conducted across various queue drivers to ensure consistent and reliable retrieval of Job IDs:

## SQLite
```
> (new \App\Jobs\Job())->dispatchAndGetResponse()
= 158

> (new \App\Jobs\Job())->dispatchAndGetResponse()
= 159

> (new \App\Jobs\Job())->dispatchAndGetResponse()
= 160
```

## MySQL
```
> (new \App\Jobs\Job())->dispatchAndGetResponse()
= 1

> (new \App\Jobs\Job())->dispatchAndGetResponse()
= 2

> (new \App\Jobs\Job())->dispatchAndGetResponse()
= 3
```

## Redis
```
> (new \App\Jobs\Job())->dispatchAndGetResponse()
= "GAD8rS5C1vbS3pj3MLf1gjiVO6RXReDg"

> (new \App\Jobs\Job())->dispatchAndGetResponse()
= "ZujBiHwWC0T2EodxOrhBJ5vXkTYyhYbf"

> (new \App\Jobs\Job())->dispatchAndGetResponse()
= "dkDmPduxXJjwWbRPwuqkKoaRcVZhxYRe"
```


## Beanstalkd
```
> (new \App\Jobs\Job())->dispatchAndGetResponse()->getId();
= "8"

> (new \App\Jobs\Job())->dispatchAndGetResponse()->getId();
= "9"

> (new \App\Jobs\Job())->dispatchAndGetResponse()->getId();
= "10"
```


In Laravel, dispatching a Job does not return the Job ID, making it inconvenient to monitor and handle Jobs effectively. By providing the Job ID immediately upon dispatch, this PR enhances the usability and observability of Jobs within the Laravel framework, aligning with the principles of ease of use and developer productivity.

# Additional Notes

- This change assumes that Jobs are dispatched to a queue.
- Ensures compatibility with existing dispatch mechanisms by internally utilizing dispatchToQueue.
- Supports multiple queue drivers, including SQLite, MySQL, Redis, and Beanstalkd, each - returning Job IDs in formats native to the respective driver.


Please point out any problems or requirements.