### PR TITLE
Fix unique job lock is not released on model not found exception, lock gets stuck.

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -209,11 +209,11 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        if($this->hasUniqueJob($this->job)){
-            $this->addLockToContext($this->job);
-        }
+        $this->rememberLockIfJobIsUnique($this->job);
 
         if (! $this->shouldDispatch()) {
+            $this->forgetLockIfJobIsUnique($this->job);
+
             return;
         } elseif ($this->afterResponse) {
             app(Dispatcher::class)->dispatchAfterResponse($this->job);
@@ -221,8 +221,6 @@ class PendingDispatch
             app(Dispatcher::class)->dispatch($this->job);
         }
 
-        if($this->hasUniqueJob($this->job)){
-            $this->forgetLockFromContext();
-        }
+        $this->forgetLockIfJobIsUnique($this->job);
     }
 }

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -9,32 +9,36 @@ use Illuminate\Support\Arr;
 trait InteractsWithUniqueJobs
 {
     /**
-     * Determine if job has unique lock.
-     */
-    public function hasUniqueJob($job): bool
-    {
-        return $job instanceof ShouldBeUnique;
-    }
-
-    /**
      * Saves the used cache driver for the lock and
      * the lock key for emergency forceRelease in
      * case we can't instantiate a job instance.
      */
-    public function addLockToContext($job)
+    public function rememberLockIfJobIsUnique($job): void
     {
-        context()->addHidden([
-            'laravel_unique_job_cache_driver' => $this->getCacheDriver($job),
-            'laravel_unique_job_key' => $this->getKey($job),
-        ]);
+        if ($this->isUniqueJob($job)) {
+            context()->addHidden([
+                'laravel_unique_job_cache_driver' => $this->getCacheDriver($job),
+                'laravel_unique_job_key' => $this->getKey($job),
+            ]);
+        }
     }
 
     /**
      * forget the used lock.
      */
-    public function forgetLockFromContext(): void
+    public function forgetLockIfJobIsUnique($job): void
     {
-        context()->forgetHidden(['laravel_unique_job_cache_driver', 'laravel_unique_job_key']);
+        if ($this->isUniqueJob($job)) {
+            context()->forgetHidden(['laravel_unique_job_cache_driver', 'laravel_unique_job_key']);
+        }
+    }
+
+    /**
+     * Determine if job has unique lock.
+     */
+    private function isUniqueJob($job): bool
+    {
+        return $job instanceof ShouldBeUnique;
     }
 
     /**

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Foundation\Queue;
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Arr;
+
+trait InteractsWithUniqueJobs
+{
+    /**
+     * Determine if job has unique lock.
+     */
+    public function hasUniqueJob($job): bool
+    {
+        return $job instanceof ShouldBeUnique;
+    }
+
+    /**
+     * Saves the used cache driver for the lock and
+     * the lock key for emergency forceRelease in
+     * case we can't instantiate a job instance.
+     */
+    public function addLockToContext($job)
+    {
+        context()->addHidden([
+            'lockCacheDriver' => $this->getCacheDriver($job),
+            'lockKey' => $this->getKey($job),
+        ]);
+    }
+
+    /**
+     * forget the used lock.
+     */
+    public function forgetLockFromContext(): void
+    {
+        context()->forgetHidden(['lockCacheDriver', 'lockKey']);
+    }
+
+    /**
+     * Get the used cache driver as string from the config.
+     * CacheManger will handle invalid drivers.
+     */
+    private function getCacheDriver($job): ?string
+    {
+        /** @var \Illuminate\Cache\Repository */
+        $cache = method_exists($job, 'uniqueVia') ?
+            $job->uniqueVia() :
+            app()->make(Repository::class);
+
+        $store = collect(config('cache')['stores'])
+
+            ->firstWhere(
+                function ($store) use ($cache) {
+                    return $cache === rescue(fn () => cache()->driver(($store['driver'])));
+                }
+            );
+
+        return Arr::get($store, 'driver');
+    }
+
+    //NOTE: can I change visibility of the original method in src/Illuminate/Bus/UniqueLock.php ?
+    /**
+     * Generate the lock key for the given job.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    private function getKey($job)
+    {
+        $uniqueId = method_exists($job, 'uniqueId')
+                    ? $job->uniqueId()
+                    : ($job->uniqueId ?? '');
+
+        return 'laravel_unique_job:'.get_class($job).':'.$uniqueId;
+    }
+}

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -24,8 +24,8 @@ trait InteractsWithUniqueJobs
     public function addLockToContext($job)
     {
         context()->addHidden([
-            'lockCacheDriver' => $this->getCacheDriver($job),
-            'lockKey' => $this->getKey($job),
+            'laravel_unique_job_cache_driver' => $this->getCacheDriver($job),
+            'laravel_unique_job_key' => $this->getKey($job),
         ]);
     }
 
@@ -34,11 +34,11 @@ trait InteractsWithUniqueJobs
      */
     public function forgetLockFromContext(): void
     {
-        context()->forgetHidden(['lockCacheDriver', 'lockKey']);
+        context()->forgetHidden(['laravel_unique_job_cache_driver', 'laravel_unique_job_key']);
     }
 
     /**
-     * Get the used cache driver as string from the config.
+     * Get the used cache driver as string from the config,
      * CacheManger will handle invalid drivers.
      */
     private function getCacheDriver($job): ?string

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -208,6 +208,24 @@ class CallQueuedHandler
     }
 
     /**
+     * Ensure the lock for a unique job is released
+     * when can't instantiate a job instance.
+     *
+     * @return void
+     */
+    protected function ensureUniqueJobLockIsReleasedWithoutInstance()
+    {
+        /**  @var string  */
+        $driver = context()->getHidden('lockCacheDriver');
+        /**  @var string  */
+        $key = context()->getHidden('lockKey');
+
+        if ($driver && $key) {
+            cache()->driver($driver)->lock($key)->forceRelease();
+        }
+    }
+
+    /**
      * Handle a model not found exception.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -217,7 +235,7 @@ class CallQueuedHandler
     protected function handleModelNotFound(Job $job, $e)
     {
         $class = $job->resolveName();
-
+        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
         try {
             $reflectionClass = new ReflectionClass($class);
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -216,9 +216,9 @@ class CallQueuedHandler
     protected function ensureUniqueJobLockIsReleasedWithoutInstance()
     {
         /**  @var string  */
