### PR TITLE
[11.x] prefer assignment over `array_push` for 1 element

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -995,7 +995,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $collectionCount = $this->count();
 
         foreach (range(1, min($count, $collectionCount)) as $item) {
-            array_push($results, array_pop($this->items));
+            $results[] = array_pop($this->items);
         }
 
         return new static($results);
@@ -1246,7 +1246,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $collectionCount = $this->count();
 
         foreach (range(1, min($count, $collectionCount)) as $item) {
-            array_push($results, array_shift($this->items));
+            $results[] = array_shift($this->items);
         }
 
         return new static($results);

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1163,7 +1163,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function tag($value)
     {
-        array_push($this->tags, $value);
+        $this->tags[] = $value;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -320,7 +320,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function tag($value)
     {
-        array_push($this->tags, $value);
+        $this->tags[] = $value;
 
         return $this;
     }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -709,7 +709,7 @@ class RedisConnectionTest extends TestCase
 
                 foreach ($returnedMembers as $member) {
                     $this->assertContains($member, $members);
-                    array_push($result, $member);
+                    $result[] = $member;
                 }
             } while ($iterator > 0);
 


### PR DESCRIPTION
according to the PHP docs, it is better to use assignment over `array_push` for 1 element because then you avoid the overhead of the function call.

https://www.php.net/manual/en/function.array-push.php#:~:text=Note%3A%20If%20you%20use%20array_push()%20to%20add%20one%20element%20to%20the%20array%2C%20it%27s%20better%20to%20use%20%24array%5B%5D%20%3D%20because%20in%20that%20way%20there%20is%20no%20overhead%20of%20calling%20a%20function.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
