### PR TITLE
Add support for custom payloads and channels in broadcasting

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -89,11 +89,55 @@ class BroadcastEvent implements ShouldQueue
         $payload = $this->getPayloadFromEvent($this->event);
 
         foreach ($connections as $connection) {
+            $connectionChannels = $this->getConnectionChannels($channels, $connection);
+            $connectionPayload = $this->getConnectionPayload($payload, $connection);
+
             $manager->connection($connection)->broadcast(
-                $channels, $name, $payload
+                $connectionChannels, $name, $connectionPayload
             );
         }
     }
+
+    /**
+     * Get the channels for the given connection.
+     *
+     * @param  array  $channels
+     * @param  string  $connection
+     * @return array
+     */
+    protected function getConnectionChannels($channels, $connection): array
+    {
+        return is_array($channels[$connection] ?? null)
+            ? $channels[$connection]
+            : $channels;
+    }
+
+    /**
+     * Get the payload for the given connection.
+     *
+     * @param  array  $payload
+     * @param  string  $connection
+     * @return array
+     */
+    protected function getConnectionPayload($payload, $connection): array
+    {
+        $connectionPayload = is_array($payload[$connection] ?? null)
+            ? $payload[$connection]
+            : $payload;
+
+        if (isset($payload['socket'])) {
+            $connectionPayload['socket'] = $payload['socket'];
+        }
+
+        return $connectionPayload;
+    }
+
+    /**
+     * Get the payload for the given event.
+     *
+     * @param  mixed  $event
+     * @return array
+     */
 
     /**
      * Get the payload for the given event.

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -99,47 +99,6 @@ class BroadcastEvent implements ShouldQueue
     }
 
     /**
-     * Get the channels for the given connection.
-     *
-     * @param  array  $channels
-     * @param  string  $connection
-     * @return array
-     */
-    protected function getConnectionChannels($channels, $connection): array
-    {
-        return is_array($channels[$connection] ?? null)
-            ? $channels[$connection]
-            : $channels;
-    }
-
-    /**
-     * Get the payload for the given connection.
-     *
-     * @param  array  $payload
-     * @param  string  $connection
-     * @return array
-     */
-    protected function getConnectionPayload($payload, $connection): array
-    {
-        $connectionPayload = is_array($payload[$connection] ?? null)
-            ? $payload[$connection]
-            : $payload;
-
-        if (isset($payload['socket'])) {
-            $connectionPayload['socket'] = $payload['socket'];
-        }
-
-        return $connectionPayload;
-    }
-
-    /**
-     * Get the payload for the given event.
-     *
-     * @param  mixed  $event
-     * @return array
-     */
-
-    /**
      * Get the payload for the given event.
      *
      * @param  mixed  $event
@@ -176,6 +135,40 @@ class BroadcastEvent implements ShouldQueue
         }
 
         return $value;
+    }
+
+    /**
+     * Get the channels for the given connection.
+     *
+     * @param  array  $channels
+     * @param  string  $connection
+     * @return array
+     */
+    protected function getConnectionChannels($channels, $connection): array
+    {
+        return is_array($channels[$connection] ?? null)
+            ? $channels[$connection]
+            : $channels;
+    }
+
+    /**
+     * Get the payload for the given connection.
+     *
+     * @param  array  $payload
+     * @param  string  $connection
+     * @return array
+     */
+    protected function getConnectionPayload($payload, $connection): array
+    {
+        $connectionPayload = is_array($payload[$connection] ?? null)
+            ? $payload[$connection]
+            : $payload;
+
+        if (isset($payload['socket'])) {
+            $connectionPayload['socket'] = $payload['socket'];
+        }
+
+        return $connectionPayload;
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -89,11 +89,10 @@ class BroadcastEvent implements ShouldQueue
         $payload = $this->getPayloadFromEvent($this->event);
 
         foreach ($connections as $connection) {
-            $connectionChannels = $this->getConnectionChannels($channels, $connection);
-            $connectionPayload = $this->getConnectionPayload($payload, $connection);
-
             $manager->connection($connection)->broadcast(
-                $connectionChannels, $name, $connectionPayload
+                $this->getConnectionChannels($channels, $connection),
+                $name,
+                $this->getConnectionPayload($payload, $connection)
             );
         }
     }

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -143,7 +143,7 @@ class BroadcastEvent implements ShouldQueue
      * @param  string  $connection
      * @return array
      */
