### PR TITLE
[11.x] Enhance URI query string manipulation

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -269,6 +269,18 @@ class Uri implements Htmlable, Responsable
     }
 
     /**
+     * Get the decoded string representation of the URI.
+     */
+    public function decode(): string
+    {
+        if (empty($this->query()->toArray())) {
+            return $this->value();
+        }
+
+        return Str::replace(Str::after($this->value(), '?'), $this->query()->decode(), $this->value());
+    }
+
+    /**
      * Get the string representation of the URI.
      */
     public function value(): string

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -106,7 +106,7 @@ class UriQueryString implements Arrayable
     /**
      * Set the query string.
      */
-    public function set(array $value = null): void
+    public function set(array $value): void
     {
         $this->data = $value;
     }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -112,6 +112,13 @@ class SupportUriTest extends TestCase
         $this->assertEquals(['tag' => ['foo', 'bar']], $uri->pushOntoQuery('tag', 'bar')->query()->all());
     }
 
+    public function test_decoding_the_entire_uri()
+    {
+        $uri = Uri::of('https://laravel.com/docs/11.x/installation')->withQuery(['tags' => ['first', 'second']]);
+
+        $this->assertEquals('https://laravel.com/docs/11.x/installation?tags[0]=first&tags[1]=second', $uri->decode());
+    }
+
     public function test_query_string_manipulation()
     {
         $uri = Uri::of('https://laravel.com?foo.bar=value&foo[bar]=4&bar[foo]=7');
@@ -119,7 +126,7 @@ class SupportUriTest extends TestCase
         // Test `withQuery`
         $this->assertEquals('foo.bar=value&foo=9&bar[foo]=7', $uri->withQuery(['foo' => 9])->query()->decode());
         $this->assertEquals('foo.bar=value&foo[bar]=9&bar[foo]=7', $uri->withQuery(['foo' => ['bar' => 9]])->query()->decode());
-        $this->assertEquals('foo.bar=9&foo[bar]=4&bar[foo]=7', $uri->withQuery(['foo.bar' => 9])->query()->decode()); // fixed
+        $this->assertEquals('foo.bar=9&foo[bar]=4&bar[foo]=7', $uri->withQuery(['foo.bar' => 9])->query()->decode());
         $this->assertEquals('foo=9', $uri->withQuery(['foo' => 9], false)->query()->decode());
         $this->assertEquals('foo[bar]=9', $uri->withQuery(['foo' => ['bar' => 9]], false)->query()->decode());
         $this->assertEquals('foo.bar=9', $uri->withQuery(['foo.bar' => 9], false)->query()->decode());
@@ -133,12 +140,12 @@ class SupportUriTest extends TestCase
         $this->assertEquals('foo.bar=value&foo[bar]=4&bar[foo]=7', $uri->withQueryIfMissing(['foo' => 9])->query()->decode());
         $this->assertEquals('foo.bar=value&foo[bar]=4&bar[foo]=7', $uri->withQueryIfMissing(['foo' => ['bar' => 9]])->query()->decode());
         $this->assertEquals('foo.bar=value&foo[bar]=4&bar[foo]=7', $uri->withQueryIfMissing(['foo.bar' => 9])->query()->decode());
-        $this->assertEquals('foo.bar=value&foo[bar]=4&bar[foo]=7&bar.foo=9', $uri->withQueryIfMissing(['bar.foo' => 9])->query()->decode()); // fixed
+        $this->assertEquals('foo.bar=value&foo[bar]=4&bar[foo]=7&bar.foo=9', $uri->withQueryIfMissing(['bar.foo' => 9])->query()->decode());
 
         // Test `pushOntoQuery`
         $this->assertEquals('foo.bar=value&foo[bar]=4&foo[0]=9&bar[foo]=7', $uri->pushOntoQuery('foo', 9)->query()->decode());
         $this->assertEquals('foo.bar=value&foo[bar]=9&bar[foo]=7', $uri->pushOntoQuery('foo', ['bar' => 9])->query()->decode());
-        $this->assertEquals('foo.bar[0]=value&foo.bar[1]=9&foo[bar]=4&bar[foo]=7', $uri->pushOntoQuery('foo.bar', 9)->query()->decode()); // fixed
+        $this->assertEquals('foo.bar[0]=value&foo.bar[1]=9&foo[bar]=4&bar[foo]=7', $uri->pushOntoQuery('foo.bar', 9)->query()->decode());
 
         // Test `withoutQuery`
         $this->assertEquals('foo.bar=value&bar[foo]=7', $uri->withoutQuery(['foo'])->query()->decode());


### PR DESCRIPTION
Related to #53731 

A query string parameter key may contain a dot, and manipulating the query string with methods that support "dot" notation makes the current implementation buggy. This PR adds two tests that demonstrate the issue.

This PR:
* Moves the logic for query string manipulation from the `Uri` class to the `UriQueryString` class.
* Fixes the issue with manipulating query parameters that have dots in their keys.

There’s room for improvement in this PR. Please mark it as a draft if you think the general approach is heading in the right direction. Any feedback is appreciated. Thanks!