### PR TITLE
[11.x] Allow `when()` to accept Closure condition parameter

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -248,6 +248,8 @@ if (! function_exists('when')) {
      */
     function when($condition, $value, $default = null)
     {
+        $condition = $condition instanceof Closure ? $condition() : $condition;
+
         if ($condition) {
             return value($value, $condition);
         }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -134,6 +134,8 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('False', when([], 'True', 'False'));  // Empty Array = Falsy
         $this->assertTrue(when(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
         $this->assertTrue(when(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
+        $this->assertEquals('Hello', when(fn () => true, 'Hello')); // lazy evaluation condition
+        $this->assertEquals('World', when(fn () => false, 'Hello', 'World')); // lazy evaluation condition
     }
 
     public function testFilled()


### PR DESCRIPTION
This PR allows the standalone `when()` helper function to accept a Closure as the condition, which brings it into line with the `Conditionable` trait, which behaves the same way. It's handy when the condition may be expensive or a few lines of code.

I also did notice the helper method here is in the `Collections` namespace, however the tests suggest it belongs in `Support`. However I figured this might be a breaking change so I left it where it is, but I can move it if necessary.