### PR TITLE
Handles factory=null in ConnectException while recording request-response in PendingRequest

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -941,7 +941,7 @@ class PendingRequest
                 $exception = new ConnectionException($e->getMessage(), 0, $e);
                 $request = new Request($e->getRequest());
 
-                $this->factory->recordRequestResponsePair($request, null);
+                $this->factory?->recordRequestResponsePair($request, null);
 
                 $this->dispatchConnectionFailedEvent($request, $exception);
 


### PR DESCRIPTION
I fixed a bug where if there's a `connectException` while making a HTTP request (in `send`) and the `factory` is `null` (not set), it fails while trying to record request-response pair. This was added in https://github.com/laravel/framework/pull/53530.

`factory` is not a mandatory object to be set while constructing `PendingRequest`. It's handled accordingly everywhere else in the code, except in the `connectException`.

This makes the code robust by ensuring the flow does not break if there's a `connectException` AND `factory` is not set.