### PR TITLE
[12.x] Return unprocessable response when parameter is not a valid UniqueStringId

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Database\Eloquent\InvalidIdFormatException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait HasUniqueStringIds
 {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -103,6 +103,6 @@ trait HasUniqueStringIds
      */
     protected function handleInvalidUniqueId($value, $field)
     {
-        throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        throw (new ModelNotFoundException)->setModel(get_class($this), $value)->setStatus(422);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Database\Eloquent\InvalidIdFormatException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait HasUniqueStringIds
@@ -99,10 +100,10 @@ trait HasUniqueStringIds
      * @param  string|null  $field
      * @return never
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\InvalidIdFormatException
      */
     protected function handleInvalidUniqueId($value, $field)
     {
-        throw (new ModelNotFoundException)->setModel(get_class($this), $value)->setStatus(422);
+        throw (new InvalidIdFormatException)->setModel(get_class($this), $value, $field);
     }
 }

--- a/src/Illuminate/Database/Eloquent/InvalidIdFormatException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidIdFormatException.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Support\Arr;
+
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
+class InvalidIdFormatException extends \RuntimeException
+{
+    /**
+     * Name of the affected Eloquent model.
+     *
+     * @var class-string<TModel>
+     */
+    protected $model;
+
+    /**
+     * The affected model IDs.
+     *
+     * @var array<int, int|string>
+     */
+    protected $ids;
+
+    /**
+     * Set the affected Eloquent model and instance id.
+     *
+     * @param  class-string<TModel>  $model
+     * @param  array<int, int|string>|int|string  $ids
+     * @param  string|null  $field
+     * @return $this
+     */
+    public function setModel($model, $ids = [], ?string $field = null)
+    {
+        $this->model = $model;
+        $this->ids = Arr::wrap($ids);
+
+        $this->message = 'Invalid key';
+        if ($field !== null) {
+            $this->message .= " [{$field}]";
+        }
+
+        $this->message .= " for model [{$model}]";
+
+        if (count($this->ids) > 0) {
+            $this->message .= ' '.implode(', ', $this->ids);
+        }
+
+        $this->message .= '.';
+
+        return $this;
+    }
+
+    /**
+     * Get the affected Eloquent model.
+     *
+     * @return class-string<TModel>
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    /**
+     * Get the affected Eloquent model IDs.
+     *
+     * @return array<int, int|string>
+     */
+    public function getIds()
+    {
+        return $this->ids;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -25,6 +25,13 @@ class ModelNotFoundException extends RecordsNotFoundException
     protected $ids;
 
     /**
+     * The HTTP status code.
+     *
+     * @var int
+     */
+    protected int $status = 404;
+
+    /**
      * Set the affected Eloquent model and instance ids.
      *
      * @param  class-string<TModel>  $model
@@ -48,6 +55,19 @@ class ModelNotFoundException extends RecordsNotFoundException
     }
 
     /**
+     * Set the HTTP status code.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    public function setStatus(int $status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
      * Get the affected Eloquent model.
      *
      * @return class-string<TModel>
@@ -65,5 +85,25 @@ class ModelNotFoundException extends RecordsNotFoundException
     public function getIds()
     {
         return $this->ids;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int
+     */
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    /**
+     * Should the response render as a 404?
+     *
+     * @return bool
+     */
+    public function isNotFound(): bool
+    {
+        return $this->status === 404;
     }
 }

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -25,13 +25,6 @@ class ModelNotFoundException extends RecordsNotFoundException
     protected $ids;
 
     /**
-     * The HTTP status code.
-     *
-     * @var int
-     */
-    protected int $status = 404;
-
-    /**
      * Set the affected Eloquent model and instance ids.
      *
      * @param  class-string<TModel>  $model
@@ -55,19 +48,6 @@ class ModelNotFoundException extends RecordsNotFoundException
     }
 
     /**
-     * Set the HTTP status code.
-     *
-     * @param  int  $status
-     * @return $this
-     */
-    public function setStatus(int $status)
-    {
-        $this->status = $status;
-
-        return $this;
-    }
-
-    /**
      * Get the affected Eloquent model.
      *
      * @return class-string<TModel>
@@ -85,25 +65,5 @@ class ModelNotFoundException extends RecordsNotFoundException
     public function getIds()
     {
         return $this->ids;
-    }
-
-    /**
-     * Get the HTTP status code.
-     *
-     * @return int
-     */
-    public function getStatus(): int
-    {
-        return $this->status;
-    }
-
-    /**
-     * Should the response render as a 404?
-     *
-     * @return bool
-     */
-    public function isNotFound(): bool
-    {
-        return $this->status === 404;
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -633,7 +633,7 @@ class Handler implements ExceptionHandlerContract
     {
         return match (true) {
             $e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-            $e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
+            $e instanceof ModelNotFoundException => $e->isNotFound() ? new NotFoundHttpException($e->getMessage(), $e) : new HttpException($e->getStatus(), $e->getMessage(), $e),
             $e instanceof AuthorizationException && $e->hasStatus() => new HttpException(
                 $e->status(), $e->response()?->message() ?: (Response::$statusTexts[$e->status()] ?? 'Whoops, looks like something went wrong.'), $e
             ),

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Contracts\Debug\ShouldntReport;
 use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Database\Eloquent\InvalidIdFormatException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordNotFoundException;
@@ -633,7 +634,8 @@ class Handler implements ExceptionHandlerContract
     {
         return match (true) {
             $e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-            $e instanceof ModelNotFoundException => $e->isNotFound() ? new NotFoundHttpException($e->getMessage(), $e) : new HttpException($e->getStatus(), $e->getMessage(), $e),
+            $e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
+            $e instanceof InvalidIdFormatException => new HttpException(422, $e->getMessage(), $e),
             $e instanceof AuthorizationException && $e->hasStatus() => new HttpException(
                 $e->status(), $e->response()?->message() ?: (Response::$statusTexts[$e->status()] ?? 'Whoops, looks like something went wrong.'), $e
             ),

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -147,6 +147,7 @@ class Handler implements ExceptionHandlerContract
         BackedEnumCaseNotFoundException::class,
         HttpException::class,
         HttpResponseException::class,
+        InvalidIdFormatException::class,
         ModelNotFoundException::class,
         MultipleRecordsFoundException::class,
         RecordNotFoundException::class,

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -403,8 +403,14 @@ class ImplicitBindingCommentByUuid extends Model
     }
 }
 
-class ImplicitBindingComment extends ImplicitBindingCommentByUuid
+class ImplicitBindingComment extends Model
 {
+    use HasUuids;
+
+    public $table = 'comments';
+
+    protected $fillable = ['slug', 'user_id'];
+
     public function getRouteKeyName()
     {
         return 'slug';

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -310,6 +310,23 @@ PHP);
         $response = $this->getJson("/post/{$post->id}/tag-slug/{$tag->slug}");
         $response->assertJsonFragment(['id' => $tag->id]);
     }
+
+    public function test_invalid_key_returns_unprocessable()
+    {
+        Route::middleware(['web'])->get(
+            '/comments/{comment}',
+            function(ImplicitBindingCommentByUuid $comment) {
+                return response()->json(['ok' => true]);
+            }
+        );
+
+        $response = $this->getJson('comments/not-a-uuid');
+
+        $response->assertUnprocessable();
+        $response->assertJson([
+            'message' => 'No query results for model [Illuminate\Tests\Integration\Routing\ImplicitBindingCommentByUuid] not-a-uuid'
+        ]);
+    }
 }
 
 class ImplicitBindingUser extends Model
@@ -357,14 +374,18 @@ class ImplicitBindingTag extends Model
     }
 }
 
-class ImplicitBindingComment extends Model
+
+class ImplicitBindingCommentByUuid extends Model
 {
     use HasUuids;
 
     public $table = 'comments';
 
     protected $fillable = ['slug', 'user_id'];
+}
 
+class ImplicitBindingComment extends ImplicitBindingCommentByUuid
+{
     public function getRouteKeyName()
     {
         return 'slug';

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -313,9 +313,9 @@ PHP);
 
     public function test_invalid_key_returns_unprocessable()
     {
-        $routeResolution = static fn(ImplicitBindingCommentByUuid $comment) => response()->json(['ok' => true]);
+        $routeResolution = static fn (ImplicitBindingCommentByUuid $comment) => response()->json(['ok' => true]);
 
-        Route::middleware(['web'])->group(function() use ($routeResolution) {
+        Route::middleware(['web'])->group(function () use ($routeResolution) {
             Route::get('/comments/{comment}', $routeResolution);
             Route::get('/comments-by-uuid/{comment:uuid}', $routeResolution);
         });
@@ -324,7 +324,7 @@ PHP);
 
         $response->assertUnprocessable();
         $response->assertJson([
-            'message' => 'Invalid key for model [Illuminate\\Tests\\Integration\\Routing\\ImplicitBindingCommentByUuid] not-a-uuid.'
+            'message' => 'Invalid key for model [Illuminate\\Tests\\Integration\\Routing\\ImplicitBindingCommentByUuid] not-a-uuid.',
         ]);
 
         // When explicitly setting a route key field
@@ -333,7 +333,7 @@ PHP);
         $response->assertUnprocessable();
         // Then the key is specified
         $response->assertJson([
-            'message' => 'Invalid key [uuid] for model [Illuminate\\Tests\\Integration\\Routing\\ImplicitBindingCommentByUuid] 1234!.'
+            'message' => 'Invalid key [uuid] for model [Illuminate\\Tests\\Integration\\Routing\\ImplicitBindingCommentByUuid] 1234!.',
         ]);
     }
 }
@@ -382,7 +382,6 @@ class ImplicitBindingTag extends Model
         return 'slug';
     }
 }
