### PR TITLE
Fix mutexName inconsistency caused by different PHP binary paths on multiple servers

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -812,7 +812,7 @@ class Event
         }
 
         // Strip the PHP binary path from the command string to ensure that 
-        // the mutexName remains consistent across different environments. 
+        // the mutexName remains consistent across different environments.
         // This accounts for variations in PHP executable paths caused by:
         // - Different PHP versions being used on different servers.
         // - Differences in operating systems that result in varying PHP paths.

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -811,7 +811,7 @@ class Event
             return $mutexNameResolver($this);
         }
 
-        // Strip the PHP binary path from the command string to ensure that 
+        // Strip the PHP binary path from the command string to ensure that
         // the mutexName remains consistent across different environments.
         // This accounts for variations in PHP executable paths caused by:
         // - Different PHP versions being used on different servers.

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -811,7 +811,15 @@ class Event
             return $mutexNameResolver($this);
         }
 
-        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command);
+        // Strip the PHP binary path from the command string to ensure that 
+        // the mutexName remains consistent across different environments. 
+        // This accounts for variations in PHP executable paths caused by:
+        // - Different PHP versions being used on different servers.
+        // - Differences in operating systems that result in varying PHP paths.
+        // The remaining command (artisan and arguments) is preserved for further processing.
+        $artisanCommand = explode(' ', $this->command, 2)[1] ?? $this->command;
+
+        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$artisanCommand);
     }
 
     /**

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -40,7 +40,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1"';
 
         $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
     }
@@ -51,7 +51,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1"';
 
         $this->assertSame('start /b cmd /v:on /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
     }
@@ -94,7 +94,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->description('Fancy command description');
 
-        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822', $event->mutexName());
+        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1', $event->mutexName());
 
         $event->createMutexNameUsing(function (Event $event) {
             return Str::slug($event->description);


### PR DESCRIPTION
## Problem Description:

Our production environment handles around 200 million requests daily, and we initially had three Ubuntu 22.04 servers running PHP 8.3, where the PHP executable path was:
```
/usr/bin/php8.3
```

Recently, we decided to expand the infrastructure and added a fourth server running AlmaLinux 9.5. While the setup was consistent across servers, the PHP executable path on the new server differed:
```
/opt/remi/php83/root/usr/bin/php
```

This caused an issue with the `mutexName` function when using Laravel’s `onOneServer()->withoutOverlapping()` feature for scheduling commands. The `$this->command` string varied between servers as follows:

- Existing servers (Ubuntu):
```
'/usr/bin/php8.3' 'artisan' my-command-signature-here
```

- New server (AlmaLinux):
```
'/opt/remi/php83/root/usr/bin/php' 'artisan' my-command-signature-here
```


## Root Cause:
The `mutexName` function generates a unique name based on the `$this->command`. Since the PHP executable paths differed across servers, the resulting mutex name was inconsistent. This led to the same scheduled command being executed on multiple servers simultaneously, despite using `->onOneServer()->withoutOverlapping()`.

## Real-Life Impact:
For example, when scheduling the following command in `Kernel.php`:
```
$scheduler->command('my-command-signature-here')->onOneServer()->withoutOverlapping();
```

The inconsistency in `mutexName` caused the command to run:

- Once on the new server (AlmaLinux).
- And once on one of the existing servers (Ubuntu), selected at random.

This behavior defeats the purpose of `->withoutOverlapping()`, which was critical in our case (high-traffic production environment).


## Solution:
To resolve this issue, I updated the code to strip the PHP binary path from the `$this->command`. By doing this, the `mutexName` function will now generate consistent names regardless of the PHP executable's location or version.

For example:
- Input command:
```
'/usr/bin/php8.3' 'artisan' my-command-signature-here
```
or
```
'/opt/remi/php83/root/usr/bin/php' 'artisan' my-command-signature-here
```
- After modification:
```
'artisan' my-command-signature-here
```

The mutex name will now be derived only from the relevant parts of the command (i.e., `'artisan' my-command-signature-here`), ensuring consistency across servers.

## Testing Considerations:
Unfortunately, testing this specific scenario programmatically is challenging because it requires:
- Multiple servers with different operating systems.
- Differing PHP binary paths.

Given these constraints, I was unable to include automated tests for this PR. However, the issue has been thoroughly tested in our production environment, and the proposed change resolves the problem reliably.