### PR TITLE
[11.x] Adds `finally` method to pipeline helper

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -42,6 +42,13 @@ class Pipeline implements PipelineContract
     protected $method = 'handle';
 
     /**
+     * The final callback to be executed after the pipeline ends regardless of the outcome.
+     *
+     * @var \Closure|null
+     */
+    protected $finally;
+
+    /**
      * Create a new class instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
@@ -116,7 +123,14 @@ class Pipeline implements PipelineContract
             array_reverse($this->pipes()), $this->carry(), $this->prepareDestination($destination)
         );
 
-        return $pipeline($this->passable);
+        try {
+            return $pipeline($this->passable);
+        } finally {
+            if ($this->finally) {
+                ($this->finally)($this->passable);
+            }
+        }
+
     }
 
     /**
@@ -129,6 +143,18 @@ class Pipeline implements PipelineContract
         return $this->then(function ($passable) {
             return $passable;
         });
+    }
+
+    /**
+     * Sets a final callback to be executed after the pipeline ends regardless of the outcome.
+     *
+     * @return $this
+     */
+    public function finally(Closure $callback)
+    {
+        $this->finally = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -145,8 +145,9 @@ class Pipeline implements PipelineContract
     }
 
     /**
-     * Sets a final callback to be executed after the pipeline ends regardless of the outcome.
+     * Set a final callback to be executed after the pipeline ends regardless of the outcome.
      *
+     * @param  \Closure  $callback
      * @return $this
      */
     public function finally(Closure $callback)

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -130,7 +130,6 @@ class Pipeline implements PipelineContract
                 ($this->finally)($this->passable);
             }
         }
-
     }
 
     /**

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Pipeline;
 
+use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Pipeline\Pipeline;
 use PHPUnit\Framework\TestCase;
@@ -272,6 +273,123 @@ class PipelineTest extends TestCase
         $this->assertSame('foo', $result);
         $this->assertNull($_SERVER['__test.pipe.one']);
         unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineFinally()
+    {
+        $pipeTwo = function ($piped, $next) {
+            $_SERVER['__test.pipe.two'] = $piped;
+
+            $next($piped);
+        };
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class, $pipeTwo])
+            ->finally(function ($piped) {
+                $_SERVER['__test.pipe.finally'] = $piped;
+            })
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame(null, $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $_SERVER['__test.pipe.two']);
+        $this->assertSame('foo', $_SERVER['__test.pipe.finally']);
+
+        unset($_SERVER['__test.pipe.one'], $_SERVER['__test.pipe.two'], $_SERVER['__test.pipe.finally']);
+    }
+
+    public function testPipelineFinallyMethodWhenChainIsStopped()
+    {
+        $pipeTwo = function ($piped) {
+            $_SERVER['__test.pipe.two'] = $piped;
+        };
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class, $pipeTwo])
+            ->finally(function ($piped) {
+                $_SERVER['__test.pipe.finally'] = $piped;
+            })
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame(null, $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $_SERVER['__test.pipe.two']);
+        $this->assertSame('foo', $_SERVER['__test.pipe.finally']);
+
+        unset($_SERVER['__test.pipe.one'], $_SERVER['__test.pipe.two'], $_SERVER['__test.pipe.finally']);
+    }
+
+    public function testPipelineFinallyOrder()
+    {
+        $std = new stdClass();
+
+        $result = (new Pipeline(new Container))
+            ->send($std)
+            ->through([
+                function ($std, $next) {
+                    $std->value = 1;
+
+                    return $next($std);
+                },
+                function ($std, $next) {
+                    $std->value++;
+
+                    return $next($std);
+                },
+            ])->finally(function ($std) {
+                $this->assertSame(3, $std->value);
+
+                $std->value++;
+            })->then(function ($std) {
+                $std->value++;
+
+                return $std;
+            });
+
+        $this->assertSame(4, $std->value);
+        $this->assertSame(4, $result->value);
+    }
+
+    public function testPipelineFinallyWhenExceptionOccurs()
+    {
+        $std = new stdClass();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('My Exception: 1');
+
+        try {
+            (new Pipeline(new Container))
+                ->send($std)
+                ->through([
+                    function ($std, $next) {
+                        $std->value = 1;
+
+                        return $next($std);
+                    },
+                    function ($std) {
+                        throw new Exception('My Exception: '.$std->value);
+                    },
+                ])->finally(function ($std) {
+                    $this->assertSame(1, $std->value);
+
+                    $std->value++;
+                })->then(function ($std) {
+                    $std->value = 0;
+
+                    return $std;
+                });
+        } catch (Exception $e) {
+            $this->assertSame('My Exception: 1', $e->getMessage());
+            $this->assertSame(2, $std->value);
+
+            throw $e;
+        }
     }
 }
 


### PR DESCRIPTION
This pull request adds the `finally` method to pipeline helper, so we can specify a callback to be executed regardless of the outcome of the pipeline.

This is the before:

```php
try {
    $result = Pipeline::send($deployment)
        ->through([PipeOne::class, PipeTwo::class]) // one of the pipes does not call the $next or throws an exception...
        ->then(fn () => $deployment->deploy());
} finally {
    // perform clean up...
}
```

This is the after:
```php
$result = Pipeline::send($deployment)
     ->through([PipeOne::class, PipeTwo::class]) // one of the pipes does not call the $next or throws an exception...
     ->finally(fn () => /** perform clean up */)
     ->then(fn () => $deployment->deploy());
```
