### PR TITLE
[11.x] add assertFailedWith to InteractsWithQueue trait

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -173,7 +173,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 get_class($exception),
                 $this->job->failedWith,
-                'Job was expected to be manually failed with ['.get_class($exception).'], but was not.'
+                'Expected job to be manually failed with ['.get_class($exception).'], but was failed with ['.get_class($this->job->failedWith).'].'
             );
 
             PHPUnit::assertEquals(

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -159,7 +159,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 $exception,
                 $this->job->failedWith,
-                'Expected job to be manually failed with ['.$exception.'], but was failed with ['.get_class($this->job->failedWith).'].'
+                'Expected job to be manually failed with ['.$exception.'] but job failed with ['.get_class($this->job->failedWith).'].'
             );
 
             return $this;
@@ -173,7 +173,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 get_class($exception),
                 $this->job->failedWith,
-                'Expected job to be manually failed with ['.get_class($exception).'], but was failed with ['.get_class($this->job->failedWith).'].'
+                'Expected job to be manually failed with ['.get_class($exception).'] but job failed with ['.get_class($this->job->failedWith).'].'
             );
 
             PHPUnit::assertEquals(

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -146,6 +146,52 @@ trait InteractsWithQueue
     }
 
     /**
+     * Assert that the job was manually failed with a specific exception.
+     *
+     * @param \Throwable|string $exception
+     *
+     * @return $this
+     */
+    public function assertFailedWith($exception)
+    {
+        $this->assertFailed();
+
+        if (is_string($exception) && class_exists($exception)) {
+            PHPUnit::assertInstanceOf(
+                $exception,
+                $this->job->failedWith,
+                'Job was expected to be manually failed with '. $exception . ', but was not.'
+            );
+            return $this;
+        }
+
+        if (is_string($exception)) {
+            $exception = new ManuallyFailedException($exception);
+        }
+
+        if ($exception instanceof Throwable) {
+            PHPUnit::assertInstanceOf(
+                get_class($exception),
+                $this->job->failedWith,
+                'Job was expected to be manually failed with '. get_class($exception) . ', but was not.'
+            );
+
+            PHPUnit::assertEquals(
+                $exception->getCode(),
+                $this->job->failedWith->getCode(),
+                'Exception code does not match. Code should be ' . $exception->getCode() . ' but is ' . $this->job->failedWith->getCode() . '.'
+            );
+            PHPUnit::assertEquals(
+                $exception->getMessage(),
+                $this->job->failedWith->getMessage(),
+                'Exception message does not match. Message should be ' . $exception->getMessage() . ' but is ' . $this->job->failedWith->getMessage() . '.'
+                );
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the job was not manually failed.
      *
      * @return $this

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -149,7 +149,6 @@ trait InteractsWithQueue
      * Assert that the job was manually failed with a specific exception.
      *
      * @param \Throwable|string $exception
-     *
      * @return $this
      */
     public function assertFailedWith($exception)
@@ -160,8 +159,9 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 $exception,
                 $this->job->failedWith,
-                'Job was expected to be manually failed with '. $exception . ', but was not.'
+                'Job was expected to be manually failed with ['.$exception.'], but was not.'
             );
+
             return $this;
         }
 
@@ -173,19 +173,19 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 get_class($exception),
                 $this->job->failedWith,
-                'Job was expected to be manually failed with '. get_class($exception) . ', but was not.'
+                'Job was expected to be manually failed with ['.get_class($exception).'], but was not.'
             );
 
             PHPUnit::assertEquals(
                 $exception->getCode(),
                 $this->job->failedWith->getCode(),
-                'Exception code does not match. Code should be ' . $exception->getCode() . ' but is ' . $this->job->failedWith->getCode() . '.'
+                'Expected exception code ['.$exception->getCode().'] but job failed with exception code ['.$this->job->failedWith->getCode().'].'
             );
+
             PHPUnit::assertEquals(
                 $exception->getMessage(),
                 $this->job->failedWith->getMessage(),
-                'Exception message does not match. Message should be ' . $exception->getMessage() . ' but is ' . $this->job->failedWith->getMessage() . '.'
-                );
+                'Expected exceptoin message ['.$exception->getMessage().'] but job failed with exception message ['.$this->job->failedWith->getMessage().'].');
         }
 
         return $this;

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -159,7 +159,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 $exception,
                 $this->job->failedWith,
-                'Job was expected to be manually failed with ['.$exception.'], but was not.'
+                'Expected job to be manually failed with ['.$exception.'], but was failed with ['.get_class($this->job->failedWith).'].'
             );
 
             return $this;


### PR DESCRIPTION
This PR improves testing  job's queue interactions for [manually failed jobs](https://laravel.com/docs/11.x/queues#manually-failing-a-job) by adding a new method `assertFailedWith`.
The existing method `assertFailed` does not allow to check the failing exception.

When manually failing the job, we can now check for the failure exception.

```php
use App\Jobs\ProcessPodcast;
use App\Exceptions\MyException;
 
$job = (new ProcessPodcast)->withFakeQueueInteractions();
 
$job->assertFailedWith('whoops');
$job->assertFailedWith(MyException::class);
$job->assertFailedWith(new MyException);
$job->assertFailedWith(new MyException(message: 'whoops'));
$job->assertFailedWith(new MyException(message: 'whoops', code: 123));
```
