### PR TITLE
Remove unnecessary `autoincrement` for SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -1150,7 +1150,7 @@ class SQLiteGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
-            return ' primary key autoincrement';
+            return ' primary key';
         }
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -30,7 +30,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" integer primary key not null, "email" varchar not null)', $statements[0]);
 
         $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
@@ -39,7 +39,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $expected = [
-            'alter table "users" add column "id" integer primary key autoincrement not null',
+            'alter table "users" add column "id" integer primary key not null',
             'alter table "users" add column "email" varchar not null',
         ];
         $this->assertEquals($expected, $statements);
@@ -55,7 +55,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create temporary table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
+        $this->assertSame('create temporary table "users" ("id" integer primary key not null, "email" varchar not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -262,7 +262,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key not null', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -272,7 +272,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key not null', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -282,7 +282,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key not null', $statements[0]);
     }
 
     public function testAddingID()
@@ -292,14 +292,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key not null', $statements[0]);
 
         $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->id('foo');
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key not null', $statements[0]);
     }
 
     public function testAddingForeignID()
@@ -374,7 +374,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key not null', $statements[0]);
     }
 
     public function testAddingString()
@@ -425,7 +425,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key not null', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -442,7 +442,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key not null', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -459,7 +459,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key not null', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -476,7 +476,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key not null', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -493,7 +493,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key not null', $statements[0]);
     }
 
     public function testAddingFloat()

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -83,7 +83,7 @@ class MigratorTest extends TestCase
 
         $this->expectTwoColumnDetail('CreatePeopleTable');
         $this->expectBulletList([
-            'create table "people" ("id" integer primary key autoincrement not null, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)',
+            'create table "people" ("id" integer primary key not null, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)',
             'create unique index "people_email_unique" on "people" ("email")',
         ]);
 
@@ -183,7 +183,7 @@ class MigratorTest extends TestCase
         $this->expectInfo('Running migrations.');
         $this->expectTwoColumnDetail('DynamicContentIsShown');
         $this->expectBulletList([
-            'create table "blogs" ("id" integer primary key autoincrement not null, "url" varchar, "name" varchar)',
+            'create table "blogs" ("id" integer primary key not null, "url" varchar, "name" varchar)',
             'insert into "blogs" ("url") values (\'www.janedoe.com\'), (\'www.johndoe.com\')',
             'ALTER TABLE \'pseudo_table_name\' MODIFY \'column_name\' VARCHAR(191)',
             'select * from "people"',
@@ -216,7 +216,7 @@ class MigratorTest extends TestCase
         $this->expectInfo('Running migrations.');
         $this->expectTwoColumnDetail('DynamicContentNotShown');
         $this->expectBulletList([
-            'create table "blogs" ("id" integer primary key autoincrement not null, "url" varchar, "name" varchar)',
+            'create table "blogs" ("id" integer primary key not null, "url" varchar, "name" varchar)',
             'insert into "blogs" ("url") values (\'www.janedoe.com\'), (\'www.johndoe.com\')',
             'ALTER TABLE \'pseudo_table_name\' MODIFY \'column_name\' VARCHAR(191)',
             'select * from "people"',


### PR DESCRIPTION
From the [SQLite docs](https://sqlite.org/autoinc.html):

> -  The `AUTOINCREMENT` keyword imposes extra CPU, memory, disk space, and disk I/O overhead and should be avoided if not strictly needed. It is usually not needed.
> - In SQLite, a column with type `INTEGER PRIMARY KEY` is an alias for the [`ROWID`](https://sqlite.org/lang_createtable.html#rowid) (except in [`WITHOUT ROWID`](https://sqlite.org/withoutrowid.html) tables) which is always a 64-bit signed integer.
> - On an [`INSERT`](https://sqlite.org/lang_insert.html), if the `ROWID` or `INTEGER PRIMARY KEY` column is not explicitly given a value, then it will be filled automatically with an unused integer, usually one more than the largest `ROWID` currently in use. This is true regardless of whether or not the `AUTOINCREMENT` keyword is used.
> - If the `AUTOINCREMENT` keyword appears after `INTEGER PRIMARY KEY`, that changes the automatic `ROWID` assignment algorithm to prevent the reuse of `ROWID`'s over the lifetime of the database. In other words, the purpose of `AUTOINCREMENT` is to prevent the reuse of `ROWID`'s from previously deleted rows.

Thus `AUTOINCREMENT` only prevents id's from being reused.

If a user were to rely on this behaviour (e.g., a check whether a previously deleted record for a foreign key exists) this could lead to unexpected behaviour. I therefore consider this a breaking change.

