### PR TITLE
[11.x] Feauture / Convert Number To A Stringable Format

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support;
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
 use RuntimeException;
-use Illuminate\Support\Stringable;
 
 class Number
 {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Support;
 
+use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
 use RuntimeException;
 use Illuminate\Support\Stringable;
-use Illuminate\Support\Traits\Macroable;
 
 class Number
 {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
 use RuntimeException;
+use Illuminate\Support\Stringable;
+use Illuminate\Support\Traits\Macroable;
 
 class Number
 {
@@ -71,7 +72,7 @@ class Number
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
 
-        return $formatter->format($number);
+        return new Stringable($formatter->format($number));
     }
 
     /**
@@ -105,7 +106,7 @@ class Number
 
         $formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, '%spellout-ordinal');
 
-        return $formatter->format($number);
+        return new Stringable($formatter->format($number));
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -109,9 +109,9 @@ class SupportNumberTest extends TestCase
     #[RequiresPhpExtension('intl')]
     public function testSpellOrdinal()
     {
-        $this->assertSame('first', Number::spellOrdinal(1));
-        $this->assertSame('second', Number::spellOrdinal(2));
-        $this->assertSame('third', Number::spellOrdinal(3));
+        $this->assertSame('first', (string) Number::spellOrdinal(1));
+        $this->assertSame('second', (string) Number::spellOrdinal(2));
+        $this->assertSame('third', (string) Number::spellOrdinal(3));
     }
 
     #[RequiresPhpExtension('intl')]

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -87,16 +87,16 @@ class SupportNumberTest extends TestCase
     #[RequiresPhpExtension('intl')]
     public function testSpelloutWithThreshold()
     {
-        $this->assertSame('9', Number::spell(9, after: 10));
-        $this->assertSame('10', Number::spell(10, after: 10));
-        $this->assertSame('eleven', Number::spell(11, after: 10));
+        $this->assertSame('9', (string) Number::spell(9, after: 10));
+        $this->assertSame('10', (string) Number::spell(10, after: 10));
+        $this->assertSame('eleven', (string) Number::spell(11, after: 10));
 
-        $this->assertSame('nine', Number::spell(9, until: 10));
-        $this->assertSame('10', Number::spell(10, until: 10));
-        $this->assertSame('11', Number::spell(11, until: 10));
+        $this->assertSame('nine', (string) Number::spell(9, until: 10));
+        $this->assertSame('10', (string) Number::spell(10, until: 10));
+        $this->assertSame('11', (string) Number::spell(11, until: 10));
 
-        $this->assertSame('ten thousand', Number::spell(10000, until: 50000));
-        $this->assertSame('100,000', Number::spell(100000, until: 50000));
+        $this->assertSame('ten thousand', (string) Number::spell(10000, until: 50000));
+        $this->assertSame('100,000', (string) Number::spell(100000, until: 50000));
     }
 
     public function testOrdinal()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -74,14 +74,14 @@ class SupportNumberTest extends TestCase
 
     public function testSpellout()
     {
-        $this->assertSame('ten', Number::spell(10));
-        $this->assertSame('one point two', Number::spell(1.2));
+        $this->assertSame('ten', (string) Number::spell(10));
+        $this->assertSame('one point two', (string) Number::spell(1.2));
     }
 
     #[RequiresPhpExtension('intl')]
     public function testSpelloutWithLocale()
     {
-        $this->assertSame('trois', Number::spell(3, 'fr'));
+        $this->assertSame('trois', (string) Number::spell(3, 'fr'));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
Hello,  

This PR proposes that the `spell` and `spellOrdinal` methods, which are already understood to return a string, should directly return a `Stringable` instance. This would make it easier to manipulate the result by allowing direct use of the methods provided by the `Illuminate\Support\Stringable` class.  

### Examples:  
```php
Number::spell(10, 'es')->upper();  
Number::spell(10, 'es')->mask('*', 1, 2); // Result: "d**z"
```  

This way, we avoid having to wrap the result manually, as in the following example:  
```php
new Stringable(Number::spell(10, 'es'));
```  

This simplifies the workflow and enhances the developer experience. 😊