### PR TITLE
[11.x] match named arguments order with parameters order

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -141,11 +141,11 @@ class VendorPublishCommand extends Command
             )
             : search(
                 label: "Which provider or tag's files would you like to publish?",
-                placeholder: 'Search...',
                 options: fn ($search) => array_values(array_filter(
                     $choices,
                     fn ($choice) => str_contains(strtolower($choice), strtolower($search))
                 )),
+                placeholder: 'Search...',
                 scroll: 15,
             );
 

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -53,9 +53,9 @@ class Factory
     public function result(array|string $output = '', array|string $errorOutput = '', int $exitCode = 0)
     {
         return new FakeProcessResult(
+            exitCode: $exitCode,
             output: $output,
             errorOutput: $errorOutput,
-            exitCode: $exitCode,
         );
     }
 

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -109,9 +109,9 @@ class ListenCommand extends Command
             memory: $this->option('memory'),
             timeout: $this->option('timeout'),
             sleep: $this->option('sleep'),
-            rest: $this->option('rest'),
             maxTries: $this->option('tries'),
-            force: $this->option('force')
+            force: $this->option('force'),
+            rest: $this->option('rest')
         );
     }
 


### PR DESCRIPTION
behavior is identical, and the point of named arguments is that you don't **have** to match the order, but for readability I think it helps to try and match them.

you still get the benefit of being able to *skip* specific arguments.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
