### PR TITLE
[12.x] use promoted properties for Auth events

### DIFF
--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -5,38 +5,17 @@ namespace Illuminate\Auth\Events;
 class Attempting
 {
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The credentials for the user.
-     *
-     * @var array
-     */
-    public $credentials;
-
-    /**
-     * Indicates if the user should be "remembered".
-     *
-     * @var bool
-     */
-    public $remember;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  array  $credentials
-     * @param  bool  $remember
+     * @param  string  $guard  The authentication guard name.
+     * @param  array  $credentials  The credentials for the user.
+     * @param  bool  $remember  Indicates if the user should be "remembered".
      * @return void
      */
-    public function __construct($guard, #[\SensitiveParameter] $credentials, $remember)
-    {
-        $this->guard = $guard;
-        $this->remember = $remember;
-        $this->credentials = $credentials;
+    public function __construct(
+        public $guard,
+        #[\SensitiveParameter] public $credentials,
+        public $remember,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -9,29 +9,15 @@ class Authenticated
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -9,29 +9,15 @@ class CurrentDeviceLogout
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -5,38 +5,17 @@ namespace Illuminate\Auth\Events;
 class Failed
 {
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The user the attempter was trying to authenticate as.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable|null
-     */
-    public $user;
-
-    /**
-     * The credentials provided by the attempter.
-     *
-     * @var array
-     */
-    public $credentials;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
-     * @param  array  $credentials
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user  The user the attempter was trying to authenticate as.
+     * @param  array  $credentials  The credentials provided by the attempter.
      * @return void
      */
-    public function __construct($guard, $user, #[\SensitiveParameter] $credentials)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-        $this->credentials = $credentials;
+    public function __construct(
+        public $guard,
+        public $user,
+        #[\SensitiveParameter] public $credentials,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -9,38 +9,17 @@ class Login
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
-     * Indicates if the user should be "remembered".
-     *
-     * @var bool
-     */
-    public $remember;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  bool  $remember
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
+     * @param  bool  $remember  Indicates if the user should be "remembered".
      * @return void
      */
-    public function __construct($guard, $user, $remember)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
-        $this->remember = $remember;
+    public function __construct(
+        public $guard,
+        public $user,
+        public $remember,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -9,29 +9,15 @@ class Logout
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -9,29 +9,15 @@ class OtherDeviceLogout
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  \Illuminate\Contracts\Auth\Authenticatable
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -9,20 +9,13 @@ class PasswordReset
     use SerializesModels;
 
     /**
-     * The user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The user.
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
+    public function __construct(
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -9,20 +9,13 @@ class PasswordResetLinkSent
     use SerializesModels;
 
     /**
-     * The user instance.
-     *
-     * @var \Illuminate\Contracts\Auth\CanResetPassword
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user  The user instance.
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
+    public function __construct(
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -9,20 +9,13 @@ class Registered
     use SerializesModels;
 
     /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
+    public function __construct(
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -9,29 +9,15 @@ class Validated
     use SerializesModels;
 
     /**
-     * The authentication guard name.
-     *
-     * @var string
-     */
-    public $guard;
-
-    /**
-     * The user retrieved and validated from the User Provider.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $guard
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $guard  The authentication guard name.
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The user retrieved and validated from the User Provider.
      * @return void
      */
-    public function __construct($guard, $user)
-    {
-        $this->user = $user;
-        $this->guard = $guard;
+    public function __construct(
+        public $guard,
+        public $user,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -9,20 +9,13 @@ class Verified
     use SerializesModels;
 
     /**
-     * The verified user.
-     *
-     * @var \Illuminate\Contracts\Auth\MustVerifyEmail
-     */
-    public $user;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Contracts\Auth\MustVerifyEmail  $user
+     * @param  \Illuminate\Contracts\Auth\MustVerifyEmail  $user  The verified user.
      * @return void
      */
-    public function __construct($user)
-    {
-        $this->user = $user;
+    public function __construct(
+        public $user,
+    ) {
     }
 }


### PR DESCRIPTION
this is a simplified version of #53834 that addresses some concerns from the first one.

- comments are maintained in the constructor docblock