### PR TITLE
Fix mutexName inconsistency caused by different PHP binary paths on multiple servers

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -811,12 +811,7 @@ class Event
             return $mutexNameResolver($this);
         }
 
-        // Strip the PHP binary path from the command string to ensure that
-        // the mutexName remains consistent across different environments.
-        // This accounts for variations in PHP executable paths caused by:
-        // - Different PHP versions being used on different servers.
-        // - Differences in operating systems that result in varying PHP paths.
-        // The remaining command (artisan and arguments) is preserved for further processing.
+        // Strip PHP binary path...
         $artisanCommand = explode(' ', $this->command, 2)[1] ?? $this->command;
 
         return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$artisanCommand);

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -811,7 +811,15 @@ class Event
             return $mutexNameResolver($this);
         }
 
-        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command);
+        // Strip the PHP binary path from the command string to ensure that
+        // the mutexName remains consistent across different environments.
+        // This accounts for variations in PHP executable paths caused by:
+        // - Different PHP versions being used on different servers.
+        // - Differences in operating systems that result in varying PHP paths.
+        // The remaining command (artisan and arguments) is preserved for further processing.
+        $artisanCommand = explode(' ', $this->command, 2)[1] ?? $this->command;
+
+        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$artisanCommand);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -787,26 +787,6 @@ class Event
     }
 
     /**
-     * Get the command string with normalized binary path of PHP.
-     *
-     * @return string
-     */
-    public function getNormalizedCommand()
-    {
-        return str_replace(
-            [
-                Application::phpBinary(),
-                Application::artisanBinary(),
-            ],
-            [
-                'php',
-                preg_replace("#['\"]#", '', Application::artisanBinary()),
-            ],
-            $this->command ?? ''
-        );
-    }
-
-    /**
      * Set the event mutex implementation to be used.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -832,7 +812,8 @@ class Event
             return $mutexNameResolver($this);
         }
 
-        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->getNormalizedCommand());
+        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.
+            sha1($this->expression.$this->normalizeCommand($this->command ?? ''));
     }
 
     /**
@@ -858,5 +839,22 @@ class Event
         if ($this->withoutOverlapping) {
             $this->mutex->forget($this);
         }
+    }
+
+    /**
+     * Format the given command string with a normalized PHP binary path.
+     *
+     * @param  string  $command
+     * @return string
+     */
+    public static function normalizeCommand($command)
+    {
+        return str_replace([
+            Application::phpBinary(),
+            Application::artisanBinary(),
+        ], [
+            'php',
+            preg_replace("#['\"]#", '', Application::artisanBinary()),
+        ], $command);
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -802,7 +802,7 @@ class Event
                 'php',
                 preg_replace("#['\"]#", '', Application::artisanBinary()),
             ],
-                $this->command ?? ''
+            $this->command ?? ''
         );
     }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -5,7 +5,6 @@ namespace Illuminate\Console\Scheduling;
 use Closure;
 use Cron\CronExpression;
 use DateTimeZone;
-use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -123,10 +122,7 @@ class ScheduleListCommand extends Command
         $description = $event->description ?? '';
 
         if (! $this->output->isVerbose()) {
-            $command = str_replace([Application::phpBinary(), Application::artisanBinary()], [
-                'php',
-                preg_replace("#['\"]#", '', Application::artisanBinary()),
-            ], $command);
+            $command = $event->getNormalizedCommand();
         }
 
         if ($event instanceof CallbackEvent) {

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -122,7 +122,7 @@ class ScheduleListCommand extends Command
         $description = $event->description ?? '';
 
         if (! $this->output->isVerbose()) {
-            $command = $event->getNormalizedCommand();
+            $command = $event->normalizeCommand($command);
         }
 
         if ($event instanceof CallbackEvent) {

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -40,7 +40,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1"';
 
         $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
     }
@@ -51,7 +51,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1"';
 
         $this->assertSame('start /b cmd /v:on /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
     }
@@ -94,7 +94,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->description('Fancy command description');
 
-        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822', $event->mutexName());
+        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1', $event->mutexName());
 
         $event->createMutexNameUsing(function (Event $event) {
             return Str::slug($event->description);

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -40,7 +40,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
         $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
     }
@@ -51,7 +51,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1"';
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
         $this->assertSame('start /b cmd /v:on /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
     }
@@ -94,7 +94,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->description('Fancy command description');
 
-        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-31c321e939d61c321842e8f8a9d1cddafd3c76d1', $event->mutexName());
+        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822', $event->mutexName());
 
         $event->createMutexNameUsing(function (Event $event) {
             return Str::slug($event->description);


### PR DESCRIPTION
## Problem Description:

Our production environment handles around 200 million requests daily, and we initially had three Ubuntu 22.04 servers running PHP 8.3, where the PHP executable path was:
```
/usr/bin/php8.3
```

Recently, we decided to expand the infrastructure and added a fourth server running AlmaLinux 9.5. While the setup was consistent across servers, the PHP executable path on the new server differed:
```
/opt/remi/php83/root/usr/bin/php
```

This caused an issue with the `mutexName` function when using Laravel’s `onOneServer()->withoutOverlapping()` feature for scheduling commands. The `$this->command` string varied between servers as follows:

- Existing servers (Ubuntu):
```
'/usr/bin/php8.3' 'artisan' my-command-signature-here
```

- New server (AlmaLinux):
```
'/opt/remi/php83/root/usr/bin/php' 'artisan' my-command-signature-here
```


## Root Cause:
The `mutexName` function generates a unique name based on the `$this->command`. Since the PHP executable paths differed across servers, the resulting mutex name was inconsistent. This led to the same scheduled command being executed on multiple servers simultaneously, despite using `->onOneServer()->withoutOverlapping()`.

## Real-Life Impact:
For example, when scheduling the following command in `Kernel.php`:
```
$scheduler->command('my-command-signature-here')->onOneServer()->withoutOverlapping();
```

The inconsistency in `mutexName` caused the command to run:

- Once on the new server (AlmaLinux).
- And once on one of the existing servers (Ubuntu), selected at random.

This behavior defeats the purpose of `->withoutOverlapping()`, which was critical in our case (high-traffic production environment).


## Solution:
To resolve this issue, I updated the code to strip the PHP binary path from the `$this->command`. By doing this, the `mutexName` function will now generate consistent names regardless of the PHP executable's location or version.

For example:
- Input command:
```
'/usr/bin/php8.3' 'artisan' my-command-signature-here
```
or
```
'/opt/remi/php83/root/usr/bin/php' 'artisan' my-command-signature-here
```
- After modification:
```
'artisan' my-command-signature-here
```

The mutex name will now be derived only from the relevant parts of the command (i.e., `'artisan' my-command-signature-here`), ensuring consistency across servers.

## Testing Considerations:
Unfortunately, testing this specific scenario programmatically is challenging because it requires:
- Multiple servers with different operating systems.
- Differing PHP binary paths.

Given these constraints, I was unable to include automated tests for this PR. However, the issue has been thoroughly tested in our production environment, and the proposed change resolves the problem reliably.