### PR TITLE
[11.x] Allow passing bool to facade Http@preventStrayRequests()

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -138,12 +138,13 @@ class Http extends Facade
     /**
      * Indicate that an exception should be thrown if any request is not faked.
      *
+     * @param  bool  $prevent
      * @return \Illuminate\Http\Client\Factory
      */
-    public static function preventStrayRequests()
+    public static function preventStrayRequests($prevent = true)
     {
-        return tap(static::getFacadeRoot(), function ($fake) {
-            static::swap($fake->preventStrayRequests());
+        return tap(static::getFacadeRoot(), function ($fake) use ($prevent) {
+            static::swap($fake->preventStrayRequests($prevent));
         });
     }
 

--- a/tests/Support/SupportFacadesHttpTest.php
+++ b/tests/Support/SupportFacadesHttpTest.php
@@ -55,4 +55,15 @@ class SupportFacadesHttpTest extends TestCase
 
         $this->assertSame($client, $this->app->make(Factory::class));
     }
+
+    public function test_can_set_prevents_to_prevents_stray_requests(): void
+    {
+        Http::preventStrayRequests(true);
+        $this->assertTrue($this->app->make(Factory::class)->preventingStrayRequests());
+        $this->assertTrue(Http::preventingStrayRequests());
+
+        Http::preventStrayRequests(false);
+        $this->assertFalse($this->app->make(Factory::class)->preventingStrayRequests());
+        $this->assertFalse(Http::preventingStrayRequests());
+    }
 }


### PR DESCRIPTION
The Http facade's `preventStrayRequests()` doesn't match the underlying the Http Factory definition.

I was wondering why my tests were failing when I wrote `\Http::preventStrayRequests(false)` and realized that when PHPStorm + Laravel Idea jumps into the definition, it's not jumping into the facade definition, but instead the underlying class.

The workaround for this is to call `\Http::allowStrayRequests()`, but I figured I'd offer this PR as tribute to the facade gods.