### PR TITLE
Execute job function after enqueued

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -96,9 +96,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             null,
             function ($payload, $queue) use ($job) {
                 $jobId = $this->pushToDatabase($queue, $payload);
-                if(is_object($job) && method_exists($job, 'afterEnqueue')) {
-                    $job->afterEnqueue($jobId);
+                if (is_object($job) && method_exists($job, 'afterEnqueue')) {
+                    $job->afterQueued($jobId);
                 }
+
                 return $jobId;
             }
         );
@@ -135,9 +136,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             $delay,
             function ($payload, $queue, $delay) use ($job) {
                 $jobId = $this->pushToDatabase($queue, $payload, $delay);
-                if(is_object($job) && method_exists($job, 'afterEnqueue')) {
-                    $job->afterEnqueue($jobId);
+                if (is_object($job) && method_exists($job, 'afterEnqueue')) {
+                    $job->afterQueued($jobId);
                 }
+                
                 return $jobId;
             }
         );

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -94,8 +94,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             $this->createPayload($job, $this->getQueue($queue), $data),
             $queue,
             null,
-            function ($payload, $queue) {
-                return $this->pushToDatabase($queue, $payload);
+            function ($payload, $queue) use ($job) {
+                $jobId = $this->pushToDatabase($queue, $payload);
+                if(is_object($job) && method_exists($job, 'afterEnqueue')) {
+                    $job->afterEnqueue($jobId);
+                }
+                return $jobId;
             }
         );
     }
@@ -129,8 +133,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             $this->createPayload($job, $this->getQueue($queue), $data),
             $queue,
             $delay,
-            function ($payload, $queue, $delay) {
-                return $this->pushToDatabase($queue, $payload, $delay);
+            function ($payload, $queue, $delay) use ($job) {
+                $jobId = $this->pushToDatabase($queue, $payload, $delay);
+                if(is_object($job) && method_exists($job, 'afterEnqueue')) {
+                    $job->afterEnqueue($jobId);
+                }
+                return $jobId;
             }
         );
     }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -139,7 +139,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
                 if (is_object($job) && method_exists($job, 'afterEnqueue')) {
                     $job->afterQueued($jobId);
                 }
-                
+
                 return $jobId;
             }
         );


### PR DESCRIPTION
# Enhance Queue Systems with Post-Enqueue Hooks

This PR overrides the DatabaseQueue to allow defining a callback function that executes immediately after a job is queued. By handling job information right after enqueuing, users can easily monitor and observe the scheduling of job executions, enhancing visibility and management of queued tasks.

If this approach is approved, similar post-enqueue functionality will be implemented for RedisQueue, BeanstalkdQueue, and SqsQueue, ensuring consistency across different queue drivers and test will be implemented soon.

```
class ExampleJob implements ShouldQueue
{

    protected $data;

    /**
     * Create a new job instance.
     *
     * @param mixed $data
     */
    public function __construct($data)
    {
        $this->data = $data;
    }

    /**
     * This method is called immediately after the job is queued.
     *
     * @param mixed $jobId
     * @return void
     */
    public function afterQueued($jobId)
    {
        Log::info('Job enqueued with ID: ' . $jobId);
    }

    /**
     * Execute the job.
     *
     * @return void
     */
    public function handle()
    {
        // Job processing logic
    }
}
```