### PR TITLE
[11.x] Fixes `Illuminate\Http\Response` to output empty string if `$content` is set to `null`

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -38,7 +38,7 @@ class Response extends SymfonyResponse
     }
 
     /**
-     * Get the current response content.
+     * Get the response content.
      */
     #[\Override]
     public function getContent(): string|false

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -81,7 +81,7 @@ class Response extends SymfonyResponse
     #[\Override]
     public function getContent(): string|false
     {
-        return $this->content;
+        return transform(parent::getContent(), fn ($content) => $content ?? '');
     }
 
     /**

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -38,6 +38,15 @@ class Response extends SymfonyResponse
     }
 
     /**
+     * Get the current response content.
+     */
+    #[\Override]
+    public function getContent(): string|false
+    {
+        return transform(parent::getContent(), fn ($content) => $content, '');
+    }
+
+    /**
      * Set the content on the response.
      *
      * @param  mixed  $content
@@ -73,15 +82,6 @@ class Response extends SymfonyResponse
         parent::setContent($content);
 
         return $this;
-    }
-
-    /**
-     * Gets the current response content.
-     */
-    #[\Override]
-    public function getContent(): string|false
-    {
-        return transform(parent::getContent(), fn ($content) => $content, '');
     }
 
     /**

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -81,7 +81,7 @@ class Response extends SymfonyResponse
     #[\Override]
     public function getContent(): string|false
     {
-        return transform(parent::getContent(), fn ($content) => $content ?? '');
+        return transform(parent::getContent(), fn ($content) => $content, '');
     }
 
     /**

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -76,6 +76,15 @@ class Response extends SymfonyResponse
     }
 
     /**
+     * Gets the current response content.
+     */
+    #[\Override]
+    public function getContent(): string|false
+    {
+        return $this->content;
+    }
+
+    /**
      * Determine if the given content should be turned into JSON.
      *
      * @param  mixed  $content


### PR DESCRIPTION
1. Symfony set the content to `null` for `response()->noContent()` https://github.com/symfony/http-foundation/blob/e88a66c3997859532bc2ddd6dd8f35aba2711744/Response.php#L246-L249
2. This cause issue with PSR-7 HTTP Stream in Octane

fixed laravel/octane#972

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
