### PR TITLE
Add support for validated enum retrieval in FormRequest.

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -246,6 +246,24 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Retrieve data from the instance as an enum ensuring validation.
+     *
+     * @template TEnum of \BackedEnum
+     *
+     * @param $key
+     * @param $enumClass
+     * @return TEnum|null
+     */
+    public function validatedEnum($key, $enumClass)
+    {
+        if ($this->validated($key) === null) {
+            return null;
+        }
+
+        return $this->enum($key, $enumClass);
+    }
+
+    /**
      * Get custom messages for validator errors.
      *
      * @return array

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -251,7 +251,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @template TEnum of \BackedEnum
      *
      * @param  string $key
-     * @param  class-string<TEnum> $enumClass
+     * @param  class-string<TEnum>  $enumClass
      * @return TEnum|null
      */
     public function validatedEnum($key, $enumClass)

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -250,7 +250,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @template TEnum of \BackedEnum
      *
-     * @param  string $key
+     * @param  string  $key
      * @param  class-string<TEnum>  $enumClass
      * @return TEnum|null
      */

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -250,8 +250,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @template TEnum of \BackedEnum
      *
-     * @param  $key
-     * @param  $enumClass
+     * @param  string $key
+     * @param  class-string<TEnum> $enumClass
      * @return TEnum|null
      */
     public function validatedEnum($key, $enumClass)

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -250,8 +250,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @template TEnum of \BackedEnum
      *
-     * @param $key
-     * @param $enumClass
+     * @param  $key
+     * @param  $enumClass
      * @return TEnum|null
      */
     public function validatedEnum($key, $enumClass)

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -232,16 +232,17 @@ class FoundationFormRequestTest extends TestCase
 
     public function testValidatedEnumMethodReturnsTheValidatedData()
     {
+        FoundationFormRequestWithEnumRules::$useRuleSet = 'a';
         $request = $this->createRequest(['day' => 'Monday'], FoundationFormRequestWithEnumRules::class);
         $request->validateResolved();
 
         $this->assertEquals(DaysOfWeekEnum::Monday, $request->validatedEnum('day', DaysOfWeekEnum::class));
 
-        $this->expectException(ValidationException::class);
+        FoundationFormRequestWithEnumRules::$useRuleSet = 'b';
         $request = $this->createRequest(['day' => 'Sunday'], FoundationFormRequestWithEnumRules::class);
         $request->validateResolved();
 
-        $this->assertEquals(null, $request->validatedEnum('day', DaysOfWeekEnum::class));
+        $this->assertNull($request->validatedEnum('day', DaysOfWeekEnum::class));
     }
 
     /**
@@ -534,11 +535,17 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
 
 class FoundationFormRequestWithEnumRules extends FormRequest
 {
+    public static $useRuleSet = 'a';
+
     public function rules()
     {
-        return [
-            'day' => ['required', Rule::enum(DaysOfWeekEnum::class), 'in:Monday,Tuesday,Wednesday,Thursday,Friday'],
-        ];
+        if (self::$useRuleSet === 'a') {
+            return [
+                'day' => ['required', Rule::enum(DaysOfWeekEnum::class), 'in:Monday,Tuesday,Wednesday,Thursday,Friday'],
+            ];
+        } else {
+            return [];
+        }
     }
 
     public function authorize()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The below code is retrieving the input in the form of a backed enum, but it does not have the additional safety of ensuring the value is validated, such as with `$request->validated('key')`.

```
Company::update([
    'payroll_day' => $request->enum('day');
]);
```

This pull request adds a new `validatedEnum` method to the FormRequest object.

For example, say you had an enum for the days of the week, but you wanted to validate the input to only be for week days.

Using `$request->validatedEnum('days')` would ensure that the validation has occurred, as well as retrieving the input as the enum.

Currently, there is no convenient way to do this:

New way:
```
Company::update([
    'payroll_day' => $request->validatedEnum('day');
]);
```