### PR TITLE
Fix: Ensure all or none Schema::create methods execute in single migration file with multiple calls

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -130,7 +130,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function delete($migration)
     {
-        $this->table()->where('migration', $migration->migration)->delete();
+        if(property_exists($migration, 'migration'))
+            $this->table()->where('migration', $migration->migration)->delete();
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -130,7 +130,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function delete($migration)
     {
-        if(property_exists($migration, 'migration')) {
+        if (property_exists($migration, 'migration')) {
             $this->table()->where('migration', $migration->migration)->delete();
         }
     }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -130,8 +130,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function delete($migration)
     {
-        if(property_exists($migration, 'migration'))
+        if(property_exists($migration, 'migration')) {
             $this->table()->where('migration', $migration->migration)->delete();
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -188,7 +188,7 @@ class Migrator
                 $this->write(Info::class, $e->getMessage());
 
                 Log::error($e->getMessage());
-                
+
                 $migration = (object) $file;
                 $this->runDown($file, $migration, $pretend);
             }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Events\NoPendingMigrations;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -177,10 +178,21 @@ class Migrator
         // migrations "up" so the changes are made to the databases. We'll then log
         // that the migration was run so we don't repeat it next time we execute.
         foreach ($migrations as $file) {
-            $this->runUp($file, $batch, $pretend);
+            try {
+                $this->runUp($file, $batch, $pretend);
 
-            if ($step) {
-                $batch++;
+                if ($step) {
+                    $batch++;
+                }
+            }
+            catch(\Exception $e) {
+
+                $this->write(Info::class, $e->getMessage());
+
+                Log::error($e->getMessage());
+                
+                $migration = (object) $file;
+                $this->runDown($file, $migration, $pretend);
             }
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -184,9 +184,7 @@ class Migrator
                 if ($step) {
                     $batch++;
                 }
-            }
-            catch(\Exception $e) {
-
+            } catch(\Exception $e) {
                 $this->write(Info::class, $e->getMessage());
 
                 Log::error($e->getMessage());


### PR DESCRIPTION

This resolves an issue where migrations containing multiple Schema::create method calls would only partially execute. The issue was caused by incomplete handling of Schema operations in a single migration file. Initial schemas defined inside up method of migration file would be created in database without logging that migration file in migrations repository if there were some errors in subsequent Schema::create calls. The real issue comes when running php artisan migrate command second time. It will throw table already exists exception preventing the migration file from creating other schemas specified after the schema with error.

This fix ensures that, if Schema::create method inside up method of migration file is partially run, it runs corresponding down method to drop those schemas if any error occours in subsequent create methods of Schema class in up method of the same migration file.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
