### PR TITLE
[12.x] Add Arr::flip()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -955,4 +955,15 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * To swap the keys with their corresponding values in an array.
+     *
+     * @param array $array
+     * @return array
+     */
+    public static function flip($array)
+    {
+        return array_flip($array);
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -959,7 +959,7 @@ class Arr
     /**
      * To swap the keys with their corresponding values in an array.
      *
-     * @param array $array
+     * @param  array  $array
      * @return array
      */
     public static function flip($array)

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1502,4 +1502,11 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::select($array, 'name'));
     }
+
+    public function testFlip()
+    {
+        $array = ['one', 'two', 'one'];
+        $this->assertEquals(['one' => 2 , 'two' => 1], Arr::flip($array));
+    }
+
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1508,5 +1508,4 @@ class SupportArrTest extends TestCase
         $array = ['one', 'two', 'one'];
         $this->assertEquals(['one' => 2, 'two' => 1], Arr::flip($array));
     }
-
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1506,7 +1506,7 @@ class SupportArrTest extends TestCase
     public function testFlip()
     {
         $array = ['one', 'two', 'one'];
-        $this->assertEquals(['one' => 2 , 'two' => 1], Arr::flip($array));
+        $this->assertEquals(['one' => 2, 'two' => 1], Arr::flip($array));
     }
 
 }


### PR DESCRIPTION
This pull request adds a new method flip() to the Arr class in Laravel, To swap the keys with their corresponding values in an array.
