### PR TITLE
[11.x] Fix inspecting columns of raw indexes

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -84,7 +84,7 @@ class MySqlProcessor extends Processor
 
             return [
                 'name' => $name = strtolower($result->name),
-                'columns' => explode(',', $result->columns),
+                'columns' => $result->columns ? explode(',', $result->columns) : [],
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => $name === 'primary',

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -124,7 +124,7 @@ class PostgresProcessor extends Processor
 
             return [
                 'name' => strtolower($result->name),
-                'columns' => explode(',', $result->columns),
+                'columns' => $result->columns ? explode(',', $result->columns) : [],
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -76,7 +76,7 @@ class SQLiteProcessor extends Processor
 
             return [
                 'name' => strtolower($result->name),
-                'columns' => explode(',', $result->columns),
+                'columns' => $result->columns ? explode(',', $result->columns) : [],
                 'type' => null,
                 'unique' => (bool) $result->unique,
                 'primary' => $isPrimary,

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -103,7 +103,7 @@ class SqlServerProcessor extends Processor
 
             return [
                 'name' => strtolower($result->name),
-                'columns' => explode(',', $result->columns),
+                'columns' => $result->columns ? explode(',', $result->columns) : [],
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database\MySql;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
@@ -28,5 +29,19 @@ class DatabaseMySqlSchemaBuilderTest extends MySqlTestCase
         $this->assertEquals('This is a comment', $tableInfo->table_comment);
 
         Schema::drop('users');
+    }
+
+    #[RequiresDatabase('mysql', '>=8.0.13')]
+    public function testGetRawIndex()
+    {
+        Schema::create('table', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->rawIndex('(year(created_at))', 'table_raw_index');
+        });
+
+        $indexes = Schema::getIndexes('table');
+
+        $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
     }
 }

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -102,10 +102,13 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
         DB::statement('create view public.foo (id) as select 1');
         DB::statement('create view private.foo (id) as select 1');
 
+        $this->assertTrue(Schema::hasView('public.foo'));
+        $this->assertTrue(Schema::hasView('private.foo'));
+
         Schema::dropAllViews();
 
-        $this->assertFalse($this->hasView('public', 'foo'));
-        $this->assertFalse($this->hasView('private', 'foo'));
+        $this->assertFalse(Schema::hasView('public.foo'));
+        $this->assertFalse(Schema::hasView('private.foo'));
     }
 
     public function testAddTableCommentOnNewTable()
@@ -190,12 +193,16 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
         $this->assertNotContains('groups_2', $tables);
     }
 
-    protected function hasView($schema, $table)
+    public function testGetRawIndex()
     {
-        return DB::table('information_schema.views')
-            ->where('table_catalog', $this->app['config']->get('database.connections.pgsql.database'))
-            ->where('table_schema', $schema)
-            ->where('table_name', $table)
-            ->exists();
+        Schema::create('public.table', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->rawIndex("DATE_TRUNC('year'::text,created_at)", 'table_raw_index');
+        });
+
+        $indexes = Schema::getIndexes('public.table');
+
+        $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
     }
 }

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -80,4 +80,17 @@ SQL);
 
         $this->assertEmpty(Schema::getViews());
     }
+
+    public function testGetRawIndex()
+    {
+        Schema::create('table', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->rawIndex('(strftime("%Y", created_at))', 'table_raw_index');
+        });
+
+        $indexes = Schema::getIndexes('table');
+
+        $this->assertSame([], collect($indexes)->firstWhere('name', 'table_raw_index')['columns']);
+    }
 }


### PR DESCRIPTION
Fixes #53936
Closes #53937

Utilizing raw indexes via `$table->rawIndex()` and inspecting the indexes using `Schema::getIndexes()` causes a warning because `columns` value passed to `explode` function is `null` on raw indexes.

This PR fixes inspecting raw indexes and add tests.