### PR TITLE
[11.x][PHPDOC] Fix bad phpdoc for \Illuminate\Database\Connection::$schemaGrammar

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -92,7 +92,7 @@ class Connection implements ConnectionInterface
     /**
      * The schema grammar implementation.
      *
-     * @var \Illuminate\Database\Schema\Grammars\Grammar
+     * @var \Illuminate\Database\Schema\Grammars\Grammar|null
      */
     protected $schemaGrammar;
 
@@ -1395,7 +1395,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the schema grammar used by the connection.
      *
-     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     * @return \Illuminate\Database\Schema\Grammars\Grammar|null
      */
     public function getSchemaGrammar()
     {


### PR DESCRIPTION
This PR fix bad phpdoc in \Illuminate\Database\Connection :

- `$schemaGrammar` : This property can be `null` or `\Illuminate\Database\Schema\Grammars\Grammar`

Here is an example where the property `$schemaGrammar` is null :
https://github.com/laravel/framework/blob/8f6a9b03b8e41eedca5f6182d1af2b81ad4be3e6/src/Illuminate/Database/Connection.php#L301-L307

https://github.com/laravel/framework/blob/8f6a9b03b8e41eedca5f6182d1af2b81ad4be3e6/src/Illuminate/Database/Connection.php#L266-L274


