### PR TITLE
[11.x] Fix/Improve Resend transport response handling

### DIFF
--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail\Transport;
 
 use Exception;
 use Resend\Contracts\Client;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
@@ -97,6 +98,8 @@ class ResendTransport extends AbstractTransport
                 'text' => $email->getTextBody(),
                 'attachments' => $attachments,
             ]);
+
+            throw_if($result['statusCode'] != Response::HTTP_OK, Exception::class, $result['message']);
         } catch (Exception $exception) {
             throw new TransportException(
                 sprintf('Request to Resend API failed. Reason: %s.', $exception->getMessage()),


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### Purpose of this PR
This small PR improves the error messages displayed when the Resend API returns an HTTP status code other than `200`. The goal is to make errors easier to understand without requiring extensive debugging.

### Problem
For example, when the daily quota is reached, the application throws an exception that lacks clarity:
`Symfony\Component\Mime\Header\Headers::addTextHeader(): Argument #2 ($value) must be of type string, null given, called in /home/nikola/Projects/project/vendor/symfony/mime/Header/Headers.php on line 154`

### Solution
With this PR, such cases are handled gracefully, and a clearer error message is provided. For instance, when the daily quota is reached, the error would now read:
`Request to Resend API failed. Reason: You have reached your daily email sending quota.`

#### Resend response codes
![2024-12-23_18-00 (1)](https://github.com/user-attachments/assets/57e5d213-cbbc-4002-95f3-0c5353db3807)

