### PR TITLE
[11.x] Fix docblock for URI

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -191,7 +191,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     }
 
     /**
-     * Register the "defer" function termination handler.
+     * Register the URI url generator.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -191,7 +191,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     }
 
     /**
-     * Register the URI url generator.
+     * Register the URL resolver for the URI generator.
      *
      * @return void
      */


### PR DESCRIPTION
It looks like the defer docblock was copied over.