### PR TITLE
[11.x] Add the ability to defer route model binding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/DeferRouteBinding.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/DeferRouteBinding.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+trait DeferRouteBinding
+{
+    protected ?object $deferredInit = null;
+
+    protected ?bool $deferredInitResolved = null;
+
+    public function resolveRouteBinding($value, $field = null)
+    {
+        $this->defer($value, $field, false);
+
+        return $this;
+    }
+
+    public function resolveSoftDeletableRouteBinding($value, $field = null)
+    {
+        $this->defer($value, $field, true);
+
+        return $this;
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field)
+    {
+        return $this->deferScoped($childType, $value, $field, false);
+    }
+
+    public function resolveSoftDeletableChildRouteBinding($childType, $value, $field)
+    {
+        return $this->deferScoped($childType, $value, $field, true);
+    }
+
+    public function __invoke(): static
+    {
+        if ($this->deferredInit !== null) {
+            $deferredInit = $this->deferredInit;
+            $this->deferredInit = null;
+            parent::__construct();
+            $model = $deferredInit();
+            $this->exists = true;
+            $this->setRawAttributes((array) $model->attributes, true);
+            $this->setConnection($model->connection);
+            $this->fireModelEvent('retrieved', false);
+            $this->deferredInitResolved = true;
+        }
+
+        return $this;
+    }
+
+    public function __get($key)
+    {
+        $this();
+
+        return parent::__get($key);
+    }
+
+    public function __set($key, $value)
+    {
+        $this();
+
+        parent::__set($key, $value);
+    }
+
+    public function __call($method, $parameters)
+    {
+        $this();
+
+        return parent::__call($method, $parameters);
+    }
+
+    public function __isset($key)
+    {
+        $this();
+
+        return parent::__isset($key);
+    }
+
+    public function __unset($key)
+    {
+        $this();
+
+        parent::__unset($key);
+    }
+
+    public function __toString()
+    {
+        $this();
+
+        return parent::__toString();
+    }
+
+    public function toArray()
+    {
+        $this();
+
+        return parent::toArray();
+    }
+
+    public function toJson($options = 0)
+    {
+        $this();
+
+        return parent::toJson($options);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        $this();
+
+        return parent::jsonSerialize();
+    }
+
+    public function update(array $attributes = [], array $options = [])
+    {
+        $this();
+
+        return parent::update($attributes, $options);
+    }
+
+    public function updateOrFail(array $attributes = [], array $options = [])
+    {
+        $this();
+
+        return parent::updateOrFail($attributes, $options);
+    }
+
+    public function updateQuietly(array $attributes = [], array $options = [])
+    {
+        $this();
+
+        return parent::updateQuietly($attributes, $options);
+    }
+
+    public function delete()
+    {
+        $this();
+
+        return parent::delete();
+    }
+
+    public function deleteOrFail()
+    {
+        $this();
+
+        return parent::deleteOrFail();
+    }
+
+    public function deleteQuietly()
+    {
+        $this();
+
+        return parent::deleteQuietly();
+    }
+
+    public function save(array $options = [])
+    {
+        $this();
+
+        return parent::save($options);
+    }
+
+    public function saveOrFail(array $options = [])
+    {
+        $this();
+
+        return parent::saveOrFail($options);
+    }
+
+    public function saveQuietly(array $options = [])
+    {
+        $this();
+
+        return parent::saveQuietly($options);
+    }
+
+    public function deferred(object $deferredInit): void
+    {
+        $this->deferredInitResolved = false;
+        $this->deferredInit = $deferredInit;
+    }
+
+    protected function defer(mixed $value, ?string $field, bool $withTrashed): void
+    {
+        $this->deferredInitResolved = false;
+
+        $closure = $withTrashed
+            ? fn () => $this->resolveRouteBindingQuery($this, $value, $field)->withTrashed()->firstOrFail()
+            : fn () => $this->resolveRouteBindingQuery($this, $value, $field)->firstOrFail();
+
+        $this->deferredInit = new class('resolveRouteBindingQuery', $value, $field, $closure)
+        {
+            public function __construct(public string $method, public mixed $value, public ?string $field, public Closure $closure)
+            {
+            }
+
+            public function __invoke()
+            {
+                return ($this->closure)();
+            }
+        };
+    }
+
+    protected function deferScoped(string $childType, mixed $value, ?string $field, bool $withTrashed): Model
+    {
+        /** @var Relation $relationship */
+        $relationship = $this->{$this->childRouteBindingRelationshipName($childType)}();
+
+        $child = $relationship->getModel();
+
+        if (! isset(\trait_uses_recursive($child)[DeferRouteBinding::class])) {
+            return parent::resolveChildRouteBindingQuery($childType, $value, $field)->first();
+        }
+
+        $closure = ! $withTrashed
+            ? fn () => $this->resolveChildRouteBindingQuery($childType, $value, $field)->firstOrFail()
+            : fn () => $this->resolveChildRouteBindingQuery($childType, $value, $field)->withTrashed()->firstOrFail();
+
+        $deferredInit = new class('resolveChildRouteBindingQuery', $value, $field, $withTrashed, $closure)
+        {
+            public function __construct(public string $method, public mixed $value, public ?string $field, public bool $withTrashed, public Closure $closure)
+            {
+            }
+
+            public function __invoke()
+            {
+                return ($this->closure)();
+            }
+        };
+
+        $child->deferred($deferredInit);
+
+        return $child;
+    }
+}

