### PR TITLE
Revert "set schema to smtps if MAIL_ENCRYPTION === tls"

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -194,9 +194,7 @@ class MailManager implements FactoryContract
         $scheme = $config['scheme'] ?? null;
 
         if (! $scheme) {
-            $scheme = ! empty($config['encryption']) && $config['encryption'] === 'tls'
-                ? 'smtps'
-                : 'smtp';
+            $scheme = ($config['port'] == 465) ? 'smtps' : 'smtp';
         }
 
         $transport = $factory->create(new Dsn(

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -74,7 +74,11 @@ class MailManagerTest extends TestCase
         $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
         $this->assertSame($port, $transport->getStream()->getPort());
         $this->assertSame($port === 465, $transport->getStream()->isTLS());
-        $this->assertTrue($transport->isAutoTls());
+
+        if (method_exists($transport, 'isAutoTls')) {
+            // Only available on Symfony Mailer 7.2
+            $this->assertTrue($transport->isAutoTls());
+        }
     }
 
     public function testBuild()

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -76,7 +76,7 @@ class MailManagerTest extends TestCase
         $this->assertSame($port === 465, $transport->getStream()->isTLS());
 
         if (method_exists($transport, 'isAutoTls')) {
-            // Only available on Symfony Mailer 7.2
+            // Only available on Symfony Mailer 7.1
             $this->assertTrue($transport->isAutoTls());
         }
     }

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -52,6 +52,31 @@ class MailManagerTest extends TestCase
         $this->assertSame($port === 465, $transport->getStream()->isTLS());
     }
 
+    #[TestWith([null, 5876])]
+    #[TestWith([null, 465])]
+    #[TestWith(['smtp', 25])]
+    #[TestWith(['smtp', 2525])]
+    #[TestWith(['smtps', 465])]
+    #[TestWith(['smtp', 465])]
+    public function testMailUrlConfigWithAutoTls($scheme, $port)
+    {
+        $this->app['config']->set('mail.mailers.smtp_url', [
+            'scheme' => $scheme,
+            'url' => "smtp://usr:pwd@127.0.0.2:{$port}?auto_tls=true",
+        ]);
+
+        $mailer = $this->app['mail.manager']->mailer('smtp_url');
+        $transport = $mailer->getSymfonyTransport();
+
+        $this->assertInstanceOf(EsmtpTransport::class, $transport);
+        $this->assertSame('usr', $transport->getUsername());
+        $this->assertSame('pwd', $transport->getPassword());
+        $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
+        $this->assertSame($port, $transport->getStream()->getPort());
+        $this->assertSame($port === 465, $transport->getStream()->isTLS());
+        $this->assertTrue($transport->isAutoTls());
+    }
+
     public function testBuild()
     {
         $config = [

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -50,6 +50,11 @@ class MailManagerTest extends TestCase
         $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
         $this->assertSame($port, $transport->getStream()->getPort());
         $this->assertSame($port === 465, $transport->getStream()->isTLS());
+
+        if (method_exists($transport, 'isAutoTls')) {
+            // Only available on Symfony Mailer 7.1
+            $this->assertTrue($transport->isAutoTls());
+        }
     }
 
     #[TestWith([null, 5876])]
@@ -78,6 +83,35 @@ class MailManagerTest extends TestCase
         if (method_exists($transport, 'isAutoTls')) {
             // Only available on Symfony Mailer 7.1
             $this->assertTrue($transport->isAutoTls());
+        }
+    }
+
+    #[TestWith([null, 5876])]
+    #[TestWith([null, 465])]
+    #[TestWith(['smtp', 25])]
+    #[TestWith(['smtp', 2525])]
+    #[TestWith(['smtps', 465])]
+    #[TestWith(['smtp', 465])]
+    public function testMailUrlConfigWithAutoTlsDisabled($scheme, $port)
+    {
+        $this->app['config']->set('mail.mailers.smtp_url', [
+            'scheme' => $scheme,
+            'url' => "smtp://usr:pwd@127.0.0.2:{$port}?auto_tls=false",
+        ]);
+
+        $mailer = $this->app['mail.manager']->mailer('smtp_url');
+        $transport = $mailer->getSymfonyTransport();
+
+        $this->assertInstanceOf(EsmtpTransport::class, $transport);
+        $this->assertSame('usr', $transport->getUsername());
+        $this->assertSame('pwd', $transport->getPassword());
+        $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
+        $this->assertSame($port, $transport->getStream()->getPort());
+        $this->assertSame($port === 465 && $scheme !== 'smtp', $transport->getStream()->isTLS());
+
+        if (method_exists($transport, 'isAutoTls')) {
+            // Only available on Symfony Mailer 7.1
+            $this->assertFalse($transport->isAutoTls());
         }
     }
 

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -52,7 +52,7 @@ class MailManagerTest extends TestCase
         $this->assertSame($port === 465, $transport->getStream()->isTLS());
 
         if (method_exists($transport, 'isAutoTls')) {
-            // Only available on Symfony Mailer 7.1
+            // Only available from Symfony Mailer 7.1
             $this->assertTrue($transport->isAutoTls());
         }
     }
@@ -81,7 +81,7 @@ class MailManagerTest extends TestCase
         $this->assertSame($port === 465, $transport->getStream()->isTLS());
 
         if (method_exists($transport, 'isAutoTls')) {
-            // Only available on Symfony Mailer 7.1
+            // Only available from Symfony Mailer 7.1
             $this->assertTrue($transport->isAutoTls());
         }
     }
@@ -110,7 +110,7 @@ class MailManagerTest extends TestCase
         $this->assertSame($port === 465 && $scheme !== 'smtp', $transport->getStream()->isTLS());
 
         if (method_exists($transport, 'isAutoTls')) {
-            // Only available on Symfony Mailer 7.1
+            // Only available from Symfony Mailer 7.1
             $this->assertFalse($transport->isAutoTls());
         }
     }

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -107,11 +107,13 @@ class MailManagerTest extends TestCase
         $this->assertSame('pwd', $transport->getPassword());
         $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
         $this->assertSame($port, $transport->getStream()->getPort());
-        $this->assertSame($port === 465 && $scheme !== 'smtp', $transport->getStream()->isTLS());
 
         if (method_exists($transport, 'isAutoTls')) {
             // Only available from Symfony Mailer 7.1
             $this->assertFalse($transport->isAutoTls());
+            $this->assertSame($port === 465 && $scheme !== 'smtp', $transport->getStream()->isTLS());
+        } else {
+            $this->assertSame($port === 465, $transport->getStream()->isTLS());
         }
     }
 


### PR DESCRIPTION
Reverts laravel/framework#53749

It seems that many of our Laravel users mistakenly configured `MAIL_ENCRYPTION=tls` when `symfony/mailer` would disregard this value completely and doesn't have any impact to determining `smtp` vs `smtps` or `tls` configuration within `symfony/mailer` since v4.4.

Moving forward it might is best to add `scheme` to the configuration and remove `MAIL_ENCRYPTION` completely.