### PR TITLE
Add Optional Auto-Registration of Seeder Class in DatabaseSeeder

### DIFF
--- a/tests/Integration/Generators/SeederMakeCommandTest.php
+++ b/tests/Integration/Generators/SeederMakeCommandTest.php
@@ -20,4 +20,49 @@ class SeederMakeCommandTest extends TestCase
             'public function run()',
         ], 'database/seeders/FooSeeder.php');
     }
+
+
+    public function testItCanAutoRegisterSeederInDatabaseSeeder()
+    {
+        // Prepare: Create a mock DatabaseSeeder file
+        $databaseSeederPath = database_path('seeders/DatabaseSeeder.php');
+        $initialContent = "<?php\n\nnamespace Database\Seeders;\n\nuse Illuminate\Database\Seeder;\n\nclass DatabaseSeeder extends Seeder\n{\n    public function run()\n    {\n        \$this->call([\n            // Existing seeders\n        ]);\n    }\n}";
+
+        // Ensure the DatabaseSeeder exists
+        file_put_contents($databaseSeederPath, $initialContent);
+
+        // Run the make:seeder command with auto-register option
+        $this->artisan('make:seeder', [
+            'name' => 'FooSeeder',
+            '--auto-register' => true
+        ])->assertExitCode(0);
+
+        // Read the updated DatabaseSeeder
+        $updatedContent = file_get_contents($databaseSeederPath);
+
+        // Assert that the new seeder is registered
+        $this->assertStringContainsString('FooSeeder::class,', $updatedContent);
+
+        // Cleanup
+        $this->files[] = 'database/seeders/FooSeeder.php';
+    }
+
+    public function testItDoesNotRegisterDuplicateSeeder()
+    {
+        // Prepare: Create a DatabaseSeeder with existing seeder
+        $databaseSeederPath = database_path('seeders/DatabaseSeeder.php');
+        $initialContent = "<?php\n\nnamespace Database\Seeders;\n\nuse Illuminate\Database\Seeder;\n\nclass DatabaseSeeder extends Seeder\n{\n    public function run()\n    {\n        \$this->call([\n            FooSeeder::class,\n        ]);\n    }\n}";
+
+        file_put_contents($databaseSeederPath, $initialContent);
+
+        // Run the make:seeder command with auto-register option
+        $this->artisan('make:seeder', [
+            'name' => 'FooSeeder',
+            '--auto-register' => true
+        ])->expectsOutput("Seeder 'FooSeeder' is already registered in DatabaseSeeder.");
+
+        // Verify the content remains unchanged
+        $finalContent = file_get_contents($databaseSeederPath);
+        $this->assertEquals($initialContent, $finalContent);
+    }
 }


### PR DESCRIPTION
This pull request allows developers to optionally auto-register the generated seeder class in DatabaseSeeder.php using the --auto-register (-r) flag.

**command example**: php artisan make:seeder -r

When the -r or --auto-register flag is used, the generated seeder class is automatically appended to the $this->call([]) array in DatabaseSeeder.php, streamlining the workflow by eliminating the need for manual registration.

**Key Features:**

1. Optional Auto-Registration:
   * Use the --auto-register flag to append the new seeder class to the $this->call([]) array in DatabaseSeeder.
2. Prevents Duplicates:
   * Checks if the seeder is already registered before adding it to avoid duplicate entries.
3. Backward Compatible:
   * The feature is completely optional, preserving existing behavior when the flag is not used.
4. Developer Feedback:
   * Provides clear messages to inform developers if the seeder was successfully registered or already present.