### PR TITLE
[11.x] Add port configuration for Beanstalkd driver

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -46,6 +46,7 @@ return [
         'beanstalkd' => [
             'driver' => 'beanstalkd',
             'host' => env('BEANSTALKD_QUEUE_HOST', 'localhost'),
+            'port' => env('BEANSTALKD_QUEUE_PORT'),
             'queue' => env('BEANSTALKD_QUEUE', 'default'),
             'retry_after' => (int) env('BEANSTALKD_QUEUE_RETRY_AFTER', 90),
             'block_for' => 0,


### PR DESCRIPTION
This PR adds the port parameter to the Beanstalkd driver configuration in config/queue.php.

### Motivation

Including the port explicitly improves readability and aligns the Beanstalkd configuration style with other drivers, which also define both host and port. The port value defaults to `null`, allowing the Pheanstalk library to use its default port (`11300`). This ensures full backward compatibility while giving users the flexibility to configure the port via the BEANSTALKD_QUEUE_PORT environment variable if needed.
