### PR TITLE
[11.x] Early return in Factory::modelName()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -813,6 +813,10 @@ abstract class Factory
      */
     public function modelName()
     {
+        if ($this->model !== null) {
+            return $this->model;
+        }
+
         $resolver = static::$modelNameResolver ?? function (self $factory) {
             $namespacedFactoryBasename = Str::replaceLast(
                 'Factory', '', Str::replaceFirst(static::$namespace, '', get_class($factory))
@@ -827,7 +831,7 @@ abstract class Factory
                         : $appNamespace.$factoryBasename;
         };
 
-        return $this->model ?? $resolver($this);
+        return $resolver($this);
     }
 
     /**


### PR DESCRIPTION
Early return in `Factory::modelName()` to avoid possibly defining a function that will not be used

(Inspired by #53902)