### PR TITLE
Specify node when sending scan to RedisCluster

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -2,12 +2,28 @@
 
 namespace Illuminate\Redis\Connections;
 
+use InvalidArgumentException;
+
 class PhpRedisClusterConnection extends PhpRedisConnection
 {
     /**
+     * The RedisCluster client.
+     *
+     * @var \RedisCluster
+     */
+    protected $client;
+
+    /**
+     * The default node to use from the cluster.
+     *
+     * @var string|array
+     */
+    protected $defaultNode;
+
+    /**
      * Flush the selected Redis database on all master nodes.
      *
-     * @return mixed
+     * @return void
      */
     public function flushdb()
     {
@@ -20,5 +36,45 @@ class PhpRedisClusterConnection extends PhpRedisConnection
                 ? $this->command('rawCommand', [$master, 'flushdb', 'async'])
                 : $this->command('flushdb', [$master]);
         }
+    }
+
+    /**
+     * Scans all keys based on options.
+     *
+     * @param  mixed  $cursor
+     * @param  array  $options
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function scan($cursor, $options = [])
+    {
+        $result = $this->client->scan($cursor,
+            $options['node'] ?? $this->defaultNode(),
+            $options['match'] ?? '*',
+            $options['count'] ?? 10
+        );
+
+        if ($result === false) {
+            $result = [];
+        }
+
+        return $cursor === 0 && empty($result) ? false : [$cursor, $result];
+    }
+
+    /**
+     * Return default node to use for cluster.
+     *
+     * @return string|array
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function defaultNode()
+    {
+        if (! isset($this->defaultNode)) {
+            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('No master nodes found in the cluster.');
+        }
+
+        return $this->defaultNode;
     }
 }

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -21,25 +21,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     protected $defaultNode;
 
     /**
-     * Flush the selected Redis database on all master nodes.
-     *
-     * @return void
-     */
-    public function flushdb()
-    {
-        $arguments = func_get_args();
-
-        $async = strtoupper((string) ($arguments[0] ?? null)) === 'ASYNC';
-
-        foreach ($this->client->_masters() as $master) {
-            $async
-                ? $this->command('rawCommand', [$master, 'flushdb', 'async'])
-                : $this->command('flushdb', [$master]);
-        }
-    }
-
-    /**
-     * Scans all keys based on options.
+     * Scan all keys based on the given options.
      *
      * @param  mixed  $cursor
      * @param  array  $options
@@ -64,6 +46,24 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     }
 
     /**
+     * Flush the selected Redis database on all master nodes.
+     *
+     * @return void
+     */
+    public function flushdb()
+    {
+        $arguments = func_get_args();
+
+        $async = strtoupper((string) ($arguments[0] ?? null)) === 'ASYNC';
+
+        foreach ($this->client->_masters() as $master) {
+            $async
+                ? $this->command('rawCommand', [$master, 'flushdb', 'async'])
+                : $this->command('flushdb', [$master]);
+        }
+    }
+
+    /**
      * Return default node to use for cluster.
      *
      * @return string|array
@@ -73,7 +73,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     private function defaultNode()
     {
         if (! isset($this->defaultNode)) {
-            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('No master nodes found in the cluster.');
+            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
         }
 
         return $this->defaultNode;

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -47,6 +47,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
      *
      * @throws \InvalidArgumentException
      */
+    #[\Override]
     public function scan($cursor, $options = [])
     {
         $result = $this->client->scan($cursor,

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+#[RequiresPhpExtension('redis')]
+class PhpRedisClusterConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testItScansUsingDefaultNode()
+    {
+        $client = m::mock(\RedisCluster::class);
+        $client->shouldReceive('_masters')->once()->andReturn([['127.0.0.1', '6379']]);
+        $client->shouldReceive('scan')
+            ->once()
+            ->with(0, ['127.0.0.1', '6379'], '*', 10)
+            ->andReturn(['key']);
+
+        $connection = new PhpRedisClusterConnection($client);
+        $this->assertEquals([0, ['key']], $connection->scan(0));
+    }
+
+    public function testItOnlyFetchesDefaultNodeOnce()
+    {
+        $client = m::mock(\RedisCluster::class);
+        $client->shouldReceive('_masters')->once()->andReturn([['127.0.0.1', '6379']]);
+        $client->shouldReceive('scan')->twice();
+
+        $connection = new PhpRedisClusterConnection($client);
+        $connection->scan(0);
+        $connection->scan(0);
+    }
+
+    public function testItScansUsingOptionNode()
+    {
+        $client = m::mock(\RedisCluster::class);
+        $client->shouldReceive('scan')
+            ->once()
+            ->with(0, 'option-node', '*', 10)
+            ->andReturn(['key']);
+
+        $connection = new PhpRedisClusterConnection($client);
+        $this->assertEquals([0, ['key']], $connection->scan(0, ['node' => 'option-node']));
+    }
+
+    public function testItThrowsExceptionWithoutNodes()
+    {
+        $client = m::mock(\RedisCluster::class);
+        $client->shouldReceive('_masters')->once()->andReturn([]);
+        $client->shouldReceive('scan');
+
+        $this->expectExceptionMessage('No master nodes found in the cluster.');
+
+        $connection = new PhpRedisClusterConnection($client);
+        $connection->scan(0);
+    }
+}

--- a/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisClusterConnectionTest.php
@@ -57,7 +57,7 @@ class PhpRedisClusterConnectionTest extends TestCase
         $client->shouldReceive('_masters')->once()->andReturn([]);
         $client->shouldReceive('scan');
 
-        $this->expectExceptionMessage('No master nodes found in the cluster.');
+        $this->expectExceptionMessage('Unable to determine default node. No master nodes found in the cluster.');
 
         $connection = new PhpRedisClusterConnection($client);
         $connection->scan(0);


### PR DESCRIPTION
This fixes the issue identified in #53826 where the wrong parameters are being sent to RedisCluster and causing a variety of issues.

I've made it so the class defaults to using the first master node and caches this value on the connection class to avoid calling `_masters` every scan.