### PR TITLE
Update MariaDbSchemaState.php - use mariadb-dump command

### DIFF
--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -11,7 +11,7 @@ class MariaDbSchemaState extends MySqlSchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
+        $command = 'mariadb-dump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';
     }


### PR DESCRIPTION
This pull request includes a critical change to the `MariaDbSchemaState` class in the `src/Illuminate/Database/Schema/MariaDbSchemaState.php` file. This updates the command used for database dumps to be compatible with MariaDB.

Database command update:

* [`src/Illuminate/Database/Schema/MariaDbSchemaState.php`](diffhunk://#diff-98c795909d74500e2d494c8ae07e14773c22b0789733d1e76bee6f7511257393L14-R14): Modified the `baseDumpCommand` method to use `mariadb-dump` instead of `mysqldump` for generating database dumps.

As [documented in the MariaDB docs](https://mariadb.com/kb/en/mysqldump/), the mysqldump command has been depreciated and removed from the official docker image, and replaced with [the mariadb-dump comand](https://mariadb.com/kb/en/mariadb-dump/).