### PR TITLE
Fixed Enum usage in whereHasMorph condition when morph attribute casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())
                 ->filter()
-                ->map(fn($item) => $item instanceof \BackedEnum ? $item->value : $item)
+                ->map(fn ($item) => $item instanceof \BackedEnum ? $item->value : $item)
                 ->all();
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 /** @mixin \Illuminate\Database\Eloquent\Builder */
 trait QueriesRelationships
 {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())
                 ->filter()
-                ->map(fn ($item) => $item instanceof \BackedEnum ? $item->value : $item)
+                ->map(fn ($item) => enum_value($item))
                 ->all();
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -229,7 +229,10 @@ trait QueriesRelationships
         $types = (array) $types;
 
         if ($types === ['*']) {
-            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
+            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())
+                ->filter()
+                ->map(fn($item) => $item instanceof \BackedEnum ? $item->value : $item)
+                ->all();
         }
 
         if (empty($types)) {


### PR DESCRIPTION
When using Laravel’s whereHasMorph condition with a model attribute that is a morph type and cast as an Enum, the following error occurs:

`->whereHasMorph('relationName', '*', function ($query) {
    $query->where('status', SomeTypeEnum::Active);
});`

`Cannot access offset of type SomeTypeEnum on array`

This issue arises due to improper handling of Enum values in the query builder when the morph attribute is processed.

