### PR TITLE
[12.x] Restore database token repository property documentation

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -14,7 +14,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * Create a new token repository instance.
      *
      * @param  int  $expires  The number of seconds a token should last.
-     * @param  int  $throttle  Minimum number of seconds before re-redefining the token.
+     * @param  int  $throttle  Minimum number of seconds before the user can generate new password reset tokens.
      */
     public function __construct(
         protected ConnectionInterface $connection,

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -12,6 +12,9 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
 {
     /**
      * Create a new token repository instance.
+     * 
+     * @param $expires The number of seconds a token should last.
+     * @param $throttle Minimum number of seconds before re-redefining the token.
      */
     public function __construct(
         protected ConnectionInterface $connection,

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -12,9 +12,8 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
 {
     /**
      * Create a new token repository instance.
-     * 
-     * @param int $expires The number of seconds a token should last.
-     * @param int $throttle Minimum number of seconds before re-redefining the token.
+     * @param  int  $expires  The number of seconds a token should last.
+     * @param  int  $throttle  Minimum number of seconds before re-redefining the token.
      */
     public function __construct(
         protected ConnectionInterface $connection,

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -13,8 +13,8 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     /**
      * Create a new token repository instance.
      * 
-     * @param $expires The number of seconds a token should last.
-     * @param $throttle Minimum number of seconds before re-redefining the token.
+     * @param int $expires The number of seconds a token should last.
+     * @param int $throttle Minimum number of seconds before re-redefining the token.
      */
     public function __construct(
         protected ConnectionInterface $connection,

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -12,6 +12,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
 {
     /**
      * Create a new token repository instance.
+     * 
      * @param  int  $expires  The number of seconds a token should last.
      * @param  int  $throttle  Minimum number of seconds before re-redefining the token.
      */

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -13,7 +13,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     /**
      * Create a new token repository instance.
      *
-     * @param  int  $expires  The number of seconds a token should last.
+     * @param  int  $expires  The number of seconds a token should remain valid.
      * @param  int  $throttle  Minimum number of seconds before the user can generate new password reset tokens.
      */
     public function __construct(

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -12,7 +12,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
 {
     /**
      * Create a new token repository instance.
-     * 
+     *
      * @param  int  $expires  The number of seconds a token should last.
      * @param  int  $throttle  Minimum number of seconds before re-redefining the token.
      */


### PR DESCRIPTION
Restoring the documentation of `DatabaseTokenRepository` properties, lost in #53746 