### PR TITLE
Introduces UseFactory attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UseFactory
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string  $factoryClass
+     * @return void
+     */
+    public function __construct(public string $factoryClass) {}
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
@@ -10,7 +10,7 @@ class UseFactory
     /**
      * Create a new attribute instance.
      *
-     * @param  string  $factoryClass
+     * @param  class-string $factoryClass
      * @return void
      */
     public function __construct(public string $factoryClass) {}

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Database\Eloquent\Factories;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
 
 /**
  * @template TFactory of \Illuminate\Database\Eloquent\Factories\Factory
@@ -24,6 +25,24 @@ trait HasFactory
     }
 
     /**
+     * Get the factory from the UseFactory class attribute.
+     *
+     * @return TFactory|null
+     */
+    protected static function getUseFactoryAttribute()
+    {
+        $attributes = (new \ReflectionClass(static::class))
+            ->getAttributes(UseFactory::class);
+
+        if (!empty($attributes)) {
+            $useFactory = $attributes[0]->newInstance();
+            $factory = new $useFactory->factoryClass;
+            $factory->guessModelNamesUsing(fn() => static::class);
+            return $factory;
+        }
+    }
+
+    /**
      * Create a new factory instance for the model.
      *
      * @return TFactory|null
@@ -32,6 +51,10 @@ trait HasFactory
     {
         if (isset(static::$factory)) {
             return static::$factory::new();
+        }
+
+        if($useFactory = static::getUseFactoryAttribute()) {
+            return $useFactory;
         }
 
         return null;

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -25,24 +25,6 @@ trait HasFactory
     }
 
     /**
-     * Get the factory from the UseFactory class attribute.
-     *
-     * @return TFactory|null
-     */
-    protected static function getUseFactoryAttribute()
-    {
-        $attributes = (new \ReflectionClass(static::class))
-            ->getAttributes(UseFactory::class);
-
-        if ($attributes !== []) {
-            $useFactory = $attributes[0]->newInstance();
-            $factory = new $useFactory->factoryClass;
-            $factory->guessModelNamesUsing(fn() => static::class);
-            return $factory;
-        }
-    }
-
-    /**
      * Create a new factory instance for the model.
      *
      * @return TFactory|null
@@ -54,5 +36,26 @@ trait HasFactory
         }
 
         return static::getUseFactoryAttribute() ?? null;
+    }
+
+    /**
+     * Get the factory from the UseFactory class attribute.
+     *
+     * @return TFactory|null
+     */
+    protected static function getUseFactoryAttribute()
+    {
+        $attributes = (new \ReflectionClass(static::class))
+            ->getAttributes(UseFactory::class);
+
+        if ($attributes !== []) {
+            $useFactory = $attributes[0]->newInstance();
+
+            $factory = new $useFactory->factoryClass;
+
+            $factory->guessModelNamesUsing(fn() => static::class);
+
+            return $factory;
+        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -34,7 +34,7 @@ trait HasFactory
         $attributes = (new \ReflectionClass(static::class))
             ->getAttributes(UseFactory::class);
 
-        if (!empty($attributes)) {
+        if ($attributes !== []) {
             $useFactory = $attributes[0]->newInstance();
             $factory = new $useFactory->factoryClass;
             $factory->guessModelNamesUsing(fn() => static::class);
@@ -53,10 +53,6 @@ trait HasFactory
             return static::$factory::new();
         }
 
-        if($useFactory = static::getUseFactoryAttribute()) {
-            return $useFactory;
-        }
-
-        return null;
+        return static::getUseFactoryAttribute() ?? null;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -17,6 +17,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -30,6 +31,8 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\MissingAttributeException;
@@ -50,6 +53,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
+
 
 include_once 'Enums.php';
 
@@ -3191,6 +3195,18 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
+
+    public function testUseFactoryAttribute()
+    {
+        $model = new EloquentModelWithUseFactoryAttribute;
+        $instance = EloquentModelWithUseFactoryAttribute::factory()->make(['name' => 'test name']);
+        $factory = EloquentModelWithUseFactoryAttribute::factory();
+        $this->assertInstanceOf(EloquentModelWithUseFactoryAttribute::class, $instance);
+        $this->assertInstanceOf(EloquentModelWithUseFactoryAttributeFactory::class, $model::factory());
+        $this->assertInstanceOf(EloquentModelWithUseFactoryAttributeFactory::class, $model::newFactory());
+        $this->assertEquals(EloquentModelWithUseFactoryAttribute::class, $factory->modelName());
+        $this->assertEquals('test name', $instance->name); // Small smoke test to ensure the factory is working
+    }
 }
 
 class EloquentTestObserverStub
@@ -3989,4 +4005,19 @@ class EloquentModelWithCollectedByAttribute extends Model
 
 class CustomEloquentCollection extends Collection
 {
+}
+
+
+class EloquentModelWithUseFactoryAttributeFactory extends Factory
+{
+    public function definition()
+    {
+        return [];
+    }
+}
+
+#[UseFactory(EloquentModelWithUseFactoryAttributeFactory::class)]
+class EloquentModelWithUseFactoryAttribute extends Model
+{
+    use HasFactory;
 }


### PR DESCRIPTION
## Description

This PR introduces a new UseFactory attribute that provides a more elegant way to associate model factories with Eloquent models using PHP 8.0+ attributes. This is especially useful for factory registration for models that are outside of the typical `App\Models` namespace and improves code readability (in my opinion).

## Usage

```php
<?php

namespace App\SomeFeatureDomain\Models\Comment;

use Database\Factories\CommentFactory;
use Illuminate\Database\Eloquent\Relations\HasMany;
use Illuminate\Database\Eloquent\Attributes\UseFactory;

#[UseFactory(CommentFactory::class)]
class Comment extends Model
{
    use HasFactory;
    // ...
}
```

Instead of defining a new method for `newFactory()`, we can simply allow developers to add the Attribute. 

### Automatic inverse detection

When using this attribute, the factory for the given model will automatically be set, so there is no need to define a `protected $model = \App\SomeFeatureDomain\Models\Comment::class` from our example above.

### Completely Optional & Fully backwards compatible

This logic only runs on classes that implement this attribute. Developers are still free to define static `newFactory` methods as they have before.

### Priority Order

The factory resolution follows this priority:
1. Static `$factory` property if defined
2. `UseFactory` attribute if present
3. Convention-based factory resolution

### Requirements
- PHP 8.0+ (required for attributes support)

### Testing
This PR includes tests that verify:
- Proper factory instantiation via attribute
- Automatic model name resolution