### PR TITLE
Make `dropForeignIdFor` method complementary to `foreignIdFor`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -531,7 +531,7 @@ class Blueprint
             $model = new $model;
         }
 
-        return $this->dropForeign([$column ?: $model->getForeignKey()]);
+        return $this->dropColumn($column ?: $model->getForeignKey());
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -444,7 +444,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         };
 
         $this->assertEquals([
-            'alter table `posts` drop foreign key `posts_user_id_foreign`',
+            'alter table `posts` drop `user_id`',
         ], $getSql(new MySqlGrammar));
     }
 
@@ -457,7 +457,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         };
 
         $this->assertEquals([
-            'alter table `posts` drop foreign key `posts_model_using_uuid_id_foreign`',
+            'alter table `posts` drop `model_using_uuid_id`',
         ], $getSql(new MySqlGrammar));
     }
 


### PR DESCRIPTION
The `dropForeignIdFor` method was originally introduced in #40950. As stated in that PR, it was intended to be the counterpart to the `foreignIdFor` method. However, the actual implementation attempts to drop a foreign key, which `foreignIdFor` *does not* add by default. It also *does not* drop the column that `foreignIdFor` adds by default.

This issue was reported in #43753 and a fix was attempted in #45134, but it did not pass tests.

I am not sure if this should be considered a true bug fix since it could potentially be a breaking change, so I have targeted `master`.

This PR changes `dropForeignIdFor` to only drop the column instead of only dropping the foreign key. The existing `dropConstrainedForeignIdFor` method should be used to drop both the foreign key and column. The tests have been updated accordingly.