### PR TITLE
[11.x] Fix unescaped table names issue of `DatabaseTruncation` trait by introducing `Connection::withoutTablePrefix()` method

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1647,6 +1647,23 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Execute the given callback without table prefix.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function withoutTablePrefix(Closure $callback): void
+    {
+        $tablePrefix = $this->getTablePrefix();
+
+        $this->setTablePrefix('');
+
+        $callback($this);
+
+        $this->setTablePrefix($tablePrefix);
+    }
+
+    /**
      * Get the server version for the connection.
      *
      * @return string

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\PostgresBuilder;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
 use Illuminate\Support\Collection;

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -99,13 +99,15 @@ trait DatabaseTruncation
                 }
             )
             ->each(function (array $table) use ($connection) {
-                $table = $connection->table(
-                    new Expression($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name'])
-                );
+                $connection->withoutTablePrefix(function ($connection) use ($table) {
+                    $table = $connection->table(
+                        $table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name']
+                    );
 
-                if ($table->exists()) {
-                    $table->truncate();
-                }
+                    if ($table->exists()) {
+                        $table->truncate();
+                    }
+                });
             });
 
         $connection->setEventDispatcher($dispatcher);

--- a/tests/Foundation/Testing/DatabaseTruncationTest.php
+++ b/tests/Foundation/Testing/DatabaseTruncationTest.php
@@ -189,18 +189,18 @@ class DatabaseTruncationTest extends TestCase
             $schema->shouldReceive('getSchemas')->once()->andReturn($schemas);
         }
 
-        $grammar = m::mock(Grammar::class);
-
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('getTablePrefix')->andReturn($prefix);
         $connection->shouldReceive('getEventDispatcher')->once()->andReturn($dispatcher = m::mock(Dispatcher::class));
         $connection->shouldReceive('unsetEventDispatcher')->once();
         $connection->shouldReceive('setEventDispatcher')->once()->with($dispatcher);
         $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
+        $connection->shouldReceive('withoutTablePrefix')->andReturnUsing(function ($callback) use ($connection) {
+            $callback($connection);
+        });
         $connection->shouldReceive('table')
-            ->with(m::type(Expression::class))
-            ->andReturnUsing(function (Expression $expression) use (&$actual, $grammar) {
-                $actual[] = $expression->getValue($grammar);
+            ->andReturnUsing(function (string $tableName) use (&$actual) {
+                $actual[] = $tableName;
 
                 $table = m::mock();
                 $table->shouldReceive('exists')->andReturnTrue();

--- a/tests/Foundation/Testing/DatabaseTruncationTest.php
+++ b/tests/Foundation/Testing/DatabaseTruncationTest.php
@@ -5,8 +5,6 @@ namespace Illuminate\Tests\Foundation\Testing;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Grammar;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\PostgresBuilder;
 use Illuminate\Foundation\Testing\DatabaseTruncation;

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Events\ConnectionEstablished;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
 class DatabaseConnectionsTest extends DatabaseTestCase
@@ -117,5 +118,20 @@ class DatabaseConnectionsTest extends DatabaseTestCase
         );
 
         self::assertSame('my-phpunit-connection', $event->connectionName);
+    }
+
+    public function testTablePrefix()
+    {
+        DB::setTablePrefix('prefix_');
+        $this->assertSame('prefix_', DB::getTablePrefix());
+
+        DB::withoutTablePrefix(function ($connection) {
+            $this->assertSame('', $connection->getTablePrefix());
+        });
+
+        $this->assertSame('prefix_', DB::getTablePrefix());
+
+        DB::setTablePrefix('');
+        $this->assertSame('', DB::getTablePrefix());
     }
 }


### PR DESCRIPTION
Fixes #53838

On PR #53787, we had to pass the table names as `Expression` to the queries on `DatabaseTruncation` trait because table names are already prefixed and passing them as `string` (instead of `Expression`) causes query grammar to prefix the table names twice!

But when passing as `Expression`, the table names are not escaped which causes issue when tables have reserved names as reported on #53838.

This PR adds `withoutTablePrefix()` method to the `Connection` class. This method temporary disables the connection's table prefix when executing its given callback. This new method is then used on the `DatabaseTruncation` trait.