### PR TITLE
Fix: Handle stringable notifiable key

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -195,7 +195,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         }
 
         PHPUnit::assertEmpty(
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()] ?? [],
+            $this->notifications[get_class($notifiable)]["{$notifiable->getKey()}"] ?? [],
             'Notifications were sent unexpectedly.',
         );
     }
@@ -279,7 +279,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        return $this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification] ?? [];
+        return $this->notifications[get_class($notifiable)]["{$notifiable->getKey()}"][$notification] ?? [];
     }
 
     /**
@@ -326,7 +326,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 continue;
             }
 
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
+            $this->notifications[get_class($notifiable)]["{$notifiable->getKey()}"][get_class($notification)][] = [
                 'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
                     ? $this->serializeAndRestoreNotification($notification)
                     : $notification,


### PR DESCRIPTION
This is a small fix that ensure that Models with stringable id type like `Ramsey\Uuid\UuidInterface` are correctly handle by `NotificationFake`.

Else this kind of error is thrown: `TypeError: Illegal offset type in /usr/project/vendor/laravel/framework/src/Illuminate/Support/Testing/Fakes/NotificationFake.php:282`
