### PR TITLE
[11.x] Fallback to parent methods on `HasUniqueStringIds` trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -38,7 +38,7 @@ trait HasUniqueStringIds
      */
     public function uniqueIds()
     {
-        return [$this->getKeyName()];
+        return $this->usesUniqueIds() ? [$this->getKeyName()] : parent::uniqueIds();
     }
 
     /**
@@ -75,7 +75,7 @@ trait HasUniqueStringIds
             return 'string';
         }
 
-        return $this->keyType;
+        return parent::getKeyType();
     }
 
     /**
@@ -89,7 +89,7 @@ trait HasUniqueStringIds
             return false;
         }
 
-        return $this->incrementing;
+        return parent::getIncrementing();
     }
 
     /**


### PR DESCRIPTION
This PR makes `HasUniqueStringIds` trait respect `$usesUniqueIds` property and fallback to parent methods:
* Determining if the model uses unique IDs before overriding `uniqueIds()` method and fallback to parent if not.
* Fallback to parent method on `getKeyType()` and `getIncrementing()` method for consistency.

This is useful when a model is using this trait optionally by setting `$usesUniqueIds` property.