### PR TITLE
Add support for missing Postgres connection options

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -150,7 +150,9 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $dsn .= ";application_name='".str_replace("'", "\'", $application_name)."'";
         }
 
-        return $this->addSslOptions($dsn, $config);
+        $dsn = $this->addSslOptions($dsn, $config);
+
+        return $this->addPostgresOptions($dsn, $config);
     }
 
     /**
@@ -162,7 +164,66 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function addSslOptions($dsn, array $config)
     {
-        foreach (['sslmode', 'sslcert', 'sslkey', 'sslrootcert'] as $option) {
+        foreach (
+            [
+                'sslmode',
+                'sslcert',
+                'sslkey',
+                'sslrootcert',
+                'requiressl',
+                'sslnegotiation',
+                'sslcompression',
+                'sslpassword',
+                'sslcertmode',
+                'sslcrl',
+                'sslcrldir',
+                'sslsni',
+            ] as $option
+        ) {
+            if (isset($config[$option])) {
+                $dsn .= ";{$option}={$config[$option]}";
+            }
+        }
+
+        return $dsn;
+    }
+
+    /**
+     * Add Postgres specific options to the DSN.
+     *
+     * @param  string  $dsn
+     * @param  array  $config
+     * @return string
+     */
+    protected function addPostgresOptions($dsn, array $config)
+    {
+        foreach (
+            [
+                'channel_binding',
+                'connect_timeout',
+                'fallback_application_name',
+                'gssdelegation',
+                'gssencmode',
+                'gsslib',
+                'hostaddr',
+                'keepalives',
+                'keepalives_count',
+                'keepalives_idle',
+                'keepalives_interval',
+                'krbsrvname',
+                'load_balance_hosts',
+                'options',
+                'passfile',
+                'replication',
+                'require_auth',
+                'requirepeer',
+                'service',
+                'ssl_max_protocol_version',
+                'ssl_min_protocol_version',
+                'target_session_attrs',
+                'tcp_user_timeout',
+            ] as $option
+        ) {
             if (isset($config[$option])) {
                 $dsn .= ";{$option}={$config[$option]}";
             }

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -164,22 +164,20 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function addSslOptions($dsn, array $config)
     {
-        foreach (
-            [
-                'sslmode',
-                'sslcert',
-                'sslkey',
-                'sslrootcert',
-                'requiressl',
-                'sslnegotiation',
-                'sslcompression',
-                'sslpassword',
-                'sslcertmode',
-                'sslcrl',
-                'sslcrldir',
-                'sslsni',
-            ] as $option
-        ) {
+        foreach ([
+            'sslmode',
+            'sslcert',
+            'sslkey',
+            'sslrootcert',
+            'requiressl',
+            'sslnegotiation',
+            'sslcompression',
+            'sslpassword',
+            'sslcertmode',
+            'sslcrl',
+            'sslcrldir',
+            'sslsni',
+        ] as $option) {
             if (isset($config[$option])) {
                 $dsn .= ";{$option}={$config[$option]}";
             }
@@ -197,33 +195,31 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function addPostgresOptions($dsn, array $config)
     {
-        foreach (
-            [
-                'channel_binding',
-                'connect_timeout',
-                'fallback_application_name',
-                'gssdelegation',
-                'gssencmode',
-                'gsslib',
-                'hostaddr',
-                'keepalives',
-                'keepalives_count',
-                'keepalives_idle',
-                'keepalives_interval',
-                'krbsrvname',
-                'load_balance_hosts',
-                'options',
-                'passfile',
-                'replication',
-                'require_auth',
-                'requirepeer',
-                'service',
-                'ssl_max_protocol_version',
-                'ssl_min_protocol_version',
-                'target_session_attrs',
-                'tcp_user_timeout',
-            ] as $option
-        ) {
+        foreach ([
+            'channel_binding',
+            'connect_timeout',
+            'fallback_application_name',
+            'gssdelegation',
+            'gssencmode',
+            'gsslib',
+            'hostaddr',
+            'keepalives',
+            'keepalives_count',
+            'keepalives_idle',
+            'keepalives_interval',
+            'krbsrvname',
+            'load_balance_hosts',
+            'options',
+            'passfile',
+            'replication',
+            'require_auth',
+            'requirepeer',
+            'service',
+            'ssl_max_protocol_version',
+            'ssl_min_protocol_version',
+            'target_session_attrs',
+            'tcp_user_timeout',
+        ] as $option) {
             if (isset($config[$option])) {
                 $dsn .= ";{$option}={$config[$option]}";
             }


### PR DESCRIPTION
Connecting to a Postgres database is currently limited to a small subset of the [available connection options](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS). In a discussion I opened earlier, I already explained why this is limiting to users wanting to use additional connection options: https://github.com/laravel/framework/discussions/53412

To prevent workarounds I implemented support for all currently existing Postgres connection options in this pull request.