### PR TITLE
[11.x] First class callable syntax

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1789,7 +1789,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function zip($items)
     {
-        $arrayableItems = array_map(fn ($items) => $this->getArrayableItems($items), func_get_args());
+        $arrayableItems = array_map($this->getArrayableItems(...), func_get_args());
 
         $params = array_merge([fn () => new static(func_get_args()), $this->items], $arrayableItems);
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1154,7 +1154,7 @@ class Container implements ArrayAccess, ContainerContract
             return $this->make($className);
         }
 
-        return array_map(fn ($abstract) => $this->resolve($abstract), $concrete);
+        return array_map($this->resolve(...), $concrete);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
+++ b/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
@@ -36,7 +36,7 @@ trait CompilesJsonPaths
         $value = preg_replace("/([\\\\]+)?\\'/", "''", $value);
 
         $jsonPath = (new Collection(explode($delimiter, $value)))
-            ->map(fn ($segment) => $this->wrapJsonPathSegment($segment))
+            ->map($this->wrapJsonPathSegment(...))
             ->join('.');
 
         return "'$".(str_starts_with($jsonPath, '[') ? '' : '.').$jsonPath."'";

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -186,7 +186,7 @@ class DatabaseTransactionsManager
         // also need to remove. We will recurse down the children of all removed transaction
         // instances until there are no more deeply nested child transactions for removal.
         $removedTransactions->each(
-            fn ($transaction) => $this->removeCommittedTransactionsThatAreChildrenOf($transaction)
+            $this->removeCommittedTransactionsThatAreChildrenOf(...)
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -601,7 +601,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function qualifyColumns($columns)
     {
         return (new BaseCollection($columns))
-            ->map(fn ($column) => $this->qualifyColumn($column))
+            ->map($this->qualifyColumn(...))
             ->all();
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -540,7 +540,7 @@ class Migrator
             ->flatMap(fn ($path) => str_ends_with($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php'))
             ->filter()
             ->values()
-            ->keyBy(fn ($file) => $this->getMigrationName($file))
+            ->keyBy($this->getMigrationName(...))
             ->sortBy(fn ($file, $key) => $key)
             ->all();
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4112,7 +4112,7 @@ class Builder implements BuilderContract
     public function getColumns()
     {
         return ! is_null($this->columns)
-                ? array_map(fn ($column) => $this->grammar->getValue($column), $this->columns)
+                ? array_map($this->grammar->getValue(...), $this->columns)
                 : [];
     }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -737,7 +737,7 @@ class PostgresGrammar extends Grammar
         $quote = func_num_args() === 2 ? func_get_arg(1) : "'";
 
         return (new Collection($path))
-            ->map(fn ($attribute) => $this->parseJsonPathArrayKeys($attribute))
+            ->map($this->parseJsonPathArrayKeys(...))
             ->collapse()
             ->map(function ($attribute) use ($quote) {
                 return filter_var($attribute, FILTER_VALIDATE_INT) !== false

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -95,7 +95,7 @@ class AboutCommand extends Command
             ->filter(function ($data, $key) {
                 return $this->option('only') ? in_array($this->toSearchKeyword($key), $this->sections()) : true;
             })
-            ->pipe(fn ($data) => $this->display($data));
+            ->pipe($this->display(...));
 
         $this->newLine();
 
@@ -270,7 +270,7 @@ class AboutCommand extends Command
     {
         return (new Collection(explode(',', $this->option('only') ?? '')))
             ->filter()
-            ->map(fn ($only) => $this->toSearchKeyword($only))
+            ->map($this->toSearchKeyword(...))
             ->all();
     }
 

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -38,7 +38,7 @@ class PackageDiscoverCommand extends Command
 
         (new Collection($manifest->manifest))
             ->keys()
-            ->each(fn ($description) => $this->components->task($description))
+            ->each($this->components->task(...))
             ->whenNotEmpty(fn () => $this->newLine());
     }
 }

--- a/src/Illuminate/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Process/FakeProcessDescription.php
@@ -57,7 +57,7 @@ class FakeProcessDescription
     public function output(array|string $output)
     {
         if (is_array($output)) {
-            (new Collection($output))->each(fn ($line) => $this->output($line));
+            (new Collection($output))->each($this->output(...));
 
             return $this;
         }
@@ -76,7 +76,7 @@ class FakeProcessDescription
     public function errorOutput(array|string $output)
     {
         if (is_array($output)) {
-            (new Collection($output))->each(fn ($line) => $this->errorOutput($line));
+            (new Collection($output))->each($this->errorOutput(...));
 
             return $this;
         }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -102,7 +102,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
     {
         return is_null($fragments)
             ? $this->allFragments()
-            : (new Collection($fragments))->map(fn ($f) => $this->fragment($f))->implode('');
+            : (new Collection($fragments))->map($this->fragment(...))->implode('');
     }
 
     /**


### PR DESCRIPTION
This PR removes some redundant anonymous functions and replaces it with PHP's first class callable syntax, improving readability a bit.