--- a/tests/Database/DatabaseConcernsDeferRouteBindingTest.php
+++ b/tests/Database/DatabaseConcernsDeferRouteBindingTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database;
+
+use Carbon\Carbon;
+use Faker\Generator;
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Tests\Database\Fixtures\Factories\UserFactory;
+use Illuminate\Tests\Database\Fixtures\Models\LazilyResolved;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class DatabaseConcernsDeferRouteBindingTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+        $container->singleton(Generator::class, function ($app, $parameters) {
+            return \Faker\Factory::create('en_US');
+        });
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema('default')->create('users', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        foreach (['default'] as $connection) {
+            $this->schema($connection)->drop('users');
+        }
+
+        Relation::morphMap([], false);
+        Eloquent::unsetConnectionResolver();
+
+        \Illuminate\Support\Carbon::setTestNow(null);
+    }
+
+    public function testExplicitlyResolvesTheModel()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $lazy();
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'name' => $user->name,
+            'email' => $user->email,
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->getRawOriginal('created_at'),
+            'updated_at' => $user->getRawOriginal('updated_at'),
+            'deleted_at' => null,
+            'id' => 1,
+        ], $this->getProtectedProperty($lazy, 'attributes'));
+    }
+
+    public function testImplicitlyResolvesTheModelOnPropertyAccess()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $lazy->name;
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'id' => $user->internal_id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->getRawOriginal('created_at'),
+            'updated_at' => $user->getRawOriginal('updated_at'),
+            'deleted_at' => null,
+        ], $this->getProtectedProperty($lazy, 'attributes'));
+    }
+
+    public function testImplicitlyResolvesTheModelOnPropertyWrite()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $lazy->name = 'Test User Changed';
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'id' => $user->internal_id,
+            'name' => 'Test User Changed',
+            'email' => $user->email,
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->getRawOriginal('created_at'),
+            'updated_at' => $user->getRawOriginal('updated_at'),
+            'deleted_at' => null,
+        ], $this->getProtectedProperty($lazy, 'attributes'));
+    }
+
+    public function testImplicitlyResolvesTheModelOnToArray()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $array = $lazy->toArray();
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'id' => $user->internal_id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->created_at->format('Y-m-d\TH:i:s.u\Z'),
+            'updated_at' => $user->updated_at->format('Y-m-d\TH:i:s.u\Z'),
+            'deleted_at' => null,
+        ], $array);
+    }
+
+    public function testImplicitlyResolvesTheModelOnToJson()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $json = $lazy->toJson();
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals(json_encode([
+            'id' => $user->internal_id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+            'deleted_at' => null,
+        ]), $json);
+    }
+
+    public function testImplicitlyResolvesTheModelOnJsonEncode()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $json = json_encode($lazy);
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals(json_encode([
+            'id' => $user->internal_id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+            'deleted_at' => null,
+        ]), $json);
+    }
+
+    #[DataProvider('updateMethodsProvider')]
+    public function testImplicitlyResolvesTheModelOnUpdate(string $method)
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        Carbon::setTestNow(now()->addSecond());
+
+        $lazy->{$method}([
+            'name' => 'Test User Updated',
+            'email' => 'davey@php.net',
+        ]);
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'id' => $user->internal_id,
+            'name' => 'Test User Updated',
+            'email' => 'davey@php.net',
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->getRawOriginal('created_at'),
+            'updated_at' => now()->format('Y-m-d H:i:s'),
+            'deleted_at' => null,
+        ], $this->getProtectedProperty($lazy, 'attributes'));
+    }
+
+    public static function updateMethodsProvider(): array
+    {
+        return [
+            ['update'],
+            ['updateQuietly'],
+            ['updateOrFail'],
+        ];
+    }
+
+    #[DataProvider('deleteMethodsProvider')]
+    public function testImplicitlyResolvesTheModelOnDelete(string $method)
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        $lazy->{$method}();
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'id' => $user->internal_id,
+            'name' => $user->getRawOriginal('name'),
+            'email' => $user->getRawOriginal('email'),
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->getRawOriginal('created_at'),
+            'updated_at' => now()->format('Y-m-d H:i:s'),
+            'deleted_at' => now()->format('Y-m-d H:i:s'),
+        ], $this->getProtectedProperty($lazy, 'attributes'));
+        $this->assertEquals(0, LazilyResolved::count());
+    }
+
+    public static function deleteMethodsProvider(): array
+    {
+        return [
+            ['delete'],
+            ['deleteQuietly'],
+            ['deleteOrFail'],
+        ];
+    }
+
+    public function testImplicitlyResolvesTheModelOnToString()
+    {
+        $user = UserFactory::new()->create();
+
+        $model = new LazilyResolved;
+        $lazy = $model->resolveRouteBinding($user->internal_id);
+
+        $this->assertInstanceOf(LazilyResolved::class, $lazy);
+        $this->assertTrue((new ReflectionClass($this->getProtectedProperty($lazy, 'deferredInit')))->isAnonymous());
+        $this->assertFalse($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertCount(0, $this->getProtectedProperty($lazy, 'attributes'));
+
+        (string) $lazy;
+
+        $this->assertNull($this->getProtectedProperty($lazy, 'deferredInit'));
+        $this->assertTrue($this->getProtectedProperty($lazy, 'deferredInitResolved'));
+        $this->assertEquals([
+            'id' => $user->internal_id,
+            'name' => $user->getRawOriginal('name'),
+            'email' => $user->getRawOriginal('email'),
+            'email_verified_at' => $user->getRawOriginal('email_verified_at'),
+            'password' => $user->getRawOriginal('password'),
+            'remember_token' => $user->getRawOriginal('remember_token'),
+            'created_at' => $user->getRawOriginal('created_at'),
+            'updated_at' => now()->format('Y-m-d H:i:s'),
+            'deleted_at' => null,
+        ], $this->getProtectedProperty($lazy, 'attributes'));
+    }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Access a protected property of an object.
+     *
+     * @return mixed
+     */
+    protected function getProtectedProperty(object $object, string $property)
+    {
+        $closure = function () use ($property) {
+            return $this->{$property};
+        };
+
+        return $closure->bindTo($object, $object)();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}

--- a/tests/Database/Fixtures/Factories/UserFactory.php
+++ b/tests/Database/Fixtures/Factories/UserFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Tests\Database\Fixtures\Models\User;
+
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'password' => $this->faker->password(),
+        ];
+    }
+}

