### PR TITLE
[11.x] Add `Fluent::set` method

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -54,6 +54,20 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Set an attribute on the fluent instance using "dot" notation.
+     *
+     * @param  TKey  $key
+     * @param  TValue  $value
+     * @return $this
+     */
+    public function set($key, $value)
+    {
+        data_set($this->attributes, $key, $value);
+
+        return $this;
+    }
+
+    /**
      * Get an attribute from the fluent instance.
      *
      * @param  string  $key

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -62,7 +62,7 @@ class SupportFluentTest extends TestCase
         $this->assertNull($fluent->foo);
     }
 
-    public function setSetMethodSetsAttribute()
+    public function testSetMethodSetsAttribute()
     {
         $fluent = new Fluent;
 
@@ -74,7 +74,7 @@ class SupportFluentTest extends TestCase
         $this->assertSame('Taylor', $fluent->name);
         $this->assertTrue($fluent->developer);
         $this->assertSame(25, $fluent->posts);
-        $this->assertSame(['color' => 'silver'], $fluent->foo['computer']);
+        $this->assertSame(['color' => 'silver'], $fluent->computer);
     }
 
     public function testArrayAccessToAttributes()

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -62,6 +62,21 @@ class SupportFluentTest extends TestCase
         $this->assertNull($fluent->foo);
     }
 
+    public function setSetMethodSetsAttribute()
+    {
+        $fluent = new Fluent;
+
+        $fluent->set('name', 'Taylor');
+        $fluent->set('developer', true);
+        $fluent->set('posts', 25);
+        $fluent->set('computer.color', 'silver');
+
+        $this->assertSame('Taylor', $fluent->name);
+        $this->assertTrue($fluent->developer);
+        $this->assertSame(25, $fluent->posts);
+        $this->assertSame(['color' => 'silver'], $fluent->foo['computer']);
+    }
+
     public function testArrayAccessToAttributes()
     {
         $fluent = new Fluent(['attributes' => '1']);


### PR DESCRIPTION
### Description

This PR adds a chainable `set` method to the `Support\Fluent` class.

This allows a developer to use dot notation to set deeply nested attributes on the `Fluent` instance.

### Usage

```php
$fluent = new Fluent;

// Set basic attributes
$fluent->set('product', 'iPhone')
       ->set('version', 15)
       ->set('developer', 'Apple');

// Use dot notation for nested attributes
$fluent->set('specs.color', 'Space Black')
       ->set('specs.storage', '256GB')
       ->set('specs.price.usd', 1199);

// Retrieve values
echo $fluent->product; // "iPhone"
echo $fluent->specs['color']; // "Space Black"
echo $fluent->specs['price']['usd']; // 1199

// Retrieve values using get with dot notation
echo $fluent->get('specs.color'); // "Space Black"
echo $fluent->get('specs.price.usd'); // 1199
```