### PR TITLE
[11.x] Add job processing time to JobAttempted event

### DIFF
--- a/src/Illuminate/Queue/Events/JobAttempted.php
+++ b/src/Illuminate/Queue/Events/JobAttempted.php
@@ -26,18 +26,27 @@ class JobAttempted
     public $exceptionOccurred;
 
     /**
+     * The time it took the job to process.
+     *
+     * @var float
+     */
+    public $time;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  float  $time
      * @param  bool  $exceptionOccurred
      * @return void
      */
-    public function __construct($connectionName, $job, $exceptionOccurred = false)
+    public function __construct($connectionName, $job, $time, $exceptionOccurred = false)
     {
         $this->job = $job;
         $this->connectionName = $connectionName;
         $this->exceptionOccurred = $exceptionOccurred;
+        $this->time = $time;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -421,9 +421,9 @@ class Worker
      */
     public function process($connectionName, $job, WorkerOptions $options)
     {
-        try {
-            $start = microtime(true);
+        $start = microtime(true);
 
+        try {
             // First we will raise the before job event and determine if the job has already run
             // over its maximum attempt limits, which could primarily happen when this job is
             // continually timing out and not actually throwing any exceptions from itself.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -422,6 +422,8 @@ class Worker
     public function process($connectionName, $job, WorkerOptions $options)
     {
         try {
+            $start = microtime(true);
+
             // First we will raise the before job event and determine if the job has already run
             // over its maximum attempt limits, which could primarily happen when this job is
             // continually timing out and not actually throwing any exceptions from itself.
@@ -447,7 +449,7 @@ class Worker
             $this->handleJobException($connectionName, $job, $options, $e);
         } finally {
             $this->events->dispatch(new JobAttempted(
-                $connectionName, $job, $exceptionOccurred ?? false
+                $connectionName, $job, $this->getElapsedTime($start), $exceptionOccurred ?? false
             ));
         }
     }
@@ -880,5 +882,16 @@ class Worker
     public function setManager(QueueManager $manager)
     {
         $this->manager = $manager;
+    }
+
+    /**
+     * Get the elapsed time since a given starting point.
+     *
+     * @param  float  $start
+     * @return float
+     */
+    protected function getElapsedTime($start)
+    {
+        return round((microtime(true) - $start) * 1000, 2);
     }
 }


### PR DESCRIPTION
The current Laravel framework does not provide a straightforward method to log the execution time of jobs. To address this, I have modified the `JobAttempted` event to include a `time` attribute that records the job's execution duration. This enhancement allows applications to listen for the `JobAttempted` event and directly access the `time` attribute for logging purposes.

The specific changes made in the commit are as follows:

- **Updated** `JobAttempted` Event: Added a `time` attribute to the `JobAttempted` event class to store the execution time of the job.
- **Modified** `Worker` Class: Adjusted the `Worker` class to dispatch the `JobAttempted` event with the newly added `time` attribute, capturing the duration of the job's execution.

These modifications enable developers to monitor and log job execution times more effectively, facilitating better performance analysis and debugging.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
