### PR TITLE
[11.x] Implements `Arrayable` contract 

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -15,7 +15,7 @@ use Illuminate\Http\Resources\DelegatesToResource;
 use JsonException;
 use JsonSerializable;
 
-class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
+class JsonResource implements Arrayable, ArrayAccess, JsonSerializable, Responsable, UrlRoutable
 {
     use ConditionallyLoadsAttributes, DelegatesToResource;
 

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -2,10 +2,11 @@
 
 namespace Illuminate\Notifications\Messages;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Notifications\Action;
 
-class SimpleMessage
+class SimpleMessage implements Arrayable
 {
     /**
      * The "level" of the notification (info, success, error).

--- a/src/Illuminate/Support/DefaultProviders.php
+++ b/src/Illuminate/Support/DefaultProviders.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Support;
 
-class DefaultProviders
+use Illuminate\Contracts\Support\Arrayable;
+
+class DefaultProviders implements Arrayable
 {
     /**
      * The current providers.


### PR DESCRIPTION
This PR addresses an inconsistency where certain classes fulfill the `Arrayable` contract but do not explicitly implement the `Arrayable` interface.

No functionality is altered, as the classes already adhere to the contract requirements. This change is primarily to improve code structure and maintainability.