### PR TITLE
Once Remember Null Values

### DIFF
--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -57,12 +57,12 @@ class Once
 
         $hash = $onceable->hash;
 
-        if (isset($this->values[$object][$hash])) {
-            return $this->values[$object][$hash];
-        }
-
         if (! isset($this->values[$object])) {
             $this->values[$object] = [];
+        }
+
+        if (array_key_exists($hash, $this->values[$object])) {
+            return $this->values[$object][$hash];
         }
 
         return $this->values[$object][$hash] = call_user_func($onceable->callable);

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -343,6 +343,26 @@ class OnceTest extends TestCase
 
         $this->assertNotSame($first, $third);
     }
+
+    public function testMemoizationNullValues()
+    {
+        $instance = new class
+        {
+            public $i = 0;
+
+            public function null()
+            {
+                return once(function () {
+                    $this->i++;
+
+                    return null;
+                });
+            }
+        };
+
+        $this->assertSame($instance->null(), $instance->null());
+        $this->assertSame(1, $instance->i);
+    }
 }
 
 $letter = 'a';


### PR DESCRIPTION
Currently due to the nature of `isset()`, it returns false for keys with null values, this PR changes to use `array_key_exists()` so it remembers null results.

I did some research if this was by design or someone faced this before, i found this https://github.com/laravel/framework/issues/52060#issuecomment-2216748304 , which is basically what we have on this PR.