### PR TITLE
[11.x] chore: add  Arr::map at the place of the collection's map method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1715,7 +1715,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function transform(callable $callback)
     {
-        $this->items = $this->map($callback)->all();
+        $this->items = Arr::map($this->items, $callback);
 
         return $this;
     }


### PR DESCRIPTION
This pull request includes a change to the `src/Illuminate/Collections/Collection.php` file. The change updates the `transform` method to use the `Arr::map` function instead of the `map` method. The map method will create new instances of collection, and while using transform, we do not intend to create a new instance.
