### PR TITLE
[12.x] Allow `when()` helper to accept Closure condition parameter

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -248,6 +248,8 @@ if (! function_exists('when')) {
      */
     function when($condition, $value, $default = null)
     {
+        $condition = $condition instanceof Closure ? $condition() : $condition;
+
         if ($condition) {
             return value($value, $condition);
         }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -134,6 +134,8 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('False', when([], 'True', 'False'));  // Empty Array = Falsy
         $this->assertTrue(when(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
         $this->assertTrue(when(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
+        $this->assertEquals('Hello', when(fn () => true, 'Hello')); // lazy evaluation condition
+        $this->assertEquals('World', when(fn () => false, 'Hello', 'World')); // lazy evaluation condition
     }
 
     public function testFilled()


### PR DESCRIPTION
https://github.com/laravel/framework/pull/54003 but for 12.x as it's breaking change. Also, I guess technically it's a bug fix, since anyone passing a callable to `when()` as the condition would always be getting true (https://3v4l.org/SqMUh). 