### PR TITLE
[11.x] Generate a random number of the given length added to Number helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
-use Random\RandomException;
 use RuntimeException;
 
 class Number
@@ -371,7 +370,7 @@ class Number
     /**
      * Generate a random number of the given length.
      *
-     * @param int $length
+     * @param  int  $length
      * @return int
      */
     public static function random(int $length = 6): int

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
+use Random\RandomException;
 use RuntimeException;
 
 class Number
@@ -365,6 +366,30 @@ class Number
     public static function defaultCurrency()
     {
         return static::$currency;
+    }
+
+    /**
+     * Generate a random number of the given length.
+     *
+     * @param int $length
+     * @return int
+     */
+    public static function random(int $length = 6): int
+    {
+        $maxLength = strlen((string) PHP_INT_MAX);
+
+        if ($length < 1 || $length > $maxLength) {
+            return 0;
+        }
+
+        $min = 10 ** ($length - 1);
+        $max = (10 ** $length) - 1;
+
+        if ($length == $maxLength) {
+            $max = PHP_INT_MAX;
+        }
+
+        return random_int($min, $max);
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -322,4 +322,13 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    public function testRandom()
+    {
+        $this->assertIsInt(Number::random());
+        $this->assertSame(0, Number::random(-1));
+        $this->assertSame(0, Number::random(0));
+        $this->assertSame(0, Number::random(strlen((string) PHP_INT_MAX) + 1));
+        $this->assertSame(8, strlen((string) Number::random(8)));
+    }
 }


### PR DESCRIPTION
This pull request introduces a random method to the Illuminate\Support\Number helper. The method generates secure random numbers of a specified length, simplifying the generation of numeric identifiers such as OTPs, reference codes, and other fixed-length numbers.

Functionality:

  The Number::random method:

- Accepts an integer $length as its only parameter (default: 6).
- Returns a random number with the specified number of digits.

Example: 

<img width="494" alt="Screenshot 2024-12-27 at 8 14 26 PM" src="https://github.com/user-attachments/assets/105b327e-7f2a-4350-9b33-6a76e965129b" />