### PR TITLE
[11.x] Add limit option to the queue failed command

### DIFF
--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'queue:failed')]
 class ListFailedCommand extends Command
@@ -15,7 +16,7 @@ class ListFailedCommand extends Command
      *
      * @var string
      */
-    protected $name = 'queue:failed {--limit= : The number of failed jobs to be displayed}';
+    protected $name = 'queue:failed';
 
     /**
      * The console command description.
@@ -123,5 +124,17 @@ class ListFailedCommand extends Command
                 sprintf('<fg=gray>%s@%s</> %s', $job[1], $job[2], $job[3])
             ),
         );
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['limit', null, InputOption::VALUE_OPTIONAL, 'The number of failed jobs to be displayed',],
+        ];
     }
 }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -134,7 +134,7 @@ class ListFailedCommand extends Command
     protected function getOptions()
     {
         return [
-            ['limit', null, InputOption::VALUE_OPTIONAL, 'The number of failed jobs to be displayed',],
+            ['limit', null, InputOption::VALUE_OPTIONAL, 'The number of failed jobs to be displayed'],
         ];
     }
 }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -15,14 +15,14 @@ class ListFailedCommand extends Command
      *
      * @var string
      */
-    protected $name = 'queue:failed';
+    protected $name = 'queue:failed {--limit= : The number of failed jobs to be displayed}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'List all of the failed queue jobs';
+    protected $description = 'List failed queue jobs';
 
     /**
      * The table headers for the command.
@@ -54,7 +54,9 @@ class ListFailedCommand extends Command
      */
     protected function getFailedJobs()
     {
-        $failed = $this->laravel['queue.failer']->all();
+        $failed = $this->option('limit') ?
+            $this->laravel['queue.failer']->limit($this->option('limit'))
+            : $this->laravel['queue.failer']->all();
 
         return (new Collection($failed))
             ->map(fn ($failed) => $this->parseFailedJob((array) $failed))

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
+class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider, LimitableFailedJobProvider
 {
     /**
      * The connection resolver implementation.
@@ -168,5 +168,20 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     protected function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
+    }
+
+    /**
+     * Get a specific number of failed jobs.
+     *
+     * @param  int  $value
+     * @return array
+     */
+    public function limit($value)
+    {
+        return $this->getTable()
+            ->orderBy('id', 'desc')
+            ->limit($value)
+            ->get()
+            ->all();
     }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider, LimitableFailedJobProvider
+class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, LimitableFailedJobProvider, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
+class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider, LimitableFailedJobProvider
 {
     /**
      * The connection resolver implementation.
@@ -181,5 +181,21 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     protected function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
+    }
+
+    /**
+     * Get a specific number of failed jobs.
+     *
+     * @param  int  $value
+     * @return array
+     */
+    public function limit($value)
+    {
+        return $this->getTable()->orderBy('id', 'desc')->limit($value)->get()->map(function ($record) {
+            $record->id = $record->uuid;
+            unset($record->uuid);
+
+            return $record;
+        })->all();
     }
 }

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider, LimitableFailedJobProvider
+class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, LimitableFailedJobProvider, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 
-class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider, LimitableFailedJobProvider
+class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, LimitableFailedJobProvider, PrunableFailedJobProvider
 {
     /**
      * The file path where the failed job file should be stored.

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 
-class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
+class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider, LimitableFailedJobProvider
 {
     /**
      * The file path where the failed job file should be stored.
@@ -234,5 +234,18 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
         return (new Collection($this->read()))
             ->filter(fn ($job) => $job->connection === ($connection ?? $job->connection) && $job->queue === ($queue ?? $job->queue))
             ->count();
+    }
+
+    /**
+     * Get a specific number of failed jobs.
+     *
+     * @param  int  $value
+     * @return array
+     */
+    public function limit($value)
+    {
+        return collect($this->read())
+            ->take($value)
+            ->all();
     }
 }

--- a/src/Illuminate/Queue/Failed/LimitableFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/LimitableFailedJobProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+interface LimitableFailedJobProvider
+{
+    /**
+     * Count the failed jobs.
+     *
+     * @param  int  $value
+     * @return array
+     */
+    public function limit($value);
+}

--- a/src/Illuminate/Queue/Failed/LimitableFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/LimitableFailedJobProvider.php
@@ -5,7 +5,7 @@ namespace Illuminate\Queue\Failed;
 interface LimitableFailedJobProvider
 {
     /**
-     * Count the failed jobs.
+     * Get a specific number of failed jobs.
      *
      * @param  int  $value
      * @return array

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -46,6 +46,16 @@ class DatabaseFailedJobProviderTest extends TestCase
         $this->assertSame('default', $this->provider->all()[1]->queue);
     }
 
+    public function testCanLimitANumberOfFailedJobs()
+    {
+        $this->assertEmpty($this->provider->all());
+
+        array_map(fn () => $this->createFailedJobsRecord(), range(1, 5));
+
+        $this->assertCount(4, $this->provider->limit(4));
+        $this->assertSame([5, 4, 3], array_column($this->provider->limit(3), 'id'));
+    }
+
     public function testCanRetrieveFailedJobsById()
     {
         array_map(fn () => $this->createFailedJobsRecord(), range(1, 2));

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -178,4 +178,23 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
 
         return new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), $database, $table);
     }
+
+    public function testFailedJobsCanBeLimited()
+    {
+        $provider = $this->getFailedJobProvider();
+
+        $this->assertEmpty($provider->all());
+
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => 'uuid-1']), new RuntimeException());
+        $provider->log('connection-2', 'queue-2', json_encode(['uuid' => 'uuid-2']), new RuntimeException());
+        $provider->log('connection-3', 'queue-3', json_encode(['uuid' => 'uuid-3']), new RuntimeException());
+        $provider->log('connection-4', 'queue-4', json_encode(['uuid' => 'uuid-4']), new RuntimeException());
+
+        $this->assertCount(3, $provider->limit(3));
+
+        $this->assertSame(
+            ['uuid-1', 'uuid-2', 'uuid-3'],
+            array_column($provider->limit(3), 'id')
+        );
+    }
 }

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -200,4 +200,36 @@ class FileFailedJobProviderTest extends TestCase
 
         return [(string) $uuid, $exception];
     }
+
+    public function testCanRetrieveLimitedFailedJobs()
+    {
+        [$uuidOne, $exceptionOne] = $this->logFailedJob();
+        [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
+        [$uuidThree, $exceptionThree] = $this->logFailedJob();
+
+        $failedJobs = $this->provider->limit(2);
+
+        $this->assertCount(2, $failedJobs);
+
+        $this->assertEquals([
+            (object) [
+                'id' => $uuidThree,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidThree]),
+                'exception' => (string) mb_convert_encoding($exceptionThree, 'UTF-8'),
+                'failed_at' => $failedJobs[0]->failed_at,
+                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
+            ],
+            (object) [
+                'id' => $uuidTwo,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidTwo]),
+                'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
+                'failed_at' => $failedJobs[1]->failed_at,
+                'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
+            ],
+        ], $failedJobs);
+    }
 }

--- a/tests/Queue/ListFailedCommandTest.php
+++ b/tests/Queue/ListFailedCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Console\ListFailedCommand;
+use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+
+class ListFailedCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testGetAllFailedJobs()
+    {
+        $container = new Application;
+        $container->instance('queue.failer', $provider = m::spy(DatabaseUuidFailedJobProvider::class));
+
+        $command = new ListFailedCommand();
+        $command->setLaravel($container);
+
+        $command->run(new ArrayInput([]), new NullOutput());
+
+        $provider->shouldHaveReceived('all')->once();
+    }
+
+    public function testLimitANumberOfLatestFailedJobs()
+    {
+        $container = new Application;
+        $container->instance('queue.failer', $provider = m::spy(DatabaseUuidFailedJobProvider::class));
+
+        $command = new ListFailedCommand();
+        $command->setLaravel($container);
+
+        $command->run(new ArrayInput(['--limit' => 10]), new NullOutput());
+
+        $provider->shouldHaveReceived('limit')->once();
+    }
+}

--- a/tests/Queue/ListFailedCommandTest.php
+++ b/tests/Queue/ListFailedCommandTest.php
@@ -8,8 +8,6 @@ use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 
 class ListFailedCommandTest extends TestCase


### PR DESCRIPTION
I find the `php artisan queue:failed` valuable. I can quickly check the latest failed jobs from the terminal.

Plus, for projects using NoSQL databases, we have to use the `file` driver to store failed jobs, it would be a bit easier to see the latest failed jobs from the terminal.

In development environments, we can have hundreds of failed jobs. This number in staging and production environments could be thousands. This command will retrieve all the failed jobs and go all the way down to the oldest ones. That makes this command mostly unusable.

A simple `limit` option is gonna help. Most of the time we are only interested in a handful of latest failed jobs.

I have symlinked this feature branch to a test Laravel project, the results are as below:

![Screenshot 2024-12-10 at 9 53 34 PM](https://github.com/user-attachments/assets/8b5a2669-0236-48eb-aaea-419cb27a4a2d)

Currently I am not skilled enough with DynamoDb to implement the `limit` method. This could be done later.
