### PR TITLE
[11.x] `Uri` and `UriQueryString` implement `Stringable`

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -14,7 +14,7 @@ use League\Uri\Uri as LeagueUri;
 use SensitiveParameter;
 use Stringable;
 
-class Uri implements Htmlable, Responsable
+class Uri implements Htmlable, Responsable, Stringable
 {
     use Conditionable, Tappable;
 

--- a/src/Illuminate/Support/UriQueryString.php
+++ b/src/Illuminate/Support/UriQueryString.php
@@ -5,8 +5,9 @@ namespace Illuminate\Support;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\InteractsWithData;
 use League\Uri\QueryString;
+use Stringable;
 
-class UriQueryString implements Arrayable
+class UriQueryString implements Arrayable, Stringable
 {
     use InteractsWithData;
 


### PR DESCRIPTION
The classes already meet the Stringable contract, so I figured it would make sense to explicitly add it.