### PR TITLE
[11.x] Update View::withErrors() docblock to reflect string parameter support

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -275,7 +275,7 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
     /**
      * Add validation errors to the view.
      *
-     * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
+     * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider
      * @param  string  $bag
      * @return $this
      */


### PR DESCRIPTION
Sync the type hint in `View::withErrors()` docblock to match `formatErrors()` by adding `string` type to the `$provider` parameter. This fixes static analysis warnings when passing string values to `withErrors()`.