### PR TITLE
[11.x] Add `Dumpable` trait to `Uri`

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -337,6 +337,19 @@ class Uri implements Htmlable, Responsable, Stringable
     }
 
     /**
+     * Dump the string representation of the URI.
+     *
+     * @param  mixed  ...$args
+     * @return $this
+     */
+    public function dump(...$args)
+    {
+        dump($this->value(), ...$args);
+
+        return $this;
+    }
+
+    /**
      * Get the string representation of the URI.
      */
     public function value(): string

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\Tappable;
 use League\Uri\Contracts\UriInterface;
 use League\Uri\Uri as LeagueUri;
@@ -16,7 +17,7 @@ use Stringable;
 
 class Uri implements Htmlable, Responsable, Stringable
 {
-    use Conditionable, Tappable;
+    use Conditionable, Dumpable, Tappable;
 
     /**
      * The URI instance.

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -337,19 +337,6 @@ class Uri implements Htmlable, Responsable, Stringable
     }
 
     /**
-     * Dump the string representation of the URI.
-     *
-     * @param  mixed  ...$args
-     * @return $this
-     */
-    public function dump(...$args)
-    {
-        dump($this->value(), ...$args);
-
-        return $this;
-    }
-
-    /**
      * Get the string representation of the URI.
      */
     public function value(): string
@@ -363,6 +350,19 @@ class Uri implements Htmlable, Responsable, Stringable
     public function isEmpty(): bool
     {
         return trim($this->value()) === '';
+    }
+
+    /**
+     * Dump the string representation of the URI.
+     *
+     * @param  mixed  ...$args
+     * @return $this
+     */
+    public function dump(...$args)
+    {
+        dump($this->value(), ...$args);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This adds the ability to the new `Uri` class to call `dd()` and `dump()` which just outputs the **string** representation of the URI.