### PR TITLE
[11.x] Let user easily modify the response for a `ModelNotFoundException`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -233,7 +233,7 @@ class Exceptions
      * @param  \Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable  $callback
      * @return $this
      */
-    public function mapModelNotFoundException(\Closure $callback)
+    public function mapModelNotFoundException(\Closure|string $callback)
     {
         $this->handler->setModelNotFoundCallback($callback);
 

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -230,10 +230,10 @@ class Exceptions
     /**
      * Set a callback to build the resulting exception for a ModelNotFoundException.
      *
-     * @param  \Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable  $callback
+     * @param  string|null|\Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable  $callback
      * @return $this
      */
-    public function mapModelNotFoundException(\Closure|string $callback)
+    public function mapModelNotFoundException(\Closure|string|null $callback)
     {
         $this->handler->setModelNotFoundCallback($callback);
 

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -226,4 +226,17 @@ class Exceptions
 
         return $this;
     }
+
+    /**
+     * Set a callback to build the resulting exception for a ModelNotFoundException.
+     *
+     * @param  \Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable  $callback
+     * @return $this
+     */
+    public function mapModelNotFoundException(\Closure $callback)
+    {
+        $this->handler->setModelNotFoundCallback($callback);
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1083,7 +1083,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Set a callback to build the resulting exception for a ModelNotFoundException.
      *
-     * @param  string|\Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable   $callback
+     * @param  string|null|\Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable   $callback
      * @return $this
      */
     public function setModelNotFoundCallback($callback)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1083,11 +1083,15 @@ class Handler implements ExceptionHandlerContract
     /**
      * Set a callback to build the resulting exception for a ModelNotFoundException.
      *
-     * @param  \Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable   $callback
+     * @param  string|\Closure(\Illuminate\Database\Eloquent\ModelNotFoundException):  \Throwable   $callback
      * @return $this
      */
     public function setModelNotFoundCallback($callback)
     {
+        if (is_string($callback)) {
+            $callback = fn ($e) => new NotFoundHttpException($callback, $e);
+        }
+
         $this->modelNotFoundResponseCallback = $callback;
 
         return $this;

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -241,7 +241,7 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         $response->assertStatus(500);
     }
 
-    public function test_it_can_set_a_custom_model_not_found_handler()
+    public function test_it_can_set_a_custom_model_not_found_handler_as_callback()
     {
         $this->app[ExceptionHandler::class]->setModelNotFoundCallback(function(ModelNotFoundException $exception) {
             return new NotFoundHttpException("my message", $exception);
@@ -253,5 +253,17 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         $response = $this->getJson('/foo');
 
         $this->assertEqualsCanonicalizing(['message' => 'my message'], $response->json());
+    }
+
+    public function test_it_can_set_a_custom_model_not_found_handler_as_string()
+    {
+        $this->app[ExceptionHandler::class]->setModelNotFoundCallback('Not found!');
+
+        Route::get('/foo', fn () => throw (new ModelNotFoundException)->setModel(User::class, [1,2,3])
+        );
+
+        $response = $this->getJson('/foo');
+
+        $this->assertEqualsCanonicalizing(['message' => 'Not found!'], $response->json());
     }
 }


### PR DESCRIPTION
We want to avoid leaking details about our application. Specifically the full model namespace in the case of a 404 on a route, and additionally an ID when using Model::findOrFail() inside of an action.

Currently, one way to do this would be:

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withExceptions(function(Exceptions $exceptions) {
            if (app()->isProduction()) {
                $exceptions->map(function(ModelNotFoundException $e, function($e) {
                    return new NotFoundHttpException("Not found", $e);
                });
            }
        });
    })
    ->create();
```

But this is sort of a pain for each application to have to do.

## Solution
```php
return Application::configure(basePath: dirname(__DIR__))
    ->withExceptions(function(Exceptions $exceptions) {
        $exceptions->mapModelNotFoundException(app()->isProduction() ? "Not found" : null);
    })
    ->create();
```