### PR TITLE
[11.x] Implement formatting of fractions

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -285,7 +285,7 @@ class Number
     /**
      * @see https://stackoverflow.com/questions/14330713/converting-float-decimal-to-fraction
      *
-     * @param bool|'auto'|'manual'  $stylized
+     * @param  bool|'auto'|'manual'  $stylized
      */
     public static function toFraction(
         float $value,

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -284,7 +284,8 @@ class Number
 
     /**
      * @see https://stackoverflow.com/questions/14330713/converting-float-decimal-to-fraction
-     * @param bool|'auto'|'manual' $stylized
+     *
+     * @param bool|'auto'|'manual'  $stylized
      */
     public static function toFraction(
         float $value,
@@ -337,7 +338,7 @@ class Number
         $fractionSlash = "\u{2044}";
 
         if (in_array($stylized, ['auto', false], true)) {
-            return $numerator . ($stylized === 'auto' ? $fractionSlash : '/') . $denominator;
+            return $numerator.($stylized === 'auto' ? $fractionSlash : '/').$denominator;
         }
 
         $numeratorFormatted = match ($numerator) {
@@ -366,7 +367,7 @@ class Number
             9 => "\u{2089}",
         };
 
-        return $numeratorFormatted . $fractionSlash . $denominatorFormatted;
+        return $numeratorFormatted.$fractionSlash.$denominatorFormatted;
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -321,5 +322,41 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3, Number::trim(12.30));
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
+    }
+
+    #[DataProvider('providesNumbersForFractions')]
+    public function testToFraction(float $input, ?string $output, int $limes = 10, bool $improper = false, bool $allowApproximation = true)
+    {
+        $this->assertSame($output, Number::toFraction($input, $limes, improper: $improper, allowApproximation: $allowApproximation));
+    }
+
+    public static function providesNumbersForFractions()
+    {
+        return [
+            'cannot be made into a fraction' => [0.06, null],
+            'exact fraction possible' => [0.75, '3/4'],
+            'exact fraction with integer' => [1.75, '1 3/4'],
+            'exact improper fraction' => [1.75, '7/4', 10, true],
+            'approximate fraction with integer' => [2.33, '2 1/3'],
+            'approximatation not allowed' => [2.33, null, 10, false, false],
+            'with limes' => [2.58, '2 3/5', 5],
+            'only integer' => [ 1.97, '2'],
+        ];
+    }
+
+    #[DataProvider('providesNumbersForFractionFormats')]
+    public function testToFractionFormat(float $input, ?string $output, bool|string $stylized = false, string $glue = ' ')
+    {
+        $this->assertSame($output, Number::toFraction($input, stylized: $stylized, glue: $glue));
+    }
+
+    public static function providesNumbersForFractionFormats()
+    {
+        return [
+            'with defaults' => [1.75, '1 3/4'],
+            'no stylization' => [1.75, '1 3/4', false],
+            'automatic stylization' => [1.75, '1 3⁄4', 'auto'],
+            'manual stylization' => [1.75, '1 ³⁄₄', 'manual'],
+        ];
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -340,7 +340,7 @@ class SupportNumberTest extends TestCase
             'approximate fraction with integer' => [2.33, '2 1/3'],
             'approximatation not allowed' => [2.33, null, 10, false, false],
             'with limes' => [2.58, '2 3/5', 5],
-            'only integer' => [ 1.97, '2'],
+            'only integer' => [1.97, '2'],
         ];
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -339,7 +339,8 @@ class SupportNumberTest extends TestCase
             'exact improper fraction' => [1.75, '7/4', 10, true],
             'approximate fraction with integer' => [2.33, '2 1/3'],
             'approximatation not allowed' => [2.33, null, 10, false, false],
-            'with limes' => [2.58, '2 3/5', 5],
+            'with default limes' => [2.58, '2 4/7'],
+            'with custom limes' => [2.58, '2 3/5', 5],
             'only integer' => [1.97, '2'],
         ];
     }
@@ -357,6 +358,7 @@ class SupportNumberTest extends TestCase
             'no stylization' => [1.75, '1 3/4', false],
             'automatic stylization' => [1.75, '1 3⁄4', 'auto'],
             'manual stylization' => [1.75, '1 ³⁄₄', 'manual'],
+            'manual stylization with less glue' => [1.75, '1³⁄₄', 'manual', ''],
         ];
     }
 }


### PR DESCRIPTION
Follow-up to #48845

## Features
* **[proper/improper fractions](https://en.wikipedia.org/wiki/Fraction#Proper_and_improper_fractions)**: When the numerator and the denominator are both positive, the fraction is called proper if the numerator is less than the denominator, and improper otherwise (e.g. 1 3/4 is "proper" while 7/4 is the same decimal in "improper" notation)
* **approximation**: Not all decimals can be mapped 1:1 to fractions and vice versa. Especially, [repeating decimals](https://en.wikipedia.org/wiki/Repeating_decimal) can sometimes be written as a fraction but not as a decimal without using additional notation (e.g. 1/3 can be approximated to 0.33, but the actual decimal would be 0.33… or 0. ̅3)
* **stylization**: We, especially when writing digitally, often resort to a simplified notation for fractions (e.g. 3/4). Actually, these would have to be written with unicode characters. This notation has to options: Just marking the numerator and denominator as part of a fraction with a unicode slash and leave the rendering to the output or display the three parts manually as subscript and superscript.
    * [What is the correct way to write fractions in Unicode?](https://superuser.com/questions/1816633/what-is-the-correct-way-to-write-fractions-in-unicode) on superuser.com
    * [Unicode subscripts and superscripts](https://en.wikipedia.org/wiki/Unicode_subscripts_and_superscripts) on wikipedia.org

## Examples (see tests)
| Input | Limes     | improper  | approximation | stylization | glue | Output |
| ----- | --------- | --------- | ------------- | ----------- | --------- | ------ |
| 0.06  | _default_ | _default_ | _default_     | _default_   | _default_ | `null` |
| 0.75  | _default_ | _default_ | _default_     | _default_   | _default_ | 3/4    |
| 1.75  | _default_ | _default_ | _default_     | _default_   | _default_ | 1 3/4  |
| 1.75  | _default_ | true      | _default_     | _default_   | _default_ | 7/4    |
| 2.33  | _default_ | _default_ | _default_     | _default_   | _default_ | 2 1/3  |
| 2.33  | _default_ | _default_ | _default_     | _default_   | _default_ | 2 1/3  |
| 2.33  | _default_ | _default_ | `false`       | _default_   | _default_ | `null` |
| 2.58  | _default_ | _default_ | _default_     | _default_   | _default_ | 2 4/7  |
| 2.58  | 5         | _default_ | _default_     | _default_   | _default_ | 2 3/5  |
| 1.97  | _default_ | _default_ | _default_     | _default_   | _default_ | 2      |
| 1.75  | _default_ | _default_ | _default_     | _default_   | _default_ | 1 3/4  |
| 1.75  | _default_ | _default_ | _default_     | `false`     | _default_ | 1 3/4  |
| 1.75  | _default_ | _default_ | _default_     | auto        | _default_ | 1 3⁄4  |
| 1.75  | _default_ | _default_ | _default_     | manual      | _default_ | 1 ³⁄₄  |
| 1.75  | _default_ | _default_ | _default_     | manual      | ''        | 1³⁄₄   |

