### PR TITLE
[11.x] handle `password_hash()` failures better

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -64,8 +64,8 @@ class ArgonHasher extends AbstractHasher implements HasherContract
         try {
             $hash = password_hash($value, $this->algorithm(), [
                 'memory_cost' => $this->memory($options),
-                'time_cost'   => $this->time($options),
-                'threads'     => $this->threads($options),
+                'time_cost' => $this->time($options),
+                'threads' => $this->threads($options),
             ]);
         } catch (Error) {
             throw new RuntimeException('Argon2 hashing not supported.');

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Hashing;
 
+use Error;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use RuntimeException;
 
@@ -60,13 +61,13 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     public function make(#[\SensitiveParameter] $value, array $options = [])
     {
-        $hash = @password_hash($value, $this->algorithm(), [
-            'memory_cost' => $this->memory($options),
-            'time_cost' => $this->time($options),
-            'threads' => $this->threads($options),
-        ]);
-
-        if (! is_string($hash)) {
+        try {
+            $hash = password_hash($value, $this->algorithm(), [
+                'memory_cost' => $this->memory($options),
+                'time_cost'   => $this->time($options),
+                'threads'     => $this->threads($options),
+            ]);
+        } catch (Error) {
             throw new RuntimeException('Argon2 hashing not supported.');
         }
 

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Hashing;
 
+use Error;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use RuntimeException;
 
@@ -44,11 +45,11 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      */
     public function make(#[\SensitiveParameter] $value, array $options = [])
     {
-        $hash = password_hash($value, PASSWORD_BCRYPT, [
-            'cost' => $this->cost($options),
-        ]);
-
-        if ($hash === false) {
+        try {
+            $hash = password_hash($value, PASSWORD_BCRYPT, [
+                'cost' => $this->cost($options),
+            ]);
+        } catch (Error) {
             throw new RuntimeException('Bcrypt hashing not supported.');
         }
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -117,4 +117,25 @@ class HasherTest extends TestCase
     {
         $this->assertFalse($this->hashManager->isHashed('foo'));
     }
+
+    public function testBasicBcryptNotSupported()
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new BcryptHasher(['rounds' => 0]))->make('password');
+    }
+
+    public function testBasicArgon2iNotSupported()
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new ArgonHasher(['time' => 0]))->make('password');
+    }
+
+    public function testBasicArgon2idNotSupported()
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new Argon2IdHasher(['time' => 0]))->make('password');
+    }
 }


### PR DESCRIPTION
as of PHP 8.0.0, `password_hash()` no longer returns false on failure, instead a `ValueError` will be thrown if the password hashing algorithm is not valid, or an `Error` if the password hashing failed for an unknown error.

I noticed the `ArgonHasher` already had a slightly updated check using error suppression, which was added in #33856.  however, I couldn't seem to get that to actually work, and for consistency I updated them both to use try/catch.

added tests for all 3 implementations to see if they correctly throw a `RuntimeException` if they are not able to be created.  I used invalid "cost" and "time" options to trigger this. not sure if there's a better way.

https://www.php.net/manual/en/function.password-hash.php#:~:text=the%20salt%20generation.-,8.0.0,-password_hash()%20no

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
