### PR TITLE
[11.x] Remove unnecessary reference operator (&) in fireAppCallbacks method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1156,7 +1156,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  callable[]  $callbacks
      * @return void
      */
-    protected function fireAppCallbacks(array &$callbacks)
+    protected function fireAppCallbacks(array $callbacks)
     {
         $index = 0;
 


### PR DESCRIPTION
This PR, simplifies the ```fireAppCallbacks``` method by removing the unnecessary & (reference operator) from the `$callbacks` parameter. Since the method does not modify the array directly, passing it by reference is redundant and has been removed for better readability and code clarity.
