### PR TITLE
[11.x] fix `chopStart` and `chopEnd` tests

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1590,18 +1590,18 @@ class SupportStrTest extends TestCase
     public function testChopStart()
     {
         foreach ([
-            'http://laravel.com' => ['http://', 'laravel.com'],
-            'http://-http://' => ['http://', '-http://'],
-            'http://laravel.com' => ['htp:/', 'http://laravel.com'],
-            'http://laravel.com' => ['http://www.', 'http://laravel.com'],
-            'http://laravel.com' => ['-http://', 'http://laravel.com'],
-            'http://laravel.com' => [['https://', 'http://'], 'laravel.com'],
-            'http://www.laravel.com' => [['http://', 'www.'], 'www.laravel.com'],
-            'http://http-is-fun.test' => ['http://', 'http-is-fun.test'],
-            '🌊✋' => ['🌊', '✋'],
-            '🌊✋' => ['✋', '🌊✋'],
-        ] as $subject => $value) {
-            [$needle, $expected] = $value;
+            ['http://laravel.com', 'http://', 'laravel.com'],
+            ['http://-http://', 'http://', '-http://'],
+            ['http://laravel.com', 'htp:/', 'http://laravel.com'],
+            ['http://laravel.com', 'http://www.', 'http://laravel.com'],
+            ['http://laravel.com', '-http://', 'http://laravel.com'],
+            ['http://laravel.com', ['https://', 'http://'], 'laravel.com'],
+            ['http://www.laravel.com', ['http://', 'www.'], 'www.laravel.com'],
+            ['http://http-is-fun.test', 'http://', 'http-is-fun.test'],
+            ['🌊✋', '🌊', '✋'],
+            ['🌊✋', '✋', '🌊✋'],
+        ] as $value) {
+            [$subject, $needle, $expected] = $value;
 
             $this->assertSame($expected, Str::chopStart($subject, $needle));
         }
@@ -1610,18 +1610,18 @@ class SupportStrTest extends TestCase
     public function testChopEnd()
     {
         foreach ([
-            'path/to/file.php' => ['.php', 'path/to/file'],
-            '.php-.php' => ['.php', '.php-'],
-            'path/to/file.php' => ['.ph', 'path/to/file.php'],
-            'path/to/file.php' => ['foo.php', 'path/to/file.php'],
-            'path/to/file.php' => ['.php-', 'path/to/file.php'],
-            'path/to/file.php' => [['.html', '.php'], 'path/to/file'],
-            'path/to/file.php' => [['.php', 'file'], 'path/to/file'],
-            'path/to/php.php' => ['.php', 'path/to/php'],
-            '✋🌊' => ['🌊', '✋'],
-            '✋🌊' => ['✋', '✋🌊'],
-        ] as $subject => $value) {
-            [$needle, $expected] = $value;
+            ['path/to/file.php', '.php', 'path/to/file'],
+            ['.php-.php', '.php', '.php-'],
+            ['path/to/file.php', '.ph', 'path/to/file.php'],
+            ['path/to/file.php', 'foo.php', 'path/to/file.php'],
+            ['path/to/file.php', '.php-', 'path/to/file.php'],
+            ['path/to/file.php', ['.html', '.php'], 'path/to/file'],
+            ['path/to/file.php', ['.php', 'file'], 'path/to/file'],
+            ['path/to/php.php', '.php', 'path/to/php'],
+            ['✋🌊', '🌊', '✋'],
+            ['✋🌊', '✋', '✋🌊'],
+        ] as $value) {
+            [$subject, $needle, $expected] = $value;
 
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }


### PR DESCRIPTION
the arrays were using duplicate keys, which meant only the latest defined element was running an assertion.

converted them to indexed arrays, and then adjusted the destructuring to treat the first element as the `$subject`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
