### PR TITLE
Fix Translation String as key, and value is empty string

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -185,7 +185,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
+        return $this->makeReplacements($line ?? $key, $replace);
     }
 
     /**


### PR DESCRIPTION
I have a Laravel project. `APP_LOCALE` is `zh`. 

when I run code:

```php
$input = $request->validate([
            'username' => [
                'required',
                'string',
                'max:255',
                Rule::unique(User::class),
            ],
            'nickname' => [
                'required',
                'string',
                'max:255',
                Rule::unique(User::class),
            ],
            'password' => [
                'required',
            ]
        ], [], [
            'username' => '用户名',
            'nickname' => '昵称',
            'password' => '密码'
        ]);
```

The lang file is `lang/zh.json`:

```json
{
    "(and :count more error)": "",
    "(and :count more errors)": ""
}
```

run result is: 

```json
{
    "message": "用户名 已占用 (and 2 more errors)",
    "errors": {
       ...
    }
}
```

## Expect

run result is: 

```json
{
    "message": "用户名 已占用",
    "errors": {
       ...
    }
}
```