### PR TITLE
Feature/string backed enum in order by

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -73,7 +73,7 @@ abstract class Grammar
     /**
      * Wrap a value in keyword identifiers.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $value
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\StringBackedEnum|string  $value
      * @return string
      */
     public function wrap($value)

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
-use StringBackedEnum;
 
 abstract class Grammar
 {

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -82,7 +82,7 @@ abstract class Grammar
             return $this->getValue($value);
         }
 
-        if($value instanceof BackedEnum) {
+        if ($value instanceof BackedEnum) {
             $value = $value->value;
         }
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use BackedEnum;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
@@ -82,7 +83,7 @@ abstract class Grammar
             return $this->getValue($value);
         }
 
-        if($value instanceof StringBackedEnum) {
+        if($value instanceof BackedEnum) {
             $value = $value->value;
         }
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -74,7 +74,7 @@ abstract class Grammar
     /**
      * Wrap a value in keyword identifiers.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|\StringBackedEnum|string  $value
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\BackedEnum|string  $value
      * @return string
      */
     public function wrap($value)

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
+use StringBackedEnum;
 
 abstract class Grammar
 {
@@ -79,6 +80,10 @@ abstract class Grammar
     {
         if ($this->isExpression($value)) {
             return $this->getValue($value);
+        }
+
+        if($value instanceof StringBackedEnum) {
+            $value = $value->value;
         }
 
         // If the value being wrapped has a column alias we will need to separate out

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2629,7 +2629,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string|\StringBackedEnum  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string|\BackedEnum  $column
      * @param  string  $direction
      * @return $this
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2629,8 +2629,8 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string|\StringBackedEnum  $direction
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string|\StringBackedEnum  $column
+     * @param  string  $direction
      * @return $this
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2630,7 +2630,7 @@ class Builder implements BuilderContract
      * Add an "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $direction
+     * @param  string|\StringBackedEnum  $direction
      * @return $this
      *
      * @throws \InvalidArgumentException

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1979,12 +1979,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->orderBy('age', 'asec');
     }
 
-    public function testOrderByStringBackedEnums()
+    public function testOrderByBackedEnums()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy(StringStatus::done)->orderBy('age', 'desc');
 
-        $this->assertSame('select * from "users" order by "done" asc, "age" desc', $builder->toSql());
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy(IntegerStatus::done)->orderBy('age', 'desc');
+
+        $this->assertSame('select * from "users" order by "2" asc, "age" desc', $builder->toSql());
     }
 
     public function testHavings()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1979,6 +1979,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->orderBy('age', 'asec');
     }
 
+    public function testOrderByStringBackedEnums()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy(StringStatus::done)->orderBy('age', 'desc');
+
+        $this->assertSame('select * from "users" order by "done" asc, "age" desc', $builder->toSql());
+    }
+
     public function testHavings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
I have an enum defined for fields that an API endpoint can be sorted by.

```php
enum UserIndexSort: string
{
    case CreatedAt = 'created_at';
    case Name = 'name';
    case Email = 'email';
}
```

I'd like to pass this directly into the query builder, rather than having to convert to a string.

```php
$sort = UserIndexSort::Name;

$users = User::query()
    ->orderBy($sort->value, 'desc')
    ->paginate();
```

The change I have made is quite deep in the framework. `Illuminate/Database/Grammar::wrap` is used in a lot of places. That being said, I do not see it being problematic - any BackedEnum being passed to `wrap` should be handled like so? Code will behave exactly as prior, unless a BackedEnum is passed.

As such, this change likely allows for BackedEnums to be used in other places too - happy to look through / update existing DocBlocks if that is desired. I think it will be, I just didn't want to do it too early, and then have the PR rejected.

