### PR TITLE
Allow to pass enums inside resource only&except methods

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -5,6 +5,8 @@ namespace Illuminate\Routing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 
+use function Illuminate\Support\enum_value;
+
 class PendingResourceRegistration
 {
     use CreatesRegularExpressionRouteConstraints, Macroable;
@@ -64,12 +66,15 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should apply to.
      *
-     * @param  array|string|mixed  $methods
+     * @param  list<string|\UnitEnum|\BackedEnum>|string|mixed  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function only($methods)
     {
-        $this->options['only'] = is_array($methods) ? $methods : func_get_args();
+        $this->options['only'] = array_map(
+            enum_value(...),
+            is_array($methods) ? $methods : func_get_args(),
+        );
 
         return $this;
     }
@@ -77,12 +82,15 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should exclude.
      *
-     * @param  array|string|mixed  $methods
+     * @param  list<string|\UnitEnum|\BackedEnum>|string|mixed  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function except($methods)
     {
-        $this->options['except'] = is_array($methods) ? $methods : func_get_args();
+        $this->options['except'] = array_map(
+            enum_value(...),
+            is_array($methods) ? $methods : func_get_args(),
+        );
 
         return $this;
     }

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -66,7 +66,7 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should apply to.
      *
-     * @param  list<string|\UnitEnum|\BackedEnum>|string|mixed  $methods
+     * @param  list<string|\UnitEnum|\BackedEnum>|\UnitEnum|\BackedEnum|string|mixed  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function only($methods)
@@ -82,7 +82,7 @@ class PendingResourceRegistration
     /**
      * Set the methods the controller should exclude.
      *
-     * @param  list<string|\UnitEnum|\BackedEnum>|string|mixed  $methods
+     * @param  list<string|\UnitEnum|\BackedEnum>|\UnitEnum|\BackedEnum|string|mixed  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function except($methods)


### PR DESCRIPTION
This PR allows to pass enums to only and except method of PendingResourceRegistration

```php
enum RestfulMethod: string {
  case INDEX = 'index';
  case SHOW = 'show';
  case DESTROY = 'destroy';

  public static function readOnly(): array {
    return [self::INDEX, self::SHOW];
  ]
}

Route::apiResource('products')->only(RestfulMethod::INDEX);
Route::apiResource('orders')->except(RestfulMethod::readOnly());
// ....
```