### PR TITLE
Update `data_get` to return `$default` if given a `null` key

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -557,7 +557,7 @@ class Arr
         [$value, $key] = static::explodePluckParameters($value, $key);
 
         foreach ($array as $item) {
-            $itemValue = data_get($item, $value);
+            $itemValue = is_null($value) ? $item : data_get($item, $value);
 
             // If the key is "null", we will just append the value to the array and keep
             // looping. Otherwise we will key the array using the value of the key we

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1094,7 +1094,7 @@ trait EnumeratesValues
         }
 
         return function ($item) use ($key, $operator, $value) {
-            $retrieved = enum_value(data_get($item, $key));
+            $retrieved = enum_value(is_null($key) ? $item : data_get($item, $key));
             $value = enum_value($value);
 
             $strings = array_filter([$retrieved, $value], function ($value) {
@@ -1149,7 +1149,7 @@ trait EnumeratesValues
             return $value;
         }
 
-        return fn ($item) => data_get($item, $value);
+        return fn ($item) => is_null($value) ? $item : data_get($item, $value);
     }
 
     /**

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -56,7 +56,7 @@ if (! function_exists('data_get')) {
             unset($key[$i]);
 
             if (is_null($segment)) {
-                return $target;
+                $segment = '*';
             }
 
             if ($segment === '*') {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -45,8 +45,9 @@ if (! function_exists('data_get')) {
      */
     function data_get($target, $key, $default = null)
     {
+        // no such thing as a null index so return default
         if (is_null($key)) {
-            return $target;
+            return $default;
         }
 
         $key = is_array($key) ? $key : explode('.', $key);

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -245,6 +245,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (is_null($key)) {
             return $this->validator->validated() ?? $default;
         }
+
         return data_get($this->validator->validated(), $key, $default);
     }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -242,7 +242,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated($key = null, $default = null)
     {
-        if (is_null($key)) return $this->validator->validated() ?? $default;
+        if (is_null($key)) {
+            return $this->validator->validated() ?? $default;
+        }
         return data_get($this->validator->validated(), $key, $default);
     }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -242,6 +242,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated($key = null, $default = null)
     {
+        if (is_null($key)) return $this->validator->validated() ?? $default;
         return data_get($this->validator->validated(), $key, $default);
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -109,6 +109,7 @@ trait InteractsWithInput
      */
     public function input($key = null, $default = null)
     {
+        if (is_null($key)) return $this->getInputSource()->all() ?? $default;
         return data_get(
             $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
@@ -244,6 +245,7 @@ trait InteractsWithInput
      */
     public function file($key = null, $default = null)
     {
+        if (is_null($key)) return $this->allFiles() ?? $default;
         return data_get($this->allFiles(), $key, $default);
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -109,7 +109,9 @@ trait InteractsWithInput
      */
     public function input($key = null, $default = null)
     {
-        if (is_null($key)) return $this->getInputSource()->all() ?? $default;
+        if (is_null($key)) {
+            return $this->getInputSource()->all() ?? $default;
+        }
         return data_get(
             $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
@@ -245,7 +247,9 @@ trait InteractsWithInput
      */
     public function file($key = null, $default = null)
     {
-        if (is_null($key)) return $this->allFiles() ?? $default;
+        if (is_null($key)) {
+            return $this->allFiles() ?? $default;
+        }
         return data_get($this->allFiles(), $key, $default);
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -112,6 +112,7 @@ trait InteractsWithInput
         if (is_null($key)) {
             return $this->getInputSource()->all() ?? $default;
         }
+
         return data_get(
             $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
@@ -250,6 +251,7 @@ trait InteractsWithInput
         if (is_null($key)) {
             return $this->allFiles() ?? $default;
         }
+
         return data_get($this->allFiles(), $key, $default);
     }
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -50,6 +50,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function get($key, $default = null)
     {
+        if (is_null($key)) return $this->attributes ?? $default;
         return data_get($this->attributes, $key, $default);
     }
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -53,6 +53,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
         if (is_null($key)) {
             return $this->attributes ?? $default;
         }
+
         return data_get($this->attributes, $key, $default);
     }
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -50,7 +50,9 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function get($key, $default = null)
     {
-        if (is_null($key)) return $this->attributes ?? $default;
+        if (is_null($key)) {
+            return $this->attributes ?? $default;
+        }
         return data_get($this->attributes, $key, $default);
     }
 

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -335,6 +335,7 @@ class ValidatedInput implements ValidatedData
      */
     public function input($key = null, $default = null)
     {
+        if (is_null($key)) return $this->all() ?? $default;
         return data_get(
             $this->all(), $key, $default
         );

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -335,7 +335,9 @@ class ValidatedInput implements ValidatedData
      */
     public function input($key = null, $default = null)
     {
-        if (is_null($key)) return $this->all() ?? $default;
+        if (is_null($key)) {
+            return $this->all() ?? $default;
+        }
         return data_get(
             $this->all(), $key, $default
         );

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -338,6 +338,7 @@ class ValidatedInput implements ValidatedData
         if (is_null($key)) {
             return $this->all() ?? $default;
         }
+
         return data_get(
             $this->all(), $key, $default
         );

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -60,6 +60,7 @@ class AssertableJsonString implements ArrayAccess, Countable
         if (is_null($key)) {
             return $this->decoded;
         }
+
         return data_get($this->decoded, $key);
     }
 

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -57,7 +57,9 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function json($key = null)
     {
-        if (is_null($key)) return $this->decoded;
+        if (is_null($key)) {
+            return $this->decoded;
+        }
         return data_get($this->decoded, $key);
     }
 

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -57,6 +57,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function json($key = null)
     {
+        if (is_null($key)) return $this->decoded;
         return data_get($this->decoded, $key);
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -411,6 +411,16 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('caret', data_get($array, 'symbols.{last}.description'));
     }
 
+    public function testDataGetNullKey()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertNull(data_get($data, null));
+        $this->assertEquals('42', data_get($data, null, '42'));
+
+        $this->assertEquals(['bar'], data_get($data, [null]));
+    }
+
     public function testDataFill()
     {
         $data = ['foo' => 'bar'];


### PR DESCRIPTION
`data_get` accepts `null` as a param, but if given that it shouldn't return *anything* because it's an impossible key. Even if it was possible, returning the target is a confusing behavior

The main benefit here is that `data_get` doesn't return the value given when looking for a key. Use of this function indicates that the end goal is get a value *from* the array for the given key, and returning the original target can lead to unexpected results.
