### PR TITLE
[11.x] Fix attribute mutator access in `loadMissing`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -271,7 +271,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return;
         }
 
-        $models = $models->pluck($name)->whereNotNull();
+        $models = $models->pluck($name)->filter();
 
         if ($models->first() instanceof BaseCollection) {
             $models = $models->collapse();

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\EloquentModelLoadMissingTest;
 
 use DB;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,20 +13,40 @@ class EloquentModelLoadMissingTest extends DatabaseTestCase
 {
     protected function afterRefreshingDatabase()
     {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('comment_mentions_users', function (Blueprint $table) {
+            $table->unsignedInteger('comment_id');
+            $table->unsignedInteger('user_id');
+        });
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedInteger('first_comment_id')->nullable();
+            $table->string('content')->nullable();
         });
 
         Schema::create('comments', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('parent_id')->nullable();
             $table->unsignedInteger('post_id');
+            $table->string('content')->nullable();
         });
 
         Post::create();
 
-        Comment::create(['parent_id' => null, 'post_id' => 1]);
+        Comment::create(['parent_id' => null, 'post_id' => 1, 'content' => 'Hello <u:1> <u:2>']);
         Comment::create(['parent_id' => 1, 'post_id' => 1]);
+
+        User::create(['name' => 'Taylor']);
+        User::create(['name' => 'Otwell']);
+
+        Comment::first()->mentionsUsers()->attach([1, 2]);
+
+        Post::first()->update(['first_comment_id' => 1]);
     }
 
     public function testLoadMissing()
@@ -39,6 +60,17 @@ class EloquentModelLoadMissingTest extends DatabaseTestCase
         $this->assertCount(1, DB::getQueryLog());
         $this->assertTrue($post->comments[0]->relationLoaded('parent'));
     }
+
+    public function testLoadMissingNoUnnecessaryAttributeMutatorAccess()
+    {
+        $posts = Post::all();
+
+        DB::enableQueryLog();
+
+        $posts->loadMissing('firstComment.parent');
+
+        $this->assertCount(1, DB::getQueryLog());
+    }
 }
 
 class Comment extends Model
@@ -51,14 +83,42 @@ class Comment extends Model
     {
         return $this->belongsTo(self::class);
     }
+
+    public function mentionsUsers()
+    {
+        return $this->belongsToMany(User::class, 'comment_mentions_users');
+    }
+
+    public function content(): Attribute
+    {
+        return new Attribute(function (?string $value) {
+            return preg_replace_callback('/<u:(\d+)>/', function ($matches) {
+                return '@'.$this->mentionsUsers->find($matches[1])?->name;
+            }, $value);
+        });
+    }
 }
 
 class Post extends Model
 {
     public $timestamps = false;
 
+    protected $guarded = [];
+
     public function comments()
     {
         return $this->hasMany(Comment::class);
     }
+
+    public function firstComment()
+    {
+        return $this->belongsTo(Comment::class, 'first_comment_id');
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
 }


### PR DESCRIPTION
**Issue**
When using `->loadMissing` collection method on a nested relationship it can cause all the models in the collection to be converted to JSON which causes attribute mutators to be accessed. This is normally not a problem, unless the mutators need to access other relationships, in which case it can become an issue as certain relationships can get loaded unnecessarily.

**Proposed Solution**
The cause is the use of `->whereNotNull` collection method, which leads to the JSON conversion. The PR changes that bit to a simpler `->filter` access.

**Additional Context**
Backtrace when using `->whereNotNull`

<details>

```
array:105 [▼
  ...app code  

  8 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Concerns/HasAttributes.php"
    "line" => 689
    "function" => "getContentAttribute"
  ]
  9 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Concerns/HasAttributes.php"
    "line" => 739
    "function" => "mutateAttribute"
  ]
  10 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Concerns/HasAttributes.php"
    "line" => 277
    "function" => "mutateAttributeForArray"
  ]
  11 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Concerns/HasAttributes.php"
    "line" => 215
    "function" => "addMutatedAttributesToArray"
  ]
  12 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Model.php"
    "line" => 1664
    "function" => "attributesToArray"
  ]
  13 => array:3 [▼
    "file" => null
    "line" => null
    "function" => "Illuminate\Database\Eloquent\{closure}"
  ]
  14 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Concerns/PreventsCircularRecursion.php"
    "line" => 46
    "function" => "call_user_func"
  ]
  15 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Model.php"
    "line" => 1663
    "function" => "withoutRecursion"
  ]
  16 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Model.php"
    "line" => 1695
    "function" => "toArray"
  ]
  17 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Model.php"
    "line" => 1680
    "function" => "jsonSerialize"
  ]
  18 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Model.php"
    "line" => 2391
    "function" => "toJson"
  ]
  19 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/support/helpers.php"
    "line" => 68
    "function" => "__toString"
  ]
  20 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/support/helpers.php"
    "line" => 166
    "function" => "blank"
  ]
  21 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/support/helpers.php"
    "line" => 483
    "function" => "filled"
  ]
  22 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/collections/functions.php"
    "line" => 20
    "function" => "transform"
  ]
  23 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/collections/Traits/EnumeratesValues.php"
    "line" => 1097
    "function" => "Illuminate\Support\enum_value"
  ]
  24 => array:3 [▼
    "file" => null
    "line" => null
    "function" => "Illuminate\Support\Traits\{closure}"
  ]
  25 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/collections/Arr.php"
    "line" => 930
    "function" => "array_filter"
  ]
  26 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/collections/Collection.php"
    "line" => 395
    "function" => "where"
  ]
  27 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/collections/Traits/EnumeratesValues.php"
    "line" => 623
    "function" => "filter"
  ]
  28 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/collections/Traits/EnumeratesValues.php"
    "line" => 645
    "function" => "where"
  ]
  29 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Collection.php"
    "line" => 274
    "function" => "whereNotNull"
  ]
  30 => array:3 [▼
    "file" => "/home/.../vendor/illuminate/database/Eloquent/Collection.php"
    "line" => 245
    "function" => "loadMissingRelation"
  ]
  31 => array:3 [▼
    "file" => "/home/.../vendor/flarum/core/src/Api/Endpoint/Concerns/HasEagerLoading.php"
    "line" => 128
    "function" => "loadMissing"
  ],
  
  ...app code
];
```


</details>

