### PR TITLE
Add --without-sanctum option to install:api command

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -24,6 +24,7 @@ class ApiInstallCommand extends Command
                     {--composer=global : Absolute path to the Composer binary which should be used to install packages}
                     {--force : Overwrite any existing API routes file}
                     {--passport : Install Laravel Passport instead of Laravel Sanctum}
+                    {--without-sanctum : Do not install Laravel Sanctum}
                     {--without-migration-prompt : Do not prompt to run pending migrations}';
 
     /**
@@ -42,6 +43,8 @@ class ApiInstallCommand extends Command
     {
         if ($this->option('passport')) {
             $this->installPassport();
+        } elseif ($this->option('without-sanctum')) {
+            $this->components->info('Skipping installation of Laravel Sanctum.');
         } else {
             $this->installSanctum();
         }
@@ -62,6 +65,14 @@ class ApiInstallCommand extends Command
                 );
             }
 
+            if ($this->option('without-sanctum')) {
+                (new Filesystem)->replaceInFile(
+                    'auth:sanctum',
+                    'auth',
+                    $apiRoutesPath,
+                );
+            }
+
             $this->uncommentApiRoutesFile();
         }
 
@@ -74,6 +85,8 @@ class ApiInstallCommand extends Command
             ]));
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
+        } elseif ($this->option('without-sanctum')) {
+            $this->components->info('API scaffolding installed');
         } else {
             if (! $this->option('without-migration-prompt')) {
                 if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', true)) {


### PR DESCRIPTION
### Overview

Not all applications use Laravel Sanctum or Passport by default. To accommodate this, the `--without-sanctum` option has been added to the `install:api` command.

### Changes
- Added the `--without-sanctum` option to the `install:api` command.
- This option allows users to skip the installation of Laravel Sanctum during API setup.

### Benefits
- Provides flexibility for applications that do not require Sanctum or Passport.
- Simplifies setup for users who only need basic API routing without Sanctum.