### PR TITLE
[11.x] adding tests for `null` & `*` key given in `data_get`

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -411,6 +411,18 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('caret', data_get($array, 'symbols.{last}.description'));
     }
 
+    public function testDataGetNullKey()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertEquals([ 'foo' => 'bar' ], data_get($data, null));
+        $this->assertEquals([ 'foo' => 'bar' ], data_get($data, null, '42'));
+        $this->assertEquals([ 'foo' => 'bar' ], data_get($data, [null]));
+
+        $data = ['foo' => 'bar', 'baz' => 42];
+        $this->assertEquals([ 'foo' => 'bar', 'baz' => 42 ], data_get($data, [null, 'foo']));
+    }
+
     public function testDataFill()
     {
         $data = ['foo' => 'bar'];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -411,6 +411,15 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('caret', data_get($array, 'symbols.{last}.description'));
     }
 
+    public function testDataGetStar()
+    {
+        $data = ['foo' => 'bar'];
+        $this->assertEquals([ 'bar' ], data_get($data, '*'));
+
+        $data = collect(['foo' => 'bar']);
+        $this->assertEquals([ 'bar' ], data_get($data, '*'));
+    }
+
     public function testDataGetNullKey()
     {
         $data = ['foo' => 'bar'];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -414,22 +414,22 @@ class SupportHelpersTest extends TestCase
     public function testDataGetStar()
     {
         $data = ['foo' => 'bar'];
-        $this->assertEquals([ 'bar' ], data_get($data, '*'));
+        $this->assertEquals(['bar'], data_get($data, '*'));
 
         $data = collect(['foo' => 'bar']);
-        $this->assertEquals([ 'bar' ], data_get($data, '*'));
+        $this->assertEquals(['bar'], data_get($data, '*'));
     }
 
     public function testDataGetNullKey()
     {
         $data = ['foo' => 'bar'];
 
-        $this->assertEquals([ 'foo' => 'bar' ], data_get($data, null));
-        $this->assertEquals([ 'foo' => 'bar' ], data_get($data, null, '42'));
-        $this->assertEquals([ 'foo' => 'bar' ], data_get($data, [null]));
+        $this->assertEquals(['foo' => 'bar'], data_get($data, null));
+        $this->assertEquals(['foo' => 'bar'], data_get($data, null, '42'));
+        $this->assertEquals(['foo' => 'bar'], data_get($data, [null]));
 
         $data = ['foo' => 'bar', 'baz' => 42];
-        $this->assertEquals([ 'foo' => 'bar', 'baz' => 42 ], data_get($data, [null, 'foo']));
+        $this->assertEquals(['foo' => 'bar', 'baz' => 42], data_get($data, [null, 'foo']));
     }
 
     public function testDataFill()


### PR DESCRIPTION
There are currently no tests covering `null` given as a key to the `data_get` helper. This PR adds a new test covering those situations, as well as when given a collection with `*` explicitly.

Used phpunit code coverage to check on what coverage was missing for the `data_get` function.