-
 
 class ImplicitBindingCommentByUuid extends Model
 {


### PR DESCRIPTION
This changes the behavior of the `HasUniqueStringIds::handleInvalidUniqueId()` method so that it returns a semantically correct HTTP response that can help callers determine the root cause of a failing response.

If I pass an incorrectly shaped UUID (`1234-th!s-is-not-A-uuid-#^@b`) to a route that expects a UUID, returning a 404 is misleading. While it is true the model _probably_ does not exist in the database and therefore is not found, the reality is that the request is failing validation. It is easy to assume that the response returned is the result of a DB query. (For instance, I tried to optimize routes by skipping route model binding because I didn't understand that the database was NOT being queried in this case).

When `HasUniqueStringIds::isValidUniqueId()` indicates the key invalid, we throw a new custom exception `InvalidIdFormatException`. It has been added to the Handler::$internalDontReport array, and when raised in the application during an HTTP request, gets converted to a 422 response.

I targeted master because I believe this behavior change will break tests for users and therefore is not appropriate for a patch release.

---
## Alternatives
* **Modify the `ModelNotFoundException`**. I'd be happy to pivot back to this if it makes more sense for the framework. It seems very muddy, but the new `InvalidIdFormatException` duplicates much of what exists in that class.
* **Throw a ValidationException instead**. Something like `ValidationException::withMessages([$field => '???'])`. I'm not sure what the message should be in that case.