### PR TITLE
[11.x] Reload relationships when unserializing collection

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -79,7 +79,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collection = $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->get();
+        )->with($value->relations ?? [])->useWritePdo()->get();
 
         if (is_a($value->class, Pivot::class, true) ||
             in_array(AsPivot::class, class_uses($value->class))) {


### PR DESCRIPTION
When a queued mailable attempts to access previously loaded relationships in a collection, it fails to resolve them.

Simplified code repro:
```
$plannedShifts = Shift::with('clientProject')->get();

Mail::queue(new ShiftSummaryMail($plannedShifts));

// and then in the mailable
foreach ($this->plannedShifts as $shift) {
    $shift->clientProject; // throws LazyLoadViolationException despite preloaded relationship
}
```
Although the collection is serialized correctly, the unserialized collection does not maintain the loaded relationships.

A similar PR (https://github.com/laravel/framework/pull/50180) addressed this issue but was rejected.

This PR implements an alternative fix by calling the `with` method directly on the query and includes a test case.

Also renamed the `users` property to `items` in `CollectionSerializationTestClass` to make it more generic.
