### PR TITLE
[11.x] Add a way to pass parameters to every Pipeline step

### DIFF
--- a/src/Illuminate/Contracts/Pipeline/Pipeline.php
+++ b/src/Illuminate/Contracts/Pipeline/Pipeline.php
@@ -25,7 +25,7 @@ interface Pipeline
     /**
      * Set the extra parameters being sent with the traveller object.
      *
-     * @param mixed|array $parameters
+     * @param  mixed|array  $parameters
      * @return $this
      */
     public function with($parameters);

--- a/src/Illuminate/Contracts/Pipeline/Pipeline.php
+++ b/src/Illuminate/Contracts/Pipeline/Pipeline.php
@@ -23,6 +23,14 @@ interface Pipeline
     public function through($stops);
 
     /**
+     * Set the extra parameters being sent with the traveller object.
+     *
+     * @param mixed|array $parameters
+     * @return $this
+     */
+    public function with($parameters);
+
+    /**
      * Set the method to call on the stops.
      *
      * @param  string  $method

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -76,7 +76,7 @@ class Pipeline implements PipelineContract
     /**
      * Set the extra parameters being sent with the traveller object.
      *
-     * @param array|mixed $parameters
+     * @param  mixed|array  $parameters
      * @return $this
      */
     public function with($parameters)

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -273,6 +273,33 @@ class PipelineTest extends TestCase
         $this->assertNull($_SERVER['__test.pipe.one']);
         unset($_SERVER['__test.pipe.one']);
     }
+
+    public function testPipelinePassesWithParametersToPipes()
+    {
+        $parameters = ['one', 'two'];
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->with($parameters)
+            ->through(PipelineTestParameterPipe::class)
+            ->thenReturn();
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+        unset($_SERVER['__test.pipe.parameters']);
+
+        // test that parameters set by "with" are passed after "through" parameters.
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->with($parameters[1])
+            ->through(PipelineTestParameterPipe::class . ':' . $parameters[0])
+            ->thenReturn();
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+    }
 }
 
 class PipelineTestPipeOne

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -292,7 +292,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->with($parameters[1])
-            ->through(PipelineTestParameterPipe::class . ':' . $parameters[0])
+            ->through(PipelineTestParameterPipe::class.':'.$parameters[0])
             ->thenReturn();
 
         $this->assertSame('foo', $result);


### PR DESCRIPTION
This PR adds a way to pass extra parameters to the Pipepile steps. This feature already kind-of existed with the notation of passing parameters after the pipe callable, like so: `Pipe::class.':arg1,arg2'`, but this is limited to just passing primitive data and only to that pipe specifically. 

A new `->with(...)` method has been added. What you can do now is be able to pass more complex contextual data (like models for example) through all the pipes alongside the main traveller object. Here's an example:

```php
$something = SomeModel::first();

return Pipeline::send(123)
    ->with($something)
    ->through([
        FirstStep::class,
        SecondStep::class,
        ThirdStep::class
    ])->thenReturn();
```

The pipe class itself can then get that model as an argument passed to its method. The arguments passed this way are always put at the end of the argument list.
```php
class FirstStep
{
    public function __invoke(int $someValue, Closure $next, SomeModel $model)
    {
	// some code that involves the passed argument, i.e.
	$someValue += $model->anotherValue;
		
        return $next($someValue);
    }
}
```

I personally found myself needing this when I was building an image generator that created a unique image for every instance of a model in the DB. I was using pipelines to add more content on the image with each step and wanted to pass the model I was making the image for as an additional parameter.