### PR TITLE
[11.x] Require `laravel/serializable-closure` on Database component

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,8 @@
         "illuminate/container": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
-        "illuminate/support": "^11.0"
+        "illuminate/support": "^11.0",
+        "laravel/serializable-closure": "^1.3|^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -41,7 +42,6 @@
         "illuminate/events": "Required to use the observers with Eloquent (^11.0).",
         "illuminate/filesystem": "Required to use the migrations (^11.0).",
         "illuminate/pagination": "Required to paginate the result set (^11.0).",
-        "laravel/serializable-closure": "Required to handle circular references in model serialization (^1.3).",
         "symfony/finder": "Required to use Eloquent model factories (^7.0)."
     },
     "config": {


### PR DESCRIPTION
The `laravel/serializable-closure` package is currently only suggested for the Database component. This PR moves it from a suggestion to a requirement.

With recent updates, the package is getting pretty ingrained into Eloquent. With the merging of PR #52883, it is now used whenever a model is saved or deleted (via calls to `touchOwners()`). This basically makes Eloquent unusable without the package, and breaks existing packages that use Eloquent in the Database component outside of the framework (`Error: Class "Laravel\SerializableClosure\Support\ReflectionClosure" not found`).

This PR updates the `composer.json` to require the package instead of just suggest it. I set the version requirements to match that found in the framework `composer.json` file and the Queue component.

Thanks,
Patrick