### PR TITLE
Add columns option for `fresh` and `refresh` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -399,9 +399,10 @@ class Collection extends BaseCollection implements QueueableCollection
      * Reload a fresh model instance from the database for all the entities.
      *
      * @param  array<array-key, string>|string  $with
+     * @param  array<array-key, string>|string  $columns
      * @return static
      */
-    public function fresh($with = [])
+    public function fresh($with = [], $columns = ['*'])
     {
         if ($this->isEmpty()) {
             return new static;
@@ -412,7 +413,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $freshModels = $model->newQueryWithoutScopes()
             ->with(is_string($with) ? func_get_args() : $with)
             ->whereIn($model->getKeyName(), $this->modelKeys())
-            ->get()
+            ->get($columns)
             ->getDictionary();
 
         return $this->filter(fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1699,9 +1699,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Reload a fresh model instance from the database.
      *
      * @param  array|string  $with
+     * @param  array|string  $columns
      * @return static|null
      */
-    public function fresh($with = [])
+    public function fresh($with = [], $columns = ['*'])
     {
         if (! $this->exists) {
             return;
@@ -1710,15 +1711,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         return $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
             ->useWritePdo()
             ->with(is_string($with) ? func_get_args() : $with)
-            ->first();
+            ->first($columns);
     }
 
     /**
      * Reload the current model instance with fresh attributes from the database.
      *
+     * @param  array|string  $columns
      * @return $this
      */
-    public function refresh()
+    public function refresh($columns = ['*'])
     {
         if (! $this->exists) {
             return $this;
@@ -1727,7 +1729,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->setRawAttributes(
             $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
                 ->useWritePdo()
-                ->firstOrFail()
+                ->firstOrFail($columns)
                 ->attributes
         );
 


### PR DESCRIPTION
Add a columns option to fetch for `refresh` and `fresh` method.

This helps to explicitly load **invisible** column from database.