### PR TITLE
[12.x] use type declaration on property

### DIFF
--- a/src/Illuminate/Bus/Events/BatchDispatched.php
+++ b/src/Illuminate/Bus/Events/BatchDispatched.php
@@ -7,20 +7,13 @@ use Illuminate\Bus\Batch;
 class BatchDispatched
 {
     /**
-     * The batch instance.
-     *
-     * @var \Illuminate\Bus\Batch
-     */
-    public $batch;
-
-    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Bus\Batch  $batch
      * @return void
      */
-    public function __construct(Batch $batch)
-    {
-        $this->batch = $batch;
+    public function __construct(
+        public Batch $batch,
+    ) {
     }
 }

--- a/src/Illuminate/Bus/Events/BatchDispatched.php
+++ b/src/Illuminate/Bus/Events/BatchDispatched.php
@@ -9,7 +9,7 @@ class BatchDispatched
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Bus\Batch  $batch
+     * @param  \Illuminate\Bus\Batch  $batch  The batch instance.
      * @return void
      */
     public function __construct(


### PR DESCRIPTION
this one was not switched to promoted properties at first because it was a `public` property.

this event constructor is called twice. both pieces of calling code pass the correct type, but this is only enforced via docblocks, not true type declarations.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
