### PR TITLE
[11.x] Allow easier overriding of the exception thrown by invalid ID in route binding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -93,7 +93,7 @@ trait HasUniqueStringIds
     }
 
     /**
-     * Throw an exception when there the key isn't valid.
+     * Throw an exception for the given invalid unique ID.
      *
      * @param  mixed  $value
      * @param  string|null  $field

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -101,7 +101,7 @@ trait HasUniqueStringIds
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    protected function handleInvalidUniqueId(mixed $value, string|null $field)
+    protected function handleInvalidUniqueId($value, $field)
     {
         throw (new ModelNotFoundException)->setModel(get_class($this), $value);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -54,11 +54,11 @@ trait HasUniqueStringIds
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
         if ($field && in_array($field, $this->uniqueIds()) && ! $this->isValidUniqueId($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            $this->handleInvalidUniqueId($value, $field);
         }
 
         if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! $this->isValidUniqueId($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            $this->handleInvalidUniqueId($value, $field);
         }
 
         return parent::resolveRouteBindingQuery($query, $value, $field);
@@ -90,5 +90,19 @@ trait HasUniqueStringIds
         }
 
         return $this->incrementing;
+    }
+
+    /**
+     * Throw an exception when there the key isn't valid.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return never
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    protected function handleInvalidUniqueId(mixed $value, string|null $field)
+    {
+        throw (new ModelNotFoundException)->setModel(get_class($this), $value);
     }
 }


### PR DESCRIPTION
This is to make it easier to handle invalid route keys without having to override `HasUniqueStringIds@resolveRouteBindingQuery()` method (which would be a lot of duplication and create maintenance overhead).

This consolidates code a little bit into a common method `handleInvalidUniqueId` which should throw an exception. There is no breaking change here, as we're still throwing the same `ModelNotFoundException`. For a team that wishes to customize their return type (such as indicating this is a 422 response, not a 404), they can easily do that as follows:

```php
// custom exception
class InvalidTwrnException extends \RuntimeException implements Responsable
{
    public $key;

    public function setTwrn($key)
    {
        $this->key = $key;

        return $this;
    }

    public function toResponse($request)
    {
        return response()->json(['message' => 'invalid twrn', 'twrn' => $this->key], 422);
    }
}

// the trait
trait HasTwrnsTrait
{
    use HasUniqueStringIds;

    public function newUniqueId()
    {
        return (string) Twrn::new();
    }
  
    protected function isValidUniqueId($value): bool
    {
        return Twrn::isValid($value);
    }

    protected function handleInvalidUniqueId($value, $field): never
    {
        throw (new InvalidTwrnException)->setTwrn($value);
    }
}
```