### PR TITLE
[11.x] Prefer `new Stringable` over `Str::of` and `str()`

### DIFF
--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\Concerns;
 
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Input\InputOption;
 
 trait CreatesMatchingTest
@@ -37,7 +37,7 @@ trait CreatesMatchingTest
         }
 
         return $this->call('make:test', [
-            'name' => Str::of($path)->after($this->laravel['path'])->beforeLast('.php')->append('Test')->replace('\\', '/'),
+            'name' => (new Stringable($path))->after($this->laravel['path'])->beforeLast('.php')->append('Test')->replace('\\', '/'),
             '--pest' => $this->option('pest'),
             '--phpunit' => $this->option('phpunit'),
         ]) == 0;

--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\View\Components\TwoColumnDetail;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -76,7 +77,7 @@ class QuestionHelper extends SymfonyQuestionHelper
      */
     protected function ensureEndsWithPunctuation($string)
     {
-        if (! str($string)->endsWith(['?', ':', '!', '.'])) {
+        if (! (new Stringable($string))->endsWith(['?', ':', '!', '.'])) {
             return "$string:";
         }
 

--- a/src/Illuminate/Console/View/Components/Mutators/EnsureNoPunctuation.php
+++ b/src/Illuminate/Console/View/Components/Mutators/EnsureNoPunctuation.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console\View\Components\Mutators;
 
+use Illuminate\Support\Stringable;
+
 class EnsureNoPunctuation
 {
     /**
@@ -12,7 +14,7 @@ class EnsureNoPunctuation
      */
     public function __invoke($string)
     {
-        if (str($string)->endsWith(['.', '?', '!', ':'])) {
+        if ((new Stringable($string))->endsWith(['.', '?', '!', ':'])) {
             return substr_replace($string, '', -1);
         }
 

--- a/src/Illuminate/Console/View/Components/Mutators/EnsurePunctuation.php
+++ b/src/Illuminate/Console/View/Components/Mutators/EnsurePunctuation.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console\View\Components\Mutators;
 
+use Illuminate\Support\Stringable;
+
 class EnsurePunctuation
 {
     /**
@@ -12,7 +14,7 @@ class EnsurePunctuation
      */
     public function __invoke($string)
     {
-        if (! str($string)->endsWith(['.', '?', '!', ':'])) {
+        if (! (new Stringable($string))->endsWith(['.', '?', '!', ':'])) {
             return "$string.";
         }
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Factories;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -99,7 +100,7 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
+        $name = (new Stringable($name))->replaceFirst($this->rootNamespace(), '')->finish('Factory')->value();
 
         return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
     }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -64,7 +65,7 @@ class StatusCommand extends BaseCommand
 
             $migrations = $this->getStatusFor($ran, $batches)
                 ->when($this->option('pending') !== false, fn ($collection) => $collection->filter(function ($migration) {
-                    return str($migration[1])->contains('Pending');
+                    return (new Stringable($migration[1]))->contains('Pending');
                 }));
 
             if (count($migrations) > 0) {
@@ -84,7 +85,7 @@ class StatusCommand extends BaseCommand
                 $this->components->info('No migrations found');
             }
 
-            if ($this->option('pending') && $migrations->some(fn ($m) => str($m[1])->contains('Pending'))) {
+            if ($this->option('pending') && $migrations->some(fn ($m) => (new Stringable($m[1]))->contains('Pending'))) {
                 return $this->option('pending');
             }
         });

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'db:show')]
@@ -99,7 +100,7 @@ class ShowCommand extends DatabaseInspectionCommand
     protected function views(ConnectionInterface $connection, Builder $schema)
     {
         return (new Collection($schema->getViews()))
-            ->reject(fn ($view) => str($view['name'])->startsWith(['pg_catalog', 'information_schema', 'spt_']))
+            ->reject(fn ($view) => (new Stringable($view['name']))->startsWith(['pg_catalog', 'information_schema', 'spt_']))
             ->map(fn ($view) => [
                 'view' => $view['name'],
                 'schema' => $view['schema'],

--- a/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 class AsStringable implements Castable
 {
@@ -20,7 +20,7 @@ class AsStringable implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($value) ? Str::of($value) : null;
+                return isset($value) ? new Stringable($value) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonException;
 use JsonSerializable;
@@ -2360,7 +2361,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         if (Str::startsWith($method, 'through') &&
-            method_exists($this, $relationMethod = Str::of($method)->after('through')->lcfirst()->toString())) {
+            method_exists($this, $relationMethod = (new SupportStringable($method))->after('through')->lcfirst()->toString())) {
             return $this->through($relationMethod);
         }
 

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 /**
  * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
@@ -106,7 +107,7 @@ class PendingHasThroughRelationship
     public function __call($method, $parameters)
     {
         if (Str::startsWith($method, 'has')) {
-            return $this->has(Str::of($method)->after('has')->lcfirst()->toString());
+            return $this->has((new Stringable($method))->after('has')->lcfirst()->toString());
         }
 
         throw new BadMethodCallException(sprintf(

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 class ForeignIdColumnDefinition extends ColumnDefinition
 {
@@ -40,7 +40,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
         $table ??= $this->table;
         $column ??= $this->referencesModelColumn ?? 'id';
 
-        return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
+        return $this->references($column, $indexName)->on($table ?? (new Stringable($this->name))->beforeLast('_'.$column)->plural());
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'about')]
@@ -144,7 +145,7 @@ class AboutCommand extends Command
     {
         $output = $data->flatMap(function ($data, $section) {
             return [
-                (string) Str::of($section)->snake() => $data->mapWithKeys(fn ($item, $key) => [
+                (new Stringable($section))->snake()->value() => $data->mapWithKeys(fn ($item, $key) => [
                     $this->toSearchKeyword($item[0]) => value($item[1], true),
                 ]),
             ];
@@ -303,7 +304,7 @@ class AboutCommand extends Command
      */
     protected function toSearchKeyword(string $value)
     {
-        return (string) Str::of($value)->lower()->snake();
+        return (new Stringable($value))->lower()->snake()->value();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,7 +46,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         $stub = parent::replaceClass($stub, $name);
 
-        $command = $this->option('command') ?: 'app:'.Str::of($name)->classBasename()->kebab()->value();
+        $command = $this->option('command') ?: 'app:'.(new Stringable($name))->classBasename()->kebab()->value();
 
         return str_replace(['dummy:command', '{{ command }}'], $command, $stub);
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -253,7 +253,7 @@ class ModelMakeCommand extends GeneratorCommand
         $replacements = [];
 
         if ($this->option('factory') || $this->option('all')) {
-            $modelPath = str($this->argument('name'))->studly()->replace('/', '\\')->toString();
+            $modelPath = Str::of($this->argument('name'))->studly()->replace('/', '\\')->toString();
 
             $factoryNamespace = '\\Database\\Factories\\'.$modelPath.'Factory';
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\ViewController;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use ReflectionClass;
 use ReflectionFunction;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -372,7 +373,7 @@ class RouteListCommand extends Command
                 'uri' => $uri,
             ] = $route;
 
-            $middleware = Str::of($middleware)->explode("\n")->filter()->whenNotEmpty(
+            $middleware = (new Stringable($middleware))->explode("\n")->filter()->whenNotEmpty(
                 fn ($collection) => $collection->map(
                     fn ($middleware) => sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware)
                 )
@@ -390,7 +391,7 @@ class RouteListCommand extends Command
                 $action = substr($action, 0, $terminalWidth - 7 - mb_strlen($method.$spaces.$uri.$dots)).'…';
             }
 
-            $method = Str::of($method)->explode('|')->map(
+            $method = (new Stringable($method))->explode('|')->map(
                 fn ($method) => sprintf('<fg=%s>%s</>', $this->verbColors[$method] ?? 'default', $method),
             )->implode('<fg=#6C7280>|</>');
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\Process;
@@ -270,7 +271,7 @@ class ServeCommand extends Command
      */
     protected function flushOutputBuffer()
     {
-        $lines = str($this->outputBuffer)->explode("\n");
+        $lines = (new Stringable($this->outputBuffer))->explode("\n");
 
         $this->outputBuffer = (string) $lines->pop();
 
@@ -278,7 +279,7 @@ class ServeCommand extends Command
             ->map(fn ($line) => trim($line))
             ->filter()
             ->each(function ($line) {
-                if (str($line)->contains('Development Server (http')) {
+                if ((new Stringable($line))->contains('Development Server (http')) {
                     if ($this->serverRunningHasBeenDisplayed === false) {
                         $this->serverRunningHasBeenDisplayed = true;
 
@@ -291,7 +292,7 @@ class ServeCommand extends Command
                     return;
                 }
 
-                if (str($line)->contains(' Accepted')) {
+                if ((new Stringable($line))->contains(' Accepted')) {
                     $requestPort = static::getRequestPortFromLine($line);
 
                     $this->requestsPool[$requestPort] = [
@@ -299,15 +300,15 @@ class ServeCommand extends Command
                         $this->requestsPool[$requestPort][1] ?? false,
                         microtime(true),
                     ];
-                } elseif (str($line)->contains([' [200]: GET '])) {
+                } elseif ((new Stringable($line))->contains([' [200]: GET '])) {
                     $requestPort = static::getRequestPortFromLine($line);
 
                     $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
-                } elseif (str($line)->contains('URI:')) {
+                } elseif ((new Stringable($line))->contains('URI:')) {
                     $requestPort = static::getRequestPortFromLine($line);
 
                     $this->requestsPool[$requestPort][1] = trim(explode('URI: ', $line)[1]);
-                } elseif (str($line)->contains(' Closing')) {
+                } elseif ((new Stringable($line))->contains(' Closing')) {
                     $requestPort = static::getRequestPortFromLine($line);
 
                     if (empty($this->requestsPool[$requestPort])) {
@@ -338,11 +339,11 @@ class ServeCommand extends Command
 
                     $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
                     $this->output->writeln(" <fg=gray>~ {$runTime}</>");
-                } elseif (str($line)->contains(['Closed without sending a request', 'Failed to poll event'])) {
+                } elseif ((new Stringable($line))->contains(['Closed without sending a request', 'Failed to poll event'])) {
                     // ...
                 } elseif (! empty($line)) {
-                    if (str($line)->startsWith('[')) {
-                        $line = str($line)->after('] ');
+                    if ((new Stringable($line))->startsWith('[')) {
+                        $line = (new Stringable($line))->after('] ');
                     }
 
                     $this->output->writeln("  <fg=gray>$line</>");

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -184,15 +185,15 @@ class ViewMakeCommand extends GeneratorCommand
         $name = Str::of(Str::lower($this->getNameInput()))->replace('.'.$this->option('extension'), '');
 
         $namespacedName = Str::of(
-            Str::of($name)
+            (new Stringable($name))
                 ->replace('/', ' ')
                 ->explode(' ')
-                ->map(fn ($part) => Str::of($part)->ucfirst())
+                ->map(fn ($part) => (new Stringable($part))->ucfirst())
                 ->implode('\\')
         )
             ->replace(['-', '_'], ' ')
             ->explode(' ')
-            ->map(fn ($part) => Str::of($part)->ucfirst())
+            ->map(fn ($part) => (new Stringable($part))->ucfirst())
             ->implode('');
 
         return 'Tests\\Feature\\View\\'.$namespacedName;

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Lottery;
 use Illuminate\Support\Reflector;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Validation\ValidationException;
@@ -1007,7 +1008,7 @@ class Handler implements ExceptionHandlerContract
     public function renderForConsole($output, Throwable $e)
     {
         if ($e instanceof CommandNotFoundException) {
-            $message = str($e->getMessage())->explode('.')->first();
+            $message = Str::of($e->getMessage())->explode('.')->first();
 
             if (! empty($alternatives = $e->getAlternatives())) {
                 $message .= '. Did you mean one of these?';

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
 
 /*
                                                    .~))>>
@@ -118,7 +119,7 @@ class Inspiring
      */
     protected static function formatForConsole($quote)
     {
-        [$text, $author] = str($quote)->explode('-');
+        [$text, $author] = (new Stringable($quote))->explode('-');
 
         return sprintf(
             "\n  <options=bold>“ %s ”</>\n  <fg=gray>— %s</>\n",

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1153,7 +1153,7 @@ class PendingRequest
 
         $laravelData = $options[$this->bodyFormat] ?? $options['query'] ?? [];
 
-        $urlString = Str::of($url);
+        $urlString = (new Stringable($url));
 
         if (empty($laravelData) && $method === 'GET' && $urlString->contains('?')) {
             $laravelData = (string) $urlString->after('?');

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Http\Resources;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 trait ConditionallyLoadsAttributes
 {
@@ -297,7 +297,7 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue;
         }
 
-        $attribute = (string) Str::of($relationship)->snake()->finish('_count');
+        $attribute = (new Stringable($relationship))->snake()->finish('_count')->value();
 
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
             return value($default);
@@ -334,7 +334,7 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue;
         }
 
-        $attribute = (string) Str::of($relationship)->snake()->append('_')->append($aggregate)->append('_')->finish($column);
+        $attribute = (new Stringable($relationship))->snake()->append('_')->append($aggregate)->append('_')->finish($column)->value();
 
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
             return value($default);
@@ -369,7 +369,7 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue;
         }
 
-        $attribute = (string) Str::of($relationship)->snake()->finish('_exists');
+        $attribute = (new Stringable($relationship))->snake()->finish('_exists')->value();
 
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
             return value($default);

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Queue\Listener;
 use Illuminate\Queue\ListenerOptions;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:listen')]
@@ -69,7 +70,7 @@ class ListenCommand extends Command
             $connection = $this->input->getArgument('connection')
         );
 
-        $this->components->info(sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue))));
+        $this->components->info(sprintf('Processing jobs from the [%s] %s.', $queue, (new Stringable('queue'))->plural(explode(',', $queue))));
 
         $this->listener->listen(
             $connection, $queue, $this->gatherOptions()

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Terminal;
 use Throwable;
@@ -124,7 +125,7 @@ class WorkCommand extends Command
 
         if (! $this->outputUsingJson() && Terminal::hasSttyAvailable()) {
             $this->components->info(
-                sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
+                sprintf('Processing jobs from the [%s] %s.', $queue, (new Stringable('queue'))->plural(explode(',', $queue)))
             );
         }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use PDO;
 
 class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
@@ -260,10 +261,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if (Str::of($databaseVersion)->contains('MariaDB')) {
+        if ((new Stringable($databaseVersion))->contains('MariaDB')) {
             $databaseEngine = 'mariadb';
             $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
-        } elseif (Str::of($databaseVersion)->contains(['vitess', 'PlanetScale'])) {
+        } elseif ((new Stringable($databaseVersion))->contains(['vitess', 'PlanetScale'])) {
             $databaseEngine = 'vitess';
             $databaseVersion = Str::before($databaseVersion, '-');
         }

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -164,7 +164,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Http\Request|mixed whenFilled(string $key, callable $callback, callable|null $default = null)
  * @method static bool missing(string|array $key)
  * @method static \Illuminate\Http\Request|mixed whenMissing(string $key, callable $callback, callable|null $default = null)
- * @method static \Illuminate\Support\Stringable str(string $key, mixed $default = null)
+ * @method static \Illuminate\Support\Stringable \Illuminate\Support\(new \Illuminate\Support\Stringable(string $key, mixed $default = null))
  * @method static \Illuminate\Support\Stringable string(string $key, mixed $default = null)
  * @method static bool boolean(string|null $key = null, bool $default = false)
  * @method static int integer(string $key, int $default = 0)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -409,14 +409,14 @@ class Str
 
         $start = ltrim($matches[1]);
 
-        $start = str(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
+        $start = Str::of(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
             fn ($startWithRadius) => $startWithRadius->exactly($start),
             fn ($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
-        $end = str(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
+        $end = Str::of(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
             fn ($endWithRadius) => $endWithRadius->exactly($end),
             fn ($endWithRadius) => $endWithRadius->append($omission),
         );

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Traits;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 use stdClass;
 
 trait InteractsWithData
@@ -240,7 +241,7 @@ trait InteractsWithData
      */
     public function string($key, $default = null)
     {
-        return str($this->data($key, $default));
+        return Str::of($this->data($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -127,7 +127,7 @@ class ValidatedInput implements ValidatedData
      */
     public function string($key, $default = null)
     {
-        return str($this->input($key, $default));
+        return Str::of($this->input($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Onceable;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable as SupportStringable;
 
 if (! function_exists('append_config')) {
     /**
@@ -370,7 +371,7 @@ if (! function_exists('str')) {
             };
         }
 
-        return Str::of($string);
+        return new SupportStringable($string);
     }
 }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation;
 
 use Exception;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 class NotPwnedVerifier implements UncompromisedVerifier
 {
@@ -97,7 +97,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
             ? $response->body()
             : '';
 
-        return Str::of($body)->trim()->explode("\n")->filter(function ($line) {
+        return (new Stringable($body))->trim()->explode("\n")->filter(function ($line) {
             return str_contains($line, ':');
         });
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\View\Component;
 use InvalidArgumentException;
@@ -835,7 +836,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $prefix ??= $directory;
 
-        $this->anonymousComponentNamespaces[$prefix] = Str::of($directory)
+        $this->anonymousComponentNamespaces[$prefix] = (new Stringable($directory))
                 ->replace('/', '.')
                 ->trim('. ')
                 ->toString();

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -3,7 +3,7 @@
 namespace Illuminate\View\Compilers\Concerns;
 
 use Closure;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 trait CompilesEchos
 {
@@ -141,7 +141,7 @@ trait CompilesEchos
      */
     protected function wrapInEchoHandler($value)
     {
-        $value = Str::of($value)
+        $value = (new Stringable($value))
             ->trim()
             ->when(str_ends_with($value, ';'), function ($str) {
                 return $str->beforeLast(';');

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -6,6 +6,7 @@ use Illuminate\Database\RecordNotFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Str;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\ViewException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -73,7 +74,7 @@ class CompilerEngine extends PhpEngine
         try {
             $results = $this->evaluatePath($this->compiler->getCompiledPath($path), $data);
         } catch (ViewException $e) {
-            if (! str($e->getMessage())->contains(['No such file or directory', 'File does not exist at path'])) {
+            if (! Str::of($e->getMessage())->contains(['No such file or directory', 'File does not exist at path'])) {
                 throw $e;
             }
 

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsInverseRelations;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -338,7 +338,7 @@ class HasInverseRelationStub extends Relation
         protected ?string $foreignKey = null,
     ) {
         parent::__construct($query, $parent);
-        $this->foreignKey ??= Str::of(class_basename($parent))->snake()->finish('_id')->toString();
+        $this->foreignKey ??= (new Stringable(class_basename($parent)))->snake()->finish('_id')->toString();
     }
 
     public function getForeignKeyName()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -43,7 +43,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\InteractsWithTime;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use LogicException;
@@ -255,10 +254,10 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(Stringable::class, $model->asStringableAttribute);
         $this->assertFalse($model->isDirty('asStringableAttribute'));
 
-        $model->asStringableAttribute = Str::of('foo bar');
+        $model->asStringableAttribute = new Stringable('foo bar');
         $this->assertFalse($model->isDirty('asStringableAttribute'));
 
-        $model->asStringableAttribute = Str::of('foo baz');
+        $model->asStringableAttribute = new Stringable('foo baz');
         $this->assertTrue($model->isDirty('asStringableAttribute'));
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use JsonSerializable;
 use Mockery as m;
 use OutOfBoundsException;
@@ -603,7 +604,7 @@ class HttpClientTest extends TestCase
             'X-Test-Header' => 'foo',
             'X-Test-ArrayHeader' => ['bar', 'baz'],
         ])->post('http://foo.com/json', [
-            'name' => Str::of('Taylor'),
+            'name' => new Stringable('Taylor'),
         ]);
 
         $this->factory->assertSent(function (Request $request) {
@@ -620,7 +621,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->asForm()->post('http://foo.com/form', [
-            'name' => Str::of('Taylor'),
+            'name' => new Stringable('Taylor'),
             'title' => 'Laravel Developer',
         ]);
 
@@ -636,7 +637,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->asForm()->post('http://foo.com/form', [
-            'posts' => [['title' => Str::of('Taylor')]],
+            'posts' => [['title' => new Stringable('Taylor')]],
         ]);
 
         $this->factory->assertSent(function (Request $request) {
@@ -970,7 +971,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->withQueryParameters(
-            ['foo' => Str::of('bar')]
+            ['foo' => new Stringable('bar')]
         )->get('https://laravel.com');
 
         $this->factory->assertSent(function (Request $request) {
@@ -983,7 +984,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->withQueryParameters(
-            ['foo' => ['bar', Str::of('baz')]],
+            ['foo' => ['bar', new Stringable('baz')]],
         )->get('https://laravel.com');
 
         $this->factory->assertSent(function (Request $request) {

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 class DatabaseCustomCastsTest extends DatabaseTestCase
 {
@@ -42,7 +42,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model->array_object = ['name' => 'Taylor'];
         $model->array_object_json = ['name' => 'Taylor'];
         $model->collection = collect(['name' => 'Taylor']);
-        $model->stringable = Str::of('Taylor');
+        $model->stringable = new Stringable('Taylor');
         $model->password = Hash::make('secret');
 
         $model->save();
@@ -90,7 +90,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
             'array_object' => ['name' => 'Taylor'],
             'array_object_json' => ['name' => 'Taylor'],
             'collection' => collect(['name' => 'Taylor']),
-            'stringable' => Str::of('Taylor'),
+            'stringable' => new Stringable('Taylor'),
             'password' => Hash::make('secret'),
         ]);
 

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Illuminate\Foundation\Events\DiscoverEvents;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
@@ -60,7 +60,7 @@ class DiscoverEventsTest extends TestCase
     public function testEventsCanBeDiscoveredUsingCustomClassNameGuessing()
     {
         DiscoverEvents::guessClassNamesUsing(function (SplFileInfo $file, $basePath) {
-            return Str::of($file->getRealPath())
+            return (new Stringable($file->getRealPath()))
                 ->after($basePath.DIRECTORY_SEPARATOR)
                 ->before('.php')
                 ->replace(DIRECTORY_SEPARATOR, '\\')

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -7,6 +7,7 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Mail\Markdown;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Stringable;
 use Orchestra\Testbench\TestCase;
 
 class SendingMarkdownMailTest extends TestCase
@@ -50,7 +51,7 @@ class SendingMarkdownMailTest extends TestCase
 
         $email = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage()->toString();
 
-        $cid = explode(' cid:', str($email)->explode("\r\n")
+        $cid = explode(' cid:', (new Stringable($email))->explode("\r\n")
             ->filter(fn ($line) => str_contains($line, 'Embed content: cid:'))
             ->first())[1];
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Stringable;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -234,17 +235,17 @@ class MigratorTest extends TestCase
     protected function expectInfo($message): void
     {
         $this->output->shouldReceive('writeln')->once()->with(m::on(
-            fn ($argument) => str($argument)->contains($message),
+            fn ($argument) => (new Stringable($argument))->contains($message),
         ), m::any());
     }
 
     protected function expectTwoColumnDetail($first, $second = null)
     {
         $this->output->shouldReceive('writeln')->with(m::on(function ($argument) use ($first, $second) {
-            $result = str($argument)->contains($first);
+            $result = (new Stringable($argument))->contains($first);
 
             if ($result && $second) {
-                $result = str($argument)->contains($second);
+                $result = (new Stringable($argument))->contains($second);
             }
 
             return $result;
@@ -255,7 +256,7 @@ class MigratorTest extends TestCase
     {
         $this->output->shouldReceive('writeln')->once()->with(m::on(function ($argument) use ($elements) {
             foreach ($elements as $element) {
-                if (! str($argument)->contains("⇂ $element")) {
+                if (! (new Stringable($argument))->contains("⇂ $element")) {
                     return false;
                 }
             }
@@ -268,20 +269,20 @@ class MigratorTest extends TestCase
     {
         // Ignore dots...
         $this->output->shouldReceive('write')->with(m::on(
-            fn ($argument) => str($argument)->contains(['<fg=gray></>', '<fg=gray>.</>']),
+            fn ($argument) => (new Stringable($argument))->contains(['<fg=gray></>', '<fg=gray>.</>']),
         ), m::any(), m::any());
 
         // Ignore duration...
         $this->output->shouldReceive('write')->with(m::on(
-            fn ($argument) => str($argument)->contains(['ms</>']),
+            fn ($argument) => (new Stringable($argument))->contains(['ms</>']),
         ), m::any(), m::any());
 
         $this->output->shouldReceive('write')->once()->with(m::on(
-            fn ($argument) => str($argument)->contains($description),
+            fn ($argument) => (new Stringable($argument))->contains($description),
         ), m::any(), m::any());
 
         $this->output->shouldReceive('writeln')->once()->with(m::on(
-            fn ($argument) => str($argument)->contains($result),
+            fn ($argument) => (new Stringable($argument))->contains($result),
         ), m::any());
     }
 }

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Stringable;
 use Orchestra\Testbench\TestCase;
 
 class SendingMailableNotificationsTest extends TestCase
@@ -50,7 +51,7 @@ class SendingMailableNotificationsTest extends TestCase
 
         $email = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage()->toString();
 
-        $cid = explode(' cid:', str($email)->explode("\r\n")
+        $cid = explode(' cid:', (new Stringable($email))->explode("\r\n")
             ->filter(fn ($line) => str_contains($line, 'Embed content: cid:'))
             ->first())[1];
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use JsonSerializable;
@@ -2314,13 +2315,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylor,dayle', $data->implode(','));
 
         $data = new $collection([
-            ['name' => Str::of('taylor'), 'email' => Str::of('foo')],
-            ['name' => Str::of('dayle'), 'email' => Str::of('bar')],
+            ['name' => new Stringable('taylor'), 'email' => new Stringable('foo')],
+            ['name' => new Stringable('dayle'), 'email' => new Stringable('bar')],
         ]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
-        $data = new $collection([Str::of('taylor'), Str::of('dayle')]);
+        $data = new $collection([new Stringable('taylor'), new Stringable('dayle')]);
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
         $this->assertSame('taylor_dayle', $data->implode('_'));
@@ -3161,7 +3162,7 @@ class SupportCollectionTest extends TestCase
     public function testGroupByAttributeWithStringableKey($collection)
     {
         $data = new $collection($payload = [
-            ['name' => Str::of('Laravel'), 'url' => '1'],
+            ['name' => new Stringable('Laravel'), 'url' => '1'],
             ['name' => new HtmlString('Laravel'), 'url' => '1'],
             ['name' => new class()
             {

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Exception;
 use Illuminate\Support\Fluent;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class BladeEchoHandlerTest extends AbstractBladeTestCase
@@ -64,7 +64,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
         $exampleObject = new Fluent();
 
-        eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
+        eval((new Stringable($this->compiler->compileString($blade)))->remove(['<?php', '?>']));
     }
 
     public static function handlerLogicDataProvider()
@@ -85,7 +85,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         app()->instance('blade.compiler', $this->compiler);
 
         ob_start();
-        eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
+        eval((new Stringable($this->compiler->compileString($blade)))->remove(['<?php', '?>']));
         $output = ob_get_contents();
         ob_end_clean();
 
@@ -107,7 +107,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         app()->instance('blade.compiler', $this->compiler);
 
         ob_start();
-        eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
+        eval((new Stringable($this->compiler->compileString($blade)))->remove(['<?php', '?>']));
         $output = ob_get_contents();
         ob_end_clean();
 


### PR DESCRIPTION
This PR updates the framework to prefer the use of `new Stringable` over `Str::of()` and the `str()` helper, aligning with the changes introduced in [PR #53563](https://github.com/laravel/framework/pull/53563). Similar to `collect()`, the `str()` helper is a straightforward alias with no additional logic. Replacing it with `new Stringable()` ensures a shorter and more direct call graph, improves performance marginally, and enhances developer experience by removing an intermediary layer when navigating the codebase.

The changes maintain the same functionality while improving consistency and code clarity within the framework. Additional updates can be made if this approach is accepted.