### PR TITLE
Add translation for "empty"

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -486,7 +486,7 @@ trait FormatsMessages
         }
 
         if (is_null($value)) {
-            return 'empty';
+            return $this->translator->get("validation.empty");
         }
 
         return (string) $value;


### PR DESCRIPTION
In the getDisplayableValue function, the word "empty" is returned.

Better if it is translated.
