### PR TITLE
Adds tagging abilities to Benchmark

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -7,6 +7,146 @@ use Closure;
 class Benchmark
 {
     /**
+     * The tasks to be measured by the benchmark.
+     *
+     * @var array<string, float|float[]>
+     */
+    protected static array $tasks = [];
+
+    /**
+     * Start measuring the time for the given task.
+     *
+     * @param  string  $task
+     * @return void
+     */
+    public static function start(string $task): void
+    {
+        static::$tasks[$task]['start'] = hrtime(true);
+    }
+
+    /**
+     * Tags a task with a given tag. If the tag already exists
+     * the time will be computed against that previous tag.
+     *
+     * @param  string  $task
+     * @param  ?string  $tag
+     * @return float
+     */
+    public static function tag(string $task, ?string $tag = null): float
+    {
+        $tag ??= sprintf('tag.%s', count(static::$tasks[$task]));
+
+        return static::$tasks[$task][$tag] = static::computeTime(static::$tasks[$task]['start']);
+    }
+
+    /**
+     * Alias for `getTask`.
+     *
+     * @param  string  $task
+     * @return array<string, float>
+     */
+    public static function getTags(string $task): array
+    {
+        return static::getTask($task);
+    }
+
+    /**
+     * Get the tags for the given task.
+     *
+     * @param  string  $task
+     * @return array<string, float>
+     */
+    public static function getTask(string $task): array
+    {
+        return static::$tasks[$task];
+    }
+
+    /**
+     * Get the time in milliseconds since the given task started.
+     * Additionally, a tag can be provided to divide the task.
+     *
+     * @param  string  $task
+     * @param  ?string  $tag
+     * @param  bool  $deleteTask
+     * @return array<string, float>|float
+     */
+    public static function task(string $task, ?string $tag = null, bool $deleteTask = false): array|float
+    {
+        $tags = static::$tasks[$task];
+
+        if ($deleteTask) {
+            static::reset($task);
+        }
+
+        return $tag ? $tags[$tag] : $tags;
+    }
+
+    /**
+     * Stop measuring the time for the given task.
+     *
+     * @param  string  $task
+     * @return array<string, float>
+     */
+    public static function stop(string $task): array
+    {
+        static::$tasks[$task]['stop'] = hrtime(true);
+        $tags = static::$tasks[$task];
+        static::reset($task);
+
+        $tags['total'] = ($tags['stop'] - $tags['start']) / 1000000;
+        unset($tags['start'], $tags['stop']);
+
+        return $tags;
+    }
+
+    /**
+     * Compute the time in milliseconds between two tags.
+     *
+     * @param  string  $task
+     * @param  string  $start
+     * @param  string  $end
+     * @return float
+     */
+    public static function computeTags(string $task, string $start, string $end): float
+    {
+        $start = static::$tasks[$task][$start] ?? throw new \InvalidArgumentException(
+            sprintf('The start tag "%s" does not exist.', $start)
+        );
+        $end = static::$tasks[$task][$end] ?? throw new \InvalidArgumentException(
+            sprintf('The end tag "%s" does not exist.', $end)
+        );
+
+        return ($end - $start) / 1000000;
+    }
+
+    /**
+     * Reset the tasks.
+     *
+     * @param  ?string  $task
+     * @return void
+     */
+    public static function reset(?string $task = null): void
+    {
+        if ($task) {
+            unset(static::$tasks[$task]);
+            return;
+        }
+
+        static::$tasks = [];
+    }
+
+    /**
+     * Compute the time in milliseconds since the given time.
+     *
+     * @param  float  $time
+     * @return float
+     */
+    protected static function computeTime(float $time): float
+    {
+        return (hrtime(true) - $time) / 1000000;
+    }
+
+    /**
      * Measure a callable or array of callables over the given number of iterations.
      *
      * @param  \Closure|array  $benchmarkables

--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -127,6 +127,7 @@ class Benchmark
     {
         if ($task) {
             unset(static::$tasks[$task]);
+
             return;
         }
 

--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -104,17 +104,15 @@ class Benchmark
      *
      * @param  string  $task
      * @param  string  $start
-     * @param  string  $end
+     * @param  ?string  $end
      * @return float
      */
-    public static function computeTags(string $task, string $start, string $end): float
+    public static function computeTags(string $task, string $start, ?string $end = null): float
     {
         $start = static::$tasks[$task][$start] ?? throw new \InvalidArgumentException(
             sprintf('The start tag "%s" does not exist.', $start)
         );
-        $end = static::$tasks[$task][$end] ?? throw new \InvalidArgumentException(
-            sprintf('The end tag "%s" does not exist.', $end)
-        );
+        $end = static::$tasks[$task][$end] ?? hrtime(true);
 
         return ($end - $start) / 1000000;
     }


### PR DESCRIPTION
# Adds tagging abilities to Benchmark

Currently, the Benchmark class allows to only run closures or collections of closures.

Whilst those features are great for specific closures/functions, the Benchmark class lacks some flexibility to allow measuring the code at different points/stages.

This feature adds the ability to use the Benchmark class in different points of the code by naming the sections. It also allows tagging each section in smaller blocks to increase flexibility.

## Usage:

```
use Illuminate\Support\Benchmark;

class MyClass
{
    public function doSomething(): void
    {
        Benchmark::start('full time'); // initializes a group of tasks

        Benchmark::start('initial tasks'); // initializes a second group of tasks. The initial tag will be named `start`
        Benchmark::tag('initial tasks', 'first'); // adds a tag on the second group of tags

        $this->doFirst();
        $time = Benchmark::computeTags('initial tasks', 'first'); // returns the difference between now and the time marked by the first tag

        Benchmark::tag('initial tasks', 'second'); // adds a second tag on the second group of tasks
        dump(['time' => $time]);

        $this->doSecond();
        $time = Benchmark::computeTags('initial tasks', 'first', 'second'); // gets the difference between the moment when the tags `first` and `second` were added
        dump(['time' => $time]);

        Benchmark::start('second group'); // Allows starting different groups of tasks
        dump(Benchmark::stop('initial tasks')); // Stops the second task and clears its contents

        $this->domeSomethingRealSlow();

        Benchmark::stop('second group'); // Stops the third task and clears its contents
        dump(Benchmark::stop('full time')); // Stops the first task and clear its contents

        Benchmark::reset() // allows clearing all contents
        Benchmark::start('useless task');
        Benchmark::reset('useless task'); // allows clearing a specific task
    }
}
```