### PR TITLE
Enhance install:api command to optionally add HasApiTokens trait to User model

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -172,10 +172,10 @@ class ApiInstallCommand extends Command
     }
 
     /**
-     * Attempt to add the given trait to the specified model.
-     *
-     * @return void
-     */
+    * Attempt to add the given trait to the specified model.
+    *
+    * @return void
+    */
     protected function addTraitToModel(string $trait, string $model)
     {
         $modelPath = $this->laravel->basePath(str_replace('\\', '/', $model) . '.php');
@@ -190,7 +190,7 @@ class ApiInstallCommand extends Command
         $sanctumTrait = 'Laravel\\Sanctum\\HasApiTokens';
         $passportTrait = 'Laravel\\Passport\\HasApiTokens';
 
-        // Detect conflicts
+        // Detect existing traits and warn
         if (str_contains($content, "use $sanctumTrait;")) {
             $this->warn("Sanctum is already installed in your [$model] model. Please manually switch to Passport if needed.");
             return;
@@ -201,8 +201,18 @@ class ApiInstallCommand extends Command
             return;
         }
 
-        // Add the top-level `use` statement if missing
+        // Confirm with the user before making changes
+        if (! $this->components->confirm(
+            "Would you like to add the [$trait] trait to your [$model] model now?",
+            true
+        )) {
+            $this->components->info("No changes were made to your [$model] model.");
+            return;
+        }
+
         $modified = false;
+
+        // Add the top-level `use` statement if missing
         $isTopLevelImported = str_contains($content, "use $trait;");
 
         if (! $isTopLevelImported) {

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -174,16 +174,15 @@ class ApiInstallCommand extends Command
     /**
      * Attempt to add the given trait to the specified model.
      *
-     * @param  string  $trait
-     * @param  string  $model
      * @return void
      */
     protected function addTraitToModel(string $trait, string $model)
     {
-        $modelPath = $this->laravel->basePath(str_replace('\\', '/', $model) . '.php');
+        $modelPath = $this->laravel->basePath(str_replace('\\', '/', $model).'.php');
 
-        if (!file_exists($modelPath)) {
+        if (! file_exists($modelPath)) {
             $this->components->error("Model not found at {$modelPath}.");
+
             return;
         }
 
@@ -193,13 +192,14 @@ class ApiInstallCommand extends Command
         // Check if the trait is already used in the model
         if (strpos($content, $traitBasename) !== false) {
             $this->components->info("The [{$trait}] trait is already present in your [{$model}] model.");
+
             return;
         }
 
         $modified = false;
 
         // Ensure the 'use $trait;' statement is inserted correctly below other imports
-        if (!str_contains($content, "use $trait;")) {
+        if (! str_contains($content, "use $trait;")) {
             $content = preg_replace(
                 '/(use\s+[\w\\\\]+;(\s+\/\/.*\n)*\s*)+/s',
                 "$0use $trait;\n",
@@ -221,11 +221,11 @@ class ApiInstallCommand extends Command
             if (preg_match('/use\s+(.*?);/s', $content, $useMatches, PREG_OFFSET_CAPTURE, $insertPosition)) {
                 $traits = $useMatches[1][0];
                 $traitList = array_map('trim', explode(',', $traits));
-                if (!in_array($traitBasename, $traitList)) {
+                if (! in_array($traitBasename, $traitList)) {
                     $traitList[] = $traitBasename;
                     $content = substr_replace(
                         $content,
-                        'use ' . implode(', ', $traitList) . ';',
+                        'use '.implode(', ', $traitList).';',
                         $useMatches[0][1],
                         strlen($useMatches[0][0])
                     );

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -75,11 +75,11 @@ class ApiInstallCommand extends Command
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
 
-            if ($this->confirm("Would you like to add the [Laravel\\Sanctum\\HasApiTokens] trait to your User model now?", true)) {
+            if ($this->confirm('Would you like to add the [Laravel\\Sanctum\\HasApiTokens] trait to your User model now?', true)) {
                 if (class_exists('App\\Models\\User')) {
                     $this->addTraitToModel('Laravel\\Sanctum\\HasApiTokens', 'App\\Models\\User');
                 } else {
-                    $this->components->warn("The [App\\Models\\User] model does not exist. Please manually add the trait to your User model if you've moved or renamed it.");
+                    $this->components->warn('The [App\\Models\\User] model does not exist. Please manually add the trait to your User model if you\'ve moved or renamed it.');
                 }
             }
 
@@ -92,11 +92,11 @@ class ApiInstallCommand extends Command
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');
 
-            if ($this->confirm("Would you like to add the [Laravel\\Sanctum\\HasApiTokens] trait to your User model now?", true)) {
+            if ($this->confirm('Would you like to add the [Laravel\\Sanctum\\HasApiTokens] trait to your User model now?', true)) {
                 if (class_exists('App\\Models\\User')) {
                     $this->addTraitToModel('Laravel\\Sanctum\\HasApiTokens', 'App\\Models\\User');
                 } else {
-                    $this->components->warn("The [App\\Models\\User] model does not exist. Please manually add the trait to your User model if you've moved or renamed it.");
+                    $this->components->warn('The [App\\Models\\User] model does not exist. Please manually add the trait to your User model if you\'ve moved or renamed it.');
                 }
             }
         }
@@ -184,6 +184,7 @@ class ApiInstallCommand extends Command
 
         if (! file_exists($modelPath)) {
             $this->components->error("Model not found at {$modelPath}.");
+
             return;
         }
 
@@ -193,13 +194,14 @@ class ApiInstallCommand extends Command
         // If trait already present, do nothing
         if (strpos($content, $traitBasename) !== false) {
             $this->components->info("The [{$trait}] trait is already present in your [{$model}] model.");
+
             return;
         }
 
         $modified = false;
 
         // Ensure the 'use $trait;' statement is present
-        if (!str_contains($content, "use $trait;")) {
+        if (! str_contains($content, "use $trait;")) {
             $content = preg_replace(
                 '/(namespace\s+.*;)/',
                 "$1\n\nuse $trait;",
@@ -214,7 +216,7 @@ class ApiInstallCommand extends Command
         }
 
         // Insert the trait into the class if not present
-        if (!str_contains($content, "use $traitBasename;")) {
+        if (! str_contains($content, "use $traitBasename;")) {
             $content = preg_replace(
                 '/(class\s+\w+\s+extends\s+\w+[A-Za-z\\\\]*)(\s*\{)/',
                 "$1 {\n    use $traitBasename;\n",

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -172,10 +172,10 @@ class ApiInstallCommand extends Command
     }
 
     /**
-    * Attempt to add the given trait to the specified model.
-    *
-    * @return void
-    */
+     * Attempt to add the given trait to the specified model.
+     *
+     * @return void
+     */
     protected function addTraitToModel(string $trait, string $model)
     {
         $modelPath = $this->laravel->basePath(str_replace('\\', '/', $model) . '.php');
@@ -187,23 +187,27 @@ class ApiInstallCommand extends Command
 
         $content = file_get_contents($modelPath);
         $traitBasename = class_basename($trait);
-        $sanctumTrait = 'Laravel\\Sanctum\\HasApiTokens';
-        $passportTrait = 'Laravel\\Passport\\HasApiTokens';
 
-        // Detect existing traits and warn
-        if (str_contains($content, "use $sanctumTrait;")) {
-            $this->warn("Sanctum is already installed in your [$model] model. Please manually switch to Passport if needed.");
-            return;
-        }
+        // Map traits to their readable names
+        $traitNames = [
+            'Laravel\\Sanctum\\HasApiTokens' => 'Sanctum',
+            'Laravel\\Passport\\HasApiTokens' => 'Passport',
+        ];
 
-        if (str_contains($content, "use $passportTrait;")) {
-            $this->warn("Passport is already installed in your [$model] model. Please manually switch to Sanctum if needed.");
-            return;
+        // Determine the readable name for the requested trait
+        $traitName = $traitNames[$trait] ?? $traitBasename;
+
+        // Detect existing traits and warn with improved messages
+        foreach ($traitNames as $existingTrait => $existingTraitName) {
+            if (str_contains($content, "use $existingTrait;")) {
+                $this->warn("$existingTraitName is already installed in your [$model] model. Please manually install [$traitName] if needed.");
+                return;
+            }
         }
 
         // Confirm with the user before making changes
         if (! $this->components->confirm(
-            "Would you like to add the [$trait] trait to your [$model] model now?",
+            "Would you like to add the [$traitName] trait to your [$model] model now?",
             true
         )) {
             $this->components->info("No changes were made to your [$model] model.");
@@ -264,7 +268,7 @@ class ApiInstallCommand extends Command
         // Save changes if modified
         if ($modified) {
             file_put_contents($modelPath, $content);
-            $this->components->info("The [$trait] trait has been added to your [$model] model.");
+            $this->components->info("The [$traitName] trait has been added to your [$model] model.");
         } else {
             $this->components->info("No changes were made to your [$model] model.");
         }

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -75,9 +75,9 @@ class ApiInstallCommand extends Command
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
 
-            if ($this->confirm('Would you like to add the [Laravel\\Sanctum\\HasApiTokens] trait to your User model now?', true)) {
+            if ($this->confirm('Would you like to add the [Laravel\Passport\HasApiTokens] trait to your User model now?', true)) {
                 if (class_exists('App\\Models\\User')) {
-                    $this->addTraitToModel('Laravel\\Sanctum\\HasApiTokens', 'App\\Models\\User');
+                    $this->addTraitToModel('Laravel\Passport\HasApiTokens', 'App\\Models\\User');
                 } else {
                     $this->components->warn('The [App\\Models\\User] model does not exist. Please manually add the trait to your User model if you\'ve moved or renamed it.');
                 }

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -182,52 +182,62 @@ class ApiInstallCommand extends Command
 
         if (! file_exists($modelPath)) {
             $this->components->error("Model not found at {$modelPath}.");
+
             return;
         }
 
         $content = file_get_contents($modelPath);
         $traitBasename = class_basename($trait);
 
+        // Check if the trait is already imported or used
         if (strpos($content, "use $trait;") !== false || strpos($content, $traitBasename) !== false) {
             $this->components->info("The [{$trait}] trait is already present in your [{$model}] model.");
+
             return;
         }
 
         $modified = false;
 
-        // Insert the trait at the top-level (import)
-        $topLevelUsePattern = '/(namespace\s+[\w\\\\]+;\s*(?:use\s+[\w\\\\]+;\s*)*)/s';
-        $topLevelUseReplacement = '$1use ' . $trait . ';' . "\n";
+        // Add the trait import statement if it doesn't exist
+        if (! str_contains($content, "use $trait;")) {
+            $content = preg_replace(
+                '/(use\s+[\w\\\\]+;(\s+\/\/.*\n)*\s*)+/s',
+                "$0use $trait;\n",
+                $content,
+                1,
+                $count
+            );
 
-        $newContent = preg_replace($topLevelUsePattern, $topLevelUseReplacement, $content, 1, $count);
-        if ($count > 0) {
-            $modified = true;
-            $content = $newContent;
+            if ($count > 0) {
+                $modified = true;
+            }
         }
 
-        // Insert or merge the trait at the class-level
-        $classPattern = '/(class\s+\w+(?:\s+extends\s+\w+(?:\\\\\w+)*)?(?:\s+implements\s+[^{]+)?\s*\{)/s';
+        // Add the trait usage within the class
+        if (preg_match('/class\s+\w+\s+extends\s+\w+[A-Za-z\\\\]*\s*\{/', $content, $matches, PREG_OFFSET_CAPTURE)) {
+            $insertPosition = $matches[0][1] + strlen($matches[0][0]);
 
-        if (preg_match('/class\s+\w+(?:\s+extends\s+\w+(?:\\\\\w+)*)?(?:\s+implements\s+[^{]+)?\s*\{\s*(use\s+[^;]+;)?/s', $content, $m, PREG_OFFSET_CAPTURE)) {
-            if (!empty($m[1][0])) {
-                // Existing class-level use line
-                $useLineStart = $m[1][1];
-                preg_match('/use\s+([^;]+);/', $m[1][0], $traitsMatches);
-                $existingTraits = array_map('trim', explode(',', $traitsMatches[1]));
+            if (preg_match('/use\s+(.*?);/s', $content, $useMatches, PREG_OFFSET_CAPTURE, $insertPosition)) {
+                $traits = array_map('trim', explode(',', $useMatches[1][0]));
 
-                if (!in_array($traitBasename, $existingTraits)) {
-                    $existingTraits[] = $traitBasename;
-                    $newUseLine = 'use ' . implode(', ', $existingTraits) . ';';
-                    $content = substr_replace($content, $newUseLine, $useLineStart, strlen($m[1][0]));
+                if (! in_array($traitBasename, $traits)) {
+                    $traits[] = $traitBasename;
+                    $content = substr_replace(
+                        $content,
+                        'use '.implode(', ', $traits).';',
+                        $useMatches[0][1],
+                        strlen($useMatches[0][0])
+                    );
                     $modified = true;
                 }
             } else {
-                // No class-level use line, insert a new one
-                $newContent = preg_replace($classPattern, '$1' . "\n    use $traitBasename;", $content, 1, $count);
-                if ($count > 0) {
-                    $modified = true;
-                    $content = $newContent;
-                }
+                $content = substr_replace(
+                    $content,
+                    "\n    use $traitBasename;",
+                    $insertPosition,
+                    0
+                );
+                $modified = true;
             }
         }
 

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -211,15 +211,6 @@ class ApiInstallCommand extends Command
             return;
         }
 
-        // Confirm with the user before making changes
-        if (! $this->components->confirm(
-            "Would you like to add the [$trait] trait to your [$model] model now?",
-            true
-        )) {
-            $this->components->info("No changes were made to your [$model] model.");
-            return;
-        }
-
         $modified = false;
 
         // Add the top-level `use` statement if missing

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -172,10 +172,10 @@ class ApiInstallCommand extends Command
     }
 
     /**
-     * Attempt to add the given trait to the specified model.
-     *
-     * @return void
-     */
+    * Attempt to add the given trait to the specified model.
+    *
+    * @return void
+    */
     protected function addTraitToModel(string $trait, string $model)
     {
         $modelPath = $this->laravel->basePath(str_replace('\\', '/', $model) . '.php');
@@ -187,27 +187,26 @@ class ApiInstallCommand extends Command
 
         $content = file_get_contents($modelPath);
         $traitBasename = class_basename($trait);
+        $sanctumTrait = 'Laravel\\Sanctum\\HasApiTokens';
+        $passportTrait = 'Laravel\\Passport\\HasApiTokens';
 
-        // Map traits to their readable names
-        $traitNames = [
-            'Laravel\\Sanctum\\HasApiTokens' => 'Sanctum',
-            'Laravel\\Passport\\HasApiTokens' => 'Passport',
-        ];
-
-        // Determine the readable name for the requested trait
-        $traitName = $traitNames[$trait] ?? $traitBasename;
+        // Determine whether the requested trait is Sanctum or Passport
+        $traitName = ($trait === $sanctumTrait) ? 'Sanctum' : (($trait === $passportTrait) ? 'Passport' : $traitBasename);
 
         // Detect existing traits and warn with improved messages
-        foreach ($traitNames as $existingTrait => $existingTraitName) {
-            if (str_contains($content, "use $existingTrait;")) {
-                $this->warn("$existingTraitName is already installed in your [$model] model. Please manually install [$traitName] if needed.");
-                return;
-            }
+        if (str_contains($content, "use $sanctumTrait;")) {
+            $this->warn("Sanctum is already installed in your [$model] model. Please manually install [$traitName] if needed.");
+            return;
+        }
+
+        if (str_contains($content, "use $passportTrait;")) {
+            $this->warn("Passport is already installed in your [$model] model. Please manually install [$traitName] if needed.");
+            return;
         }
 
         // Confirm with the user before making changes
         if (! $this->components->confirm(
-            "Would you like to add the [$traitName] trait to your [$model] model now?",
+            "Would you like to add the [$trait] trait to your [$model] model now?",
             true
         )) {
             $this->components->info("No changes were made to your [$model] model.");
@@ -268,7 +267,7 @@ class ApiInstallCommand extends Command
         // Save changes if modified
         if ($modified) {
             file_put_contents($modelPath, $content);
-            $this->components->info("The [$traitName] trait has been added to your [$model] model.");
+            $this->components->info("The [$trait] trait has been added to your [$model] model.");
         } else {
             $this->components->info("No changes were made to your [$model] model.");
         }


### PR DESCRIPTION
**Before:** 

![Screenshot 2024-12-20 at 8 28 44 pm](https://github.com/user-attachments/assets/45737c79-f48a-49fd-9795-c84123e5eeef)

**After:**

![Screenshot 2024-12-21 at 12 20 06 am](https://github.com/user-attachments/assets/d4e28108-3411-40d1-b8cb-ba537f32edd3)
**Expected changes to the file:**

![image](https://github.com/user-attachments/assets/ff1937a0-0e90-4b88-a9e6-0b907a69d361)

This PR improves the developer experience when running `php artisan install:api`. After installing Sanctum or Passport, the command now offers to automatically add the `HasApiTokens` trait to the `User` model. If `App\Models\User `does not exist, it provides a gentle warning rather than making incorrect assumptions.

**Key Changes:**

- Added a confirmation prompt after installing Sanctum or Passport to optionally insert the HasApiTokens trait into the User model.
- Verified existence of `App\Models\User` before editing the file, preventing errors if the model has been relocated.
- Ensured non-destructive file modifications by checking for existing trait usage and use statements.
- Maintained backward compatibility and did not break any existing behavior. If the user declines or the model is missing, the command simply informs them and moves on.

**Why This Change?**

This enhancement streamlines the initial setup process by removing an additional manual step often missed by newcomers. It ensures developers can get their API scaffolding set up and ready to use more quickly, without digging into model files themselves—unless they need to.

**Testing Notes:**

- Run `php artisan install:api` without --passport to install Sanctum and confirm the migration and trait insertion prompts.
- Run `php artisan install:api --passport` to test Passport installation and the subsequent trait insertion prompt.
- Verify that the `User` model is only modified if `App\Models\User` exists

# Feature-by-Feature Analysis

| **Feature**                     | **Does the Code Support It?** | **Explanation**                                                                                       |
|----------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------------|
| **Detects existing top-level trait** | ✅                            | The code uses `strpos` to detect if the top-level `use` statement (e.g., `use Laravel\Passport\HasApiTokens;`) exists. |
| **Detects existing class-level trait** | ✅                            | The code uses `preg_match` on the class-level `use` block to check if the trait is already included.   |
| **Adds top-level `use` statement**  | ✅                            | If the `use` statement is missing, it adds it using `preg_replace`.                                   |
| **Adds class-level `use` statement** | ✅                            | If the trait is missing in the class-level `use` block, it inserts it in the correct location.         |
| **Modifies existing `use` block**   | ✅                            | Appends the trait to an existing `use` block inside the class (e.g., `use HasFactory, Notifiable;`).   |
| **Prevents duplicate additions**    | ✅                            | The code checks both top-level and class-level locations to ensure the trait isn’t added redundantly.  |
| **Provides conflict warnings**      | ✅                            | Warns the user if `Sanctum` or `Passport` traits are detected, asking them to manually resolve conflicts. |
| **Handles multiple traits in class**| ✅                            | Uses `array_map` to handle multiple traits and appends the new one if missing.                        |
| **Writes changes to file**          | ✅                            | Writes the updated content back to the file if modifications were made.                               |

**Potential issues:**
- If anyone has a better way to accurately find the correct text to change with regex, let me know. 
- Code simplified or improved to the _Laravel way_ added this PR as a proof of concept if acceptable solution, may need improvements.
- Scenario: How should we handle a situation where someone runs `php artisan install:api` and later runs `php artisan install:api --passport`?
**Proposed Solution:** Notify the user if `Sanctum `or `Passport` traits are already present, advising them to manually address any potential conflicts.