### PR TITLE
[11.x] Fix client path value in file uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/console": "^7.0.3",
         "symfony/error-handler": "^7.0.3",
         "symfony/finder": "^7.0.3",
-        "symfony/http-foundation": "^7.0.3",
+        "symfony/http-foundation": "^7.2.0",
         "symfony/http-kernel": "^7.0.3",
         "symfony/mailer": "^7.0.3",
         "symfony/mime": "^7.0.3",

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -133,7 +133,7 @@ class UploadedFile extends SymfonyUploadedFile
     {
         return $file instanceof static ? $file : new static(
             $file->getPathname(),
-            $file->getClientOriginalName(),
+            $file->getClientOriginalPath(),
             $file->getClientMimeType(),
             $file->getError(),
             $test

--- a/tests/Http/HttpUploadedFileTest.php
+++ b/tests/Http/HttpUploadedFileTest.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\Tests\Http;
 
-use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\TestCase;
-
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
-
 
 class HttpUploadedFileTest extends TestCase
 {
@@ -26,7 +23,6 @@ class HttpUploadedFileTest extends TestCase
 
     public function testUploadedFileInRequestContainsOriginalPathAndName()
     {
-
         $symfonyFile = new SymfonyUploadedFile(__FILE__, '');
         $this->assertSame('', $symfonyFile->getClientOriginalName());
         $this->assertSame('', $symfonyFile->getClientOriginalPath());
@@ -62,13 +58,11 @@ class HttpUploadedFileTest extends TestCase
         $this->assertSame('test.txt', $file->getClientOriginalName());
         $this->assertSame('/foo/bar/test.txt', $file->getClientOriginalPath());
 
-
         $symfonyFile = new SymfonyUploadedFile(__FILE__, 'file:\\foo\\test.txt');
         $this->assertSame('test.txt', $symfonyFile->getClientOriginalName());
         $this->assertSame('file:/foo/test.txt', $symfonyFile->getClientOriginalPath());
         $file = UploadedFile::createFromBase($symfonyFile);
         $this->assertSame('test.txt', $file->getClientOriginalName());
         $this->assertSame('file:/foo/test.txt', $file->getClientOriginalPath());
-
     }
 }

--- a/tests/Http/HttpUploadedFileTest.php
+++ b/tests/Http/HttpUploadedFileTest.php
@@ -2,8 +2,12 @@
 
 namespace Illuminate\Tests\Http;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\TestCase;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+
 
 class HttpUploadedFileTest extends TestCase
 {
@@ -18,5 +22,53 @@ class HttpUploadedFileTest extends TestCase
         );
 
         $this->assertSame('This is a story about something that happened long ago when your grandfather was a child.', trim($file->get()));
+    }
+
+    public function testUploadedFileInRequestContainsOriginalPathAndName()
+    {
+
+        $symfonyFile = new SymfonyUploadedFile(__FILE__, '');
+        $this->assertSame('', $symfonyFile->getClientOriginalName());
+        $this->assertSame('', $symfonyFile->getClientOriginalPath());
+        $file = UploadedFile::createFromBase($symfonyFile);
+        $this->assertSame('', $file->getClientOriginalName());
+        $this->assertSame('', $file->getClientOriginalPath());
+
+        $symfonyFile = new SymfonyUploadedFile(__FILE__, 'test.txt');
+        $this->assertSame('test.txt', $symfonyFile->getClientOriginalName());
+        $this->assertSame('test.txt', $symfonyFile->getClientOriginalPath());
+        $file = UploadedFile::createFromBase($symfonyFile);
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame('test.txt', $file->getClientOriginalPath());
+
+        $symfonyFile = new SymfonyUploadedFile(__FILE__, '/test.txt');
+        $this->assertSame('test.txt', $symfonyFile->getClientOriginalName());
+        $this->assertSame('/test.txt', $symfonyFile->getClientOriginalPath());
+        $file = UploadedFile::createFromBase($symfonyFile);
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame('/test.txt', $file->getClientOriginalPath());
+
+        $symfonyFile = new SymfonyUploadedFile(__FILE__, '/foo/bar/test.txt');
+        $this->assertSame('test.txt', $symfonyFile->getClientOriginalName());
+        $this->assertSame('/foo/bar/test.txt', $symfonyFile->getClientOriginalPath());
+        $file = UploadedFile::createFromBase($symfonyFile);
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame('/foo/bar/test.txt', $file->getClientOriginalPath());
+
+        $symfonyFile = new SymfonyUploadedFile(__FILE__, '/foo/bar/test.txt');
+        $this->assertSame('test.txt', $symfonyFile->getClientOriginalName());
+        $this->assertSame('/foo/bar/test.txt', $symfonyFile->getClientOriginalPath());
+        $file = UploadedFile::createFromBase($symfonyFile);
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame('/foo/bar/test.txt', $file->getClientOriginalPath());
+
+
+        $symfonyFile = new SymfonyUploadedFile(__FILE__, 'file:\\foo\\test.txt');
+        $this->assertSame('test.txt', $symfonyFile->getClientOriginalName());
+        $this->assertSame('file:/foo/test.txt', $symfonyFile->getClientOriginalPath());
+        $file = UploadedFile::createFromBase($symfonyFile);
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame('file:/foo/test.txt', $file->getClientOriginalPath());
+
     }
 }


### PR DESCRIPTION
PHP 8.1 introduced the 'full_path' key in $_FILES during file uploads. The purpose is to support Folder uploads.
```
array(1) {
  ["files"]=>
  array(6) {
    ["name"]=>
    array(2) {
      [0]=>
      string(23) "laravel-svgrepo-com.svg"
    }
    ["full_path"]=>
    array(2) {
      [0]=>
      string(30) "foldit/laravel-svgrepo-com.svg"
    }
  }
}
```

Symphony handles this. When a new instance of UploadedFile is created, $file['full_path'] ?? $file['name']  is passed to it
originalPath is set to the full value ->   /path/filename.txt -> getClientOriginalPath()
originalName is set to the file name after extracting it from the full_path (if needed) // filename.txt

```php
    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $error = null, bool $test = false)
    {
        $this->originalName = $this->getName($originalName);
        $this->originalPath = strtr($originalName, '\\', '/');
```

```php
$file = new UploadedFile($file['tmp_name'], $file['full_path'] ?? $file['name'], $file['type'], $file['error'], false);
```



Laravel doesn't handle this change.

InteractsWithInput.php file: 
convertUploadedFiles() is defined. "Convert the given array of Symfony UploadedFiles to custom Laravel UploadedFiles."

convertUploadedFiles calls UploadedFile::createFromBase($file). This is where the Issue lies  (UploadedFile.php ln 144)

A new instance of uploadedFile is created using the 'getClientOriginalName' causing us to lose the 'full_path' value. Which was stored in getClientOriginalPath()

```php
  public static function createFromBase(SymfonyUploadedFile $file, $test = false)
    {
        return $file instanceof static ? $file : new static(
            $file->getPathname(),
            $file->getClientOriginalName(), //problem
            $file->getClientMimeType(),
            $file->getError(),
            $test
        );
    }

```
Note: path here is not the temporary path. Not the uploadedTo path. But the original path sent by the client in the full_path key.

My fix: is to use getClientOriginalPath() instead. I think it should be okay. Since symfony extracts the originalname from the full_path.

This is my first attempt of such a PR. Please do tell if I have missed anything.

Thank you!

