### PR TITLE
[11.x] Allows `enum_value()` to be use in standalone `illuminate/collections`

### DIFF
--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -8,16 +8,20 @@ if (! function_exists('Illuminate\Support\enum_value')) {
      *
      * @internal
      *
-     * @param  mixed  $value
-     * @return mixed
+     * @template TValue
+     * @template TDefault
+     *
+     * @param  TValue  $value
+     * @param  TDefault|callable(TValue): TDefault  $default
+     * @return ($value is empty ? TDefault : mixed)
      */
-    function enum_value($value)
+    function enum_value($value, $default = null)
     {
         return match (true) {
             $value instanceof \BackedEnum => $value->value,
             $value instanceof \UnitEnum => $value->name,
 
-            default => $value,
+            default => $value ?? value($default),
         };
     }
 }

--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -17,11 +17,20 @@ if (! function_exists('Illuminate\Support\enum_value')) {
      */
     function enum_value($value, $default = null)
     {
-        return transform($value, fn ($value) => match (true) {
+        if (function_exists('transform')) {
+            return transform($value, fn ($value) => match (true) {
+                $value instanceof \BackedEnum => $value->value,
+                $value instanceof \UnitEnum => $value->name,
+
+                default => $value,
+            }, $default ?? $value);
+        }
+
+        return match (true) {
             $value instanceof \BackedEnum => $value->value,
             $value instanceof \UnitEnum => $value->name,
 
             default => $value,
-        }, $default ?? $value);
+        };
     }
 }

--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -8,24 +8,11 @@ if (! function_exists('Illuminate\Support\enum_value')) {
      *
      * @internal
      *
-     * @template TValue
-     * @template TDefault
-     *
-     * @param  TValue  $value
-     * @param  TDefault|callable(TValue): TDefault  $default
-     * @return ($value is empty ? TDefault : mixed)
+     * @param  mixed  $value
+     * @return mixed
      */
-    function enum_value($value, $default = null)
+    function enum_value($value)
     {
-        if (function_exists('transform')) {
-            return transform($value, fn ($value) => match (true) {
-                $value instanceof \BackedEnum => $value->value,
-                $value instanceof \UnitEnum => $value->name,
-
-                default => $value,
-            }, $default ?? $value);
-        }
-
         return match (true) {
             $value instanceof \BackedEnum => $value->value,
             $value instanceof \UnitEnum => $value->name,

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -393,7 +393,7 @@ class ModelInspector
     {
         $attributeDefault = $model->getAttributes()[$column['name']] ?? null;
 
-        return enum_value($attributeDefault, $column['default']);
+        return enum_value($attributeDefault) ?? $column['default'];
     }
 
     /**

--- a/tests/Support/SupportEnumValueFunctionTest.php
+++ b/tests/Support/SupportEnumValueFunctionTest.php
@@ -28,6 +28,12 @@ class SupportEnumValueFunctionTest extends TestCase
         $this->assertSame($expected, enum_value($given));
     }
 
+    public function test_it_can_fallback_to_use_default_if_value_is_null()
+    {
+        $this->assertSame('laravel', enum_value(null, 'laravel'));
+        $this->assertSame('laravel', enum_value(null, fn () => 'laravel'));
+    }
+
     public static function scalarDataProvider()
     {
         yield [null, null];

--- a/tests/Support/SupportEnumValueFunctionTest.php
+++ b/tests/Support/SupportEnumValueFunctionTest.php
@@ -11,17 +11,6 @@ include_once 'Enums.php';
 
 class SupportEnumValueFunctionTest extends TestCase
 {
-    public function test_it_can_handle_enums_value()
-    {
-        $this->assertSame('A', enum_value(TestEnum::A));
-
-        $this->assertSame(1, enum_value(TestBackedEnum::A));
-        $this->assertSame(2, enum_value(TestBackedEnum::B));
-
-        $this->assertSame('A', enum_value(TestStringBackedEnum::A));
-        $this->assertSame('B', enum_value(TestStringBackedEnum::B));
-    }
-
     #[DataProvider('scalarDataProvider')]
     public function test_it_can_handle_enum_value($given, $expected)
     {
@@ -36,6 +25,11 @@ class SupportEnumValueFunctionTest extends TestCase
 
     public static function scalarDataProvider()
     {
+        yield [TestEnum::A, 'A'];
+        yield [TestBackedEnum::A, 1];
+        yield [TestBackedEnum::B, 2];
+        yield [TestStringBackedEnum::A, 'A'];
+        yield [TestStringBackedEnum::B, 'B'];
         yield [null, null];
         yield [0, 0];
         yield ['0', '0'];


### PR DESCRIPTION
fixes #53867

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
