### PR TITLE
Add support for array views in `MailFake`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -501,11 +501,9 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     protected function sendMail($view, $shouldQueue = false)
     {
-        if (! $view instanceof Mailable) {
-            return;
+        if ($view instanceof Mailable) {
+            $view->mailer($this->currentMailer);
         }
-
-        $view->mailer($this->currentMailer);
 
         if ($shouldQueue) {
             return $this->queue($view);

--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Mail\Mailable;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
 use Orchestra\Testbench\TestCase;
 
@@ -38,6 +40,36 @@ class SupportMailTest extends TestCase
         Mail::to('hello@laravel.com')->send(new TestMail());
 
         Mail::assertSent(TestMail::class);
+    }
+
+    public function testNotificationEmailSent()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        $notification = new class extends Notification
+        {
+            public function via($notifiable)
+            {
+                return ['mail'];
+            }
+
+            public function toMail($notifiable)
+            {
+                return new TestMail();
+            }
+        };
+
+        $notifiable = new class
+        {
+            use Notifiable;
+
+            public $email = 'hello@laravel.com';
+        };
+
+        \Illuminate\Support\Facades\Notification::send($notifiable, $notification);
+
+        Mail::assertSentCount(1);
     }
 }
 


### PR DESCRIPTION
The `Mailable` class has a `send` method that builds an array representation of a view and passes it to `send` on the `Mailer`.

That then calls the `sendMail` method on `MailFake` which return early if the given `$view` was not an instance of `Mailable`.

As a result, any codepath that attempts to send a mailable via `$mailable->send($mailer)` cannot be tested using the `MailFake`.

The example that lead me to this is Notifications.

This PR adjusts the `MailFake` slightly so that array views _are_ tracked. This makes it possible to assert the "sent count".

It doesn't really work with the other methods i.e. `Mail::assertSent`, but fixing that is a bigger issue then I want to propose without consultation from the core team.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Personal Context

I'm trying to write some comprehensive integration tests around a Notification. 

It is effectively a "New Message" notification that's going to be sent via both database and mail channels. It'll get saved to the database immediately, but the mail channel has more logic. The email will be both delayed and rate-limited. If a user gets sent 10 messages in that half-hour, they should only get 1 email listing them all. But also, if they see the notification in-app before the delay is up, then 0 emails will be sent.

The issue solved by this PR was blocking my ability to make sure the first email was sent by a notification, even without a delay.

