### PR TITLE
[11.x] Fix `numericAggregate`  on eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -121,6 +121,7 @@ class Builder implements BuilderContract
         'insertorignoreusing',
         'max',
         'min',
+        'numericaggregate',
         'raw',
         'rawvalue',
         'sum',

--- a/tests/Integration/Database/EloquentAggregateTest.php
+++ b/tests/Integration/Database/EloquentAggregateTest.php
@@ -68,6 +68,21 @@ class EloquentAggregateTest extends DatabaseTestCase
         $this->assertEquals(0, $result);
         $this->assertEquals(2, UserAggregateTest::query()->where('c', '>', 1)->sum('balance'));
     }
+
+    public function testNumericAggregate()
+    {
+        UserAggregateTest::create(['c' => 1, 'name' => 'name-1', 'balance' => 40]);
+        UserAggregateTest::create(['c' => 2, 'name' => 'name-2', 'balance' => -40]);
+        UserAggregateTest::create(['c' => 3, 'name' => 'name-3', 'balance' => 0]);
+        UserAggregateTest::create(['c' => 4, 'name' => 'name-4', 'balance' => 20]);
+        UserAggregateTest::create(['c' => 5, 'name' => 'name-5', 'balance' => null]);
+
+        $this->assertEquals(20, UserAggregateTest::query()->numericAggregate('sum', ['balance']));
+        // When calculating the average, rows with NULL values are excluded
+        $this->assertEquals(5, UserAggregateTest::query()->numericAggregate('avg', ['balance']));
+        $this->assertEquals(40, UserAggregateTest::query()->numericAggregate('max', ['balance']));
+        $this->assertEquals(-40, UserAggregateTest::query()->numericAggregate('min', ['balance']));
+    }
 }
 
 class UserAggregateTest extends Model


### PR DESCRIPTION

Hey, 
In one of my projects, I encountered an issue where the `numericAggregate`  method returned a builder instance instead of the expected numerical result."

Reason:

https://github.com/laravel/framework/blob/3b2db757a634515d814f11817e866efae1c0932b/src/Illuminate/Database/Eloquent/Builder.php#L2049-L2055