### PR TITLE
[11.x] `Collection::wrap`

### DIFF
--- a/src/Illuminate/Concurrency/SyncDriver.php
+++ b/src/Illuminate/Concurrency/SyncDriver.php
@@ -4,7 +4,6 @@ namespace Illuminate\Concurrency;
 
 use Closure;
 use Illuminate\Contracts\Concurrency\Driver;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Defer\DeferredCallback;
 
@@ -17,7 +16,7 @@ class SyncDriver implements Driver
      */
     public function run(Closure|array $tasks): array
     {
-        return (new Collection(Arr::wrap($tasks)))->map(
+        return Collection::wrap($tasks)->map(
             fn ($task) => $task()
         )->all();
     }
@@ -27,6 +26,6 @@ class SyncDriver implements Driver
      */
     public function defer(Closure|array $tasks): DeferredCallback
     {
-        return defer(fn () => (new Collection(Arr::wrap($tasks)))->each(fn ($task) => $task()));
+        return defer(fn () => Collection::wrap($tasks)->each(fn ($task) => $task()));
     }
 }

--- a/src/Illuminate/Console/Concerns/InteractsWithSignals.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithSignals.php
@@ -31,7 +31,7 @@ trait InteractsWithSignals
                 $this->getApplication()->getSignalRegistry(),
             );
 
-            (new Collection(Arr::wrap(value($signals))))
+            Collection::wrap(value($signals))
                 ->each(fn ($signal) => $this->signals->register($signal, $callback));
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -151,7 +151,7 @@ trait CanBeOneOfMany
      */
     public function latestOfMany($column = 'id', $relation = null)
     {
-        return $this->ofMany((new Collection(Arr::wrap($column)))->mapWithKeys(function ($column) {
+        return $this->ofMany(Collection::wrap($column)->mapWithKeys(function ($column) {
             return [$column => 'MAX'];
         })->all(), 'MAX', $relation);
     }
@@ -165,7 +165,7 @@ trait CanBeOneOfMany
      */
     public function oldestOfMany($column = 'id', $relation = null)
     {
-        return $this->ofMany((new Collection(Arr::wrap($column)))->mapWithKeys(function ($column) {
+        return $this->ofMany(Collection::wrap($column)->mapWithKeys(function ($column) {
             return [$column => 'MIN'];
         })->all(), 'MIN', $relation);
     }

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -5,7 +5,6 @@ namespace Illuminate\Queue\Middleware;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Container\Container;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 use function Illuminate\Support\enum_value;
@@ -68,7 +67,7 @@ class RateLimited
         return $this->handleJob(
             $job,
             $next,
-            (new Collection(Arr::wrap($limiterResponse)))->map(function ($limit) {
+            Collection::wrap($limiterResponse)->map(function ($limit) {
                 return (object) [
                     'key' => md5($this->limiterName.$limit->key),
                     'maxAttempts' => $limit->maxAttempts,

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
@@ -215,7 +214,7 @@ abstract class Queue
             return;
         }
 
-        return (new Collection(Arr::wrap($backoff)))
+        return Collection::wrap($backoff)
             ->map(fn ($backoff) => $backoff instanceof DateTimeInterface ? $this->secondsUntil($backoff) : $backoff)
             ->implode(',');
     }

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 use function Illuminate\Support\enum_value;
@@ -90,7 +89,7 @@ trait CreatesRegularExpressionRouteConstraints
      */
     protected function assignExpressionToParameters($parameters, $expression)
     {
-        return $this->where((new Collection(Arr::wrap($parameters)))
+        return $this->where(Collection::wrap($parameters)
                     ->mapWithKeys(fn ($parameter) => [$parameter => $expression])
                     ->all());
     }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -8,7 +8,6 @@ use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Exceptions\MissingRateLimiterException;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use RuntimeException;
@@ -128,7 +127,7 @@ class ThrottleRequests
         return $this->handleRequest(
             $request,
             $next,
-            (new Collection(Arr::wrap($limiterResponse)))->map(function ($limit) use ($limiterName) {
+            Collection::wrap($limiterResponse)->map(function ($limit) use ($limiterName) {
                 return (object) [
                     'key' => self::$shouldHashKeys ? md5($limiterName.$limit->key) : $limiterName.':'.$limit->key,
                     'maxAttempts' => $limit->maxAttempts,

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -529,7 +529,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function toRoute($route, $parameters, $absolute)
     {
-        $parameters = (new Collection(Arr::wrap($parameters)))->map(function ($value, $key) use ($route) {
+        $parameters = Collection::wrap($parameters)->map(function ($value, $key) use ($route) {
             return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}
                     : $value;

--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -15,7 +15,7 @@ class Benchmark
      */
     public static function measure(Closure|array $benchmarkables, int $iterations = 1): array|float
     {
-        return (new Collection(Arr::wrap($benchmarkables)))->map(function ($callback) use ($iterations) {
+        return Collection::wrap($benchmarkables)->map(function ($callback) use ($iterations) {
             return (new Collection(range(1, $iterations)))->map(function () use ($callback) {
                 gc_collect_cycles();
 

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -330,7 +330,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function fail($messages)
     {
-        $messages = (new Collection(Arr::wrap($messages)))
+        $messages = Collection::wrap($messages)
             ->map(fn ($message) => $this->validator->getTranslator()->get($message))
             ->all();
 


### PR DESCRIPTION
This PR updates the framework to prefer the use of `Collection::wrap` when possible. In some case, if the value is `Enumerable`, `Arr::wrap` won't even need to be called internally.

The changes maintain the same functionality while improving consistency and code clarity within the framework. Additional updates can be made if this approach is accepted.