### PR TITLE
[11.x] Fix breaking change in `RefreshDatabase`

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -109,7 +109,7 @@ trait RefreshDatabase
 
                 $connection->unsetEventDispatcher();
 
-                if (! $connection->getPdo()->inTransaction()) {
+                if ($connection->getPdo() && ! $connection->getPdo()->inTransaction()) {
                     RefreshDatabaseState::$migrated = false;
                 }
 


### PR DESCRIPTION
This PR fixes a breaking chance introduced by https://github.com/laravel/framework/pull/53997, as reported by [this comment](https://github.com/laravel/framework/pull/53997#issuecomment-2569395689).

I haven't been able to reproduce it, but sometimes `$connection->getPdo()` can be `null`.

Also, [you've asked](https://github.com/laravel/framework/pull/53997#issuecomment-2563119134) if it was possible to test the changes in the original PR. I've tried, but I haven't been able to come up with a meaningful way to unit test this.
