### PR TITLE
[12.x] use type declarations for Auth events

### DIFF
--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -13,9 +13,9 @@ class Attempting
      * @return void
      */
     public function __construct(
-        public $guard,
-        #[\SensitiveParameter] public $credentials,
-        public $remember,
+        public string $guard,
+        #[\SensitiveParameter] public array $credentials,
+        public bool $remember,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class Authenticated
@@ -16,8 +17,8 @@ class Authenticated
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
+        public string $guard,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class CurrentDeviceLogout
@@ -16,8 +17,8 @@ class CurrentDeviceLogout
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
+        public string $guard,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
+
 class Failed
 {
     /**
@@ -13,9 +15,9 @@ class Failed
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
-        #[\SensitiveParameter] public $credentials,
+        public string $guard,
+        public ?Authenticatable $user,
+        #[\SensitiveParameter] public array $credentials,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Lockout.php
+++ b/src/Illuminate/Auth/Events/Lockout.php
@@ -7,20 +7,13 @@ use Illuminate\Http\Request;
 class Lockout
 {
     /**
-     * The throttled request.
-     *
-     * @var \Illuminate\Http\Request
-     */
-    public $request;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return void
      */
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
+    public function __construct(
+        public Request $request,
+    ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class Login
@@ -17,9 +18,9 @@ class Login
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
-        public $remember,
+        public string $guard,
+        public Authenticatable $user,
+        public bool $remember,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class Logout
@@ -16,8 +17,8 @@ class Logout
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
+        public string $guard,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class OtherDeviceLogout
@@ -16,8 +17,8 @@ class OtherDeviceLogout
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
+        public string $guard,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class PasswordReset
@@ -15,7 +16,7 @@ class PasswordReset
      * @return void
      */
     public function __construct(
-        public $user,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Queue\SerializesModels;
 
 class PasswordResetLinkSent
@@ -15,7 +16,7 @@ class PasswordResetLinkSent
      * @return void
      */
     public function __construct(
-        public $user,
+        public CanResetPassword $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class Registered
@@ -15,7 +16,7 @@ class Registered
      * @return void
      */
     public function __construct(
-        public $user,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class Validated
@@ -16,8 +17,8 @@ class Validated
      * @return void
      */
     public function __construct(
-        public $guard,
-        public $user,
+        public string $guard,
+        public Authenticatable $user,
     ) {
     }
 }

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Events;
 
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Queue\SerializesModels;
 
 class Verified
@@ -15,7 +16,7 @@ class Verified
      * @return void
      */
     public function __construct(
-        public $user,
+        public MustVerifyEmail $user,
     ) {
     }
 }


### PR DESCRIPTION
this one is a little more curious than the last. there are some events that are completely unused. 1 that is only used in tests.

some of the calling code also only ensures the correct type based on a docblock and not an actual type declaration. honestly not surprised to see that. imagine that will just be part of the process.

we also have a couple scenarios again where the event is expecting a class, but the code can technically (but unlikely or impossible) pass `null`.