### PR TITLE
Add dispatchNow() to Dispatchable Trait

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -64,6 +64,17 @@ trait Dispatchable
     }
 
     /**
+     * Dispatch the job immediately with the given arguments.
+     *
+     * @param  mixed  ...$arguments
+     * @return mixed
+     */
+    public static function dispatchNow(...$arguments)
+    {
+        return app(Dispatcher::class)->dispatchNow(new static(...$arguments));
+    }
+
+    /**
      * Dispatch a command to its appropriate handler in the current process.
      *
      * Queueable jobs will be dispatched to the "sync" queue.


### PR DESCRIPTION
When I'm trying to dispatch a job immediately, using `MyJob::dispatch()` technically creates a `PendingDispatch` instance, which dispatches upon deconstruction.

There are niche scenarios, but they do exist, where I want to dispatch a job immediately, before the remainder of the code executes. This can also be a hassle when dispatching within Tinker, as Ctrl+C kills the terminal without dispatching the job.

Dispatching a job immediately can be done through `Bus::dispatchNow(new MyJob)`, but it would be way more convenient if I could just do `MyJob::dispatchNow()`.

For the record, there's also `dispatchSync`, but this runs on the sync queue, which is not the behavior I want.