### PR TITLE
[11.x] use new PHP 8 `str_` functions

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -107,7 +107,7 @@ trait DatabaseTruncation
     {
         $prefix = $connection->getTablePrefix();
 
-        return strpos($table, $prefix) === 0
+        return str_starts_with($table, $prefix)
             ? substr($table, strlen($prefix))
             : $table;
     }

--- a/tests/Integration/Database/MySql/JoinLateralTest.php
+++ b/tests/Integration/Database/MySql/JoinLateralTest.php
@@ -56,7 +56,7 @@ class JoinLateralTest extends MySqlTestCase
     {
         $mySqlVersion = DB::select('select version()')[0]->{'version()'} ?? '';
 
-        if (strpos($mySqlVersion, 'Maria') !== false) {
+        if (str_contains($mySqlVersion, 'Maria')) {
             $this->markTestSkipped('Lateral joins are not supported on MariaDB'.__CLASS__);
         } elseif ((float) $mySqlVersion < '8.0.14') {
             $this->markTestSkipped('Lateral joins are not supported on MySQL < 8.0.14'.__CLASS__);

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -76,7 +76,7 @@ class MailSesTransportTest extends TestCase
                     $arg['Destinations'] === ['me@example.com', 'you@example.com'] &&
                     $arg['ListManagementOptions'] === ['ContactListName' => 'TestList', 'TopicName' => 'TestTopic'] &&
                     $arg['Tags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
-                    strpos($arg['RawMessage']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>') !== false;
+                    str_contains($arg['RawMessage']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>');
             }))
             ->andReturn($sesResult);
 

--- a/tests/Mail/MailSesV2TransportTest.php
+++ b/tests/Mail/MailSesV2TransportTest.php
@@ -76,7 +76,7 @@ class MailSesV2TransportTest extends TestCase
                     $arg['Destination']['ToAddresses'] === ['me@example.com', 'you@example.com'] &&
                     $arg['ListManagementOptions'] === ['ContactListName' => 'TestList', 'TopicName' => 'TestTopic'] &&
                     $arg['EmailTags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']] &&
-                    strpos($arg['Content']['Raw']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>') !== false;
+                    str_contains($arg['Content']['Raw']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>');
             }))
             ->andReturn($sesResult);
 


### PR DESCRIPTION
behavior is identical, but readability should be improved

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
