### PR TITLE
[11.x] Updates component dependencies 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,6 @@
         "symfony/translation": "^7.0.3"
     },
     "conflict": {
-        "mockery/mockery": "1.6.8",
         "tightenco/collect": "<5.5.33"
     },
     "provide": {

--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.0",
         "illuminate/process": "^11.0",
         "illuminate/support": "^11.0",
-        "laravel/serializable-closure": "^1.2.2"
+        "laravel/serializable-closure": "^1.3|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -48,7 +48,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the Composer class (^11.0).",
-        "laravel/serializable-closure": "Required to use the once function (^1.3).",
+        "laravel/serializable-closure": "Required to use the once function (^1.3|^2.0).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.6).",
         "league/uri": "Required to use the Uri class (^7.5.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",


### PR DESCRIPTION
* Allows `laravel/serializable-closure` 1.3+ and 2.0+ (missing in Concurrency component)
* Remove `mockery/mockery` conflict as it will not resolve the conflicting version.
