### PR TITLE
[11.x] Introduce `InRangeCastable`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/InRangeCastable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/InRangeCastable.php
@@ -21,12 +21,12 @@ class InRangeCastable implements Castable
     public static function castUsing(array $arguments)
     {
         if (count($arguments) < 2) {
-            throw new \InvalidArgumentException("InRangeCastable must be called with at least 2 arguments.");
+            throw new \InvalidArgumentException('InRangeCastable must be called with at least 2 arguments.');
         }
 
         $type = $arguments[0];
-        if (!in_array($type, self::$validTypes)) {
-            throw new \InvalidArgumentException("Cast value must be one of: ".implode(", ", self::$validTypes));
+        if (! in_array($type, self::$validTypes)) {
+            throw new \InvalidArgumentException('Cast value must be one of: '.implode(', ', self::$validTypes));
         }
 
         $min = $arguments[1];
@@ -49,10 +49,11 @@ class InRangeCastable implements Castable
         }
 
         if (is_null($min) && is_null($max)) {
-            throw new \InvalidArgumentException("You must specify at least one of min and max.");
+            throw new \InvalidArgumentException('You must specify at least one of min and max.');
         }
 
-        return new class($type, $min, $max) implements CastsAttributes {
+        return new class($type, $min, $max) implements CastsAttributes
+        {
             public function __construct(
                 protected string $type,
                 protected int $min,
@@ -104,7 +105,7 @@ class InRangeCastable implements Castable
      * @param  positive-int|null  $max
      * @return string
      */
-    public static function forString(int $min = null, int $max = null): string
+    public static function forString(?int $min = null, ?int $max = null): string
     {
         return static::class.":string,{$min},{$max}";
     }
@@ -114,7 +115,7 @@ class InRangeCastable implements Castable
      * @param  positive-int|null  $max
      * @return string
      */
-    public static function forInteger(int $min = null, int $max = null): string
+    public static function forInteger(?int $min = null, ?int $max = null): string
     {
         return static::class.":integer,{$min},{$max}";
     }

--- a/src/Illuminate/Database/Eloquent/Casts/InRangeCastable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/InRangeCastable.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use DomainException;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+class InRangeCastable implements Castable
+{
+    protected static $validTypes = [
+        'int',
+        'integer',
+        'string',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public static function castUsing(array $arguments)
+    {
+        if (count($arguments) < 2) {
+            throw new \InvalidArgumentException("InRangeCastable must be called with at least 2 arguments.");
+        }
+
+        $type = $arguments[0];
+        if (!in_array($type, self::$validTypes)) {
+            throw new \InvalidArgumentException("Cast value must be one of: ".implode(", ", self::$validTypes));
+        }
+
+        $min = $arguments[1];
+        $max = $arguments[2];
+
+        if (is_string($min)) {
+            if (strlen(trim($min)) === 0) {
+                $min = null;
+            } else {
+                $min = (int) $min;
+            }
+        }
+
+        if (is_string($max)) {
+            if (strlen(trim($max)) === 0) {
+                $max = null;
+            } else {
+                $max = (int) $max;
+            }
+        }
+
+        if (is_null($min) && is_null($max)) {
+            throw new \InvalidArgumentException("You must specify at least one of min and max.");
+        }
+
+        return new class($type, $min, $max) implements CastsAttributes {
+            public function __construct(
+                protected string $type,
+                protected int $min,
+                protected int $max,
+            ) {
+            }
+
+            public function get(Model $model, string $key, mixed $value, array $attributes)
+            {
+                return $value;
+            }
+
+            public function set(Model $model, string $key, mixed $value, array $attributes)
+            {
+                if (! $this->isValueInRange($value)) {
+                    throw $this->buildException($key);
+                }
+
+                return $value;
+            }
+
+            private function buildException(string $key): DomainException
+            {
+                $type = $this->type === 'string' ? 'Length' : 'Value';
+
+                return new DomainException("{$type} of key [$key] must be between $this->min and $this->max.");
+            }
+
+            private function isValueInRange($value): bool
+            {
+                $length = match ($this->type) {
+                    'string' => mb_strlen($value),
+                    'int', 'integer' => $value,
+                };
+
+                if (
+                    (isset($this->min) && $length < $this->min)
+                    || (isset($this->max) && $length > $this->max)) {
+                    return false;
+                }
+
+                return true;
+            }
+        };
+    }
+
+    /**
+     * @param  non-negative-int|null  $min
+     * @param  positive-int|null  $max
+     * @return string
+     */
+    public static function forString(int $min = null, int $max = null): string
+    {
+        return static::class.":string,{$min},{$max}";
+    }
+
+    /**
+     * @param  non-negative-int|null  $min
+     * @param  positive-int|null  $max
+     * @return string
+     */
+    public static function forInteger(int $min = null, int $max = null): string
+    {
+        return static::class.":integer,{$min},{$max}";
+    }
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2517,7 +2517,7 @@ class DatabaseEloquentModelTest extends TestCase
         $message = null;
         try {
             $model->integerRangeAttribute = $value;
-            $this->fail("No exception was thrown");
+            $this->fail('No exception was thrown');
         } catch (\DomainException $exception) {
             $message = $exception->getMessage();
         }
@@ -2528,9 +2528,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testStringInRangeCastable(): void
     {
         $model = new EloquentModelCastingStub;
-        $model->stringRangeAttribute = "hi";
+        $model->stringRangeAttribute = 'hi';
 
-        self::assertSame("hi", $model->getAttribute('stringRangeAttribute'));
+        self::assertSame('hi', $model->getAttribute('stringRangeAttribute'));
     }
 
     #[TestWith(['hello'], 'string is longer than limit')]
@@ -2540,7 +2540,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelCastingStub;
         try {
             $model->stringRangeAttribute = $string;
-            $this->fail("No exception was thrown");
+            $this->fail('No exception was thrown');
         } catch (\DomainException $exception) {
             self::assertEquals('Length of key [stringRangeAttribute] must be between 1 and 4.', $exception->getMessage());
         }


### PR DESCRIPTION
## Problem
Database columns have limits to the size of data they can represent. Models unfortunately do not know about what the underlying data type their attributes are representing. A model doesn't know that my column is a MySQL unsigned tinyint, and cannot except values of -1 or 794. It is possible to represent an invalid state in my application code.

I as a developer however do know a bit about the underlying data types and do not need a trip to the database to find out that an insert will because a string exceeds the length. I can add checks in requests, but it would be nice for the logic to be centralized.

## Solution
`InRangeCastable` creates a custom cast that will assert a value passed to a Model is valid.

<details>
<summary>An example</summary>

```php
class User extends Model
{
    protected function casts()
    {
        return [
            'name' => InRangeCastable::forString(5, 255),
            'tokens' => InRangeCastable::forInteger(0, 10),
        ];
    }
}

$user = new User();
$user->name = "Taylor"; // ✅ no problem
$user->tokens = 42; // ❌ DomainException
```

</details>

## Other solutions
Obviously this cast can just become userland code. Or a user could hook into model events to perform attribute validation. I do believe however there is benefit here for the community at large.

It seems like this could apply to any number of different primitive datatypes, and therefore maybe it makes more sense to live inside of the `HasAttributes` trait. I had thought of something like:

```php
'sort_order' => 'range:int,0,255',
```
but got the feeling that maybe Laravel as a framework was pushing more towards new Castables instead?


## Future additions
Float, decimal, datetime, et cetera could also be added.

The ability to check the Model's connection type and match based on that

```php
'sort_order' => InRangeCastable::unsignedTinyInt()
```

