### PR TITLE
[11.x] simplify passing arguments to `when()`

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -416,7 +416,8 @@ trait ConditionallyLoadsAttributes
 
         return $this->when(
             $this->hasPivotLoadedAs($accessor, $table),
-            ...[$value, $default]
+            $value,
+            $default,
         );
     }
 


### PR DESCRIPTION
the `when()` method accepts 3 parameters. we can just pass 3 arguments rather than putting them into an array, and then spreading them.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
