### PR TITLE
[11.x] Add fluent `Email` validation rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -171,7 +171,7 @@ class Rule
     }
 
     /**
-     * Get am email rule builder instance.
+     * Get an email rule builder instance.
      *
      * @return \Illuminate\Validation\Rules\Email
      */

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
@@ -167,6 +168,16 @@ class Rule
     public static function prohibitedIf($callback)
     {
         return new ProhibitedIf($callback);
+    }
+
+    /**
+     * Get am email rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\Email
+     */
+    public static function email()
+    {
+        return new Email;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -24,17 +24,17 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 {
     use Conditionable, Macroable;
 
-    public bool $strict = false;
+    public bool $rfcCompliantWithoutWarnings = false;
 
-    public bool $dns = false;
+    public bool $domainExists = false;
 
-    public bool $spoof = false;
+    public bool $preventEmailSpoofing = false;
 
-    public bool $filter = false;
+    public bool $basicFormat = false;
 
-    public bool $filter_unicode = false;
+    public bool $basicFormatUnicodeAllowed = false;
 
-    public bool $rfc = false;
+    public bool $rfcCompliant = false;
 
     /**
      * An array of custom rules that will be merged into the validation rules.
@@ -113,7 +113,22 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public static function strictSecurity()
     {
-        return (new self())->strict()->dns()->spoof();
+        return (new self())
+            ->rfcCompliantWithoutWarnings()
+            ->domainExists()
+            ->preventEmailSpoofing();
+    }
+
+    /**
+     * Validate against RFCValidation.
+     *
+     * @return $this
+     */
+    public function rfcCompliant()
+    {
+        $this->rfcCompliant = true;
+
+        return $this;
     }
 
     /**
@@ -121,9 +136,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function strict()
+    public function rfcCompliantWithoutWarnings()
     {
-        $this->strict = true;
+        $this->rfcCompliantWithoutWarnings = true;
 
         return $this;
     }
@@ -134,9 +149,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function dns()
+    public function domainExists()
     {
-        $this->dns = true;
+        $this->domainExists = true;
 
         return $this;
     }
@@ -147,9 +162,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function spoof()
+    public function preventEmailSpoofing()
     {
-        $this->spoof = true;
+        $this->preventEmailSpoofing = true;
 
         return $this;
     }
@@ -159,9 +174,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function filter()
+    public function basicFormat()
     {
-        $this->filter = true;
+        $this->basicFormat = true;
 
         return $this;
     }
@@ -171,21 +186,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function filterUnicode()
+    public function basicFormatUnicodeAllowed()
     {
-        $this->filter_unicode = true;
-
-        return $this;
-    }
-
-    /**
-     * Validate against RFCValidation.
-     *
-     * @return $this
-     */
-    public function rfc()
-    {
-        $this->rfc = true;
+        $this->basicFormatUnicodeAllowed = true;
 
         return $this;
     }
@@ -253,27 +256,27 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     {
         $rules = [];
 
-        if ($this->rfc) {
+        if ($this->rfcCompliant) {
             $rules[] = new RFCValidation;
         }
 
-        if ($this->strict) {
+        if ($this->rfcCompliantWithoutWarnings) {
             $rules[] = new NoRFCWarningsValidation;
         }
 
-        if ($this->dns) {
+        if ($this->domainExists) {
             $rules[] = new DNSCheckValidation;
         }
 
-        if ($this->spoof) {
+        if ($this->preventEmailSpoofing) {
             $rules[] = new SpoofCheckValidation;
         }
 
-        if ($this->filter) {
+        if ($this->basicFormat) {
             $rules[] = new FilterEmailValidation;
         }
 
-        if ($this->filter_unicode) {
+        if ($this->basicFormatUnicodeAllowed) {
             $rules[] = FilterEmailValidation::unicode();
         }
 

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -9,20 +9,16 @@ use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Concerns\FilterEmailValidation;
 use InvalidArgumentException;
-use Stringable;
-use function Illuminate\Support\enum_value;
 
 class Email implements Rule, DataAwareRule, ValidatorAwareRule
 {

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
+use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Concerns\FilterEmailValidation;
+use InvalidArgumentException;
+use Stringable;
+use function Illuminate\Support\enum_value;
+
+class Email implements Rule, DataAwareRule, ValidatorAwareRule
+{
+    use Conditionable, Macroable;
+
+    public bool $strict = false;
+
+    public bool $dns = false;
+
+    public bool $spoof = false;
+
+    public bool $filter = false;
+
+    public bool $filter_unicode = false;
+
+    public bool $rfc = false;
+
+    /**
+     * An array of custom rules that will be merged into the validation rules.
+     *
+     * @var array
+     */
+    protected $customRules = [];
+
+    /**
+     * The error message after validation, if any.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The callback that will generate the "default" version of the file rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * Set the default callback to be used for determining the email default rules.
+     *
+     * If no arguments are passed, the default email rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|void
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the file rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $email = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $email instanceof self ? $email : new self();
+    }
+
+    /**
+     * A strict rule set which includes DNS and Spoof checks.
+     *
+     * @return static
+     */
+    public static function strictSecurity()
+    {
+        return (new self())->strict()->dns()->spoof();
+    }
+
+    /**
+     * Validate against NoRFCWarningsValidation.
+     *
+     * @return $this
+     */
+    public function strict()
+    {
+        $this->strict = true;
+
+        return $this;
+    }
+
+    /**
+     * Validate against DNSCheckValidation.
+     * Requires the PHP intl extension.
+     *
+     * @return $this
+     */
+    public function dns()
+    {
+        $this->dns = true;
+
+        return $this;
+    }
+
+    /**
+     * Validate against SpoofCheckValidation.
+     * Requires the PHP intl extension.
+     *
+     * @return $this
+     */
+    public function spoof()
+    {
+        $this->spoof = true;
+
+        return $this;
+    }
+
+    /**
+     * Validate against FilterEmailValidation.
+     *
+     * @return $this
+     */
+    public function filter()
+    {
+        $this->filter = true;
+
+        return $this;
+    }
+
+    /**
+     * Validate against FilterEmailValidation::unicode().
+     *
+     * @return $this
+     */
+    public function filterUnicode()
+    {
+        $this->filter_unicode = true;
+
+        return $this;
+    }
+
+    /**
+     * Validate against RFCValidation.
+     *
+     * @return $this
+     */
+    public function rfc()
+    {
+        $this->rfc = true;
+
+        return $this;
+    }
+
+    /**
+     * Specify additional validation rules that should be merged with the default rules during validation.
+     *
+     * @param  string|array  $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        $this->customRules = array_merge($this->customRules, Arr::wrap($rules));
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->messages = [];
+
+        if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+            return false;
+        }
+
+        $emailValidator = Container::getInstance()->make(EmailValidator::class);
+
+        $passes = $emailValidator->isValid((string) $value, new MultipleValidationWithAnd($this->buildValidationRules()));
+
+        if (! $passes) {
+            $this->messages = [trans('validation.email', ['attribute' => $attribute])];
+
+            return false;
+        }
+
+        if ($this->customRules) {
+            $validator = Validator::make(
+                $this->data,
+                [$attribute => $this->customRules],
+                $this->validator->customMessages,
+                $this->validator->customAttributes
+            );
+
+            if ($validator->fails()) {
+                return $this->fail($validator->messages()->all());
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Build the array of underlying validation rules based on the current state.
+     *
+     * @return array
+     */
+    protected function buildValidationRules()
+    {
+        $rules = [];
+
+        if ($this->rfc) {
+            $rules[] = new RFCValidation;
+        }
+
+        if ($this->strict) {
+            $rules[] = new NoRFCWarningsValidation;
+        }
+
+        if ($this->dns) {
+            $rules[] = new DNSCheckValidation;
+        }
+
+        if ($this->spoof) {
+            $rules[] = new SpoofCheckValidation;
+        }
+
+        if ($this->filter) {
+            $rules[] = new FilterEmailValidation;
+        }
+
+        if ($this->filter_unicode) {
+            $rules[] = FilterEmailValidation::unicode();
+        }
+
+        if ($rules) {
+            return $rules;
+        }
+
+        return [new RFCValidation];
+    }
+
+    /**
+     * Adds the given failures, and return false.
+     *
+     * @param  array|string  $messages
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $messages = Collection::wrap($messages)
+            ->map(fn ($message) => $this->validator->getTranslator()->get($message))
+            ->all();
+
+        $this->messages = array_merge($this->messages, $messages);
+
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the current data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -24,15 +24,15 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 {
     use Conditionable, Macroable;
 
-    public bool $rfcCompliantWithoutWarnings = false;
+    public bool $rfcCompliantStrict = false;
 
-    public bool $domainExists = false;
+    public bool $verifyMxRecord = false;
 
     public bool $preventEmailSpoofing = false;
 
-    public bool $basicFormat = false;
+    public bool $nativeFilter = false;
 
-    public bool $basicFormatUnicodeAllowed = false;
+    public bool $nativeFilterWithUnicodeAllowed = false;
 
     public bool $rfcCompliant = false;
 
@@ -114,8 +114,8 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     public static function strictSecurity()
     {
         return (new self())
-            ->rfcCompliantWithoutWarnings()
-            ->domainExists()
+            ->rfcCompliant(true)
+            ->verifyMxRecord()
             ->preventEmailSpoofing();
     }
 
@@ -124,23 +124,20 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function rfcCompliant()
+    public function rfcCompliant(bool $strict = false)
     {
-        $this->rfcCompliant = true;
+        if ($strict) {
+            $this->rfcCompliantStrict = true;
+        } else {
+            $this->rfcCompliant = true;
+        }
 
         return $this;
     }
 
-    /**
-     * Validate against NoRFCWarningsValidation.
-     *
-     * @return $this
-     */
-    public function rfcCompliantWithoutWarnings()
+    public function strict()
     {
-        $this->rfcCompliantWithoutWarnings = true;
-
-        return $this;
+        return $this->rfcCompliant(true);
     }
 
     /**
@@ -149,9 +146,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function domainExists()
+    public function verifyMxRecord()
     {
-        $this->domainExists = true;
+        $this->verifyMxRecord = true;
 
         return $this;
     }
@@ -174,21 +171,13 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @return $this
      */
-    public function basicFormat()
+    public function nativeFilter(bool $unicodeAllowed = false)
     {
-        $this->basicFormat = true;
-
-        return $this;
-    }
-
-    /**
-     * Validate against FilterEmailValidation::unicode().
-     *
-     * @return $this
-     */
-    public function basicFormatUnicodeAllowed()
-    {
-        $this->basicFormatUnicodeAllowed = true;
+        if ($unicodeAllowed) {
+            $this->nativeFilterWithUnicodeAllowed = true;
+        } else {
+            $this->nativeFilter = true;
+        }
 
         return $this;
     }
@@ -260,11 +249,11 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             $rules[] = new RFCValidation;
         }
 
-        if ($this->rfcCompliantWithoutWarnings) {
+        if ($this->rfcCompliantStrict) {
             $rules[] = new NoRFCWarningsValidation;
         }
 
-        if ($this->domainExists) {
+        if ($this->verifyMxRecord) {
             $rules[] = new DNSCheckValidation;
         }
 
@@ -272,11 +261,11 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             $rules[] = new SpoofCheckValidation;
         }
 
-        if ($this->basicFormat) {
+        if ($this->nativeFilter) {
             $rules[] = new FilterEmailValidation;
         }
 
-        if ($this->basicFormatUnicodeAllowed) {
+        if ($this->nativeFilterWithUnicodeAllowed) {
             $rules[] = FilterEmailValidation::unicode();
         }
 

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -26,8 +26,8 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 
     public bool $validateMxRecord = false;
     public bool $preventSpoofing = false;
-    public bool $nativeFilter = false;
-    public bool $nativeFilterWithUnicodeAllowed = false;
+    public bool $nativeValidation = false;
+    public bool $nativeValidationWithUnicodeAllowed = false;
     public bool $rfcCompliant = false;
     public bool $strictRfcCompliant = false;
 
@@ -163,9 +163,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     public function withNativeValidation(bool $allowUnicode = false)
     {
         if ($allowUnicode) {
-            $this->nativeFilterWithUnicodeAllowed = true;
+            $this->nativeValidationWithUnicodeAllowed = true;
         } else {
-            $this->nativeFilter = true;
+            $this->nativeValidation = true;
         }
 
         return $this;
@@ -250,11 +250,11 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             $rules[] = new SpoofCheckValidation;
         }
 
-        if ($this->nativeFilter) {
+        if ($this->nativeValidation) {
             $rules[] = new FilterEmailValidation;
         }
 
-        if ($this->nativeFilterWithUnicodeAllowed) {
+        if ($this->nativeValidationWithUnicodeAllowed) {
             $rules[] = FilterEmailValidation::unicode();
         }
 

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -86,7 +86,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      * If no arguments are passed, the default file rule configuration will be returned.
      *
      * @param  static|callable|null  $callback
-     * @return static|null
+     * @return static|void
      */
     public static function defaults($callback = null)
     {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -124,7 +124,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      * If no arguments are passed, the default password rule configuration will be returned.
      *
      * @param  static|callable|null  $callback
-     * @return static|null
+     * @return static|void
      */
     public static function defaults($callback = null)
     {

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -1,0 +1,457 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Email;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationEmailRuleTest extends TestCase
+{
+    public function testBasic()
+    {
+        $this->fails(
+            Email::default(),
+            'foo',
+            ['validation.email'],
+        );
+        $this->fails(
+            Rule::email(),
+            'foo',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            Email::default(),
+            'taylor@laravel.com',
+        );
+
+        $this->passes(
+            Rule::email(),
+            'taylor@laravel.com',
+        );
+
+        $this->passes(Email::default(), null);
+
+        $this->passes(Rule::email(), null);
+    }
+
+    protected function fails($rule, $values, $messages)
+    {
+        $this->assertValidationRules($rule, $values, false, $messages);
+    }
+
+    protected function assertValidationRules($rule, $values, $result, $messages)
+    {
+        $values = Arr::wrap($values);
+
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['my_file' => $value],
+                ['my_file' => is_object($rule) ? clone $rule : $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['my_file' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function passes($rule, $values)
+    {
+        $this->assertValidationRules($rule, $values, true, []);
+    }
+
+    public function testStrict()
+    {
+        $this->fails(
+            (new Email())->strict(),
+            'invalid.@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->strict(),
+            'invalid.@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            (new Email())->strict(),
+            'username@sub..example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->strict(),
+            'username@sub..example.com',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->strict(),
+            'plainaddress@example.com',
+        );
+
+        $this->passes(
+            Rule::email()->strict(),
+            'plainaddress@example.com',
+        );
+    }
+
+    public function testDns()
+    {
+        $this->fails(
+            (new Email())->dns(),
+            'plainaddress@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->dns(),
+            'plainaddress@example.com',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->dns(),
+            'taylor@laravel.com',
+        );
+
+        $this->passes(
+            Rule::email()->dns(),
+            'taylor@laravel.com',
+        );
+    }
+
+    public function testSpoof()
+    {
+        $this->fails(
+            (new Email())->spoof(),
+            'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->spoof(),
+            'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
+            ['validation.email'],
+        );
+
+        $email = 'admin@exam' . "\u{0440}" . 'le.com';
+        $this->fails(
+            (new Email())->spoof(),
+            $email,
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->spoof(),
+            $email,
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->spoof(),
+            'admin@example.com',
+        );
+
+        $this->passes(
+            Rule::email()->spoof(),
+            'admin@example.com',
+        );
+
+        $this->passes(
+            (new Email())->spoof(),
+            'test👨‍💻@domain.com',
+        );
+
+        $this->passes(
+            Rule::email()->spoof(),
+            'test👨‍💻@domain.com',
+        );
+    }
+
+    public function testFilter()
+    {
+        $this->fails(
+            (new Email())->filter(),
+            'tést@domain.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->filter(),
+            'tést@domain.com',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->filter(),
+            'admin@example.com',
+        );
+
+        $this->passes(
+            Rule::email()->filter(),
+            'admin@example.com',
+        );
+    }
+
+    public function testFilterUnicode()
+    {
+        $this->fails(
+            (new Email())->filterUnicode(),
+            'invalid.@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->filterUnicode(),
+            'invalid.@example.com',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->filterUnicode(),
+            'tést@domain.com',
+        );
+
+        $this->passes(
+            Rule::email()->filterUnicode(),
+            'tést@domain.com',
+        );
+
+        $this->passes(
+            (new Email())->filterUnicode(),
+            'admin@example.com',
+        );
+
+        $this->passes(
+            Rule::email()->filterUnicode(),
+            'admin@example.com',
+        );
+    }
+
+    public function testRfc()
+    {
+        $this->fails(
+            (new Email())->rfc(),
+            'invalid.@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->rfc(),
+            'invalid.@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            (new Email())->rfc(),
+            'test👨‍💻@domain.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->rfc(),
+            'test👨‍💻@domain.com',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->rfc(),
+            'admin@example.com',
+        );
+
+        $this->passes(
+            Rule::email()->rfc(),
+            'admin@example.com',
+        );
+
+        $this->passes(
+            (new Email())->rfc(),
+            'tést@domain.com',
+        );
+
+        $this->passes(
+            Rule::email()->rfc(),
+            'tést@domain.com',
+        );
+    }
+
+    public function testCombiningRules()
+    {
+        $this->passes(
+            (new Email())->rfc()->strict()->spoof(),
+            'test@example.com',
+        );
+
+        $this->passes(
+            Rule::email()->rfc()->strict()->spoof(),
+            'test@example.com',
+        );
+
+        $this->fails(
+            (new Email())->rfc()->strict()->spoof()->dns(),
+            'test@example.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->rfc()->strict()->spoof()->dns(),
+            'test@example.com',
+            ['validation.email'],
+        );
+
+        $this->passes(
+            (new Email())->spoof(),
+            'test👨‍💻@domain.com',
+        );
+
+        $this->passes(
+            Rule::email()->spoof(),
+            'test👨‍💻@domain.com',
+        );
+
+        $this->fails(
+            (new Email())->spoof()->rfc(),
+            'test👨‍💻@domain.com',
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->spoof()->rfc(),
+            'test👨‍💻@domain.com',
+            ['validation.email'],
+        );
+
+        $spoofingEmail = 'admin@exam' . "\u{0440}" . 'le.com';
+
+        $this->passes(
+            (new Email())->rfc(),
+            $spoofingEmail,
+        );
+
+        $this->passes(
+            Rule::email()->rfc(),
+            $spoofingEmail,
+        );
+
+        $this->fails(
+            (new Email())->rfc()->spoof(),
+            $spoofingEmail,
+            ['validation.email'],
+        );
+
+        $this->fails(
+            Rule::email()->rfc()->spoof(),
+            $spoofingEmail,
+            ['validation.email'],
+        );
+    }
+
+    public function testMacro()
+    {
+        Email::macro('laravelEmployee', function () {
+            return static::default()->rules('ends_with:@laravel.com');
+        });
+
+        $this->fails(
+            Email::laravelEmployee(),
+            'taylor@example.com',
+            ['validation.ends_with']
+        );
+
+        $this->fails(
+            Rule::email()->laravelEmployee(),
+            'taylor@example.com',
+            ['validation.ends_with']
+        );
+
+        $this->passes(
+            Email::laravelEmployee(),
+            'taylor@laravel.com',
+        );
+
+        $this->passes(
+            Rule::email()->laravelEmployee(),
+            'taylor@laravel.com',
+        );
+    }
+
+    public function testItCanSetDefaultUsing()
+    {
+        $this->assertInstanceOf(Email::class, Email::default());
+
+        $spoofingEmail = 'admin@exam' . "\u{0440}" . 'le.com';
+
+        $this->passes(
+            Email::default(),
+            $spoofingEmail,
+        );
+
+        Email::defaults(function () {
+            return (new Email())->spoof();
+        });
+
+        $this->fails(
+            Email::default(),
+            $spoofingEmail,
+            ['validation.email'],
+        );
+
+        Email::defaults(function () {
+            return Rule::email()->rfc();
+        });
+
+        $this->passes(
+            Email::default(),
+            $spoofingEmail,
+        );
+
+        Email::defaults(function () {
+            return Rule::email()->spoof();
+        });
+
+        $this->fails(
+            Email::default(),
+            $spoofingEmail,
+            ['validation.email'],
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+}

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -55,14 +55,14 @@ class ValidationEmailRuleTest extends TestCase
         foreach ($values as $value) {
             $v = new Validator(
                 resolve('translator'),
-                ['my_file' => $value],
-                ['my_file' => is_object($rule) ? clone $rule : $rule]
+                ['my_email' => $value],
+                ['my_email' => is_object($rule) ? clone $rule : $rule]
             );
 
             $this->assertSame($result, $v->passes());
 
             $this->assertSame(
-                $result ? [] : ['my_file' => $messages],
+                $result ? [] : ['my_email' => $messages],
                 $v->messages()->toArray()
             );
         }
@@ -149,16 +149,16 @@ class ValidationEmailRuleTest extends TestCase
             ['validation.email'],
         );
 
-        $email = 'admin@exam' . "\u{0440}" . 'le.com';
+        $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
         $this->fails(
             (new Email())->spoof(),
-            $email,
+            $spoofingEmail,
             ['validation.email'],
         );
 
         $this->fails(
             Rule::email()->spoof(),
-            $email,
+            $spoofingEmail,
             ['validation.email'],
         );
 
@@ -336,7 +336,7 @@ class ValidationEmailRuleTest extends TestCase
             ['validation.email'],
         );
 
-        $spoofingEmail = 'admin@exam' . "\u{0440}" . 'le.com';
+        $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
 
         $this->passes(
             (new Email())->rfc(),
@@ -394,7 +394,7 @@ class ValidationEmailRuleTest extends TestCase
     {
         $this->assertInstanceOf(Email::class, Email::default());
 
-        $spoofingEmail = 'admin@exam' . "\u{0440}" . 'le.com';
+        $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
 
         $this->passes(
             Email::default(),

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -76,36 +76,36 @@ class ValidationEmailRuleTest extends TestCase
     public function testStrict()
     {
         $this->fails(
-            (new Email())->strict(),
+            (new Email())->rfcCompliantWithoutWarnings(),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->strict(),
+            Rule::email()->rfcCompliantWithoutWarnings(),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            (new Email())->strict(),
+            (new Email())->rfcCompliantWithoutWarnings(),
             'username@sub..example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->strict(),
+            Rule::email()->rfcCompliantWithoutWarnings(),
             'username@sub..example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->strict(),
+            (new Email())->rfcCompliantWithoutWarnings(),
             'plainaddress@example.com',
         );
 
         $this->passes(
-            Rule::email()->strict(),
+            Rule::email()->rfcCompliantWithoutWarnings(),
             'plainaddress@example.com',
         );
     }
@@ -113,24 +113,24 @@ class ValidationEmailRuleTest extends TestCase
     public function testDns()
     {
         $this->fails(
-            (new Email())->dns(),
+            (new Email())->domainExists(),
             'plainaddress@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->dns(),
+            Rule::email()->domainExists(),
             'plainaddress@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->dns(),
+            (new Email())->domainExists(),
             'taylor@laravel.com',
         );
 
         $this->passes(
-            Rule::email()->dns(),
+            Rule::email()->domainExists(),
             'taylor@laravel.com',
         );
     }
@@ -138,47 +138,47 @@ class ValidationEmailRuleTest extends TestCase
     public function testSpoof()
     {
         $this->fails(
-            (new Email())->spoof(),
+            (new Email())->preventEmailSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->spoof(),
+            Rule::email()->preventEmailSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
             ['validation.email'],
         );
 
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
         $this->fails(
-            (new Email())->spoof(),
+            (new Email())->preventEmailSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->spoof(),
+            Rule::email()->preventEmailSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->spoof(),
+            (new Email())->preventEmailSpoofing(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->spoof(),
+            Rule::email()->preventEmailSpoofing(),
             'admin@example.com',
         );
 
         $this->passes(
-            (new Email())->spoof(),
+            (new Email())->preventEmailSpoofing(),
             'test👨‍💻@domain.com',
         );
 
         $this->passes(
-            Rule::email()->spoof(),
+            Rule::email()->preventEmailSpoofing(),
             'test👨‍💻@domain.com',
         );
     }
@@ -186,24 +186,24 @@ class ValidationEmailRuleTest extends TestCase
     public function testFilter()
     {
         $this->fails(
-            (new Email())->filter(),
+            (new Email())->basicFormat(),
             'tést@domain.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->filter(),
+            Rule::email()->basicFormat(),
             'tést@domain.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->filter(),
+            (new Email())->basicFormat(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->filter(),
+            Rule::email()->basicFormat(),
             'admin@example.com',
         );
     }
@@ -211,34 +211,34 @@ class ValidationEmailRuleTest extends TestCase
     public function testFilterUnicode()
     {
         $this->fails(
-            (new Email())->filterUnicode(),
+            (new Email())->basicFormatUnicodeAllowed(),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->filterUnicode(),
+            Rule::email()->basicFormatUnicodeAllowed(),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->filterUnicode(),
+            (new Email())->basicFormatUnicodeAllowed(),
             'tést@domain.com',
         );
 
         $this->passes(
-            Rule::email()->filterUnicode(),
+            Rule::email()->basicFormatUnicodeAllowed(),
             'tést@domain.com',
         );
 
         $this->passes(
-            (new Email())->filterUnicode(),
+            (new Email())->basicFormatUnicodeAllowed(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->filterUnicode(),
+            Rule::email()->basicFormatUnicodeAllowed(),
             'admin@example.com',
         );
     }
@@ -246,46 +246,46 @@ class ValidationEmailRuleTest extends TestCase
     public function testRfc()
     {
         $this->fails(
-            (new Email())->rfc(),
+            (new Email())->rfcCompliant(),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfc(),
+            Rule::email()->rfcCompliant(),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            (new Email())->rfc(),
+            (new Email())->rfcCompliant(),
             'test👨‍💻@domain.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfc(),
+            Rule::email()->rfcCompliant(),
             'test👨‍💻@domain.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->rfc(),
+            (new Email())->rfcCompliant(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->rfc(),
+            Rule::email()->rfcCompliant(),
             'admin@example.com',
         );
 
         $this->passes(
-            (new Email())->rfc(),
+            (new Email())->rfcCompliant(),
             'tést@domain.com',
         );
 
         $this->passes(
-            Rule::email()->rfc(),
+            Rule::email()->rfcCompliant(),
             'tést@domain.com',
         );
     }
@@ -293,45 +293,45 @@ class ValidationEmailRuleTest extends TestCase
     public function testCombiningRules()
     {
         $this->passes(
-            (new Email())->rfc()->strict()->spoof(),
+            (new Email())->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing(),
             'test@example.com',
         );
 
         $this->passes(
-            Rule::email()->rfc()->strict()->spoof(),
+            Rule::email()->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing(),
             'test@example.com',
         );
 
         $this->fails(
-            (new Email())->rfc()->strict()->spoof()->dns(),
+            (new Email())->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing()->domainExists(),
             'test@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfc()->strict()->spoof()->dns(),
+            Rule::email()->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing()->domainExists(),
             'test@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->spoof(),
+            (new Email())->preventEmailSpoofing(),
             'test👨‍💻@domain.com',
         );
 
         $this->passes(
-            Rule::email()->spoof(),
+            Rule::email()->preventEmailSpoofing(),
             'test👨‍💻@domain.com',
         );
 
         $this->fails(
-            (new Email())->spoof()->rfc(),
+            (new Email())->preventEmailSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->spoof()->rfc(),
+            Rule::email()->preventEmailSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
             ['validation.email'],
         );
@@ -339,23 +339,23 @@ class ValidationEmailRuleTest extends TestCase
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
 
         $this->passes(
-            (new Email())->rfc(),
+            (new Email())->rfcCompliant(),
             $spoofingEmail,
         );
 
         $this->passes(
-            Rule::email()->rfc(),
+            Rule::email()->rfcCompliant(),
             $spoofingEmail,
         );
 
         $this->fails(
-            (new Email())->rfc()->spoof(),
+            (new Email())->rfcCompliant()->preventEmailSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfc()->spoof(),
+            Rule::email()->rfcCompliant()->preventEmailSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
@@ -402,7 +402,7 @@ class ValidationEmailRuleTest extends TestCase
         );
 
         Email::defaults(function () {
-            return (new Email())->spoof();
+            return (new Email())->preventEmailSpoofing();
         });
 
         $this->fails(
@@ -412,7 +412,7 @@ class ValidationEmailRuleTest extends TestCase
         );
 
         Email::defaults(function () {
-            return Rule::email()->rfc();
+            return Rule::email()->rfcCompliant();
         });
 
         $this->passes(
@@ -421,7 +421,7 @@ class ValidationEmailRuleTest extends TestCase
         );
 
         Email::defaults(function () {
-            return Rule::email()->spoof();
+            return Rule::email()->preventEmailSpoofing();
         });
 
         $this->fails(

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -76,36 +76,36 @@ class ValidationEmailRuleTest extends TestCase
     public function testStrict()
     {
         $this->fails(
-            (new Email())->rfcCompliantWithoutWarnings(),
+            (new Email())->rfcCompliant(true),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliantWithoutWarnings(),
+            Rule::email()->rfcCompliant(true),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            (new Email())->rfcCompliantWithoutWarnings(),
+            (new Email())->rfcCompliant(true),
             'username@sub..example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliantWithoutWarnings(),
+            Rule::email()->rfcCompliant(true),
             'username@sub..example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->rfcCompliantWithoutWarnings(),
+            (new Email())->rfcCompliant(true),
             'plainaddress@example.com',
         );
 
         $this->passes(
-            Rule::email()->rfcCompliantWithoutWarnings(),
+            Rule::email()->rfcCompliant(true),
             'plainaddress@example.com',
         );
     }
@@ -113,24 +113,24 @@ class ValidationEmailRuleTest extends TestCase
     public function testDns()
     {
         $this->fails(
-            (new Email())->domainExists(),
+            (new Email())->verifyMxRecord(),
             'plainaddress@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->domainExists(),
+            Rule::email()->verifyMxRecord(),
             'plainaddress@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->domainExists(),
+            (new Email())->verifyMxRecord(),
             'taylor@laravel.com',
         );
 
         $this->passes(
-            Rule::email()->domainExists(),
+            Rule::email()->verifyMxRecord(),
             'taylor@laravel.com',
         );
     }
@@ -186,24 +186,24 @@ class ValidationEmailRuleTest extends TestCase
     public function testFilter()
     {
         $this->fails(
-            (new Email())->basicFormat(),
+            (new Email())->nativeFilter(),
             'tést@domain.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->basicFormat(),
+            Rule::email()->nativeFilter(),
             'tést@domain.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->basicFormat(),
+            (new Email())->nativeFilter(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->basicFormat(),
+            Rule::email()->nativeFilter(),
             'admin@example.com',
         );
     }
@@ -211,34 +211,34 @@ class ValidationEmailRuleTest extends TestCase
     public function testFilterUnicode()
     {
         $this->fails(
-            (new Email())->basicFormatUnicodeAllowed(),
+            (new Email())->nativeFilter(true),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->basicFormatUnicodeAllowed(),
+            Rule::email()->nativeFilter(true),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->basicFormatUnicodeAllowed(),
+            (new Email())->nativeFilter(true),
             'tést@domain.com',
         );
 
         $this->passes(
-            Rule::email()->basicFormatUnicodeAllowed(),
+            Rule::email()->nativeFilter(true),
             'tést@domain.com',
         );
 
         $this->passes(
-            (new Email())->basicFormatUnicodeAllowed(),
+            (new Email())->nativeFilter(true),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->basicFormatUnicodeAllowed(),
+            Rule::email()->nativeFilter(true),
             'admin@example.com',
         );
     }
@@ -293,23 +293,23 @@ class ValidationEmailRuleTest extends TestCase
     public function testCombiningRules()
     {
         $this->passes(
-            (new Email())->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing(),
+            (new Email())->rfcCompliant(true)->preventEmailSpoofing(),
             'test@example.com',
         );
 
         $this->passes(
-            Rule::email()->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing(),
+            Rule::email()->rfcCompliant(true)->preventEmailSpoofing(),
             'test@example.com',
         );
 
         $this->fails(
-            (new Email())->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing()->domainExists(),
+            (new Email())->rfcCompliant(true)->preventEmailSpoofing()->verifyMxRecord(),
             'test@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliant()->rfcCompliantWithoutWarnings()->preventEmailSpoofing()->domainExists(),
+            Rule::email()->rfcCompliant(true)->preventEmailSpoofing()->verifyMxRecord(),
             'test@example.com',
             ['validation.email'],
         );

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -113,24 +113,24 @@ class ValidationEmailRuleTest extends TestCase
     public function testDns()
     {
         $this->fails(
-            (new Email())->verifyMxRecord(),
+            (new Email())->validateMxRecord(),
             'plainaddress@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->verifyMxRecord(),
+            Rule::email()->validateMxRecord(),
             'plainaddress@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->verifyMxRecord(),
+            (new Email())->validateMxRecord(),
             'taylor@laravel.com',
         );
 
         $this->passes(
-            Rule::email()->verifyMxRecord(),
+            Rule::email()->validateMxRecord(),
             'taylor@laravel.com',
         );
     }
@@ -138,47 +138,47 @@ class ValidationEmailRuleTest extends TestCase
     public function testSpoof()
     {
         $this->fails(
-            (new Email())->preventEmailSpoofing(),
+            (new Email())->preventSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->preventEmailSpoofing(),
+            Rule::email()->preventSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
             ['validation.email'],
         );
 
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
         $this->fails(
-            (new Email())->preventEmailSpoofing(),
+            (new Email())->preventSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->preventEmailSpoofing(),
+            Rule::email()->preventSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->preventEmailSpoofing(),
+            (new Email())->preventSpoofing(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->preventEmailSpoofing(),
+            Rule::email()->preventSpoofing(),
             'admin@example.com',
         );
 
         $this->passes(
-            (new Email())->preventEmailSpoofing(),
+            (new Email())->preventSpoofing(),
             'test👨‍💻@domain.com',
         );
 
         $this->passes(
-            Rule::email()->preventEmailSpoofing(),
+            Rule::email()->preventSpoofing(),
             'test👨‍💻@domain.com',
         );
     }
@@ -186,24 +186,24 @@ class ValidationEmailRuleTest extends TestCase
     public function testFilter()
     {
         $this->fails(
-            (new Email())->nativeFilter(),
+            (new Email())->withNativeValidation(),
             'tést@domain.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->nativeFilter(),
+            Rule::email()->withNativeValidation(),
             'tést@domain.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->nativeFilter(),
+            (new Email())->withNativeValidation(),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->nativeFilter(),
+            Rule::email()->withNativeValidation(),
             'admin@example.com',
         );
     }
@@ -211,34 +211,34 @@ class ValidationEmailRuleTest extends TestCase
     public function testFilterUnicode()
     {
         $this->fails(
-            (new Email())->nativeFilter(true),
+            (new Email())->withNativeValidation(true),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->nativeFilter(true),
+            Rule::email()->withNativeValidation(true),
             'invalid.@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->nativeFilter(true),
+            (new Email())->withNativeValidation(true),
             'tést@domain.com',
         );
 
         $this->passes(
-            Rule::email()->nativeFilter(true),
+            Rule::email()->withNativeValidation(true),
             'tést@domain.com',
         );
 
         $this->passes(
-            (new Email())->nativeFilter(true),
+            (new Email())->withNativeValidation(true),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->nativeFilter(true),
+            Rule::email()->withNativeValidation(true),
             'admin@example.com',
         );
     }
@@ -293,45 +293,45 @@ class ValidationEmailRuleTest extends TestCase
     public function testCombiningRules()
     {
         $this->passes(
-            (new Email())->rfcCompliant(true)->preventEmailSpoofing(),
+            (new Email())->rfcCompliant(true)->preventSpoofing(),
             'test@example.com',
         );
 
         $this->passes(
-            Rule::email()->rfcCompliant(true)->preventEmailSpoofing(),
+            Rule::email()->rfcCompliant(true)->preventSpoofing(),
             'test@example.com',
         );
 
         $this->fails(
-            (new Email())->rfcCompliant(true)->preventEmailSpoofing()->verifyMxRecord(),
+            (new Email())->rfcCompliant(true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliant(true)->preventEmailSpoofing()->verifyMxRecord(),
+            Rule::email()->rfcCompliant(true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
             ['validation.email'],
         );
 
         $this->passes(
-            (new Email())->preventEmailSpoofing(),
+            (new Email())->preventSpoofing(),
             'test👨‍💻@domain.com',
         );
 
         $this->passes(
-            Rule::email()->preventEmailSpoofing(),
+            Rule::email()->preventSpoofing(),
             'test👨‍💻@domain.com',
         );
 
         $this->fails(
-            (new Email())->preventEmailSpoofing()->rfcCompliant(),
+            (new Email())->preventSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->preventEmailSpoofing()->rfcCompliant(),
+            Rule::email()->preventSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
             ['validation.email'],
         );
@@ -349,13 +349,13 @@ class ValidationEmailRuleTest extends TestCase
         );
 
         $this->fails(
-            (new Email())->rfcCompliant()->preventEmailSpoofing(),
+            (new Email())->rfcCompliant()->preventSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliant()->preventEmailSpoofing(),
+            Rule::email()->rfcCompliant()->preventSpoofing(),
             $spoofingEmail,
             ['validation.email'],
         );
@@ -402,7 +402,7 @@ class ValidationEmailRuleTest extends TestCase
         );
 
         Email::defaults(function () {
-            return (new Email())->preventEmailSpoofing();
+            return (new Email())->preventSpoofing();
         });
 
         $this->fails(
@@ -421,7 +421,7 @@ class ValidationEmailRuleTest extends TestCase
         );
 
         Email::defaults(function () {
-            return Rule::email()->preventEmailSpoofing();
+            return Rule::email()->preventSpoofing();
         });
 
         $this->fails(


### PR DESCRIPTION
This PR aims to provide a similar experience as the Password validation rule and File validation rule (#43271) for emails. It does so by providing a fluent, extendable Email rule object.

## Basic usage
```php
// Before
$request->validate([
  'email' => ['required', 'string', 'email', 'strict', 'dns'],
]);
 
// After
$request->validate([
  'email' => ['required', 'string', Rule::email()->strict()->dns()],
]);
```

## Available methods
The following methods are available on the rule:

* `::default`: equivalent to the `Password::default()` rule
* `::strictSecurity`: equivalent to `Rule::email()->strict()->dns()->spoof()`
* `strict`: equivalent to the `strict` rule
* `dns`: equivalent to the `dns` rule
* `spoof`: equivalent to the `spoof` rule
* `filter`: equivalent to the `filter` rule
* `filterUnicode`: equivalent to the `filter_unicode` rule
* `rfc`: equivalent to the `rfc` rule

## Extending for custom types
Whilst the `File` rule only ships with the `::image` method as a custom type, the rule is `Macroable`, allowing each application to specify more granular file permissions as required.

```php
// AppServiceProvider
public function boot()
{
  Email::macro('employee', function () {
    return Email::default()->rules('ends_with:@laravel.com');
  });
}

// Usage
$request->validate([
  'email' => ['required', Email::employee()->spoof()]
]);
```

## Open for discussion
I've added `strictSecurity` method as an option to easily create a solid email validation check, since the differences between the available rules are rather complex. Not including this method would be a valid choice as well. However, I hope this method will help Laravel developers better secure the email inputs, for example example against spoofing. The composition of this methods (strict + DNS + spoof) is a result of running applications in production and handling all kinds of edge cases with invalid emails that passed validation before using this combination.

Thanks to @lukeraymonddowning for providing #43271. I've used his PR as inspiration for the body text of this PR.