### PR TITLE
[11.x] Remove duplicated method call from if-else construct

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -954,11 +954,10 @@ abstract class Factory
 
         $relatedModel = get_class($this->newModel()->{$relationship}()->getRelated());
 
-        if (method_exists($relatedModel, 'newFactory') && ($_factory = $relatedModel::newFactory()) !== null) {
-            $factory = $_factory;
-        } else {
-            $factory = static::factoryForModel($relatedModel);
+        if (method_exists($relatedModel, 'newFactory')) {
+            $factory = $relatedModel::newFactory();
         }
+        $factory ??= static::factoryForModel($relatedModel);
 
         if (str_starts_with($method, 'for')) {
             return $this->for($factory->state($parameters[0] ?? []), $relationship);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -954,8 +954,8 @@ abstract class Factory
 
         $relatedModel = get_class($this->newModel()->{$relationship}()->getRelated());
 
-        if (method_exists($relatedModel, 'newFactory')) {
-            $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);
+        if (method_exists($relatedModel, 'newFactory') && ($_factory = $relatedModel::newFactory()) !== null) {
+            $factory = $_factory;
         } else {
             $factory = static::factoryForModel($relatedModel);
         }


### PR DESCRIPTION
`static::factoryForModel($relatedModel)` is called twice

## Alternative considerations
Other considerations:
```diff
-       if (method_exists($relatedModel, 'newFactory')) {
-           $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);
+       if (method_exists($relatedModel, 'newFactory') && ($factory = $relatedModel::newFactory()) !== null) {
+           //
        } else {
            $factory = static::factoryForModel($relatedModel);
        }
```
```diff
-       if (method_exists($relatedModel, 'newFactory')) {
-           $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);
+       if (method_exists($relatedModel, 'newFactory') && ($_factory = $relatedModel::newFactory()) !== null) {
+           $factory = $_factory;
        } else {
            $factory = static::factoryForModel($relatedModel);
        }
```

(Inspired by #53902)