### PR TITLE
Update helpers.php, remove goto statement

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -330,24 +330,23 @@ if (! function_exists('retry')) {
             $times = count($times) + 1;
         }
 
-        beginning:
-        $attempts++;
-        $times--;
+        while (true) {
+            $attempts++;
+            $times--;
 
-        try {
-            return $callback($attempts);
-        } catch (Throwable $e) {
-            if ($times < 1 || ($when && ! $when($e))) {
-                throw $e;
+            try {
+                return $callback($attempts);
+            } catch (Throwable $e) {
+                if ($times < 1 || ($when && ! $when($e))) {
+                    throw $e;
+                }
+
+                $sleepMilliseconds = $backoff[$attempts - 1] ?? $sleepMilliseconds;
+
+                if ($sleepMilliseconds) {
+                    Sleep::usleep(value($sleepMilliseconds, $attempts, $e) * 1000);
+                }
             }
-
-            $sleepMilliseconds = $backoff[$attempts - 1] ?? $sleepMilliseconds;
-
-            if ($sleepMilliseconds) {
-                Sleep::usleep(value($sleepMilliseconds, $attempts, $e) * 1000);
-            }
-
-            goto beginning;
         }
     }
 }


### PR DESCRIPTION
The goto statement can make the code's flow difficult to follow. PHP code is typically expected to have a more linear and understandable structure. For example, when using goto, it can jump from one part of the code to another in a non - sequential manner. This can lead to confusion for developers who are trying to understand the program's logic, especially in larger codebases.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
