### PR TITLE
[11.x] remove unnecessary `return` statement

### DIFF
--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -64,6 +64,6 @@ class VerifyCsrfTokenExceptTest extends TestCase
 
     private function assertNonMatchingExcept(array $except)
     {
-        return $this->assertMatchingExcept($except, false);
+        $this->assertMatchingExcept($except, false);
     }
 }


### PR DESCRIPTION
the called function returns void, and the result of the method is never used

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
