### PR TITLE
Fix: (Queue Worker) firing the JobPopped event when $popCallbacks returns null

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -355,10 +355,11 @@ class Worker
 
         try {
             if (isset(static::$popCallbacks[$this->name])) {
-                return tap(
-                    (static::$popCallbacks[$this->name])($popJobCallback, $queue),
-                    fn ($job) => $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job)
-                );
+                if (! is_null($job = (static::$popCallbacks[$this->name])($popJobCallback, $queue))) {
+                    $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
+                }
+
+                return $job;
             }
 
             foreach (explode(',', $queue) as $index => $queue) {


### PR DESCRIPTION
When $popCallbacks is assigned to the Illuminate\Queue\Worker class and it returns null the JobPopped event is fired with $job value null
