### PR TITLE
[12.x] Ignore querystring parameters using closure when validating signed url 

### DIFF
--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -803,6 +803,12 @@ class RoutingUrlGeneratorTest extends TestCase
         $request = Request::create($url->signedRoute('foo').'?tampered=true');
 
         $this->assertFalse($url->hasValidSignature($request));
+
+        $request = Request::create($url->signedRoute('foo').'&tampered=true');
+
+        $this->assertTrue($url->hasValidSignature($request, ignoreQuery: ['tampered']));
+
+        $this->assertTrue($url->hasValidSignature($request, ignoreQuery: fn ($parameter) => $parameter === 'tampered'));
     }
 
     public function testSignedUrlImplicitModelBinding()


### PR DESCRIPTION
If you want to ignore all utm querystring parameters when validating a signed url, you currently have to provide all those utm parameters in an array:
```php
$request->hasValidSignatureWhileIgnoring(['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'])
```
This PR makes that easier by allowing you to provide a closure to determine which querystring parameters should be ignored:
```php
$request->hasValidSignatureWhileIgnoring(fn ($parameter) => Str::startsWith($parameter, 'utm_'));
```
