### PR TITLE
[11.x] use promoted properties

### DIFF
--- a/src/Illuminate/Auth/Access/Events/GateEvaluated.php
+++ b/src/Illuminate/Auth/Access/Events/GateEvaluated.php
@@ -5,34 +5,6 @@ namespace Illuminate\Auth\Access\Events;
 class GateEvaluated
 {
     /**
-     * The authenticatable model.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable|null
-     */
-    public $user;
-
-    /**
-     * The ability being evaluated.
-     *
-     * @var string
-     */
-    public $ability;
-
-    /**
-     * The result of the evaluation.
-     *
-     * @var bool|null
-     */
-    public $result;
-
-    /**
-     * The arguments given during evaluation.
-     *
-     * @var array
-     */
-    public $arguments;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
@@ -41,11 +13,10 @@ class GateEvaluated
      * @param  array  $arguments
      * @return void
      */
-    public function __construct($user, $ability, $result, $arguments)
-    {
-        $this->user = $user;
-        $this->ability = $ability;
-        $this->result = $result;
-        $this->arguments = $arguments;
-    }
+    public function __construct(
+        public $user,
+        public $ability,
+        public $result,
+        public $arguments,
+    ) {}
 }

--- a/src/Illuminate/Auth/Access/Events/GateEvaluated.php
+++ b/src/Illuminate/Auth/Access/Events/GateEvaluated.php
@@ -18,5 +18,6 @@ class GateEvaluated
         public $ability,
         public $result,
         public $arguments,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -12,27 +12,6 @@ use Illuminate\Database\ConnectionInterface;
 class DatabaseUserProvider implements UserProvider
 {
     /**
-     * The active database connection.
-     *
-     * @var \Illuminate\Database\ConnectionInterface
-     */
-    protected $connection;
-
-    /**
-     * The hasher implementation.
-     *
-     * @var \Illuminate\Contracts\Hashing\Hasher
-     */
-    protected $hasher;
-
-    /**
-     * The table containing the users.
-     *
-     * @var string
-     */
-    protected $table;
-
-    /**
      * Create a new database user provider.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -40,12 +19,11 @@ class DatabaseUserProvider implements UserProvider
      * @param  string  $table
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, HasherContract $hasher, $table)
-    {
-        $this->connection = $connection;
-        $this->table = $table;
-        $this->hasher = $hasher;
-    }
+    public function __construct(
+        protected ConnectionInterface $connection,
+        protected HasherContract $hasher,
+        protected $table,
+    ) {}
 
     /**
      * Retrieve a user by their unique identifier.

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -23,7 +23,8 @@ class DatabaseUserProvider implements UserProvider
         protected ConnectionInterface $connection,
         protected HasherContract $hasher,
         protected $table,
-    ) {}
+    ) {
+    }
 
     /**
      * Retrieve a user by their unique identifier.

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -27,7 +27,8 @@ class EloquentUserProvider implements UserProvider
     public function __construct(
         protected HasherContract $hasher,
         protected $model,
-    ) {}
+    ) {
+    }
 
     /**
      * Retrieve a user by their unique identifier.

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -11,20 +11,6 @@ use Illuminate\Contracts\Support\Arrayable;
 class EloquentUserProvider implements UserProvider
 {
     /**
-     * The hasher implementation.
-     *
-     * @var \Illuminate\Contracts\Hashing\Hasher
-     */
-    protected $hasher;
-
-    /**
-     * The Eloquent user model.
-     *
-     * @var string
-     */
-    protected $model;
-
-    /**
      * The callback that may modify the user retrieval queries.
      *
      * @var (\Closure(\Illuminate\Database\Eloquent\Builder<*>):mixed)|null
@@ -38,11 +24,10 @@ class EloquentUserProvider implements UserProvider
      * @param  string  $model
      * @return void
      */
-    public function __construct(HasherContract $hasher, $model)
-    {
-        $this->model = $model;
-        $this->hasher = $hasher;
-    }
+    public function __construct(
+        protected HasherContract $hasher,
+        protected $model,
+    ) {}
 
     /**
      * Retrieve a user by their unique identifier.

--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -5,27 +5,6 @@ namespace Illuminate\Auth\Events;
 class Attempting
 {
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The credentials for the user.
-     *
-     * @var array
-     */
-    public $credentials;
-
-    /**
-     * Indicates if the user should be "remembered".
-     *
-     * @var bool
-     */
-    public $remember;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
@@ -33,10 +12,9 @@ class Attempting
      * @param  bool  $remember
      * @return void
      */
-    public function __construct($guard, #[\SensitiveParameter] $credentials, $remember)
-    {
-        $this->guard = $guard;
-        $this->remember = $remember;
-        $this->credentials = $credentials;
-    }
+    public function __construct(
+        public $guard,
+        #[\SensitiveParameter] public $credentials,
+        public $remember,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -16,5 +16,6 @@ class Attempting
         public $guard,
         #[\SensitiveParameter] public $credentials,
         public $remember,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -9,29 +9,14 @@ class Authenticated
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -18,5 +18,6 @@ class Authenticated
     public function __construct(
         public $guard,
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -9,29 +9,14 @@ class CurrentDeviceLogout
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -18,5 +18,6 @@ class CurrentDeviceLogout
     public function __construct(
         public $guard,
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -5,27 +5,6 @@ namespace Illuminate\Auth\Events;
 class Failed
 {
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The user the attempter was trying to authenticate as.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable|null
-     */
-    public $user;
-
-    /**
-     * The credentials provided by the attempter.
-     *
-     * @var array
-     */
-    public $credentials;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
@@ -33,10 +12,9 @@ class Failed
      * @param  array  $credentials
      * @return void
      */
-    public function __construct($guard, $user, #[\SensitiveParameter] $credentials)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-        $this->credentials = $credentials;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+        #[\SensitiveParameter] public $credentials,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -16,5 +16,6 @@ class Failed
         public $guard,
         public $user,
         #[\SensitiveParameter] public $credentials,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -9,27 +9,6 @@ class Login
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
-     * Indicates if the user should be "remembered".
-     *
-     * @var bool
-     */
-    public $remember;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
@@ -37,10 +16,9 @@ class Login
      * @param  bool  $remember
      * @return void
      */
-    public function __construct($guard, $user, $remember)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-        $this->remember = $remember;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+        public $remember,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -20,5 +20,6 @@ class Login
         public $guard,
         public $user,
         public $remember,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -9,29 +9,14 @@ class Logout
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -18,5 +18,6 @@ class Logout
     public function __construct(
         public $guard,
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -9,29 +9,14 @@ class OtherDeviceLogout
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -18,5 +18,6 @@ class OtherDeviceLogout
     public function __construct(
         public $guard,
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -16,5 +16,6 @@ class PasswordReset
      */
     public function __construct(
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -9,20 +9,12 @@ class PasswordReset
     use SerializesModels;
 
     /**
-     * The user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
-    }
+    public function __construct(
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -16,5 +16,6 @@ class PasswordResetLinkSent
      */
     public function __construct(
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -9,20 +9,12 @@ class PasswordResetLinkSent
     use SerializesModels;
 
     /**
-     * The user instance.
-     *
-     * @var \Illuminate\Contracts\Auth\CanResetPassword
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
-    }
+    public function __construct(
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -9,20 +9,12 @@ class Registered
     use SerializesModels;
 
     /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
-    }
+    public function __construct(
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -16,5 +16,6 @@ class Registered
      */
     public function __construct(
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -18,5 +18,6 @@ class Validated
     public function __construct(
         public $guard,
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -9,29 +9,14 @@ class Validated
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The user retrieved and validated from the User Provider.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-    }
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -16,5 +16,6 @@ class Verified
      */
     public function __construct(
         public $user,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -9,20 +9,12 @@ class Verified
     use SerializesModels;
 
     /**
-     * The verified user.
-     *
-     * @var \Illuminate\Contracts\Auth\MustVerifyEmail
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\MustVerifyEmail  $user
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
-    }
+    public function __construct(
+        public $user,
+    ) {}
 }

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -14,7 +14,8 @@ class GenericUser implements UserContract
      */
     public function __construct(
         protected array $attributes,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the name of the unique identifier for the user.

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -7,22 +7,14 @@ use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 class GenericUser implements UserContract
 {
     /**
-     * All of the user's attributes.
-     *
-     * @var array
-     */
-    protected $attributes;
-
-    /**
      * Create a new generic User object.
      *
      * @param  array  $attributes
      * @return void
      */
-    public function __construct(array $attributes)
-    {
-        $this->attributes = $attributes;
-    }
+    public function __construct(
+        protected array $attributes,
+    ) {}
 
     /**
      * Get the name of the unique identifier for the user.

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -11,13 +11,6 @@ use Illuminate\Http\Request;
 class Authenticate implements AuthenticatesRequests
 {
     /**
-     * The authentication factory instance.
-     *
-     * @var \Illuminate\Contracts\Auth\Factory
-     */
-    protected $auth;
-
-    /**
      * The callback that should be used to generate the authentication redirect path.
      *
      * @var callable
@@ -30,10 +23,9 @@ class Authenticate implements AuthenticatesRequests
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @return void
      */
-    public function __construct(Auth $auth)
-    {
-        $this->auth = $auth;
-    }
+    public function __construct(
+        protected Auth $auth,
+    ) {}
 
     /**
      * Specify the guards for the middleware.

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -25,7 +25,8 @@ class Authenticate implements AuthenticatesRequests
      */
     public function __construct(
         protected Auth $auth,
-    ) {}
+    ) {
+    }
 
     /**
      * Specify the guards for the middleware.

--- a/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
+++ b/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
@@ -15,7 +15,8 @@ class AuthenticateWithBasicAuth
      */
     public function __construct(
         protected AuthFactory $auth,
-    ) {}
+    ) {
+    }
 
     /**
      * Specify the guard and field for the middleware.

--- a/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
+++ b/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
@@ -8,22 +8,14 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 class AuthenticateWithBasicAuth
 {
     /**
-     * The guard factory instance.
-     *
-     * @var \Illuminate\Contracts\Auth\Factory
-     */
-    protected $auth;
-
-    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @return void
      */
-    public function __construct(AuthFactory $auth)
-    {
-        $this->auth = $auth;
-    }
+    public function __construct(
+        protected AuthFactory $auth,
+    ) {}
 
     /**
      * Specify the guard and field for the middleware.

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -12,22 +12,14 @@ use function Illuminate\Support\enum_value;
 class Authorize
 {
     /**
-     * The gate instance.
-     *
-     * @var \Illuminate\Contracts\Auth\Access\Gate
-     */
-    protected $gate;
-
-    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
      */
-    public function __construct(Gate $gate)
-    {
-        $this->gate = $gate;
-    }
+    public function __construct(
+        protected Gate $gate,
+    ) {}
 
     /**
      * Specify the ability and models for the middleware.

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -19,7 +19,8 @@ class Authorize
      */
     public function __construct(
         protected Gate $gate,
-    ) {}
+    ) {
+    }
 
     /**
      * Specify the ability and models for the middleware.

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -9,13 +9,6 @@ use Illuminate\Support\Facades\Lang;
 class ResetPassword extends Notification
 {
     /**
-     * The password reset token.
-     *
-     * @var string
-     */
-    public $token;
-
-    /**
      * The callback that should be used to create the reset password URL.
      *
      * @var (\Closure(mixed, string): string)|null
@@ -35,10 +28,9 @@ class ResetPassword extends Notification
      * @param  string  $token
      * @return void
      */
-    public function __construct(#[\SensitiveParameter] $token)
-    {
-        $this->token = $token;
-    }
+    public function __construct(
+        #[\SensitiveParameter] public $token,
+    ) {}
 
     /**
      * Get the notification's channels.

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -30,7 +30,8 @@ class ResetPassword extends Notification
      */
     public function __construct(
         #[\SensitiveParameter] public $token,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the notification's channels.

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -25,7 +25,8 @@ class PasswordBrokerManager implements FactoryContract
      */
     public function __construct(
         protected $app,
-    ) {}
+    ) {
+    }
 
     /**
      * Attempt to get the broker from the local cache.

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -11,13 +11,6 @@ use InvalidArgumentException;
 class PasswordBrokerManager implements FactoryContract
 {
     /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * The array of created "drivers".
      *
      * @var array
@@ -30,10 +23,9 @@ class PasswordBrokerManager implements FactoryContract
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
-    {
-        $this->app = $app;
-    }
+    public function __construct(
+        protected $app,
+    ) {}
 
     /**
      * Attempt to get the broker from the local cache.

--- a/src/Illuminate/Bus/BatchFactory.php
+++ b/src/Illuminate/Bus/BatchFactory.php
@@ -15,7 +15,8 @@ class BatchFactory
      */
     public function __construct(
         protected QueueFactory $queue,
-    ) {}
+    ) {
+    }
 
     /**
      * Create a new batch instance.

--- a/src/Illuminate/Bus/BatchFactory.php
+++ b/src/Illuminate/Bus/BatchFactory.php
@@ -8,22 +8,14 @@ use Illuminate\Contracts\Queue\Factory as QueueFactory;
 class BatchFactory
 {
     /**
-     * The queue factory implementation.
-     *
-     * @var \Illuminate\Contracts\Queue\Factory
-     */
-    protected $queue;
-
-    /**
      * Create a new batch factory instance.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $queue
      * @return void
      */
-    public function __construct(QueueFactory $queue)
-    {
-        $this->queue = $queue;
-    }
+    public function __construct(
+        protected QueueFactory $queue,
+    ) {}
 
     /**
      * Create a new batch instance.

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -14,39 +14,17 @@ use Throwable;
 class DatabaseBatchRepository implements PrunableBatchRepository
 {
     /**
-     * The batch factory instance.
-     *
-     * @var \Illuminate\Bus\BatchFactory
-     */
-    protected $factory;
-
-    /**
-     * The database connection instance.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    protected $connection;
-
-    /**
-     * The database table to use to store batch information.
-     *
-     * @var string
-     */
-    protected $table;
-
-    /**
      * Create a new batch repository instance.
      *
      * @param  \Illuminate\Bus\BatchFactory  $factory
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $table
      */
-    public function __construct(BatchFactory $factory, Connection $connection, string $table)
-    {
-        $this->factory = $factory;
-        $this->connection = $connection;
-        $this->table = $table;
-    }
+    public function __construct(
+        protected BatchFactory $factory,
+        protected Connection $connection,
+        protected string $table,
+    ) {}
 
     /**
      * Retrieve a list of batches.

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -24,7 +24,8 @@ class DatabaseBatchRepository implements PrunableBatchRepository
         protected BatchFactory $factory,
         protected Connection $connection,
         protected string $table,
-    ) {}
+    ) {
+    }
 
     /**
      * Retrieve a list of batches.

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -14,7 +14,8 @@ class UniqueLock
      */
     public function __construct(
         protected Cache $cache,
-    ) {}
+    ) {
+    }
 
     /**
      * Attempt to acquire a lock for the given job.

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -7,22 +7,14 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 class UniqueLock
 {
     /**
-     * The cache repository implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    protected $cache;
-
-    /**
      * Create a new unique lock manager instance.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(Cache $cache)
-    {
-        $this->cache = $cache;
-    }
+    public function __construct(
+        protected Cache $cache,
+    ) {}
 
     /**
      * Attempt to acquire a lock for the given job.

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -7,31 +7,16 @@ class ApcStore extends TaggableStore
     use RetrievesMultipleKeys;
 
     /**
-     * The APC wrapper instance.
-     *
-     * @var \Illuminate\Cache\ApcWrapper
-     */
-    protected $apc;
-
-    /**
-     * A string that should be prepended to keys.
-     *
-     * @var string
-     */
-    protected $prefix;
-
-    /**
      * Create a new APC store.
      *
      * @param  \Illuminate\Cache\ApcWrapper  $apc
      * @param  string  $prefix
      * @return void
      */
-    public function __construct(ApcWrapper $apc, $prefix = '')
-    {
-        $this->apc = $apc;
-        $this->prefix = $prefix;
-    }
+    public function __construct(
+        protected ApcWrapper $apc,
+        protected $prefix = '',
+    ) {}
 
     /**
      * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -16,7 +16,8 @@ class ApcStore extends TaggableStore
     public function __construct(
         protected ApcWrapper $apc,
         protected $prefix = '',
-    ) {}
+    ) {
+    }
 
     /**
      * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -25,22 +25,14 @@ class ArrayStore extends TaggableStore implements LockProvider
     public $locks = [];
 
     /**
-     * Indicates if values are serialized within the store.
-     *
-     * @var bool
-     */
-    protected $serializesValues;
-
-    /**
      * Create a new Array store.
      *
      * @param  bool  $serializesValues
      * @return void
      */
-    public function __construct($serializesValues = false)
-    {
-        $this->serializesValues = $serializesValues;
-    }
+    public function __construct(
+        protected $serializesValues = false,
+    ) {}
 
     /**
      * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -32,7 +32,8 @@ class ArrayStore extends TaggableStore implements LockProvider
      */
     public function __construct(
         protected $serializesValues = false,
-    ) {}
+    ) {
+    }
 
     /**
      * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -17,13 +17,6 @@ use InvalidArgumentException;
 class CacheManager implements FactoryContract
 {
     /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * The array of resolved cache stores.
      *
      * @var array
@@ -43,10 +36,9 @@ class CacheManager implements FactoryContract
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
-    {
-        $this->app = $app;
-    }
+    public function __construct(
+        protected $app,
+    ) {}
 
     /**
      * Get a cache store instance by name, wrapped in a repository.

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -38,7 +38,8 @@ class CacheManager implements FactoryContract
      */
     public function __construct(
         protected $app,
-    ) {}
+    ) {
+    }
 
     /**
      * Get a cache store instance by name, wrapped in a repository.

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -27,32 +27,17 @@ class ClearCommand extends Command
     protected $description = 'Flush the application cache';
 
     /**
-     * The cache manager instance.
-     *
-     * @var \Illuminate\Cache\CacheManager
-     */
-    protected $cache;
-
-    /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
      * Create a new cache clear command instance.
      *
      * @param  \Illuminate\Cache\CacheManager  $cache
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @return void
      */
-    public function __construct(CacheManager $cache, Filesystem $files)
-    {
+    public function __construct(
+        protected CacheManager $cache,
+        protected Filesystem $files,
+    ) {
         parent::__construct();
-
-        $this->cache = $cache;
-        $this->files = $files;
     }
 
     /**

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -24,23 +24,15 @@ class ForgetCommand extends Command
     protected $description = 'Remove an item from the cache';
 
     /**
-     * The cache manager instance.
-     *
-     * @var \Illuminate\Cache\CacheManager
-     */
-    protected $cache;
-
-    /**
      * Create a new cache clear command instance.
      *
      * @param  \Illuminate\Cache\CacheManager  $cache
      * @return void
      */
-    public function __construct(CacheManager $cache)
-    {
+    public function __construct(
+        protected CacheManager $cache,
+    ) {
         parent::__construct();
-
-        $this->cache = $cache;
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -28,7 +28,8 @@ class RateLimiter
      */
     public function __construct(
         protected Cache $cache,
-    ) {}
+    ) {
+    }
 
     /**
      * Register a named limiter configuration.

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -14,13 +14,6 @@ class RateLimiter
     use InteractsWithTime;
 
     /**
-     * The cache store implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    protected $cache;
-
-    /**
      * The configured limit object resolvers.
      *
      * @var array
@@ -33,10 +26,9 @@ class RateLimiter
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(Cache $cache)
-    {
-        $this->cache = $cache;
-    }
+    public function __construct(
+        protected Cache $cache,
+    ) {}
 
     /**
      * Register a named limiter configuration.

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -60,7 +60,8 @@ class Repository implements ArrayAccess, CacheContract
     public function __construct(
         protected Store $store,
         protected array $config = [],
-    ) {}
+    ) {
+    }
 
     /**
      * Determine if an item exists in the cache.

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -37,13 +37,6 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * The cache store implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Store
-     */
-    protected $store;
-
-    /**
      * The event dispatcher implementation.
      *
      * @var \Illuminate\Contracts\Events\Dispatcher|null
@@ -58,24 +51,16 @@ class Repository implements ArrayAccess, CacheContract
     protected $default = 3600;
 
     /**
-     * The cache store configuration options.
-     *
-     * @var array
-     */
-    protected $config = [];
-
-    /**
      * Create a new cache repository instance.
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
      * @param  array  $config
      * @return void
      */
-    public function __construct(Store $store, array $config = [])
-    {
-        $this->store = $store;
-        $this->config = $config;
-    }
+    public function __construct(
+        protected Store $store,
+        protected array $config = [],
+    ) {}
 
     /**
      * Determine if an item exists in the cache.

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -16,7 +16,8 @@ class TagSet
     public function __construct(
         protected Store $store,
         protected array $names = [],
-    ) {}
+    ) {
+    }
 
     /**
      * Reset all tags in the set.

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -7,31 +7,16 @@ use Illuminate\Contracts\Cache\Store;
 class TagSet
 {
     /**
-     * The cache store implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Store
-     */
-    protected $store;
-
-    /**
-     * The tag names.
-     *
-     * @var array
-     */
-    protected $names = [];
-
-    /**
      * Create a new TagSet instance.
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
      * @param  array  $names
      * @return void
      */
-    public function __construct(Store $store, array $names = [])
-    {
-        $this->store = $store;
-        $this->names = $names;
-    }
+    public function __construct(
+        protected Store $store,
+        protected array $names = [],
+    ) {}
 
     /**
      * Reset all tags in the set.

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -13,13 +13,6 @@ class Request implements ArrayAccess
     use Macroable;
 
     /**
-     * The underlying PSR request.
-     *
-     * @var \Psr\Http\Message\RequestInterface
-     */
-    protected $request;
-
-    /**
      * The decoded payload for the request.
      *
      * @var array
@@ -32,10 +25,9 @@ class Request implements ArrayAccess
      * @param  \Psr\Http\Message\RequestInterface  $request
      * @return void
      */
-    public function __construct($request)
-    {
-        $this->request = $request;
-    }
+    public function __construct(
+        protected $request,
+    ) {}
 
     /**
      * Get the request method.

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -27,7 +27,8 @@ class Request implements ArrayAccess
      */
     public function __construct(
         protected $request,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the request method.

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -20,13 +20,6 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * The underlying PSR response.
-     *
-     * @var \Psr\Http\Message\ResponseInterface
-     */
-    protected $response;
-
-    /**
      * The decoded JSON response.
      *
      * @var array
@@ -53,10 +46,9 @@ class Response implements ArrayAccess, Stringable
      * @param  \Psr\Http\Message\MessageInterface  $response
      * @return void
      */
-    public function __construct($response)
-    {
-        $this->response = $response;
-    }
+    public function __construct(
+        protected $response,
+    ) {}
 
     /**
      * Get the body of the response.

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -48,7 +48,8 @@ class Response implements ArrayAccess, Stringable
      */
     public function __construct(
         protected $response,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the body of the response.

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -11,13 +11,6 @@ class ResponseSequence
     use Macroable;
 
     /**
-     * The responses in the sequence.
-     *
-     * @var array
-     */
-    protected $responses;
-
-    /**
      * Indicates that invoking this sequence when it is empty should throw an exception.
      *
      * @var bool
@@ -37,10 +30,9 @@ class ResponseSequence
      * @param  array  $responses
      * @return void
      */
-    public function __construct(array $responses)
-    {
-        $this->responses = $responses;
-    }
+    public function __construct(
+        protected array $responses,
+    ) {}
 
     /**
      * Push a response to the sequence.

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -32,7 +32,8 @@ class ResponseSequence
      */
     public function __construct(
         protected array $responses,
-    ) {}
+    ) {
+    }
 
     /**
      * Push a response to the sequence.

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -9,19 +9,6 @@ use Illuminate\Http\Request;
 
 class HandleCors
 {
-    /**
-     * The container instance.
-     *
-     * @var \Illuminate\Contracts\Container\Container
-     */
-    protected $container;
-
-    /**
-     * The CORS service instance.
-     *
-     * @var \Fruitcake\Cors\CorsService
-     */
-    protected $cors;
 
     /**
      * Create a new middleware instance.
@@ -30,11 +17,10 @@ class HandleCors
      * @param  \Fruitcake\Cors\CorsService  $cors
      * @return void
      */
-    public function __construct(Container $container, CorsService $cors)
-    {
-        $this->container = $container;
-        $this->cors = $cors;
-    }
+    public function __construct(
+        protected Container $container,
+        protected CorsService $cors,
+    ) {}
 
     /**
      * Handle the incoming request.

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -20,7 +20,8 @@ class HandleCors
     public function __construct(
         protected Container $container,
         protected CorsService $cors,
-    ) {}
+    ) {
+    }
 
     /**
      * Handle the incoming request.

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 
 class HandleCors
 {
-
     /**
      * Create a new middleware instance.
      *

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -29,7 +29,8 @@ class TrustHosts
      */
     public function __construct(
         protected Application $app,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the host patterns that should be trusted.

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -8,13 +8,6 @@ use Illuminate\Http\Request;
 class TrustHosts
 {
     /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * The trusted hosts that have been configured to always be trusted.
      *
      * @var array<int, string>|(callable(): array<int, string>)|null
@@ -34,10 +27,9 @@ class TrustHosts
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct(Application $app)
-    {
-        $this->app = $app;
-    }
+    public function __construct(
+        protected Application $app,
+    ) {}
 
     /**
      * Get the host patterns that should be trusted.

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -20,13 +20,6 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     use ConditionallyLoadsAttributes, DelegatesToResource;
 
     /**
-     * The resource instance.
-     *
-     * @var mixed
-     */
-    public $resource;
-
-    /**
      * The additional data that should be added to the top-level resource array.
      *
      * @var array
@@ -55,10 +48,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * @param  mixed  $resource
      * @return void
      */
-    public function __construct($resource)
-    {
-        $this->resource = $resource;
-    }
+    public function __construct(
+        public $resource,
+    ) {}
 
     /**
      * Create a new resource instance.

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -50,7 +50,8 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function __construct(
         public $resource,
-    ) {}
+    ) {
+    }
 
     /**
      * Create a new resource instance.

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -16,7 +16,8 @@ class ResourceResponse implements Responsable
      */
     public function __construct(
         public $resource,
-    ) {}
+    ) {
+    }
 
     /**
      * Create an HTTP response that represents the object.

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -9,22 +9,14 @@ use Illuminate\Support\Collection;
 class ResourceResponse implements Responsable
 {
     /**
-     * The underlying resource.
-     *
-     * @var mixed
-     */
-    public $resource;
-
-    /**
      * Create a new resource response.
      *
      * @param  mixed  $resource
      * @return void
      */
-    public function __construct($resource)
-    {
-        $this->resource = $resource;
-    }
+    public function __construct(
+        public $resource,
+    ) {}
 
     /**
      * Create an HTTP response that represents the object.

--- a/src/Illuminate/Log/Context/Events/ContextDehydrating.php
+++ b/src/Illuminate/Log/Context/Events/ContextDehydrating.php
@@ -11,5 +11,6 @@ class ContextDehydrating
      */
     public function __construct(
         public $context,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Log/Context/Events/ContextDehydrating.php
+++ b/src/Illuminate/Log/Context/Events/ContextDehydrating.php
@@ -5,19 +5,11 @@ namespace Illuminate\Log\Context\Events;
 class ContextDehydrating
 {
     /**
-     * The context instance.
-     *
-     * @var \Illuminate\Log\Context\Repository
-     */
-    public $context;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Log\Context\Repository  $context
      */
-    public function __construct($context)
-    {
-        $this->context = $context;
-    }
+    public function __construct(
+        public $context,
+    ) {}
 }

--- a/src/Illuminate/Log/Context/Events/ContextHydrated.php
+++ b/src/Illuminate/Log/Context/Events/ContextHydrated.php
@@ -11,5 +11,6 @@ class ContextHydrated
      */
     public function __construct(
         public $context,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Log/Context/Events/ContextHydrated.php
+++ b/src/Illuminate/Log/Context/Events/ContextHydrated.php
@@ -5,19 +5,11 @@ namespace Illuminate\Log\Context\Events;
 class ContextHydrated
 {
     /**
-     * The context instance.
-     *
-     * @var \Illuminate\Log\Context\Repository
-     */
-    public $context;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Log\Context\Repository  $context
      */
-    public function __construct($context)
-    {
-        $this->context = $context;
-    }
+    public function __construct(
+        public $context,
+    ) {}
 }

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -31,13 +31,6 @@ class LogManager implements LoggerInterface
     use ParsesLogConfiguration;
 
     /**
-     * The application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * The array of resolved channels.
      *
      * @var array
@@ -71,10 +64,9 @@ class LogManager implements LoggerInterface
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
-    {
-        $this->app = $app;
-    }
+    public function __construct(
+        protected $app,
+    ) {}
 
     /**
      * Build an on-demand log channel.

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -66,7 +66,8 @@ class LogManager implements LoggerInterface
      */
     public function __construct(
         protected $app,
-    ) {}
+    ) {
+    }
 
     /**
      * Build an on-demand log channel.

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -16,20 +16,6 @@ class Logger implements LoggerInterface
     use Conditionable;
 
     /**
-     * The underlying logger implementation.
-     *
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
-
-    /**
-     * The event dispatcher instance.
-     *
-     * @var \Illuminate\Contracts\Events\Dispatcher|null
-     */
-    protected $dispatcher;
-
-    /**
      * Any context to be added to logs.
      *
      * @var array
@@ -43,11 +29,10 @@ class Logger implements LoggerInterface
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(LoggerInterface $logger, ?Dispatcher $dispatcher = null)
-    {
-        $this->logger = $logger;
-        $this->dispatcher = $dispatcher;
-    }
+    public function __construct(
+        protected LoggerInterface $logger,
+        protected ?Dispatcher $dispatcher = null,
+    ) {}
 
     /**
      * Log an emergency message to the logs.

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -32,7 +32,8 @@ class Logger implements LoggerInterface
     public function __construct(
         protected LoggerInterface $logger,
         protected ?Dispatcher $dispatcher = null,
-    ) {}
+    ) {
+    }
 
     /**
      * Log an emergency message to the logs.

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -47,7 +47,8 @@ class PendingMail
      */
     public function __construct(
         protected MailerContract $mailer,
-    ) {}
+    ) {
+    }
 
     /**
      * Set the locale of the message.

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -12,13 +12,6 @@ class PendingMail
     use Conditionable;
 
     /**
-     * The mailer instance.
-     *
-     * @var \Illuminate\Contracts\Mail\Mailer
-     */
-    protected $mailer;
-
-    /**
      * The locale of the message.
      *
      * @var string
@@ -52,10 +45,9 @@ class PendingMail
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
      * @return void
      */
-    public function __construct(MailerContract $mailer)
-    {
-        $this->mailer = $mailer;
-    }
+    public function __construct(
+        protected MailerContract $mailer,
+    ) {}
 
     /**
      * Set the locale of the message.

--- a/src/Illuminate/Mail/SentMessage.php
+++ b/src/Illuminate/Mail/SentMessage.php
@@ -21,7 +21,8 @@ class SentMessage
      */
     public function __construct(
         protected SymfonySentMessage $sentMessage,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the underlying Symfony Email instance.

--- a/src/Illuminate/Mail/SentMessage.php
+++ b/src/Illuminate/Mail/SentMessage.php
@@ -14,22 +14,14 @@ class SentMessage
     use ForwardsCalls;
 
     /**
-     * The Symfony SentMessage instance.
-     *
-     * @var \Symfony\Component\Mailer\SentMessage
-     */
-    protected $sentMessage;
-
-    /**
      * Create a new SentMessage instance.
      *
      * @param  \Symfony\Component\Mailer\SentMessage  $sentMessage
      * @return void
      */
-    public function __construct(SymfonySentMessage $sentMessage)
-    {
-        $this->sentMessage = $sentMessage;
-    }
+    public function __construct(
+        protected SymfonySentMessage $sentMessage,
+    ) {}
 
     /**
      * Get the underlying Symfony Email instance.

--- a/src/Illuminate/Mail/TextMessage.php
+++ b/src/Illuminate/Mail/TextMessage.php
@@ -19,7 +19,8 @@ class TextMessage
      */
     public function __construct(
         protected $message,
-    ) {}
+    ) {
+    }
 
     /**
      * Embed a file in the message and get the CID.

--- a/src/Illuminate/Mail/TextMessage.php
+++ b/src/Illuminate/Mail/TextMessage.php
@@ -12,22 +12,14 @@ class TextMessage
     use ForwardsCalls;
 
     /**
-     * The underlying message instance.
-     *
-     * @var \Illuminate\Mail\Message
-     */
-    protected $message;
-
-    /**
      * Create a new text message instance.
      *
      * @param  \Illuminate\Mail\Message  $message
      * @return void
      */
-    public function __construct($message)
-    {
-        $this->message = $message;
-    }
+    public function __construct(
+        protected $message,
+    ) {}
 
     /**
      * Embed a file in the message and get the CID.

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -13,22 +13,14 @@ use Symfony\Component\Mime\RawMessage;
 class LogTransport implements Stringable, TransportInterface
 {
     /**
-     * The Logger instance.
-     *
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
-
-    /**
      * Create a new log transport instance.
      *
      * @param  \Psr\Log\LoggerInterface  $logger
      * @return void
      */
-    public function __construct(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
-    }
+    public function __construct(
+        protected LoggerInterface $logger,
+    ) {}
 
     /**
      * {@inheritdoc}

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -20,7 +20,8 @@ class LogTransport implements Stringable, TransportInterface
      */
     public function __construct(
         protected LoggerInterface $logger,
-    ) {}
+    ) {
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Illuminate/View/Engines/FileEngine.php
+++ b/src/Illuminate/View/Engines/FileEngine.php
@@ -15,7 +15,8 @@ class FileEngine implements Engine
      */
     public function __construct(
         protected Filesystem $files,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the evaluated contents of the view.

--- a/src/Illuminate/View/Engines/FileEngine.php
+++ b/src/Illuminate/View/Engines/FileEngine.php
@@ -8,22 +8,14 @@ use Illuminate\Filesystem\Filesystem;
 class FileEngine implements Engine
 {
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
      * Create a new file engine instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @return void
      */
-    public function __construct(Filesystem $files)
-    {
-        $this->files = $files;
-    }
+    public function __construct(
+        protected Filesystem $files,
+    ) {}
 
     /**
      * Get the evaluated contents of the view.

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -16,7 +16,8 @@ class PhpEngine implements Engine
      */
     public function __construct(
         protected Filesystem $files,
-    ) {}
+    ) {
+    }
 
     /**
      * Get the evaluated contents of the view.

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -9,22 +9,14 @@ use Throwable;
 class PhpEngine implements Engine
 {
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
      * Create a new file engine instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @return void
      */
-    public function __construct(Filesystem $files)
-    {
-        $this->files = $files;
-    }
+    public function __construct(
+        protected Filesystem $files,
+    ) {}
 
     /**
      * Get the evaluated contents of the view.

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -9,22 +9,14 @@ use Illuminate\Support\ViewErrorBag;
 class ShareErrorsFromSession
 {
     /**
-     * The view factory implementation.
-     *
-     * @var \Illuminate\Contracts\View\Factory
-     */
-    protected $view;
-
-    /**
      * Create a new error binder instance.
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
      * @return void
      */
-    public function __construct(ViewFactory $view)
-    {
-        $this->view = $view;
-    }
+    public function __construct(
+        protected ViewFactory $view
+    ) {}
 
     /**
      * Handle an incoming request.

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -16,7 +16,8 @@ class ShareErrorsFromSession
      */
     public function __construct(
         protected ViewFactory $view
-    ) {}
+    ) {
+    }
 
     /**
      * Handle an incoming request.


### PR DESCRIPTION
this commit uses promoted properties to remove a lot of boilerplate code.

I avoided promoting any `public` properties that lacked type-hints, but had type-hints in the constructor signature. while unlikely to cause issues, this technically is a change in behavior, and should be handled against the `master` branch.

I **did** upgrade `protected` properties that lacked type hints to the type hint provided in the constructor signature. This should be okay because even though the properties themselves weren't type-hinted, the only way to update them was through a type-hinted constructor.

some styling decisions made in this PR:

- ALWAYS use multiline constructors, with each parameter on a new line. provides for very simple to grok git diffs.
- use a trailing comma in multiline constructors
- leave in constructor docblocks for now. could/should be removed eventually

there are many more to go, but wanted to test the waters with how this would be received first.