### PR TITLE
Fix handling of null columns in PostgresProcessor processIndexes.

### DIFF
--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -124,7 +124,7 @@ class PostgresProcessor extends Processor
 
             return [
                 'name' => strtolower($result->name),
-                'columns' => explode(',', $result->columns),
+                'columns' => $result->columns ? explode(',', $result->columns) : '',
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,


### PR DESCRIPTION
Previously, null values in the `columns` field caused issues during the `explode` operation. This fix ensures that `explode` is only called when `columns` is not null, preventing potential errors, deprecation warnings and improving data consistency.

Background:

When indexes are created with an expression, [Indexes on Expressions](https://www.postgresql.org/docs/current/indexes-expressional.html) rather than a table column, php raises a deprecation warning message `LOG.warning: explode(): Passing null to parameter #2 ($string) of type string is deprecated in vendor/laravel/framework/src/Illuminate/Database/Query/Processors/PostgresProcessor.php on line 127`

An example of when you would want to do this might be indexing based upon an aggregation of the year in a timestamp field.

```
$table->rawIndex("DATE_TRUNC('year'::text,created_at)", 'radar_records_created_at_trunc_year_idx');
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
