### PR TITLE
[12.x] add type declarations for Console Events

### DIFF
--- a/src/Illuminate/Console/Events/ArtisanStarting.php
+++ b/src/Illuminate/Console/Events/ArtisanStarting.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console\Events;
 
+use Illuminate\Console\Application;
+
 class ArtisanStarting
 {
     /**
@@ -11,7 +13,7 @@ class ArtisanStarting
      * @return void
      */
     public function __construct(
-        public $artisan,
+        public Application $artisan,
     ) {
     }
 }

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -17,10 +17,10 @@ class CommandFinished
      * @return void
      */
     public function __construct(
-        public string          $command,
-        public InputInterface  $input,
+        public string $command,
+        public InputInterface $input,
         public OutputInterface $output,
-        public int             $exitCode,
+        public int $exitCode,
     ) {
     }
 }

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -17,10 +17,10 @@ class CommandFinished
      * @return void
      */
     public function __construct(
-        public $command,
-        public InputInterface $input,
+        public string          $command,
+        public InputInterface  $input,
         public OutputInterface $output,
-        public $exitCode,
+        public int             $exitCode,
     ) {
     }
 }

--- a/src/Illuminate/Console/Events/CommandStarting.php
+++ b/src/Illuminate/Console/Events/CommandStarting.php
@@ -16,8 +16,8 @@ class CommandStarting
      * @return void
      */
     public function __construct(
-        public string          $command,
-        public InputInterface  $input,
+        public string $command,
+        public InputInterface $input,
         public OutputInterface $output,
     ) {
     }

--- a/src/Illuminate/Console/Events/CommandStarting.php
+++ b/src/Illuminate/Console/Events/CommandStarting.php
@@ -16,8 +16,8 @@ class CommandStarting
      * @return void
      */
     public function __construct(
-        public $command,
-        public InputInterface $input,
+        public string          $command,
+        public InputInterface  $input,
         public OutputInterface $output,
     ) {
     }

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -15,7 +15,7 @@ class ScheduledTaskFinished
      */
     public function __construct(
         public Event $task,
-        public $runtime,
+        public float $runtime,
     ) {
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -163,13 +163,13 @@ class Kernel implements KernelContract
 
             $this->symfonyDispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
                 $this->events->dispatch(
-                    new CommandStarting($event->getCommand()->getName(), $event->getInput(), $event->getOutput())
+                    new CommandStarting($event->getCommand()?->getName() ?? '', $event->getInput(), $event->getOutput())
                 );
             });
 
             $this->symfonyDispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) {
                 $this->events->dispatch(
-                    new CommandFinished($event->getCommand()->getName(), $event->getInput(), $event->getOutput(), $event->getExitCode())
+                    new CommandFinished($event->getCommand()?->getName() ?? '', $event->getInput(), $event->getOutput(), $event->getExitCode())
                 );
             });
         }


### PR DESCRIPTION
the added types match the existing constructor docblocks.

not sure what the current sentiment on stricter typing is from the core team, but thought I'd throw this out there. these events are a good place to start as their construction should basically only be internal.

I checked all the calling code, and this may have already uncovered a bug. the `CommandStarting` claims to accept a string `$command` parameter, but the calling code possibly sends `null`.  two ways to fix this would be to accept `string|null`, or to have the calling code null coalesce and empty string (`?? ''`).

if accepted, I'll update all the other events as well.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
