### PR TITLE
[11.x] Added an event that reports files being deleted when calling the `schema:dump --prune` command

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Events\SchemaDumped;
+use Illuminate\Database\Events\SchemaPruned;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -52,10 +53,12 @@ class DumpCommand extends Command
 
         if ($this->option('prune')) {
             (new Filesystem)->deleteDirectory(
-                database_path('migrations'), $preserve = false
+                $path = database_path('migrations'), $preserve = false
             );
 
             $info .= ' and pruned';
+
+            $dispatcher->dispatch(new SchemaPruned($connection, $path));
         }
 
         $this->components->info($info.' successfully.');

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -6,8 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Events\MigrationsPruned;
 use Illuminate\Database\Events\SchemaDumped;
-use Illuminate\Database\Events\SchemaPruned;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -58,7 +58,7 @@ class DumpCommand extends Command
 
             $info .= ' and pruned';
 
-            $dispatcher->dispatch(new SchemaPruned($connection, $path));
+            $dispatcher->dispatch(new MigrationsPruned($connection, $path));
         }
 
         $this->components->info($info.' successfully.');

--- a/src/Illuminate/Database/Events/MigrationsPruned.php
+++ b/src/Illuminate/Database/Events/MigrationsPruned.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Database\Events;
 
 use Illuminate\Database\Connection;
@@ -13,21 +11,21 @@ class MigrationsPruned
      *
      * @var \Illuminate\Database\Connection
      */
-    public Connection $connection;
+    public $connection;
 
     /**
      * The database connection name.
      *
      * @var string|null
      */
-    public ?string $connectionName;
+    public $connectionName;
 
     /**
-     * Path to the deleted directory.
+     * The path to the directory where migrations were pruned.
      *
      * @var string
      */
-    public string $path;
+    public $path;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Database/Events/MigrationsPruned.php
+++ b/src/Illuminate/Database/Events/MigrationsPruned.php
@@ -6,7 +6,7 @@ namespace Illuminate\Database\Events;
 
 use Illuminate\Database\Connection;
 
-class SchemaPruned
+class MigrationsPruned
 {
     /**
      * The database connection instance.
@@ -18,7 +18,7 @@ class SchemaPruned
     /**
      * The database connection name.
      *
-     * @var string
+     * @var string|null
      */
     public ?string $connectionName;
 

--- a/src/Illuminate/Database/Events/SchemaPruned.php
+++ b/src/Illuminate/Database/Events/SchemaPruned.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Database\Connection;
+
+class SchemaPruned
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    public Connection $connection;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    public ?string $connectionName;
+
+    /**
+     * Path to the deleted directory.
+     *
+     * @var string
+     */
+    public string $path;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $path
+     * @return void
+     */
+    public function __construct(Connection $connection, string $path)
+    {
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+        $this->path = $path;
+    }
+}


### PR DESCRIPTION
The `art schema:dump` console command is able to report the end of a job by sending the `SchemaDumped` event, but is unable to report file deletion if the command is called with the `--prune` parameter.

This PR adds a new event to implement this feature.

P.S.: I didn't find any tests to check both the `art schema:dump` command and the event, so I didn't add tests for the new event either.

P.S.2: The static analyzer error has nothing to do with my code :)

P.S.3: My case that started it all:

I am developing a [package](https://github.com/TheDragonCode/laravel-data-dumper) to export data from tables selected by the developer. Yesterday I added the ability to delete files, but I was surprised that in Laravel the `SchemaDumped` event doesn't contain a label when calling the console command with the `--prune` flag (and it shouldn't, because the essence of the event is related to the database schema, not to the files). That's why I decided to add a new event, called in case of launching a console command with the parameter of file trimming.