-        $driver = context()->getHidden('lockCacheDriver');
+        $driver = context()->getHidden('laravel_unique_job_cache_driver');
         /**  @var string  */
-        $key = context()->getHidden('lockKey');
+        $key = context()->getHidden('laravel_unique_job_key');
 
         if ($driver && $key) {
             cache()->driver($driver)->lock($key)->forceRelease();

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -209,7 +209,7 @@ class CallQueuedHandler
 
     /**
      * Ensure the lock for a unique job is released
-     * when can't instantiate a job instance.
+     * when can't unserialize the job instance.
      *
      * @return void
      */

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -235,7 +235,7 @@ class CallQueuedHandler
     protected function handleModelNotFound(Job $job, $e)
     {
         $class = $job->resolveName();
-        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
+
         try {
             $reflectionClass = new ReflectionClass($class);
 
@@ -248,6 +248,8 @@ class CallQueuedHandler
         if ($shouldDelete) {
             return $job->delete();
         }
+
+        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
 
         return $job->fail($e);
     }


### PR DESCRIPTION
# Overview
- [Bug description](#description)
- [Steps to reproduce](#steps_to_reproduce)
- [Cause](#cause)
- [Solution](#solution)

# Description
When using `SerializesModels` on a `Unique job` and the model is deleted before the job is being processed, `ModelNotFoundException` will be thrown and the job will fail and that's okay and well documented.
However the unique lock is not released and gets stuck until expired, this happens a lot with delayed jobs.

Related issues: #50211, #49890, possibly #37729

# Steps to reproduce
1- Create or open a laravel project, for ease of inspecting use `database` cache driver.

2- Create `TestJob.php` in your app/Jobs :

```php
<?php

namespace App\Jobs;

use App\Models\User;
use Illuminate\Contracts\Queue\ShouldBeUnique;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;

class TestJob implements ShouldQueue, ShouldBeUnique
{
    use InteractsWithQueue, Dispatchable, SerializesModels;

    public function __construct(public User $user) {}

    public function handle()
    {
    }

    public function uniqueId(): string
    {
        return "some_key";
    }
}

```

3- Add a test route to your `web.php`:

```php
<?php

use App\Jobs\TestJob;
use App\Models\User;
use Illuminate\Support\Facades\Route;

Route::get('test', function () {
    /** @var \App\Models\User */
    $user = User::factory()->create();

    dispatch(new TestJob($user));

    $user->delete();

    return "job will fail and lock will be stuck, if you refresh the page it won't dispatch again";
});

```

4- Run the web and queue servers via `composer run dev` and hit the `/test` route

5- Refresh the page and inspect your database's `cache_locks` and `failed_jobs` tables

![image](https://github.com/user-attachments/assets/4c3e5af4-e70f-4de1-bab3-75c717974313)

# Cause

## TLDR
No serialized job command instance = no unique lock to release

```php
    /**
     * Ensure the lock for a unique job is released.
     *
     * @param  mixed  $command
     * @return void
     */
    protected function ensureUniqueJobLockIsReleased($command)
    {
        if ($command instanceof ShouldBeUnique) {
            (new UniqueLock($this->container->make(Cache::class)))->release($command);
        }
    }
```
## In depth

`callQueuedHanlder.php`'s `call()` is responsible for handling the queued job, when we try to unserialize the payload of the job `ModelNotFoundException` is thrown because the model was deleted.

In this case we don't have a job command instance which is currently **required** to release the lock.

```php
    /**
     * Handle the queued job.
     *
     * @param  \Illuminate\Contracts\Queue\Job  $job
     * @param  array  $data
     * @return void
     */
    public function call(Job $job, array $data)
    {
        try {
            $command = $this->setJobInstanceIfNecessary(
                $job, $this->getCommand($data) //this fails
            );
        } catch (ModelNotFoundException $e) {
            return $this->handleModelNotFound($job, $e); //early return: this will call $job->fail() eventually triggering failed()
        }
        
      // unreachable code (depends on a job command instance and releases the lock)
      if ($command instanceof ShouldBeUniqueUntilProcessing) {
            $this->ensureUniqueJobLockIsReleased($command);
      }
      ...
    }
```

after `$this->handleMedelNotFound(...)` is done the job is marked as `failed` and the `failed()` method will be called:

```php
    /**
     * Call the failed method on the job instance.
     *
     * The exception that caused the failure will be passed.
     *
     * @param  array  $data
     * @param  \Throwable|null  $e
     * @param  string  $uuid
     * @return void
     */
    public function failed(array $data, $e, string $uuid)
    {
        $command = $this->getCommand($data); // this will fail again
        
        // unreachable code (depends on a job command instance and releases the lock)
        
        if (! $command instanceof ShouldBeUniqueUntilProcessing) { 
            $this->ensureUniqueJobLockIsReleased($command);
        }
        ...
     }
```

# Solution

## The idea
Wrap the job with a hidden context in order to have access to the lock key and the cache driver used, here's a simple overview of the flow:

```php

context()->addHidden([
    'lock_key' => $lockKey,
    'cache_driver' => $cacheDriver
]);

dispatch(new TestJob($user));

context()->forgetHidden(['lock_key','cache_driver']);

```

Now when handling `ModelNotFoundException` via the `handleModelNotFound()` method, we can forceRelease the lock by using the provided `cache_driver` and `lock_key` from the hidden context

```php
        $driver = context()->getHidden('cache_driver');

        $key = context()->getHidden('lock_key');

        if ($driver && $key) {
            cache()->driver($driver)->lock($key)->forceRelease();
        }
```

## Implementation
See code diff.

If this gets closed for any reason use my test to research and implement another possible solution, add this to `tests/Integration/Queue/UniqueTestJob.php`

```php
    use Orchestra\Testbench\Factories\UserFactory;

    public function testLockIsReleasedOnModelNotFoundException()
    {
        UniqueTestSerializesModelsJob::$handled = false;

        /**  @var  \Illuminate\Foundation\Auth\User */
        $user = UserFactory::new()->create();
        $job = new UniqueTestSerializesModelsJob($user);

        $this->expectException(ModelNotFoundException::class);

        try {
            $user->delete();
            dispatch($job);
        } finally {
            $this->assertFalse($job::$handled);
            $this->assertModelMissing($user);
            $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
        }
    }


class UniqueTestSerializesModelsJob extends UniqueTestJob
{
    use SerializesModels;

    public function __construct(public User $user) {}
}
```
