### PR TITLE
[11.x] Ensure non-empty array before dispatching WritingManyKeys

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -273,7 +273,9 @@ class Repository implements ArrayAccess, CacheContract
             return $this->deleteMultiple(array_keys($values));
         }
 
-        $this->event(new WritingManyKeys($this->getName(), array_keys($values), array_values($values), $seconds));
+        if (count($values) > 0) {
+            $this->event(new WritingManyKeys($this->getName(), array_keys($values), array_values($values), $seconds));
+        }
 
         $result = $this->store->putMany($values, $seconds);
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -8,6 +8,7 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Events\WritingManyKeys;
 use Illuminate\Cache\FileStore;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
@@ -200,6 +201,13 @@ class CacheRepositoryTest extends TestCase
         $repo->getStore()->shouldReceive('forever')->with('foo', 'bar')->andReturn(true);
         $repo->getStore()->shouldReceive('forever')->with('bar', 'baz')->andReturn(true);
         $this->assertTrue($repo->putMany(['foo' => 'bar', 'bar' => 'baz']));
+    }
+
+    public function testPutManyWithEmptyArray()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('putMany')->with([], 60)->andReturn(false);
+        $this->assertFalse($repo->putMany([], 60));
     }
 
     public function testAddWithStoreFailureReturnsFalse()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -8,7 +8,6 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use Illuminate\Cache\ArrayStore;
-use Illuminate\Cache\Events\WritingManyKeys;
 use Illuminate\Cache\FileStore;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;


### PR DESCRIPTION
Calling `Cache::putMany()` with empty array now causes an error due to the new event being dispatch called `WritingManyKeys` which is expecting a non-empty array. This causes a breaking bug in Cache implementation which could be passing in empty array.

Added check to only dispatch if the values are non-empty array.