### PR TITLE
[12.x] Refactor env get option

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -106,7 +106,7 @@ class Env
                 'null', '(null)' => null,
                 default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)
                     ? $matches[2]
-                    $value,
+                    : $value,
             });
     }
 }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -99,27 +99,14 @@ class Env
     protected static function getOption($key)
     {
         return Option::fromValue(static::getRepository()->get($key))
-            ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
+            ->map(fn ($value) => match (strtolower($value)) {
+                'true', '(true)' => true,
+                'false', '(false)' => false,
+                'empty', '(empty)' => '',
+                'null', '(null)' => null,
+                default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)
+                    ? $matches[2]
+                    $value,
             });
     }
 }


### PR DESCRIPTION
Theoretically, case 1 and 2 could be combined into one by using [`filter_var($value, FILTER_VALIDATE_BOOLEAN)`](https://www.php.net/manual/de/filter.constants.php#constant.filter-validate-bool), but parentheses would have to be conditionally removed, so I refrained from overengineering this for now, unless this is wanted.
```diff
    protected static function getOption($key)
    {
        return Option::fromValue(static::getRepository()->get($key))
            ->map(fn ($value) => match (strtolower($value)) {
-               'true', '(true)' => true,
-               'false', '(false)' => false,
+               'true', '(true)', 'false', '(false)' => filter_var(str_replace(['(', ')'], '', $value), FILTER_VALIDATE_BOOLEAN),
                'empty', '(empty)' => '',
                'null', '(null)' => null,
                default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)
                    ? $matches[2]
                    : $value,
            });
    }
```