### PR TITLE
[11.x] Update Uri `withoutQuery` method to accept string or array input

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -274,7 +274,7 @@ class Uri implements Htmlable, Responsable, Stringable
     /**
      * Remove the given query parameters from the URI.
      */
-    public function withoutQuery(string|array $keys): static
+    public function withoutQuery(array|string $keys): static
     {
         return $this->replaceQuery(Arr::except($this->query()->all(), $keys));
     }

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -274,7 +274,7 @@ class Uri implements Htmlable, Responsable, Stringable
     /**
      * Remove the given query parameters from the URI.
      */
-    public function withoutQuery(array $keys): static
+    public function withoutQuery(string|array $keys): static
     {
         return $this->replaceQuery(Arr::except($this->query()->all(), $keys));
     }


### PR DESCRIPTION
Updated Uri `withoutQuery` method to allow accepting a single string or an array of keys.