### PR TITLE
[11.x] Don’t serialise virtual properties in `SerializesModels`

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -32,6 +32,10 @@ trait SerializesModels
                 continue;
             }
 
+            if ($this->isVirtualProperty($property)) {
+                continue;
+            }
+
             if (! $property->isInitialized($this)) {
                 continue;
             }
@@ -77,6 +81,10 @@ trait SerializesModels
                 continue;
             }
 
+            if ($this->isVirtualProperty($property)) {
+                continue;
+            }
+
             $name = $property->getName();
 
             if ($property->isPrivate()) {
@@ -104,5 +112,14 @@ trait SerializesModels
     protected function getPropertyValue(ReflectionProperty $property)
     {
         return $property->getValue($this);
+    }
+
+    /**
+     * @param  \ReflectionProperty  $property
+     * @return bool
+     */
+    protected function isVirtualProperty(ReflectionProperty $property): bool
+    {
+        return method_exists($property, 'isVirtual') && $property->isVirtual();
     }
 }


### PR DESCRIPTION
With the introduction of [property hooks](https://www.php.net/manual/en/language.oop5.property-hooks.php) in php 8.4, developers now have the ability to create [virtual properties](https://www.php.net/manual/en/language.oop5.property-hooks.php#language.oop5.property-hooks.virtual). As these properties are in fact virtual, I believe they may be excluded from being serialised in `Illuminate\Queue\SerializesModels`.

With the current implementation, read-only virtual properties will fail when trying to set their value when unserialising an instance. Excluding virtual properties from serialisation should solve this.

> [!NOTE]
> I couldn't find test coverage for the specific cases defined in `SerializesModels` (such as excluding static or uninitialised properties), so I'm not 100% sure how this would be tested. Any feedback or guidance is welcome.

## Backwards compatibility 

As virtual properties were introduced in php 8.4 and Laravel currently supports anything above 8.2, this implementation first checks whether the `isVirtual()` method exists on `ReflectionProperty`. This should ensure these changes don't break `Illuminate\Queue\SerializesModels` on earlier php versions.