### PR TITLE
[12.x] Add `assertThrown()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -240,4 +240,30 @@ trait InteractsWithExceptionHandling
 
         return $this;
     }
+
+    /**
+     * Assert that in instance of $exceptionClass was thrown and return the exception.
+     *
+     * @template TThrowable of Throwable
+     *
+     * @param  \Closure  $test
+     * @param  class-string<TThrowable>  $exceptionClass
+     * @param  string  $noExceptionThrownMessage
+     * @return TThrowable
+     */
+    protected static function assertThrown(
+        Closure $test,
+        string $exceptionClass = Throwable::class,
+        string $noExceptionThrownMessage = 'Did not throw expected exception',
+    ) {
+        try {
+            $test();
+        } catch (Throwable $exception) {
+            self::assertInstanceOf($exceptionClass, $exception, "Expected to throw $exceptionClass but threw ".$exception::class);
+
+            return $exception;
+        }
+
+        Assert::fail($noExceptionThrownMessage);
+    }
 }

--- a/tests/Testing/Concerns/InteractsWithExceptionHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithExceptionHandlingTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Concerns;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
+use InvalidArgumentException;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class InteractsWithExceptionHandlingTest extends TestCase
+{
+    use InteractsWithExceptionHandling;
+
+    public function test_assert_thrown_returns_exception_when_throwable()
+    {
+        $func = static fn (): never => throw new RuntimeException('My runtime exception');
+
+        $thrownException = $this->assertThrown($func);
+
+        $this->assertSame('My runtime exception', $thrownException->getMessage());
+    }
+
+    public function test_assert_thrown_returns_exception_when_custom_exception()
+    {
+        $func = static function (): never {
+            throw (new CustomExceptionForInteractsWithExceptionHandlingTest('A message'))->setValue(1993);
+        };
+
+        $thrownException1 = $this->assertThrown($func, RuntimeException::class);
+        $thrownException2 = $this->assertThrown($func, CustomExceptionForInteractsWithExceptionHandlingTest::class);
+
+        foreach ([$thrownException1, $thrownException2] as $exception) {
+            $this->assertSame('A message', $exception->getMessage());
+            $this->assertSame(1993, $exception->value);
+            $this->assertInstanceOf(CustomExceptionForInteractsWithExceptionHandlingTest::class, $exception);
+        }
+    }
+
+    public function test_assert_thrown_fails_if_not_thrown()
+    {
+        $func = static fn (): int => 200;
+
+        try {
+            $this->assertThrown($func);
+            $this->fail('assertThrown did not raise an assertion error');
+        } catch (AssertionFailedError $assertionFailedError) {
+            $this->assertSame('Did not throw expected exception', $assertionFailedError->getMessage());
+        }
+    }
+
+    public function test_assert_thrown_fails_if_not_subclass()
+    {
+        $func = static fn (): never => throw new CustomExceptionForInteractsWithExceptionHandlingTest('invalid argument exception');
+
+        try {
+            $this->assertThrown($func, InvalidArgumentException::class, 'abcd');
+            $this->fail('assertThrown did not raise an assertion error');
+        } catch (AssertionFailedError $assertionFailedError) {
+            $this->assertStringContainsString(
+                'Expected to throw InvalidArgumentException but threw Illuminate\Tests\Testing\Concerns\CustomExceptionForInteractsWithExceptionHandlingTest',
+                $assertionFailedError->getMessage()
+            );
+        }
+    }
+
+    public function test_assert_thrown_matches_expected_exception_test_passes()
+    {
+        $func = static fn (): never => throw new CustomExceptionForInteractsWithExceptionHandlingTest('zzz');
+
+        $this->assertThrown($func, CustomExceptionForInteractsWithExceptionHandlingTest::class);
+        $this->assertThrown($func, RuntimeException::class);
+    }
+}
+
+class CustomExceptionForInteractsWithExceptionHandlingTest extends RuntimeException
+{
+    public $value;
+
+    public function setValue($value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This adds a testing helper for asserting a closure throws an exception/error, ensures the type, and then returns the exception. This is similar to how [JUnit's assertThrows](https://www.baeldung.com/junit-assert-exception) works.

The big difference from Laravel's `assertThrows()` is that you can make expectations against the exception.

<details>
  <summary>Code examples</summary>

   This is taken from `tests/Auth/AuthAccessResponseTest.php`.
## The way its written currently
```php
public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied_original()
{
    $response = Response::deny('Some message.', 'some_code');

    try {
        $response->authorize();
    } catch (AuthorizationException $e) {
        $this->assertSame('Some message.', $e->getMessage());
        $this->assertSame('some_code', $e->getCode());
        $this->assertEquals($response, $e->response());
    }
}
```

## Rewritten to use the `assertThrows`
```php
public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied_assertThrows()
{
    $response = Response::deny('Some message.', 'some_code');

    $this->assertThrows(
        fn() => $response->authorize(),
        function(AuthorizationException $e) use ($response) {
            $this->assertSame('some_code', $e->getCode());
            $this->assertEquals($response, $e->response());

            return true;
        },
        "Some message"
    );
}
```

## Using the newly added method
```php
public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied_assertThrown()
{
    $response = Response::deny('Some message.', 'some_code');

    $e = $this->assertThrown(fn () => $response->authorize(), AuthorizationException::class);

    $this->assertSame('Some message.', $e->getMessage());
    $this->assertSame('some_code', $e->getCode());
    $this->assertEquals($response, $e->response());
}
```
</details>

My belief is:
The first way (try-catch and perform assertions in the catch block) is most common and works fine.

The second way (`assertThrows()`) is cumbersome to write, requires you to remember to add `return true` to the end, and the nested closure makes it difficult to parse. If you don't add `return true` to the end, you can just convert the second closure into a series of boolean statements, but then you can't really leverage the PHPUnit assertion methods which is a big loss.

The third way (`assertThrown()`) breaks down a layer of indentation, doesn't require adding any `use ($otherVariablesFromOuterScope)`, nor does it have the gotcha of remembering to return true.

---
I do not love the name of this method, but couldn't think of anything better. I have added this as a trait in a work project, and figured I would see if it was of interest to the Laravel community at large.