### PR TITLE
Fix: Handle mixed-type values in compileInsert

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1169,10 +1169,10 @@ class Grammar extends BaseGrammar
         }
 
         if (! array_is_list($values)) {
-            $arrayKeysCollection = new Collection(array_keys($values));
-            $someKeyIsString = $arrayKeysCollection->some(fn (string|int $key) => ! is_numeric($key));
-
-            $values = $someKeyIsString ? [$values] : array_values($values);
+            $values = (new Collection(array_keys($values)))
+                ->some(fn ($key) => ! is_numeric($key))
+                    ? [$values]
+                    : array_values($values);
         }
 
         $columns = $this->columnize(array_keys(reset($values)));

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1168,7 +1168,6 @@ class Grammar extends BaseGrammar
             return "insert into {$table} default values";
         }
 
-
         if (! array_is_list($values)) {
             $arrayKeysCollection = new Collection(array_keys($values));
             $someKeyIsString = $arrayKeysCollection->some(fn (string|int $key) => ! is_numeric($key));

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1168,7 +1168,8 @@ class Grammar extends BaseGrammar
             return "insert into {$table} default values";
         }
 
-        if (! is_array(reset($values))) {
+        reset($values);
+        if (! array_is_list($values)) {
             $values = [$values];
         }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1171,7 +1171,7 @@ class Grammar extends BaseGrammar
 
         if (! array_is_list($values)) {
             $arrayKeysCollection = new Collection(array_keys($values));
-            $someKeyIsString = $arrayKeysCollection->some(fn (string|int $key) => !is_numeric($key));
+            $someKeyIsString = $arrayKeysCollection->some(fn (string|int $key) => ! is_numeric($key));
 
             $values = $someKeyIsString ? [$values] : array_values($values);
         }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1168,9 +1168,12 @@ class Grammar extends BaseGrammar
             return "insert into {$table} default values";
         }
 
-        reset($values);
+
         if (! array_is_list($values)) {
-            $values = [$values];
+            $arrayKeysCollection = new Collection(array_keys($values));
+            $someKeyIsString = $arrayKeysCollection->some(fn (string|int $key) => !is_numeric($key));
+
+            $values = $someKeyIsString ? [$values] : array_values($values);
         }
 
         $columns = $this->columnize(array_keys(reset($values)));

--- a/tests/Database/DatabaseQueryGrammarTest.php
+++ b/tests/Database/DatabaseQueryGrammarTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -40,5 +42,80 @@ class DatabaseQueryGrammarTest extends TestCase
         $rawQuery = $method->invoke($grammar, $builder, $stringArray);
 
         $this->assertSame('select * from "users"', $rawQuery);
+    }
+
+    public function testCompileInsertSingleValue()
+    {
+        $builder = $this->getBuilder();
+        $grammar = $builder->getGrammar();
+
+        $sql = $grammar->compileInsert($builder, ['name' => 'John Doe', 'email' => 'johndoe@laravel.com']);
+        $this->assertSame('insert into "users" ("name", "email") values (?, ?)', $sql);
+    }
+
+    public function testCompileInsertMultipleValues()
+    {
+        $builder = $this->getBuilder();
+        $grammar = $builder->getGrammar();
+        $values = [
+            ['name' => 'John Doe', 'email' => 'john@doe.com'],
+            ['name' => 'Alice Wong', 'email' => 'alice@wong.com'],
+        ];
+
+        $sql = $grammar->compileInsert($builder, $values);
+        $this->assertSame('insert into "users" ("name", "email") values (?, ?), (?, ?)', $sql);
+    }
+
+    public function testCompileInsertSingleValueWhereFirstKeyIsArray()
+    {
+        $builder = $this->getBuilder();
+        $grammar = $builder->getGrammar();
+        $value = [
+            'configuration' => [
+                'dark_mode' => false,
+                'language' => 'en',
+            ],
+            'name' => 'John Doe',
+            'email' => 'john@doe.com',
+        ];
+
+        $sql = $grammar->compileInsert($builder, $value);
+
+        $this->assertSame('insert into "users" ("configuration", "name", "email") values (?, ?, ?)', $sql);
+    }
+
+    public function testCompileInsertSingleValueWhereFirstKeyIsNotArray()
+    {
+        $builder = $this->getBuilder();
+        $grammar = $builder->getGrammar();
+
+        $value = [
+            'name' => 'John Doe',
+            'configuration' => [
+                'dark_mode' => false,
+                'language' => 'en',
+            ],
+            'email' => 'john@doe.com',
+        ];
+
+        $sql = $grammar->compileInsert($builder, $value);
+
+        $this->assertSame('insert into "users" ("name", "configuration", "email") values (?, ?, ?)', $sql);
+    }
+
+    protected function getConnection()
+    {
+        return m::mock(ConnectionInterface::class);
+    }
+
+    protected function getBuilder($tableName = 'users')
+    {
+        $grammar = new Grammar;
+        $processor = m::mock(Processor::class);
+
+        $builder = new Builder($this->getConnection(), $grammar, $processor);
+        $builder->from = $tableName;
+
+        return $builder;
     }
 }


