### PR TITLE
[11.x] Add word-break to mail links

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -145,6 +145,10 @@ img {
     width: 570px;
 }
 
+.inner-body a {
+    word-break: break-all;
+}
+
 /* Subcopy */
 
 .subcopy {


### PR DESCRIPTION
The default email template's layout breaks when it contains long links. I suggest adding the css property `word-break: break-all;` on links in the `.inner-body` to fix this issue. 

See the before and after in these screenshots: 

Before
![mail-before](https://github.com/user-attachments/assets/ddd573e5-3f32-4ed3-8127-c66386c08ae4)

After
![mail-after](https://github.com/user-attachments/assets/58316871-a428-4f27-aaf7-89c8c419b4e9)


