### PR TITLE
[11.x] Fix incorrect typechange in `Illuminate\Database\Query\Builder`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -123,7 +123,7 @@ class Builder implements BuilderContract
     /**
      * The where constraints for the query.
      *
-     * @var array|null
+     * @var array
      */
     public $wheres = [];
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In #53793 various properties in the `Illuminate\Database\Query\Builder` class were marked as nullable as they have no initial value, thus defaulting to `null`. However the `wheres` properties is initialized with an empty array, thus already is an array on class construction and should never be `null`.