### PR TITLE
[11.x] Make `Exceptions@reportable()` call `Exceptions@report()`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -23,7 +23,7 @@ class Exceptions
      * Register a reportable callback.
      *
      * @param  callable  $using
-     * @return \Illuminate\Foundation\Exceptions\ReportableHandler
+     * @return $this
      */
     public function report(callable $using)
     {
@@ -34,7 +34,7 @@ class Exceptions
      * Register a reportable callback.
      *
      * @param  callable  $reportUsing
-     * @return \Illuminate\Foundation\Exceptions\ReportableHandler
+     * @return $this
      */
     public function reportable(callable $reportUsing)
     {

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -27,7 +27,7 @@ class Exceptions
      */
     public function report(callable $using)
     {
-        return $this->handler->reportable($reportUsing);
+        return $this->handler->reportable($using);
     }
 
     /**

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -27,7 +27,7 @@ class Exceptions
      */
     public function report(callable $using)
     {
-        return $this->reportable($using);
+        return $this->handler->reportable($reportUsing);
     }
 
     /**
@@ -38,7 +38,7 @@ class Exceptions
      */
     public function reportable(callable $reportUsing)
     {
-        return $this->handler->reportable($reportUsing);
+        return $this->report($reportUsing);
     }
 
     /**

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -27,7 +27,7 @@ class Exceptions
      */
     public function report(callable $using)
     {
-        return $this->handler->reportable($using);
+        return $this->reportable($using);
     }
 
     /**


### PR DESCRIPTION
This mirrors how `render()` and `renderable()` work in the same class. I also fixed the docblocks to indicate we're returning the instance itself.