--- a/tests/Database/Fixtures/Models/LazilyResolved.php
+++ b/tests/Database/Fixtures/Models/LazilyResolved.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\DeferRouteBinding;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class LazilyResolved extends Model
+{
+    use DeferRouteBinding;
+    use SoftDeletes;
+
+    protected $table = 'users';
+
+    protected $fillable = ['name', 'email'];
+
+    public static function factory()
+    {
+        return Factory::factoryForModel(User::class);
+    }
+}


### PR DESCRIPTION
I ran into the behavior that was reported in #44177 and am proposing this addition to help resolve it by deferring the query until the model is used.

To be clear: **this changes no existing behavior**. There is a single thing I couldn't resolve with this, which is that when using scoped bindings only the final child model will end up being deferred. I don't think this is a big deal, but it would be great if the entire chain could be deferred — the problem is there's no way to get the relationship to figure out the child model without it pulling the `id` of the parent and that implicitly resolves the parent.

This probably should just be a package, but I wanted to see if there was interest in including it in the core framework first.

Here's a draft attempt at docs to explain it:

## Deferred Binding

By default, models are resolved **before** route middleware has been executed, this means that any global scopes applied to the model that rely on data created in middleware will not function as expected.

To resolve this, you can use the `DeferRouteBinding` trait. When used in your models, the query is deferred when binding until either explicitly or implicitly loaded within the method itself:

```php
class MyModel extends Model {
    use DeferResolveRouteBinding;

    …
}

class MyController {
    /**
     * @throws ModelNotFound when attempting to load the model if not found
     */
    public function update(Request $request, MyModel $myModel) {
      // loads implicitly most of the time when using the model:
      $myModel->update($request->validated());
      
      // OR load explicitly and then use it as normal:
      $myModel();
    }
  }
```

You should ensure to load the model prior to executing any other code that would later fail if the model is not found.

**Note:** when using scoped bindings, only the final "child" model will be deferred.