### PR TITLE
Policy stub returns a nullable boolean to support fallthrough

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -11,7 +11,7 @@ class {{ class }}
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny({{ user }} $user): bool
+    public function viewAny({{ user }} $user): ?bool
     {
         return false;
     }
@@ -19,7 +19,7 @@ class {{ class }}
     /**
      * Determine whether the user can view the model.
      */
-    public function view({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
+    public function view({{ user }} $user, {{ model }} ${{ modelVariable }}): ?bool
     {
         return false;
     }
@@ -27,7 +27,7 @@ class {{ class }}
     /**
      * Determine whether the user can create models.
      */
-    public function create({{ user }} $user): bool
+    public function create({{ user }} $user): ?bool
     {
         return false;
     }
@@ -35,7 +35,7 @@ class {{ class }}
     /**
      * Determine whether the user can update the model.
      */
-    public function update({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
+    public function update({{ user }} $user, {{ model }} ${{ modelVariable }}): ?bool
     {
         return false;
     }
@@ -43,7 +43,7 @@ class {{ class }}
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
+    public function delete({{ user }} $user, {{ model }} ${{ modelVariable }}): ?bool
     {
         return false;
     }
@@ -51,7 +51,7 @@ class {{ class }}
     /**
      * Determine whether the user can restore the model.
      */
-    public function restore({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
+    public function restore({{ user }} $user, {{ model }} ${{ modelVariable }}): ?bool
     {
         return false;
     }
@@ -59,7 +59,7 @@ class {{ class }}
     /**
      * Determine whether the user can permanently delete the model.
      */
-    public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
+    public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }}): ?bool
     {
         return false;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a non-breaking, minor change to the policy stubs. Since a policy can also return `null` to support a fallthrough `Gate::after`. 