### PR TITLE
feature/11.x Reject and Filter Method for defer collection instance

### DIFF
--- a/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
@@ -89,6 +89,38 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
     }
 
     /**
+     * Filter the callbacks in the collection.
+     *
+     * @param  (callable(mixed): bool)  $callback
+     * @return $this
+     */
+    public function filter(callable $callback): self
+    {
+        $this->callbacks = (new Collection($this->callbacks))
+            ->filter($callback)
+            ->values()
+            ->all();
+
+        return $this;
+    }
+
+    /**
+     * Filter the callbacks in the collection.
+     *
+     * @param  (callable(mixed): bool)  $callback
+     * @return $this
+     */
+    public function reject(callable $callback): self
+    {
+        $this->callbacks = (new Collection($this->callbacks))
+            ->reject($callback)
+            ->values()
+            ->all();
+
+        return $this;
+    }
+
+    /**
      * Determine if the collection has a callback with the given key.
      *
      * @param  mixed  $offset

--- a/tests/Support/Defer/DeferredCallbackCollectionTest.php
+++ b/tests/Support/Defer/DeferredCallbackCollectionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Support\Defer;
+
+use Illuminate\Support\Defer\DeferredCallback;
+use Illuminate\Support\Defer\DeferredCallbackCollection;
+use PHPUnit\Framework\TestCase;
+
+class DeferredCallbackCollectionTest extends TestCase
+{
+    public function testFirstMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback = new DeferredCallback(fn () => 'test');
+        $collection[] = $callback;
+
+        $this->assertSame($callback, $collection->first());
+    }
+
+    public function testForgetMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback = new DeferredCallback(fn () => 'test', 'test');
+        $collection[] = $callback;
+
+        $collection->forget('test');
+
+        $this->assertCount(0, $collection);
+    }
+
+    public function testFilterMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback1 = new DeferredCallback(fn () => 'test1', 'callback1');
+        $callback2 = new DeferredCallback(fn () => 'test2', 'callback2');
+        $collection[] = $callback1;
+        $collection[] = $callback2;
+
+        $filteredCollection = $collection->filter(fn ($callback) => $callback->name === 'callback1');
+
+        $this->assertCount(1, $filteredCollection);
+        $this->assertSame($callback1, $filteredCollection->first());
+    }
+
+    public function testRejectMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback1 = new DeferredCallback(fn () => 'test1', 'callback1');
+        $callback2 = new DeferredCallback(fn () => 'test2', 'callback2');
+        $collection[] = $callback1;
+        $collection[] = $callback2;
+
+        $rejectedCollection = $collection->reject(fn ($callback) => $callback->name === 'callback1');
+
+        $this->assertCount(1, $rejectedCollection);
+        $this->assertSame($callback2, $rejectedCollection->first());
+    }
+
+    public function testOffsetExistsMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback = new DeferredCallback(fn () => 'test');
+        $collection[] = $callback;
+
+        $this->assertTrue(isset($collection[0]));
+    }
+
+    public function testOffsetGetMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback = new DeferredCallback(fn () => 'test');
+        $collection[] = $callback;
+
+        $this->assertSame($callback, $collection[0]);
+    }
+
+    public function testOffsetSetMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback = new DeferredCallback(fn () => 'test');
+        $collection[0] = $callback;
+
+        $this->assertSame($callback, $collection[0]);
+    }
+
+    public function testOffsetUnsetMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $callback = new DeferredCallback(fn () => 'test');
+        $collection[] = $callback;
+
+        unset($collection[0]);
+
+        $this->assertFalse(isset($collection[0]));
+    }
+
+    public function testCountMethod(): void
+    {
+        $collection = new DeferredCallbackCollection();
+        $collection[] = new DeferredCallback(fn () => 'test');
+
+        $this->assertCount(1, $collection);
+    }
+}


### PR DESCRIPTION
**Implementation of filter and reject Methods for Defer: Enhancing Middleware Flexibility**

Benefits to End Users:

Customizable Request and Response Handling: These methods enable users to easily filter or exclude specific requests or responses based on custom conditions, making middleware implementation more powerful and intuitive.

Improved Workflow Control: By supporting conditional logic, users can streamline their application's request and response flow without resorting to verbose or repetitive code.
