### PR TITLE
[12.x] chore: remove support for Carbon v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,15 +64,6 @@ jobs:
       - name: Set Framework version
         run: composer config version "12.x-dev"
 
-      - name: Set Minimum PHP 8.4 Versions
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require  nesbot/carbon:^3.4 --no-interaction --no-update
-          shell: bash
-        if: matrix.php >= 8.4
-
       - name: Set PHPUnit
         uses: nick-fields/retry@v3
         with:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
         "monolog/monolog": "^3.0",
-        "nesbot/carbon": "^2.72.2|^3.4",
+        "nesbot/carbon": "^3.4",
         "nunomaduro/termwind": "^2.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -266,7 +266,7 @@ class StartSession
         $config = $this->manager->getSessionConfig();
 
         return $config['expire_on_close'] ? 0 : Date::instance(
-            Carbon::now()->addRealMinutes($config['lifetime'])
+            Carbon::now()->addMinutes($config['lifetime'])
         );
     }
 

--- a/src/Illuminate/Support/InteractsWithTime.php
+++ b/src/Illuminate/Support/InteractsWithTime.php
@@ -35,7 +35,7 @@ trait InteractsWithTime
 
         return $delay instanceof DateTimeInterface
                             ? $delay->getTimestamp()
-                            : Carbon::now()->addRealSeconds($delay)->getTimestamp();
+                            : Carbon::now()->addSeconds($delay)->getTimestamp();
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,7 +23,7 @@
         "illuminate/conditionable": "^12.0",
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
-        "nesbot/carbon": "^2.72.2|^3.4",
+        "nesbot/carbon": "^3.4",
         "voku/portable-ascii": "^2.0.2"
     },
     "conflict": {


### PR DESCRIPTION
Hello!

This removes support for Carbon v2 and cleans up the `addReal*` methods to use the `add*` equivalents.

Thanks!