### PR TITLE
Avoid writing multiple keys when using redis in cluster mode

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -4,13 +4,19 @@ namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 
 class RedisStore extends TaggableStore implements LockProvider
 {
+    use RetrievesMultipleKeys {
+        putMany as private putManyAlias;
+    }
+
     /**
      * The Redis factory implementation.
      *
@@ -118,25 +124,32 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function putMany(array $values, $seconds)
     {
+        $connection = $this->connection();
+
+        // Cluster connections do not support writing multiple values if the keys hash differently.
+        if ($connection instanceof PhpRedisClusterConnection || $connection instanceof PredisClusterConnection) {
+            return $this->putManyAlias($values, $seconds);
+        }
+
         $serializedValues = [];
 
         foreach ($values as $key => $value) {
             $serializedValues[$this->prefix.$key] = $this->serialize($value);
         }
 
-        $this->connection()->multi();
+        $connection->multi();
 
         $manyResult = null;
 
         foreach ($serializedValues as $key => $value) {
-            $result = (bool) $this->connection()->setex(
+            $result = (bool) $connection->setex(
                 $key, (int) max(1, $seconds), $value
             );
 
             $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
         }
 
-        $this->connection()->exec();
+        $connection->exec();
 
         return $manyResult ?: false;
     }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -126,8 +126,9 @@ class RedisStore extends TaggableStore implements LockProvider
     {
         $connection = $this->connection();
 
-        // Cluster connections do not support writing multiple values if the keys hash differently.
-        if ($connection instanceof PhpRedisClusterConnection || $connection instanceof PredisClusterConnection) {
+        // Cluster connections do not support writing multiple values if the keys hash differently...
+        if ($connection instanceof PhpRedisClusterConnection ||
+            $connection instanceof PredisClusterConnection) {
             return $this->putManyAlias($values, $seconds);
         }
 

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Tests\Integration\Cache;
 
 use DateTime;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Sleep;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class RedisStoreTest extends TestCase
@@ -25,6 +28,7 @@ class RedisStoreTest extends TestCase
         parent::tearDown();
 
         $this->tearDownRedis();
+        m::close();
     }
 
     public function testCacheTtl(): void
@@ -230,5 +234,19 @@ class RedisStoreTest extends TestCase
         ], $store->many(['foo', 'fizz', 'quz', 'norf']));
 
         $this->assertEquals([], $store->many([]));
+    }
+
+    public function testPutManyCallsPutWhenClustered()
+    {
+        $store = m::mock(RedisStore::class)->makePartial();
+        $store->expects('connection')->andReturn(m::mock(PhpRedisClusterConnection::class));
+        $store->expects('put')
+            ->twice()
+            ->andReturn(true);
+
+        $store->putMany([
+            'foo' => 'bar',
+            'fizz' => 'buz',
+        ], 10);
     }
 }


### PR DESCRIPTION
This PR should prevent Redis failing with a "Error processing EXEC across the cluster" error when using `Cache::flexible` with Redis in cluster mode (#53266).

The problem is that open-source Redis doesn't allow commands that will update multiple "hash slots" (how Redis splits up keys). As far as I can tell this will only be an issue for Redis in cluster mode.

Redis has some info about this [on their blog](https://redis.io/blog/redis-clustering-best-practices-with-keys/). See the "Redis Hashtags" section, in particular:
> Open source Redis is quite strict about this and any command that manipulates multiple hash slots is forbidden. Redis Enterprise has a few workarounds for simple commands, notably MGET and MSET.

There is also a pre-existing issue for this problem that has been reported on phpredis: https://github.com/phpredis/phpredis/issues/876

The issue there has existed since 2016 and the author of the extension suggests there may not have a path forwards due to limitations of Redis / complexity.

As such, I've opted to calling `put` multiple times when the connection is a cluster connection.

This isn't a pretty solution, but I'm not sure what else we can do.
