### PR TITLE
[11.x] Add --environment option to the schedule:list command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -24,6 +24,7 @@ class ScheduleListCommand extends Command
     protected $signature = 'schedule:list
         {--timezone= : The timezone that times should be displayed in}
         {--next : Sort the listed tasks by their next due date}
+        {--environment : Only show tasks for the current environment}
     ';
 
     /**
@@ -51,6 +52,10 @@ class ScheduleListCommand extends Command
     public function handle(Schedule $schedule)
     {
         $events = new Collection($schedule->events());
+
+        if ($this->option('environment')) {
+            $events = $events->filter->runsInEnvironment($this->laravel->environment());
+        }
 
         if ($events->isEmpty()) {
             $this->components->info('No scheduled tasks have been defined.');

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -99,6 +99,21 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now');
     }
 
+    public function testDisplayScheduleForEnvironment()
+    {
+        $this->schedule->command(FooCommand::class)->quarterly();
+        $this->schedule->command('inspire')->twiceDaily(14, 18)->environments(['local', 'production']);
+        $this->schedule->command('foobar')->everyMinute()->environments(['production']);
+
+        $this->app->detectEnvironment(fn () => 'local');
+
+        $this->artisan(ScheduleListCommand::class, ['--environment' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('foo:command')
+            ->expectsOutputToContain('inspire')
+            ->doesntExpectOutputToContain('foobar');
+    }
+
     public function testDisplayScheduleInVerboseMode()
     {
         $this->schedule->command(FooCommand::class)->everyMinute();


### PR DESCRIPTION
Add `--environment` option to the `schedule:list` command to only show tasks for the current environment.

Scheduled tasks can limit the task to certain environments using  `->environments($env)`, Currently the `schedule:list` command will show tasks for all environments which makes it hard to know which tasks will run for a specific environment. Other users shared this concern in this discussion https://github.com/laravel/framework/discussions/49143

When the `--environment` option is used it will filter the tasks to those that are defined for the current environment. You can also combine this with the `--env` option to see what tasks would run for a different environment.

```bash
# list tasks for ALL environments
php artisan schedule:list

# list tasks for current environment
php artisan schedule:list --environment

# list tasks for the production environment
php artisan schedule:list --environment --env=production

```

This change is backwards compatible because it is a new option, and the default behavior is not changed.

I also thought about updating the verbose output to show the environments but that could be done in a separate PR if desired.
