### PR TITLE
Preserve dynamic database connections on reconnect

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -117,12 +117,12 @@ class DatabaseManager implements ConnectionResolverInterface
     public function build(array $config)
     {
         if (! isset($config['name'])) {
-            $config['name'] = 'dynamic_' . Str::uuid();
+            $config['name'] = 'dynamic_'.Str::uuid();
         }
 
         $this->dynamicConnections[$config['name']] = $config;
 
-        return $this->connectUsing($config['name'], $config,true);
+        return $this->connectUsing($config['name'], $config, true);
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -48,7 +48,7 @@ class DatabaseManager implements ConnectionResolverInterface
      *
      * @var array<string, array>
      */
-    protected $dynamicConnections = [];
+    protected $dynamicConnectionConfigurations = [];
 
     /**
      * The custom connection resolvers.
@@ -121,7 +121,7 @@ class DatabaseManager implements ConnectionResolverInterface
             $config['name'] = static::calculateDynamicConnectionName($config);
         }
 
-        $this->dynamicConnections[$config['name']] = $config;
+        $this->dynamicConnectionConfigurations[$config['name']] = $config;
 
         return $this->connectUsing($config['name'], $config, true);
     }
@@ -221,7 +221,7 @@ class DatabaseManager implements ConnectionResolverInterface
 
         $connections = $this->app['config']['database.connections'];
 
-        $config = $this->dynamicConnections[$name] ?? Arr::get($connections, $name);
+        $config = $this->dynamicConnectionConfigurations[$name] ?? Arr::get($connections, $name);
 
         if (is_null($config)) {
             throw new InvalidArgumentException("Database connection [{$name}] not configured.");

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Events\ConnectionEstablished;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Mockery;
 use RuntimeException;
 
 class DatabaseConnectionsTest extends DatabaseTestCase
@@ -133,5 +135,24 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
         DB::setTablePrefix('');
         $this->assertSame('', DB::getTablePrefix());
+    }
+
+    public function testDynamicConnectionFailsOnReconnect()
+    {
+        $connection = DB::build([
+            'name' => 'projects',
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $this->expectNotToPerformAssertions();
+
+        try {
+            $connection->reconnect();
+        } catch (InvalidArgumentException $e) {
+            if ($e->getMessage() === 'Database connection [projects] not configured.') {
+                $this->fail('Dynamic connection should not throw an exception on reconnect.');
+            }
+        }
     }
 }

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -136,10 +136,28 @@ class DatabaseConnectionsTest extends DatabaseTestCase
         $this->assertSame('', DB::getTablePrefix());
     }
 
-    public function testDynamicConnectionFailsOnReconnect()
+    public function testDynamicConnectionDoesntFailOnReconnect()
     {
         $connection = DB::build([
             'name' => 'projects',
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $this->expectNotToPerformAssertions();
+
+        try {
+            $connection->reconnect();
+        } catch (InvalidArgumentException $e) {
+            if ($e->getMessage() === 'Database connection [projects] not configured.') {
+                $this->fail('Dynamic connection should not throw an exception on reconnect.');
+            }
+        }
+    }
+
+    public function testDynamicConnectionWithNoNameDoesntFailOnReconnect()
+    {
+        $connection = DB::build([
             'driver' => 'sqlite',
             'database' => ':memory:',
         ]);

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -10,7 +10,6 @@ use Illuminate\Database\SQLiteConnection;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
-use Mockery;
 use RuntimeException;
 
 class DatabaseConnectionsTest extends DatabaseTestCase


### PR DESCRIPTION
This pull request is intended as a fix to Issue #53886 https://github.com/laravel/framework/issues/53886

It introduces a way to automatically reconnect to dynamically built database connections.

Currently calling `DB::build()` with a configuration that is not registered in configuration files will create a new 'on demand' connection. However, should this connection fail,  when Laravel attempts to reconnect it will fail with an `InvalidArgumentException` due to the connection configuration not existing.

With this PR, dynamically built connections are stored in a local registry within the `DatabaseManager`. When a reconnection is attempted, the framework can now correctly retrieve the configuration and re-establish the PDO connection without error.

**Benefit to End Users:**
Developers who dynamically create database connections at runtime will no longer need to manually register them in `config()` arrays or handle reconnections themselves. The framework now supports transparent reconnections out-of-the-box for these on-demand connections.

**How It Makes Building Web Applications Easier:**
Before this change, any "lost connection" scenario for dynamically built connections required workarounds, such as manually re-registering configurations or catching and recreating connections on each failure. Now, developers can rely on Laravel’s built-in reconnection logic, reducing boilerplate and complexity.

**Code example:**

Before: Dynamically built connections would fail on reconnection:
```
$connection = DB::build([
    'driver' => 'mysql',
    'database' => 'forge',
    'username' => 'root',
    'password' => 'secret',
]);

// If the connection is lost, calling $connection->reconnect() 
// will throw "Database connection [dynamic_something] not configured."
```

After: Dynamically built connections are registered and can reconnect seamlessly:
```
$connection = DB::build([
    'driver' => 'mysql',
    'database' => 'forge',
    'username' => 'root',
    'password' => 'secret',
]);

// If the connection is lost, calling reconnect() now works as expected:
$connection->reconnect(); // Automatically refreshes the PDO without errors.
```

The user experience is improved by removing a hidden pitfall in dynamic connection usage.