### PR TITLE
Remove use of new Expression

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\PostgresBuilder;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
 use Illuminate\Support\Collection;

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -99,9 +99,7 @@ trait DatabaseTruncation
                 }
             )
             ->each(function (array $table) use ($connection) {
-                $table = $connection->table(
-                    new Expression($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name'])
-                );
+                $table = $connection->table($table['schema'] ? $table['schema'].'.'.$table['name'] : $table['name']);
 
                 if ($table->exists()) {
                     $table->truncate();

--- a/tests/Foundation/Testing/DatabaseTruncationTest.php
+++ b/tests/Foundation/Testing/DatabaseTruncationTest.php
@@ -5,8 +5,6 @@ namespace Illuminate\Tests\Foundation\Testing;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Grammar;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\PostgresBuilder;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
@@ -189,8 +187,6 @@ class DatabaseTruncationTest extends TestCase
             $schema->shouldReceive('getSchemas')->once()->andReturn($schemas);
         }
 
-        $grammar = m::mock(Grammar::class);
-
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('getTablePrefix')->andReturn($prefix);
         $connection->shouldReceive('getEventDispatcher')->once()->andReturn($dispatcher = m::mock(Dispatcher::class));
@@ -198,9 +194,9 @@ class DatabaseTruncationTest extends TestCase
         $connection->shouldReceive('setEventDispatcher')->once()->with($dispatcher);
         $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
         $connection->shouldReceive('table')
-            ->with(m::type(Expression::class))
-            ->andReturnUsing(function (Expression $expression) use (&$actual, $grammar) {
-                $actual[] = $expression->getValue($grammar);
+            ->with(m::type('string'))
+            ->andReturnUsing(function (string $expression) use (&$actual) {
+                $actual[] = $expression;
 
                 $table = m::mock();
                 $table->shouldReceive('exists')->andReturnTrue();


### PR DESCRIPTION
This closes #53838 by eliminating the passing of un-escaped schema and table names to the `exists()` and `truncate()` methods and will allow users who have [MySQL reserved/keyword](https://dev.mysql.com/doc/refman/8.4/en/keywords.html#keywords-in-current-series) table names to continue using the `DatabaseTruncation` as all previous versions allowed.

The use of `new Expression` prevented the `Database\Query\Builder` instance from automatically escaping the table names which is not picked up in the tests as that part is mocked.


