### PR TITLE
[12.x] Remove duplicated method call from if-else construct

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -955,10 +955,9 @@ abstract class Factory
         $relatedModel = get_class($this->newModel()->{$relationship}()->getRelated());
 
         if (method_exists($relatedModel, 'newFactory')) {
-            $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);
-        } else {
-            $factory = static::factoryForModel($relatedModel);
+            $factory = $relatedModel::newFactory();
         }
+        $factory ??= static::factoryForModel($relatedModel);
 
         if (str_starts_with($method, 'for')) {
             return $this->for($factory->state($parameters[0] ?? []), $relationship);


### PR DESCRIPTION
Retrying #53913 for a later version since it was delayed when targeted at 11.x