### PR TITLE
[11.x] Add Blade @var directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -36,6 +36,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesStyles,
         Concerns\CompilesTranslations,
         Concerns\CompilesUseStatements,
+        Concerns\CompilesVarStatements,
         ReflectsClosures;
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesVarStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesVarStatements.php
@@ -12,7 +12,7 @@ trait CompilesVarStatements
      */
     protected function compileVar($expression)
     {
-        $var = preg_replace("/[()]/", '', $expression);
+        $var = preg_replace('/[()]/', '', $expression);
 
         $var = ltrim(trim($var, " '\""), '\\');
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesVarStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesVarStatements.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesVarStatements
+{
+    /**
+     * Compile the var statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileVar($expression)
+    {
+        $var = preg_replace("/[()]/", '', $expression);
+
+        $var = ltrim(trim($var, " '\""), '\\');
+
+        return "<?php /** @var \\{$var} */ ?>";
+    }
+}

--- a/tests/View/Blade/BladeVarTest.php
+++ b/tests/View/Blade/BladeVarTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeVarTest extends AbstractBladeTestCase
+{
+    public function testUseStatementsAreCompiled()
+    {
+        $string = 'Foo @var(App\Livewire\SomeComponent $this) bar';
+        $expected = 'Foo <?php /** @var \App\Livewire\SomeComponent $this */ ?> bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testVarStatementsWithBackslashAtBeginningAreCompiled()
+    {
+        $string = 'Foo @var(\App\Livewire\SomeComponent $this) bar';
+        $expected = 'Foo <?php /** @var \App\Livewire\SomeComponent $this */ ?> bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Same idea as #49179 but to add docblocks to improve IDE support like `/** var \Namespace\Class $variable */`. This is especially useful in Livewire components, Filament views and other Blade files where the IDE can not infer the variable types.

This is only an addition, so shouldn't cause any trouble or disturbance - unless someone has create a custom Blade directive called `@var`.

A minor addition for convenience when adding extra type information for your IDE in Blade components.

### Benefits
* 1 line instead of 3 🔥
* Less code to type ⏱️
* Makes templates look cleaner 🧹

### Example (Filament table in this case)

```blade
{{-- Before --}}
@php
    /** @var \App\Livewire\Playlist\Index $this */
@endphp

{{-- After --}}
@var(\App\Livewire\Playlist\Index $this)

{{ $this->table }}
```

### Caveats
IDE support won't be there initially for folks, so there will be squigglies.

Credits to @simonhamp for a decent part of this PR description text (based on #49179)