### PR TITLE
[11.x] Allow exceptions to the `optimize` and `optimize:clear` commands

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -77,7 +77,7 @@ class OptimizeClearCommand extends Command
     protected function getOptions()
     {
         return [
-            ['except', 'e', InputOption::VALUE_OPTIONAL, 'Do not run the commands matching the key or name'],
+            ['except', 'e', InputOption::VALUE_OPTIONAL, 'The commands to skip'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'optimize:clear')]
 class OptimizeClearCommand extends Command
@@ -32,7 +34,17 @@ class OptimizeClearCommand extends Command
     {
         $this->components->info('Clearing cached bootstrap files.');
 
-        foreach ($this->getOptimizeClearTasks() as $description => $command) {
+        $exceptions = Collection::wrap(explode(',', $this->option('except')))
+            ->map(fn ($except) => trim($except))
+            ->filter()
+            ->unique()
+            ->flip();
+
+        $tasks = Collection::wrap($this->getOptimizeTasks())
+            ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
+            ->toArray();
+
+        foreach ($tasks as $description => $command) {
             $this->components->task($description, fn () => $this->callSilently($command) == 0);
         }
 
@@ -54,6 +66,18 @@ class OptimizeClearCommand extends Command
             'routes' => 'route:clear',
             'views' => 'view:clear',
             ...ServiceProvider::$optimizeClearCommands,
+        ];
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['except', 'e', InputOption::VALUE_OPTIONAL, 'Do not run the commands matching the key or name'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -40,7 +40,7 @@ class OptimizeClearCommand extends Command
             ->unique()
             ->flip();
 
-        $tasks = Collection::wrap($this->getOptimizeTasks())
+        $tasks = Collection::wrap($this->getOptimizeClearTasks())
             ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'optimize')]
 class OptimizeCommand extends Command
@@ -32,7 +34,17 @@ class OptimizeCommand extends Command
     {
         $this->components->info('Caching framework bootstrap, configuration, and metadata.');
 
-        foreach ($this->getOptimizeTasks() as $description => $command) {
+        $exceptions = Collection::wrap(explode(',', $this->option('except')))
+            ->map(fn ($except) => trim($except))
+            ->filter()
+            ->unique()
+            ->flip();
+
+        $tasks = Collection::wrap($this->getOptimizeTasks())
+            ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
+            ->toArray();
+
+        foreach ($tasks as $description => $command) {
             $this->components->task($description, fn () => $this->callSilently($command) == 0);
         }
 
@@ -52,6 +64,18 @@ class OptimizeCommand extends Command
             'routes' => 'route:cache',
             'views' => 'view:cache',
             ...ServiceProvider::$optimizeCommands,
+        ];
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['except', 'e', InputOption::VALUE_OPTIONAL, 'Do not run the commands matching the key or name'],
         ];
     }
 }

--- a/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
@@ -19,6 +19,20 @@ class OptimizeClearCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutputToContain('ServiceProviderWithOptimizeClear');
     }
+
+    public function testCanExcludeCommandsByKey(): void
+    {
+        $this->artisan('optimize:clear', ['--except' => 'my package'])
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('my package');
+    }
+
+    public function testCanExcludeCommandsByCommand(): void
+    {
+        $this->artisan('optimize:clear', ['--except' => 'my_package:cache'])
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('my_package:cache');
+    }
 }
 
 class ServiceProviderWithOptimizeClear extends ServiceProvider

--- a/tests/Integration/Foundation/Console/OptimizeCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeCommandTest.php
@@ -27,6 +27,20 @@ class OptimizeCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutputToContain('my package');
     }
+
+    public function testCanExcludeCommandsByKey(): void
+    {
+        $this->artisan('optimize', ['--except' => 'my package'])
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('my package');
+    }
+
+    public function testCanExcludeCommandsByCommand(): void
+    {
+        $this->artisan('optimize', ['--except' => 'my_package:cache'])
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('my_package:cache');
+    }
 }
 
 class ServiceProviderWithOptimize extends ServiceProvider


### PR DESCRIPTION
### Summary

This PR introduces the `--except` option to the `optimize` and `optimize:clear` commands, enabling greater flexibility in managing optimization tasks. This change allows developers to integrate with these commands while providing control over which specific tasks are executed or skipped.

### Use Case

In applications deployed on **Laravel Vapor**, route caching is [unsupported](https://github.com/laravel/vapor-cli/blob/master/src/BuildProcess/ExecuteBuildCommands.php). By leveraging the `--except` option, we can utilize the `optimize` command without triggering unsupported operations like `route:cache`.

### Examples

```
// Skip by command name
php artisan optimize --except route:cache

 // Skip by key
php artisan optimize --except route

// Skip by comma delimited list of keys or command names
php artisan optimize:clear --except route,view:cache
``` 

### New Help

<img width="868" alt="Screenshot 2025-01-03 at 9 09 16 AM" src="https://github.com/user-attachments/assets/388bfe2b-98e3-452a-aac2-a1dc4dda084c" />

### Feedback

Welcome to input on strategy or additional use cases this feature could support.