### PR TITLE
[11.x] Prefer `new Fluent` over `fluent()` helper

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\InteractsWithData;
 use SplFileInfo;
@@ -121,7 +122,7 @@ trait InteractsWithInput
      */
     public function fluent($key = null)
     {
-        return fluent(is_array($key) ? $this->only($key) : $this->input($key));
+        return new Fluent(is_array($key) ? $this->only($key) : $this->input($key));
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -414,10 +414,10 @@ class HttpClientTest extends TestCase
         $response = $this->factory->get('http://foo.com/api');
 
         $this->assertInstanceOf(Fluent::class, $response->fluent());
-        $this->assertEquals(fluent(['result' => ['foo' => 'bar']]), $response->fluent());
-        $this->assertEquals(fluent(['foo' => 'bar']), $response->fluent('result'));
-        $this->assertEquals(fluent(['bar']), $response->fluent('result.foo'));
-        $this->assertEquals(fluent([]), $response->fluent('missing_key'));
+        $this->assertEquals(new Fluent(['result' => ['foo' => 'bar']]), $response->fluent());
+        $this->assertEquals(new Fluent(['foo' => 'bar']), $response->fluent('result'));
+        $this->assertEquals(new Fluent(['bar']), $response->fluent('result.foo'));
+        $this->assertEquals(new Fluent([]), $response->fluent('missing_key'));
     }
 
     public function testSendRequestBodyAsJsonByDefault()


### PR DESCRIPTION
This PR updates the framework to prefer the use of `new Fluent()` the `fluent()` helper.

The changes maintain the same functionality while improving consistency and code clarity within the framework. Additional updates can be made if this approach is accepted.