### PR TITLE
[11.x] Makes dividing easier with the `group` method.

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Support\Str;
 use NumberFormatter;
 use RuntimeException;
 
@@ -47,8 +46,11 @@ class Number
             $integer = Str::padRight($integer, ceil(strlen($integer) / $interval) * $interval, $padding);
         }
 
-        // Split the integer part into chunks of the specified interval
-        $pairs = Str::split($integer, $interval);
+        // Split the integer part into chunks of the specified interval using callback
+        $pairs = array_map(
+            fn($chunk) => Str::padRight($chunk, $interval, $padding),
+            str_split($integer, $interval)
+        );
 
         // Join pairs with the delimiter
         $result = implode($delimiter, $pairs);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Str;
 use NumberFormatter;
 use RuntimeException;
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -46,15 +46,15 @@ class Number
             $integer = Str::padRight($integer, ceil(strlen($integer) / $interval) * $interval, $padding);
         }
 
-        // Split the integer part into chunks of the specified interval 
+        // Split the integer part into chunks of the specified interval
         $pairs = Str::split($integer, $interval);
 
-        // Join pairs with the delimiter 
+        // Join pairs with the delimiter
         $result = implode($delimiter, $pairs);
 
         // Append decimal part if exists
-        if (! empty($decimal)) { 
-            $result .= '.'.$decimal; 
+        if (! empty($decimal)) {
+            $result .= '.'.$decimal;
         }
 
         return $result;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -48,7 +48,7 @@ class Number
 
         // Split the integer part into chunks of the specified interval using callback
         $pairs = array_map(
-            fn($chunk) => Str::padRight($chunk, $interval, $padding),
+            fn ($chunk) => Str::padRight($chunk, $interval, $padding),
             str_split($integer, $interval)
         );
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -59,7 +59,7 @@ class Number
 
         // Append decimal part if exists
         if ($decimal !== '') {
-            $result .= '.' . $decimal;
+            $result .= '.'.$decimal;
         }
 
         return $result;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,6 +25,47 @@ class Number
     protected static $currency = 'USD';
 
     /**
+     * Divides a number into pairs of specified intervals with optional delimiters and padding.
+     *
+     * @param  string|int|float  $number
+     * @param  int  $interval
+     * @param  string  $delimiter
+     * @param  string  $padding
+     * @return string
+     */
+    public static function divides(string|int|float $number, int $interval = 1, string $delimiter = '', string $padding = '')
+    {
+        // Convert number to string
+        $number = strval($number);
+
+        // Handle decimal part separately
+        $parts = explode('.', $number);
+        $number = $parts[0];
+        $decimal = $parts[1] ?? '';
+
+        $pairs = [];
+        $length = strlen($number);
+
+        for ($i = 0; $i < $length; $i += $interval) {
+            $segment = substr($number, $i, $interval);
+            if (strlen($segment) < $interval && $padding) {
+                $segment = str_pad($segment, $interval, $padding, STR_PAD_RIGHT);
+            }
+            $pairs[] = $segment;
+        }
+
+        // Join pairs with the delimiter
+        $result = implode($delimiter, $pairs);
+
+        // Append decimal part if exists
+        if ($decimal !== '') {
+            $result .= '.' . $decimal;
+        }
+
+        return $result;
+    }
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -33,33 +33,28 @@ class Number
      * @param  string  $padding
      * @return string
      */
-    public static function divides(string|int|float $number, int $interval = 1, string $delimiter = '', string $padding = '')
+    public static function group($number, int $interval = 1, string $delimiter = '', string $padding = '')
     {
         // Convert number to string
-        $number = strval($number);
+        $number = (string) $number;
 
         // Handle decimal part separately
-        $parts = explode('.', $number);
-        $number = $parts[0];
-        $decimal = $parts[1] ?? '';
+        [$integer, $decimal] = explode('.', $number.'.0');
 
-        $pairs = [];
-        $length = strlen($number);
-
-        for ($i = 0; $i < $length; $i += $interval) {
-            $segment = substr($number, $i, $interval);
-            if (strlen($segment) < $interval && $padding) {
-                $segment = str_pad($segment, $interval, $padding, STR_PAD_RIGHT);
-            }
-            $pairs[] = $segment;
+        // Pad the integer part to ensure it's a multiple of the interval
+        if ($padding) {
+            $integer = Str::padRight($integer, ceil(strlen($integer) / $interval) * $interval, $padding);
         }
 
-        // Join pairs with the delimiter
+        // Split the integer part into chunks of the specified interval 
+        $pairs = Str::split($integer, $interval);
+
+        // Join pairs with the delimiter 
         $result = implode($delimiter, $pairs);
 
         // Append decimal part if exists
-        if ($decimal !== '') {
-            $result .= '.'.$decimal;
+        if (! empty($decimal)) { 
+            $result .= '.'.$decimal; 
         }
 
         return $result;


### PR DESCRIPTION
### `group` Method

This method divides a given number into pairs of specified intervals, returning each segment in an array. It also supports adding delimiters and padding characters.

#### Parameters :
- `$number` : The number to be masked. This parameter can be a string, integer, or float.
- `$interval` : The length of each segment. The default value is 2.
- `$delimiter` : The character used to separate segments. The default value is an empty string ('').
- `$padding` : The character used to pad the last segment if it is shorter. The default value is an empty string ('').

#### Return :
- `string` The masked number with segments joined by the specified delimiter.

#### Example :

```php
use Illuminate\Support\Number;

// Example 1
Number::group(4465646434546464, 4); // Output : 4465 6464 3454 6464

// Example 2
Number::group('4465646434546464', 4, '-'); // Output : 4465-6464-3454-6464

// Example 3
Number::group(446564643454, 4, '-', 3434); // Output : 4465-6464-3454-3434

// Example 4
Number::group(12345.678, 2, '-'); // Output : 12-34-5.678

// Example 5
Number::group(4465646434546464, 0); // Output : 4465646434546464

// Example 6
Number::group(4465646434546464, 2, ':'); // Output : 44:65:64:64:34:54:64:64
```