### PR TITLE
[11.x] Add getModel method to FactoryClass for more code flexibility

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -827,7 +827,17 @@ abstract class Factory
                         : $appNamespace.$factoryBasename;
         };
 
-        return $this->model ?? $resolver($this);
+        return $this->getModel() ?? $resolver($this);
+    }
+
+    /**
+     * Get the model class.
+     *
+     * @return class-string<TModel>
+     */
+    protected function getModel()
+    {
+        return $this->model;
     }
 
     /**


### PR DESCRIPTION
Introduced a `getModel()` method to encapsulate access to the `$model` property.
Updated the `modelName()` method to use `getModel() ` for more flexibility to factories. It can be used when using third party factories.
