### PR TITLE
[11.x] Fix unique job lock is not released on model not found exception, lock gets stuck.

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -64,7 +64,7 @@ class UniqueLock
      * @param  mixed  $job
      * @return string
      */
-    protected function getKey($job)
+    public static function getKey($job)
     {
         $uniqueId = method_exists($job, 'uniqueId')
                     ? $job->uniqueId()

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
 class PendingDispatch
 {
     use InteractsWithUniqueJobs;
+
     /**
      * The job.
      *
@@ -209,10 +210,10 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        $this->rememberLockIfJobIsUnique($this->job);
+        $this->addUniqueJobInformationToContext($this->job);
 
         if (! $this->shouldDispatch()) {
-            $this->forgetLockIfJobIsUnique($this->job);
+            $this->removeUniqueJobInformationFromContext($this->job);
 
             return;
         } elseif ($this->afterResponse) {
@@ -221,6 +222,6 @@ class PendingDispatch
             app(Dispatcher::class)->dispatch($this->job);
         }
 
-        $this->forgetLockIfJobIsUnique($this->job);
+        $this->removeUniqueJobInformationFromContext($this->job);
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -209,11 +209,11 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        if($this->hasUniqueJob($this->job)){
-            $this->addLockToContext($this->job);
-        }
+        $this->rememberLockIfJobIsUnique($this->job);
 
         if (! $this->shouldDispatch()) {
+            $this->forgetLockIfJobIsUnique($this->job);
+
             return;
         } elseif ($this->afterResponse) {
             app(Dispatcher::class)->dispatchAfterResponse($this->job);
@@ -221,8 +221,6 @@ class PendingDispatch
             app(Dispatcher::class)->dispatch($this->job);
         }
 
-        if($this->hasUniqueJob($this->job)){
-            $this->forgetLockFromContext();
-        }
+        $this->forgetLockIfJobIsUnique($this->job);
     }
 }

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -18,7 +18,7 @@ trait InteractsWithUniqueJobs
     {
         if ($this->isUniqueJob($job)) {
             Context::addHidden([
-                'laravel_unique_job_cache_driver' => $this->getUniqueJobCacheStore($job),
+                'laravel_unique_job_cache_store' => $this->getUniqueJobCacheStore($job),
                 'laravel_unique_job_key' => UniqueLock::getKey($job),
             ]);
         }
@@ -34,7 +34,7 @@ trait InteractsWithUniqueJobs
     {
         if ($this->isUniqueJob($job)) {
             Context::forgetHidden([
-                'laravel_unique_job_cache_driver',
+                'laravel_unique_job_cache_store',
                 'laravel_unique_job_key',
             ]);
         }

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -56,7 +56,7 @@ trait InteractsWithUniqueJobs
 
             ->firstWhere(
                 function ($store) use ($cache) {
-                    return $cache === rescue(fn () => cache()->driver(($store['driver'])));
+                    return $cache === rescue(fn () => cache()->driver($store['driver']));
                 }
             );
 

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -9,32 +9,36 @@ use Illuminate\Support\Arr;
 trait InteractsWithUniqueJobs
 {
     /**
-     * Determine if job has unique lock.
-     */
-    public function hasUniqueJob($job): bool
-    {
-        return $job instanceof ShouldBeUnique;
-    }
-
-    /**
      * Saves the used cache driver for the lock and
      * the lock key for emergency forceRelease in
      * case we can't instantiate a job instance.
      */
-    public function addLockToContext($job)
+    public function rememberLockIfJobIsUnique($job): void
     {
-        context()->addHidden([
-            'laravel_unique_job_cache_driver' => $this->getCacheDriver($job),
-            'laravel_unique_job_key' => $this->getKey($job),
-        ]);
+        if ($this->isUniqueJob($job)) {
+            context()->addHidden([
+                'laravel_unique_job_cache_driver' => $this->getCacheDriver($job),
+                'laravel_unique_job_key' => $this->getKey($job),
+            ]);
+        }
     }
 
     /**
      * forget the used lock.
      */
-    public function forgetLockFromContext(): void
+    public function forgetLockIfJobIsUnique($job): void
     {
-        context()->forgetHidden(['laravel_unique_job_cache_driver', 'laravel_unique_job_key']);
+        if ($this->isUniqueJob($job)) {
+            context()->forgetHidden(['laravel_unique_job_cache_driver', 'laravel_unique_job_key']);
+        }
+    }
+
+    /**
+     * Determine if job has unique lock.
+     */
+    private function isUniqueJob($job): bool
+    {
+        return $job instanceof ShouldBeUnique;
     }
 
     /**

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Foundation\Queue;
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Arr;
+
+trait InteractsWithUniqueJobs
+{
+    /**
+     * Determine if job has unique lock.
+     */
+    public function hasUniqueJob($job): bool
+    {
+        return $job instanceof ShouldBeUnique;
+    }
+
+    /**
+     * Saves the used cache driver for the lock and
+     * the lock key for emergency forceRelease in
+     * case we can't instantiate a job instance.
+     */
+    public function addLockToContext($job)
+    {
+        context()->addHidden([
+            'lockCacheDriver' => $this->getCacheDriver($job),
+            'lockKey' => $this->getKey($job),
+        ]);
+    }
+
+    /**
+     * forget the used lock.
+     */
+    public function forgetLockFromContext(): void
+    {
+        context()->forgetHidden(['lockCacheDriver', 'lockKey']);
+    }
+
+    /**
+     * Get the used cache driver as string from the config.
+     * CacheManger will handle invalid drivers.
+     */
+    private function getCacheDriver($job): ?string
+    {
+        /** @var \Illuminate\Cache\Repository */
+        $cache = method_exists($job, 'uniqueVia') ?
+            $job->uniqueVia() :
+            app()->make(Repository::class);
+
+        $store = collect(config('cache')['stores'])
+
+            ->firstWhere(
+                function ($store) use ($cache) {
+                    return $cache === rescue(fn () => cache()->driver(($store['driver'])));
+                }
+            );
+
+        return Arr::get($store, 'driver');
+    }
+
+    //NOTE: can I change visibility of the original method in src/Illuminate/Bus/UniqueLock.php ?
+    /**
+     * Generate the lock key for the given job.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    private function getKey($job)
+    {
+        $uniqueId = method_exists($job, 'uniqueId')
+                    ? $job->uniqueId()
+                    : ($job->uniqueId ?? '');
+
+        return 'laravel_unique_job:'.get_class($job).':'.$uniqueId;
+    }
+}

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -24,8 +24,8 @@ trait InteractsWithUniqueJobs
     public function addLockToContext($job)
     {
         context()->addHidden([
-            'lockCacheDriver' => $this->getCacheDriver($job),
-            'lockKey' => $this->getKey($job),
+            'laravel_unique_job_cache_driver' => $this->getCacheDriver($job),
+            'laravel_unique_job_key' => $this->getKey($job),
         ]);
     }
 
@@ -34,11 +34,11 @@ trait InteractsWithUniqueJobs
      */
     public function forgetLockFromContext(): void
     {
-        context()->forgetHidden(['lockCacheDriver', 'lockKey']);
+        context()->forgetHidden(['laravel_unique_job_cache_driver', 'laravel_unique_job_key']);
     }
 
     /**
-     * Get the used cache driver as string from the config.
+     * Get the used cache driver as string from the config,
      * CacheManger will handle invalid drivers.
      */
     private function getCacheDriver($job): ?string

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -11,12 +11,12 @@ trait InteractsWithUniqueJobs
     /**
      * Store unique job information in the context in case we can't resolve the job on the queue side.
      *
-     * @param  object  $job
+     * @param  mixed  $job
      * @return void
      */
     public function addUniqueJobInformationToContext($job): void
     {
-        if ($this->isUniqueJob($job)) {
+        if ($job instanceof ShouldBeUnique) {
             Context::addHidden([
                 'laravel_unique_job_cache_store' => $this->getUniqueJobCacheStore($job),
                 'laravel_unique_job_key' => UniqueLock::getKey($job),
@@ -27,12 +27,12 @@ trait InteractsWithUniqueJobs
     /**
      * Remove the unique job information from the context.
      *
-     * @param  object  $job
+     * @param  mixed  $job
      * @return void
      */
     public function removeUniqueJobInformationFromContext($job): void
     {
-        if ($this->isUniqueJob($job)) {
+        if ($job instanceof ShouldBeUnique) {
             Context::forgetHidden([
                 'laravel_unique_job_cache_store',
                 'laravel_unique_job_key',
@@ -43,24 +43,13 @@ trait InteractsWithUniqueJobs
     /**
      * Determine the cache store used by the unique job to acquire locks.
      *
-     * @param  object  $job
-     * @return string
+     * @param  mixed  $job
+     * @return string|null
      */
-    private function getUniqueJobCacheStore($job): ?string
+    protected function getUniqueJobCacheStore($job): ?string
     {
         return method_exists($job, 'uniqueVia')
-            ? $job->uniqueVia()
+            ? $job->uniqueVia()->getName()
             : config('cache.default');
-    }
-
-    /**
-     * Determine if job uses unique locks.
-     *
-     * @param  mixed  $job
-     * @return bool
-     */
-    private function isUniqueJob($job): bool
-    {
-        return $job instanceof ShouldBeUnique;
     }
 }

--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -54,7 +54,7 @@ trait InteractsWithUniqueJobs
     }
 
     /**
-     * Determine if job should be unique.
+     * Determine if job uses unique locks.
      *
      * @param  mixed  $job
      * @return bool

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -208,6 +208,24 @@ class CallQueuedHandler
     }
 
     /**
+     * Ensure the lock for a unique job is released
+     * when can't instantiate a job instance.
+     *
+     * @return void
+     */
+    protected function ensureUniqueJobLockIsReleasedWithoutInstance()
+    {
+        /**  @var string  */
+        $driver = context()->getHidden('lockCacheDriver');
+        /**  @var string  */
+        $key = context()->getHidden('lockKey');
+
+        if ($driver && $key) {
+            cache()->driver($driver)->lock($key)->forceRelease();
+        }
+    }
+
+    /**
      * Handle a model not found exception.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -217,7 +235,7 @@ class CallQueuedHandler
     protected function handleModelNotFound(Job $job, $e)
     {
         $class = $job->resolveName();
-
+        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
         try {
             $reflectionClass = new ReflectionClass($class);
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -208,24 +208,6 @@ class CallQueuedHandler
     }
 
     /**
-     * Ensure the lock for a unique job is released
-     * when can't unserialize the job instance.
-     *
-     * @return void
-     */
-    protected function ensureUniqueJobLockIsReleasedWithoutInstance()
-    {
-        /** @var string */
-        $driver = context()->getHidden('laravel_unique_job_cache_driver');
-        /** @var string */
-        $key = context()->getHidden('laravel_unique_job_key');
-
-        if ($driver && $key) {
-            cache()->driver($driver)->lock($key)->forceRelease();
-        }
-    }
-
-    /**
      * Handle a model not found exception.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -252,6 +234,24 @@ class CallQueuedHandler
         }
 
         return $job->fail($e);
+    }
+
+    /**
+     * Ensure the lock for a unique job is released
+     * when can't unserialize the job instance.
+     *
+     * @return void
+     */
+    protected function ensureUniqueJobLockIsReleasedWithoutInstance()
+    {
+        /** @var string */
+        $driver = context()->getHidden('laravel_unique_job_cache_driver');
+        /** @var string */
+        $key = context()->getHidden('laravel_unique_job_key');
+
+        if ($driver && $key) {
+            cache()->driver($driver)->lock($key)->forceRelease();
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -216,9 +216,9 @@ class CallQueuedHandler
     protected function ensureUniqueJobLockIsReleasedWithoutInstance()
     {
         /**  @var string  */
-        $driver = context()->getHidden('lockCacheDriver');
+        $driver = context()->getHidden('laravel_unique_job_cache_driver');
         /**  @var string  */
-        $key = context()->getHidden('lockKey');
+        $key = context()->getHidden('laravel_unique_job_key');
 
         if ($driver && $key) {
             cache()->driver($driver)->lock($key)->forceRelease();

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -13,6 +14,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use ReflectionClass;
@@ -227,7 +229,7 @@ class CallQueuedHandler
             $shouldDelete = false;
         }
 
-        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
+        $this->ensureUniqueJobLockIsReleasedViaContext();
 
         if ($shouldDelete) {
             return $job->delete();
@@ -237,20 +239,31 @@ class CallQueuedHandler
     }
 
     /**
-     * Ensure the lock for a unique job is released
-     * when can't unserialize the job instance.
+     * Ensure the lock for a unique job is released via context.
+     *
+     * This is required when we can't unserialize the job due to missing models.
      *
      * @return void
      */
-    protected function ensureUniqueJobLockIsReleasedWithoutInstance()
+    protected function ensureUniqueJobLockIsReleasedViaContext()
     {
-        /** @var string */
-        $store = context()->getHidden('laravel_unique_job_cache_store');
-        /** @var string */
-        $key = context()->getHidden('laravel_unique_job_key');
+        if (! $this->container->bound(ContextRepository::class) ||
+            ! $this->container->bound(CacheFactory::class)) {
+            return;
+        }
+
+        $context = $this->container->make(ContextRepository::class);
+
+        [$store, $key] = [
+            $context->getHidden('laravel_unique_job_cache_store'),
+            $context->getHidden('laravel_unique_job_key'),
+        ];
 
         if ($store && $key) {
-            cache()->store($store)->lock($key)->forceRelease();
+            $this->container->make(CacheFactory::class)
+                ->store($store)
+                ->lock($key)
+                ->forceRelease();
         }
     }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -209,7 +209,7 @@ class CallQueuedHandler
 
     /**
      * Ensure the lock for a unique job is released
-     * when can't instantiate a job instance.
+     * when can't unserialize the job instance.
      *
      * @return void
      */

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -245,12 +245,12 @@ class CallQueuedHandler
     protected function ensureUniqueJobLockIsReleasedWithoutInstance()
     {
         /** @var string */
-        $driver = context()->getHidden('laravel_unique_job_cache_driver');
+        $store = context()->getHidden('laravel_unique_job_cache_store');
         /** @var string */
         $key = context()->getHidden('laravel_unique_job_key');
 
-        if ($driver && $key) {
-            cache()->driver($driver)->lock($key)->forceRelease();
+        if ($store && $key) {
+            cache()->store($store)->lock($key)->forceRelease();
         }
     }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -215,9 +215,9 @@ class CallQueuedHandler
      */
     protected function ensureUniqueJobLockIsReleasedWithoutInstance()
     {
-        /**  @var string  */
+        /** @var string */
         $driver = context()->getHidden('laravel_unique_job_cache_driver');
-        /**  @var string  */
+        /** @var string */
         $key = context()->getHidden('laravel_unique_job_key');
 
         if ($driver && $key) {

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -235,7 +235,7 @@ class CallQueuedHandler
     protected function handleModelNotFound(Job $job, $e)
     {
         $class = $job->resolveName();
-        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
+
         try {
             $reflectionClass = new ReflectionClass($class);
 
@@ -248,6 +248,8 @@ class CallQueuedHandler
         if ($shouldDelete) {
             return $job->delete();
         }
+
+        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
 
         return $job->fail($e);
     }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -245,11 +245,11 @@ class CallQueuedHandler
             $shouldDelete = false;
         }
 
+        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
+
         if ($shouldDelete) {
             return $job->delete();
         }
-
-        $this->ensureUniqueJobLockIsReleasedWithoutInstance();
 
         return $job->fail($e);
     }

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -147,6 +147,7 @@ class UniqueJobTest extends QueueTestCase
         try {
             $user->delete();
             dispatch($job);
+            $this->runQueueWorkerCommand(['--once' => true]);
             unserialize(serialize($job));
         } finally {
             $this->assertFalse($job::$handled);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -9,13 +9,13 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Factories\UserFactory;
-use Illuminate\Foundation\Auth\User;
 
 #[WithMigration]
 #[WithMigration('cache')]
@@ -138,7 +138,7 @@ class UniqueJobTest extends QueueTestCase
     {
         UniqueTestSerializesModelsJob::$handled = false;
 
-        /**  @var  \Illuminate\Foundation\Auth\User */
+        /** @var \Illuminate\Foundation\Auth\User */
         $user = UserFactory::new()->create();
         $job = new UniqueTestSerializesModelsJob($user);
 
@@ -214,5 +214,7 @@ class UniqueTestSerializesModelsJob extends UniqueTestJob
 {
     use SerializesModels;
 
-    public function __construct(public User $user) {}
+    public function __construct(public User $user)
+    {
+    }
 }

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -146,7 +146,8 @@ class UniqueJobTest extends QueueTestCase
 
         try {
             $user->delete();
-            dispatch($job);
+            dispatch_sync($job);
+            unserialize(serialize($job));
         } finally {
             $this->assertFalse($job::$handled);
             $this->assertModelMissing($user);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -146,7 +146,7 @@ class UniqueJobTest extends QueueTestCase
 
         try {
             $user->delete();
-            dispatch_sync($job);
+            dispatch($job);
             unserialize(serialize($job));
         } finally {
             $this->assertFalse($job::$handled);
@@ -214,6 +214,8 @@ class UniqueUntilStartTestJob extends UniqueTestJob implements ShouldBeUniqueUnt
 class UniqueTestSerializesModelsJob extends UniqueTestJob
 {
     use SerializesModels;
+
+    public $deleteWhenMissingModels = true;
 
     public function __construct(public User $user)
     {


### PR DESCRIPTION
<details>
<summary>Description</summary>

When using `SerializesModels` on a `Unique job` and the model is deleted before the job is being processed, `ModelNotFoundException` will be thrown and the job will fail and that's okay and well documented.
However the unique lock is not released and gets stuck until expired, this happens a lot with delayed jobs.

Related issues: #50211, #49890, possibly #37729
</details>

<details>
<summary>Steps to reproduce</summary>

1- Create or open a laravel project, for ease of inspecting use `database` cache driver.

2- Create `TestJob.php` in your app/Jobs :

```php
<?php

namespace App\Jobs;

use App\Models\User;
use Illuminate\Contracts\Queue\ShouldBeUnique;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;

class TestJob implements ShouldQueue, ShouldBeUnique
{
    use InteractsWithQueue, Dispatchable, SerializesModels;

    public function __construct(public User $user) {}

    public function handle()
    {
    }

    public function uniqueId(): string
    {
        return "some_key";
    }
}

```

3- Add a test route to your `web.php`:

```php
<?php

use App\Jobs\TestJob;
use App\Models\User;
use Illuminate\Support\Facades\Route;

Route::get('test', function () {
    /** @var \App\Models\User */
    $user = User::factory()->create();

    dispatch(new TestJob($user));

    $user->delete();

    return "job will fail and lock will be stuck, if you refresh the page it won't dispatch again";
});

```

4- Run the web and queue servers via `composer run dev` and hit the `/test` route

5- Refresh the page and inspect your database's `cache_locks` and `failed_jobs` tables

![image](https://github.com/user-attachments/assets/4c3e5af4-e70f-4de1-bab3-75c717974313)
</details>

<details>
<summary>Cause</summary>

## TLDR
No serialized job command instance = no unique lock to release

```php
    /**
     * Ensure the lock for a unique job is released.
     *
     * @param  mixed  $command
     * @return void
     */
    protected function ensureUniqueJobLockIsReleased($command)
    {
        if ($command instanceof ShouldBeUnique) {
            (new UniqueLock($this->container->make(Cache::class)))->release($command);
        }
    }
```
## In depth

`callQueuedHanlder.php`'s `call()` is responsible for handling the queued job, when we try to unserialize the payload of the job `ModelNotFoundException` is thrown because the model was deleted.

In this case we don't have a job command instance which is currently **required** to release the lock.

```php
    /**
     * Handle the queued job.
     *
     * @param  \Illuminate\Contracts\Queue\Job  $job
     * @param  array  $data
     * @return void
     */
    public function call(Job $job, array $data)
    {
        try {
            $command = $this->setJobInstanceIfNecessary(
                $job, $this->getCommand($data) //this fails
            );
        } catch (ModelNotFoundException $e) {
            return $this->handleModelNotFound($job, $e); //early return: this will call $job->fail() eventually triggering failed()
        }
        
      // unreachable code (depends on a job command instance and releases the lock)
      if ($command instanceof ShouldBeUniqueUntilProcessing) {
            $this->ensureUniqueJobLockIsReleased($command);
      }
      ...
    }
```

after `$this->handleMedelNotFound(...)` is done the job is marked as `failed` and the `failed()` method will be called:

```php
    /**
     * Call the failed method on the job instance.
     *
     * The exception that caused the failure will be passed.
     *
     * @param  array  $data
     * @param  \Throwable|null  $e
     * @param  string  $uuid
     * @return void
     */
    public function failed(array $data, $e, string $uuid)
    {
        $command = $this->getCommand($data); // this will fail again
        
        // unreachable code (depends on a job command instance and releases the lock)
        
        if (! $command instanceof ShouldBeUniqueUntilProcessing) { 
            $this->ensureUniqueJobLockIsReleased($command);
        }
        ...
     }
```
</details>

<details>
<summary>Solution</summary>

## The idea
Wrap the job with a hidden context in order to have access to the lock key and the cache driver used, here's a simple overview of the flow:

```php

context()->addHidden([
    'lock_key' => $lockKey,
    'cache_driver' => $cacheDriver
]);

dispatch(new TestJob($user));

context()->forgetHidden(['lock_key','cache_driver']);

```

Now when handling `ModelNotFoundException` via the `handleModelNotFound()` method, we can forceRelease the lock by using the provided `cache_driver` and `lock_key` from the hidden context

```php
        $driver = context()->getHidden('cache_driver');

        $key = context()->getHidden('lock_key');

        if ($driver && $key) {
            cache()->driver($driver)->lock($key)->forceRelease();
        }
```
</details>

<details>
<summary>Implementation</summary>
See code diff.
</details>

If this gets closed for any reason use my test to research and implement another possible solution, add this to `tests/Integration/Queue/UniqueTestJob.php`

```php
    use Orchestra\Testbench\Factories\UserFactory;

    public function testLockIsReleasedOnModelNotFoundException()
    {
        UniqueTestSerializesModelsJob::$handled = false;

        /**  @var  \Illuminate\Foundation\Auth\User */
        $user = UserFactory::new()->create();
        $job = new UniqueTestSerializesModelsJob($user);

        $this->expectException(ModelNotFoundException::class);

        try {
            $user->delete();
            dispatch($job);
            $this->runQueueWorkerCommand(['--once' => true]);
            unserialize(serialize($job));
        } finally {
            $this->assertFalse($job::$handled);
            $this->assertModelMissing($user);
            $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());
        }
    }


class UniqueTestSerializesModelsJob extends UniqueTestJob
{
    use SerializesModels;

    public function __construct(public User $user) {}
}
```
