### PR TITLE
[11.x] Re-refresh the database if the `RefreshDatabase` transaction was committed

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -108,6 +108,11 @@ trait RefreshDatabase
                 $dispatcher = $connection->getEventDispatcher();
 
                 $connection->unsetEventDispatcher();
+
+                if (! $connection->getPdo()->inTransaction()) {
+                    RefreshDatabaseState::$migrated = false;
+                }
+
                 $connection->rollBack();
                 $connection->setEventDispatcher($dispatcher);
                 $connection->disconnect();


### PR DESCRIPTION
The `RefreshDatabase` trait:
- Runs `migrate:fresh` before the first test
- Opens a database transaction before each test
- Rolls back that transaction after each test

The issue is that it is possible to accidentally commit the transaction started by `RefreshDatabase`. For example, truncating a table automatically commits any active transactions. If a test commits the transaction, all database records created by that test won't be rolled back, causing each subsequent test to have a dirty database.

This is especially frustrating to debug because the test that commits the transaction passes, but tests after that fail unpredictably depending on the type of assertions they do. The logical place to start debugging the issue is with the failing tests, but those have nothing to do with the problem.

This PR solves this issue by refreshing the database if you (accidentally) commit the database transaction started by the `RefreshDatabase` trait. 

To reproduce this issue, use MySQL, then run the following tests:
```php
class ExampleTest extends TestCase
{
    use RefreshDatabase; // or LazilyRefreshDatabase

    public function test_the_first_test()
    {
        User::truncate();

        User::factory()->create();

        $this->expectNotToPerformAssertions();
    }

    public function test_the_second_test()
    {
        // This test passes if you run it in isolation, but it fails if you run all tests
        $this->assertSame(0, User::count());
    }
}
```
