### PR TITLE
[12.x] use promoted properties for Console events

### DIFF
--- a/src/Illuminate/Console/Events/ArtisanStarting.php
+++ b/src/Illuminate/Console/Events/ArtisanStarting.php
@@ -5,20 +5,13 @@ namespace Illuminate\Console\Events;
 class ArtisanStarting
 {
     /**
-     * The Artisan application instance.
-     *
-     * @var \Illuminate\Console\Application
-     */
-    public $artisan;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Application  $artisan
+     * @param  \Illuminate\Console\Application  $artisan  The Artisan application instance.
      * @return void
      */
-    public function __construct($artisan)
-    {
-        $this->artisan = $artisan;
+    public function __construct(
+        public $artisan,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -8,47 +8,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandFinished
 {
     /**
-     * The command name.
-     *
-     * @var string
-     */
-    public $command;
-
-    /**
-     * The console input implementation.
-     *
-     * @var \Symfony\Component\Console\Input\InputInterface|null
-     */
-    public $input;
-
-    /**
-     * The command output implementation.
-     *
-     * @var \Symfony\Component\Console\Output\OutputInterface|null
-     */
-    public $output;
-
-    /**
-     * The command exit code.
-     *
-     * @var int
-     */
-    public $exitCode;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $command
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @param  int  $exitCode
+     * @param  string  $command  The command name.
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input  The console input implementation.
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output  The command output implementation.
+     * @param  int  $exitCode  The command exit code.
      * @return void
      */
-    public function __construct($command, InputInterface $input, OutputInterface $output, $exitCode)
-    {
-        $this->input = $input;
-        $this->output = $output;
-        $this->command = $command;
-        $this->exitCode = $exitCode;
+    public function __construct(
+        public $command,
+        public InputInterface $input,
+        public OutputInterface $output,
+        public $exitCode,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/CommandStarting.php
+++ b/src/Illuminate/Console/Events/CommandStarting.php
@@ -8,38 +8,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CommandStarting
 {
     /**
-     * The command name.
-     *
-     * @var string
-     */
-    public $command;
-
-    /**
-     * The console input implementation.
-     *
-     * @var \Symfony\Component\Console\Input\InputInterface|null
-     */
-    public $input;
-
-    /**
-     * The command output implementation.
-     *
-     * @var \Symfony\Component\Console\Output\OutputInterface|null
-     */
-    public $output;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $command
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param  string  $command  The command name.
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input  The console input implementation.
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output  The command output implementation.
      * @return void
      */
-    public function __construct($command, InputInterface $input, OutputInterface $output)
-    {
-        $this->input = $input;
-        $this->output = $output;
-        $this->command = $command;
+    public function __construct(
+        public $command,
+        public InputInterface $input,
+        public OutputInterface $output,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
@@ -7,20 +7,13 @@ use Illuminate\Console\Scheduling\Event;
 class ScheduledBackgroundTaskFinished
 {
     /**
-     * The scheduled event that ran.
-     *
-     * @var \Illuminate\Console\Scheduling\Event
-     */
-    public $task;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event that ran.
      * @return void
      */
-    public function __construct(Event $task)
-    {
-        $this->task = $task;
+    public function __construct(
+        public Event $task,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskFailed.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFailed.php
@@ -8,29 +8,15 @@ use Throwable;
 class ScheduledTaskFailed
 {
     /**
-     * The scheduled event that failed.
-     *
-     * @var \Illuminate\Console\Scheduling\Event
-     */
-    public $task;
-
-    /**
-     * The exception that was thrown.
-     *
-     * @var \Throwable
-     */
-    public $exception;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $task
-     * @param  \Throwable  $exception
+     * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event that failed.
+     * @param  \Throwable  $exception  The exception that was thrown.
      * @return void
      */
-    public function __construct(Event $task, Throwable $exception)
-    {
-        $this->task = $task;
-        $this->exception = $exception;
+    public function __construct(
+        public Event $task,
+        public Throwable $exception,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -7,29 +7,15 @@ use Illuminate\Console\Scheduling\Event;
 class ScheduledTaskFinished
 {
     /**
-     * The scheduled event that ran.
-     *
-     * @var \Illuminate\Console\Scheduling\Event
-     */
-    public $task;
-
-    /**
-     * The runtime of the scheduled event.
-     *
-     * @var float
-     */
-    public $runtime;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $task
-     * @param  float  $runtime
+     * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event that ran.
+     * @param  float  $runtime  The runtime of the scheduled event.
      * @return void
      */
-    public function __construct(Event $task, $runtime)
-    {
-        $this->task = $task;
-        $this->runtime = $runtime;
+    public function __construct(
+        public Event $task,
+        public $runtime,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
@@ -7,20 +7,13 @@ use Illuminate\Console\Scheduling\Event;
 class ScheduledTaskSkipped
 {
     /**
-     * The scheduled event being run.
-     *
-     * @var \Illuminate\Console\Scheduling\Event
-     */
-    public $task;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event being run.
      * @return void
      */
-    public function __construct(Event $task)
-    {
-        $this->task = $task;
+    public function __construct(
+        public Event $task,
+    ) {
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskStarting.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskStarting.php
@@ -7,20 +7,13 @@ use Illuminate\Console\Scheduling\Event;
 class ScheduledTaskStarting
 {
     /**
-     * The scheduled event being run.
-     *
-     * @var \Illuminate\Console\Scheduling\Event
-     */
-    public $task;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event being run.
      * @return void
      */
-    public function __construct(Event $task)
-    {
-        $this->task = $task;
+    public function __construct(
+        public Event $task,
+    ) {
     }
 }


### PR DESCRIPTION
- move property comments to constructor docblock

there is technically a small change in this commit. because the properties are `public`, even though the constructor type hints what it accepts, techically the properties could have been set to anything. this change tightens things up slightly so whether the properties are being set via the constructor or via direct property access, they **must** be the desired type.

this commit also highlight a benefit of moving to promoted properties in that we don't duplicate certain code or docblocks that could accidentally become out of sync.

for example, in the `CommandStarting` class, the `$input` property is hinted as `\Symfony\Component\Console\Input\InputInterface|null`, while the constructor does not allow `null`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
