### PR TITLE
[11.x] Prevent `blank` Helper from Serializing Eloquent Models

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;
@@ -58,6 +59,10 @@ if (! function_exists('blank')) {
         }
 
         if (is_numeric($value) || is_bool($value)) {
+            return false;
+        }
+
+        if ($value instanceof Model) {
             return false;
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Countable;
 use Error;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
@@ -73,6 +74,18 @@ class SupportHelpersTest extends TestCase
 
         $object = new SupportTestCountable();
         $this->assertTrue(blank($object));
+    }
+
+    public function testBlankDoesntJsonSerializeModels()
+    {
+        $model = new class extends Model {
+            public function jsonSerialize(): mixed
+            {
+                throw new RuntimeException('Model should not be serialized');
+            }
+        };
+
+        $this->assertFalse(blank($model));
     }
 
     public function testClassBasename()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -78,7 +78,8 @@ class SupportHelpersTest extends TestCase
 
     public function testBlankDoesntJsonSerializeModels()
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
             public function jsonSerialize(): mixed
             {
                 throw new RuntimeException('Model should not be serialized');


### PR DESCRIPTION
### Description:
This PR ensures that the `blank` helper does not attempt to serialize Eloquent models when checking if they are blank. The issue was encountered when using `->loadMissing()` on a model, where calling the `blank` helper unexpectedly triggered `jsonSerialize`, leading to unintended behavior and overhead.

#### Changes:
- Updated the `blank` helper to return `false` for instances of `Illuminate\Database\Eloquent\Model`.
- Added a test to verify that models are not serialized when passed to the `blank` helper.

#### Benefits:
- Prevents unexpected model serialization when using the `blank` helper, particularly in cases like `->loadMissing()`.
- Avoids runtime exceptions or side effects caused by serialization during blank checks.
- Improves developer experience by aligning the helper's behavior with expectations.

#### Impact:
This change is non-breaking and does not alter the behavior of the `blank` helper for non-model values. It ensures consistent and safe handling of Eloquent models.