### PR TITLE
[11.x] Add "previous" state to models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -62,6 +62,13 @@ trait HasAttributes
     protected $original = [];
 
     /**
+     * The model attribute's previous state.
+     *
+     * @var array
+     */
+    protected $previous = [];
+
+    /**
      * The changed model attributes.
      *
      * @var array
@@ -1960,6 +1967,32 @@ trait HasAttributes
     }
 
     /**
+     * Get the model's previous attribute values.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed|array
+     */
+    public function getPrevious($key = null, $default = null)
+    {
+        return (new static)->setRawAttributes(
+            $this->previous, $sync = true
+        )->getOriginalWithoutRewindingModel($key, $default);
+    }
+
+    /**
+     * Get the model's raw previous attribute values.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed|array
+     */
+    public function getRawPrevious($key = null, $default = null)
+    {
+        return Arr::get($this->previous, $key, $default);
+    }
+
+    /**
      * Get a subset of the model's attributes.
      *
      * @param  array|mixed  $attributes
@@ -2014,6 +2047,18 @@ trait HasAttributes
         foreach ($attributes as $attribute) {
             $this->original[$attribute] = $modelAttributes[$attribute];
         }
+
+        return $this;
+    }
+
+    /**
+     * Sync the previous attributes with the original.
+     *
+     * @return $this
+     */
+    public function syncPrevious()
+    {
+        $this->previous = $this->original;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -989,6 +989,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $amount = (clone $this)->setAttribute($column, $amount)->getAttributeFromArray($column);
         }
 
+        $this->syncPrevious();
+
         return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($column, $amount, $extra), function () use ($column) {
             $this->syncChanges();
 
@@ -1236,6 +1238,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $dirty = $this->getDirtyForUpdate();
 
         if (count($dirty) > 0) {
+            $this->syncPrevious();
+
             $this->setKeysForSaveQuery($query)->update($dirty);
 
             $this->syncChanges();

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -33,6 +33,15 @@ class EloquentDeleteTest extends DatabaseTestCase
         });
     }
 
+    public function testBasicDelete()
+    {
+        $post = Post::create();
+
+        Post::where('id', $post->id)->delete();
+
+        $this->assertCount(0, Post::all());
+    }
+
     public function testDeleteWithLimit()
     {
         if ($this->driver === 'sqlsrv') {

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -54,6 +54,18 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         $this->assertSame('patrick', $post->getOriginal('title'));
     }
 
+    public function testItDoesNotSyncPreviousOnRefresh()
+    {
+        $post = Post::create(['title' => 'pat']);
+
+        Post::find($post->id)->update(['title' => 'patrick']);
+
+        $post->refresh();
+
+        $this->assertEmpty($post->getDirty());
+        $this->assertEmpty($post->getPrevious());
+    }
+
     public function testAsPivot()
     {
         Schema::create('post_posts', function (Blueprint $table) {

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -84,12 +84,14 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertFalse($user->wasChanged());
         $this->assertSame($originalName, $user->getOriginal('name'));
         $this->assertSame($overrideName, $user->getAttribute('name'));
+        $this->assertEmpty($user->getPrevious());
 
         $user->discardChanges();
 
         $this->assertEmpty($user->getDirty());
         $this->assertSame($originalName, $user->getOriginal('name'));
         $this->assertSame($originalName, $user->getAttribute('name'));
+        $this->assertEmpty($user->getPrevious());
 
         $user->save();
         $this->assertFalse($user->wasChanged());


### PR DESCRIPTION
This change make it possible to retrieve the previously saved state (i.e. what `original` was before update/save). This gives you the ability to do similar checks as with current vs original state _after_ save.

This adds `->getPrevious($key = null, $default = null)` and `->getRawPrevious($key = null, $default = null)`, as well as `syncPrevious()` but it might be better to make the latter `protected`.

I also noticed a delete test in the `EloquentUpdateTest` so I moved it to the `EloquentDeleteTest` and added a correct test case in `EloquentUpdateTest` in its place.