-    protected function getConnectionChannels($channels, $connection): array
+    protected function getConnectionChannels($channels, $connection)
     {
         return is_array($channels[$connection] ?? null)
             ? $channels[$connection]
@@ -157,7 +157,7 @@ class BroadcastEvent implements ShouldQueue
      * @param  string  $connection
      * @return array
      */
-    protected function getConnectionPayload($payload, $connection): array
+    protected function getConnectionPayload($payload, $connection)
     {
         $connectionPayload = is_array($payload[$connection] ?? null)
             ? $payload[$connection]

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -64,6 +64,28 @@ class BroadcastEventTest extends TestCase
 
         (new BroadcastEvent($event))->handle($manager);
     }
+
+    public function testSpecificChannelsPerConnection()
+    {
+        $broadcaster = m::mock(Broadcaster::class);
+
+        $broadcaster->shouldReceive('broadcast')->once()->with(
+            ['first-channel'], TestBroadcastEventWithChannelsPerConnection::class, ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
+        );
+
+        $broadcaster->shouldReceive('broadcast')->once()->with(
+            ['second-channel'], TestBroadcastEventWithChannelsPerConnection::class, ['firstName' => 'Taylor']
+        );
+
+        $manager = m::mock(BroadcastingFactory::class);
+
+        $manager->shouldReceive('connection')->once()->with('first_connection')->andReturn($broadcaster);
+        $manager->shouldReceive('connection')->once()->with('second_connection')->andReturn($broadcaster);
+
+        $event = new TestBroadcastEventWithChannelsPerConnection;
+
+        (new BroadcastEvent($event))->handle($manager);
+    }
 }
 
 class TestBroadcastEvent
@@ -84,7 +106,7 @@ class TestBroadcastEvent
     }
 }
 
-class TestBroadcastEventWithManualData extends TestBroadcastEvent
+class TestBroadcastEventWithcoManualData extends TestBroadcastEvent
 {
     public function broadcastWith()
     {
@@ -99,5 +121,38 @@ class TestBroadcastEventWithSpecificBroadcaster extends TestBroadcastEvent
     public function __construct()
     {
         $this->broadcastVia('log');
+    }
+}
+
+class TestBroadcastEventWithChannelsPerConnection extends TestBroadcastEvent
+{
+    public function broadcastConnections()
+    {
+        return [
+            'first_connection',
+            'second_connection',
+        ];
+    }
+
+    public function broadcastWith()
+    {
+        return [
+            'first_connection' => [
+                'firstName' => 'Taylor',
+                'lastName' => 'Otwell',
+                'collection' => ['foo' => 'bar'],
+            ],
+            'second_connection' => [
+                'firstName' => 'Taylor',
+            ],
+        ];
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            'first_connection' => ['first-channel'],
+            'second_connection' => ['second-channel'],
+        ];
     }
 }

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -106,7 +106,7 @@ class TestBroadcastEvent
     }
 }
 
-class TestBroadcastEventWithcoManualData extends TestBroadcastEvent
+class TestBroadcastEventWithManualData extends TestBroadcastEvent
 {
     public function broadcastWith()
     {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -339,11 +339,6 @@ class BroadcasterTest extends TestCase
             ['customerorder.1', 'order.{id}', false],
         ];
     }
-
-    public function testDefinedChannelPerConnection()
-    {
-
-    }
 }
 
 class FakeBroadcaster extends Broadcaster

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -339,6 +339,11 @@ class BroadcasterTest extends TestCase
             ['customerorder.1', 'order.{id}', false],
         ];
     }
+
+    public function testDefinedChannelPerConnection()
+    {
+
+    }
 }
 
 class FakeBroadcaster extends Broadcaster


### PR DESCRIPTION
This pull request introduces support for broadcasting events to multiple channels and connections with specific payloads for each connection. The changes include:  

**BroadcastEvent Class Enhancements:**  
- Added methods to handle broadcasting to multiple connections and channels.
- Implemented logic to format and send payloads specific to each connection.

**Test Cases:**

- Added new test cases in BroadcastEventTest to verify the functionality of broadcasting to multiple channels and connections.
- Ensured existing tests are updated to reflect the new broadcasting logic.