### PR TITLE
[11.x] Add wildcard directory discovery to the EventServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -146,6 +146,9 @@ class EventServiceProvider extends ServiceProvider
     public function discoverEvents()
     {
         return (new Collection($this->discoverEventsWithin()))
+                    ->flatMap(function ($directory) {
+                        return glob($directory, GLOB_ONLYDIR);
+                    })
                     ->reject(function ($directory) {
                         return ! is_dir($directory);
                     })


### PR DESCRIPTION
(Most of this post is copied from my Ideas discussion here: https://github.com/laravel/framework/discussions/53893#discussion-7677336)

## Overview

As someone who uses the "Features/" project structure for larger applications, a way to automatically scan each new feature's Listeners directory is a nice, albeit simple, QOL improvement. My suggested change lives in the `EventServiceProvider->discoverEvents()` function:

## Implementation

```php
/**
 * Discover the events and listeners for the application.
 *
 * @return array
 */
public function discoverEvents(): array
{
    return (new Collection($this->discoverEventsWithin()))
        ->flatMap(function ($directory) {
            // Use glob to expand wildcard patterns into directory paths
            return glob($directory, GLOB_ONLYDIR);
        })
        ->reject(function ($directory) {
            return ! is_dir($directory);
        })
        ->reduce(function ($discovered, $directory) {
            return array_merge_recursive(
                $discovered,
                DiscoverEvents::within($directory, $this->eventDiscoveryBasePath())
            );
        }, []);
}
```

## Result

This would allow a user to add the following line to their `withEvents()` function:

```php
->withEvents(discover: [
    __DIR__.'/../app/Features/*/Listeners',
])
```

## Tests

I could not find an existing test class for the `EventServiceProvider`, but I can create one if necessary.