### PR DESCRIPTION
This pull request addresses a potential issue that could arise when using `Model::query()->create()` and the first element in the attributes list is an array (representing a JSON column) while subsequent elements are not arrays.

The original code might have encountered type hinting issues due to this structure.

This change ensures that the `compileInsert` method in `Grammar.php` correctly handles such scenarios. Additionally, new unit tests in `DatabaseQueryGrammarTest.php` verify this behavior for various insert conditions.

## Benefits:

- Improves robustness of data insertion with mixed value structures
- Enhances code maintainability with clearer handling of edge cases

## Notes:

Leverages `array_is_list` function (available in PHP 8.1+) for improved type checking

## Example 1

```php
User::query()->create([
    'possible_json_column' => [1, 2, 3, 4],
    'name' => 'Test',
    'email' => 'test@mail.com'
]);
```

Throws:

`TypeError Illuminate\Database\Grammar::parameterize(): Argument #1 ($values) must be of type array, string given, called in vendor\laravel\framework\src\Illuminate\Database\Query\Grammars\Grammar.php on line 1180`

If you instead try:

```php
User::query()->create([
    'name' => 'Test',
    'possible_json_column' => [1, 2, 3, 4],
    'email' => 'test@mail.com',
]);
```

It won't give you the error.

That is because [this line](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Query/Grammars/Grammar.php#L1171) when `reset($values)` is called it returns the first element in the `$values` array but `$values` is an associative array so it returns `[1, 2, 3, 4]` and the next check `! is_array([1, 2, 3, 4])` gives `false` and it does not wrap the associative array in a list array.

Then in line [1180](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Query/Grammars/Grammar.php#L1180) when `new Collection($values)` is called it uses

```php
new Collection([
    'possible_json_column' => [1, 2, 3, 4],
    'name' => 'Test',
    'email' => 'test@mail.com'
]);
```
to create the collection and iterates over its values.

When the code tries to execute `$this->parameterize($record)` fails for the second iteration because `$record` is not an associative array (it is the `'Test'` string).

## Example 2

If you try this scenario:

```php
User::query()->toBase()->grammar->compileInsert(User::query()->toBase(), ['possible_json' => [1, 2, 3, 4]]);
```

Gives:

`insert into "users" ("0", "1", "2", "3") values (?, ?, ?, ?)`

## Example 3

When you try:

```php
User::query()->toBase()->grammar->compileInsert(User::query()->toBase(), ['possible_json' => [1, 2, 3, 4], 'another_column' => 'value']);
````

It gives you the `TypeError` mentioned before.

## Example 4

Instead, when you use:

```php
User::query()->toBase()->grammar->compileInsert(User::query()->toBase(), ['another_column' => 'value', 'possible_json' => [1, 2, 3, 4]]);
```

It gives you the expected result:

`insert into "users" ("another_column", "possible_json") values (?, ?)`

## Conclusion

We can conclude that when the first value of the array is an array, the code fails. An easy fix would be to just change the order of the array values, but it will give hard time to anyone who is in a similar situation.

Please review and provide feedback. Thanks!