### PR TITLE
Refactor parse method: update regex and add return type declarations

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -13,6 +13,7 @@ class Parser
      *
      * @param  string  $expression
      * @return array
+     *
      * @throws InvalidArgumentException
      */
     public static function parse(string $expression): array
@@ -30,6 +31,7 @@ class Parser
      *
      * @param  string  $expression
      * @return string
+     *
      * @throws InvalidArgumentException
      */
     protected static function name(string $expression): string

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -13,14 +13,12 @@ class Parser
      *
      * @param  string  $expression
      * @return array
-     *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    public static function parse(string $expression)
+    public static function parse(string $expression): array
     {
         $name = static::name($expression);
-
-        if (preg_match_all('/\{\s*(.*?)\s*\}/', $expression, $matches) && count($matches[1])) {
+        if (preg_match_all('/\{([^}]*)}/s', $expression, $matches) && count($matches[1])) {
             return array_merge([$name], static::parameters($matches[1]));
         }
 
@@ -32,10 +30,9 @@ class Parser
      *
      * @param  string  $expression
      * @return string
-     *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    protected static function name(string $expression)
+    protected static function name(string $expression): string
     {
         if (! preg_match('/[^\s]+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
@@ -50,7 +47,7 @@ class Parser
      * @param  array  $tokens
      * @return array
      */
-    protected static function parameters(array $tokens)
+    protected static function parameters(array $tokens): array
     {
         $arguments = [];
 
@@ -73,7 +70,7 @@ class Parser
      * @param  string  $token
      * @return \Symfony\Component\Console\Input\InputArgument
      */
-    protected static function parseArgument(string $token)
+    protected static function parseArgument(string $token): InputArgument
     {
         [$token, $description] = static::extractDescription($token);
 
@@ -99,7 +96,7 @@ class Parser
      * @param  string  $token
      * @return \Symfony\Component\Console\Input\InputOption
      */
-    protected static function parseOption(string $token)
+    protected static function parseOption(string $token): InputOption
     {
         [$token, $description] = static::extractDescription($token);
 
@@ -132,7 +129,7 @@ class Parser
      * @param  string  $token
      * @return array
      */
-    protected static function extractDescription(string $token)
+    protected static function extractDescription(string $token): array
     {
         $parts = preg_split('/\s+:\s+/', trim($token), 2);
 


### PR DESCRIPTION
This PR introduces the following improvements to the `parse` method and related parts of the codebase:

1. **Updated Regex in the `parse` Method**:  
   - Replaced the regular expression `/\{\s*(.*?)\s*\}/` with `/\{([^}]*)}/s`.  
   - **Reason for Change**:  
     - The previous regex did not handle multi-line expressions properly. For better readability, we often break long code lines into multiple lines. However, the previous regex failed to parse correctly when arguments were spread across multiple lines.  
     - The new regex ensures proper handling of multi-line content by using the `s` modifier, which allows `.` to match newline characters.  
     - Removed the unnecessary escape for the closing brace `}` to simplify and improve readability.  
   - **Impact**: No change to existing functionality, but the regex is now more robust and modern.

2. **Added Return Type Declarations**:  
   - Updated the `parse` method to declare its return type as `array`.  
     ```php
     public static function parse(string $expression): array
     ```
   - Return type declarations were also added to other methods in the class for consistency and better type safety.  
   - **Impact**: Improves code clarity, helps with static analysis tools, and aligns with modern PHP standards.

---

## **Why This Change is Necessary**  
- **Multi-line Parsing**:  
  In our codebase, we strive for better readability by breaking long lines of code into multiple lines where necessary. However, the previous regex did not support parsing arguments correctly when they were written across multiple lines. This change resolves that limitation.  
- **Improved Readability**:  
  The new regex is simpler, removing redundant escapes, and is easier to maintain.  
- **Modern Standards**:  
  Adding return type declarations ensures better type safety and consistency across the codebase.