### PR TITLE
[11.x] Use Str::wrap() instead of nesting Str::start() inside Str::finish()

### DIFF
--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -95,7 +95,7 @@ class Headers
     public function referencesString(): string
     {
         return (new Collection($this->references))
-            ->map(fn ($messageId) => Str::finish(Str::start($messageId, '<'), '>'))
+            ->map(fn ($messageId) => Str::wrap($messageId, '<', '>'))
             ->implode(' ');
     }
 }


### PR DESCRIPTION
Btw, is there a reason, why the null coalescing assignment operator is used instead of just the null coalescing operator?

https://github.com/laravel/framework/blob/5d81b45a3227114da97b10e0059cec824eb3d4c2/src/Illuminate/Support/Str.php#L441-L452
