### PR TITLE
[12.x] Simplify `HasFactory`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -10,17 +10,11 @@ trait HasFactory
     /**
      * Get a new factory instance for the model.
      *
-     * @param  (callable(array<string, mixed>, static|null): array<string, mixed>)|array<string, mixed>|int|null  $count
-     * @param  (callable(array<string, mixed>, static|null): array<string, mixed>)|array<string, mixed>  $state
      * @return TFactory
      */
-    public static function factory($count = null, $state = [])
+    public static function factory()
     {
-        $factory = static::newFactory() ?? Factory::factoryForModel(static::class);
-
-        return $factory
-                    ->count(is_numeric($count) ? $count : null)
-                    ->state(is_callable($count) || is_array($count) ? $count : $state);
+        return static::newFactory() ?? Factory::factoryForModel(static::class);
     }
 
     /**
@@ -30,10 +24,8 @@ trait HasFactory
      */
     protected static function newFactory()
     {
-        if (isset(static::$factory)) {
-            return static::$factory::new();
-        }
-
-        return null;
+        return isset(static::$factory)
+            ? static::$factory::new()
+            : null;
     }
 }

--- a/tests/Database/DatabaseEloquentInverseRelationHasOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationHasOneTest.php
@@ -59,7 +59,7 @@ class DatabaseEloquentInverseRelationHasOneTest extends TestCase
 
     public function testHasOneInverseRelationIsProperlySetToParentWhenLazyLoaded()
     {
-        HasOneInverseChildModel::factory(5)->create();
+        HasOneInverseChildModel::factory()->count(5)->create();
         $models = HasOneInverseParentModel::all();
 
         foreach ($models as $parent) {
@@ -72,7 +72,7 @@ class DatabaseEloquentInverseRelationHasOneTest extends TestCase
 
     public function testHasOneInverseRelationIsProperlySetToParentWhenEagerLoaded()
     {
-        HasOneInverseChildModel::factory(5)->create();
+        HasOneInverseChildModel::factory()->count(5)->create();
 
         $models = HasOneInverseParentModel::with('child')->get();
 

--- a/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationMorphOneTest.php
@@ -59,7 +59,7 @@ class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
 
     public function testMorphOneInverseRelationIsProperlySetToParentWhenLazyLoaded()
     {
-        MorphOneInverseImageModel::factory(6)->create();
+        MorphOneInverseImageModel::factory()->count(6)->create();
         $posts = MorphOneInversePostModel::all();
 
         foreach ($posts as $post) {
@@ -72,7 +72,7 @@ class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
 
     public function testMorphOneInverseRelationIsProperlySetToParentWhenEagerLoaded()
     {
-        MorphOneInverseImageModel::factory(6)->create();
+        MorphOneInverseImageModel::factory()->count(6)->create();
         $posts = MorphOneInversePostModel::with('image')->get();
 
         foreach ($posts as $post) {
@@ -85,7 +85,7 @@ class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
 
     public function testMorphOneGuessedInverseRelationIsProperlySetToParentWhenLazyLoaded()
     {
-        MorphOneInverseImageModel::factory(6)->create();
+        MorphOneInverseImageModel::factory()->count(6)->create();
         $posts = MorphOneInversePostModel::all();
 
         foreach ($posts as $post) {
@@ -98,7 +98,7 @@ class DatabaseEloquentInverseRelationMorphOneTest extends TestCase
 
     public function testMorphOneGuessedInverseRelationIsProperlySetToParentWhenEagerLoaded()
     {
-        MorphOneInverseImageModel::factory(6)->create();
+        MorphOneInverseImageModel::factory()->count(6)->create();
         $posts = MorphOneInversePostModel::with('guessedImage')->get();
 
         foreach ($posts as $post) {

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -12,19 +12,6 @@ use function PHPStan\Testing\assertType;
 
 function test(User $user, Post $post, Comment $comment, Article $article): void
 {
-    assertType('UserFactory', User::factory(function ($attributes, $model) {
-        assertType('array<string, mixed>', $attributes);
-        assertType('User|null', $model);
-
-        return ['string' => 'string'];
-    }));
-    assertType('UserFactory', User::factory(42, function ($attributes, $model) {
-        assertType('array<string, mixed>', $attributes);
-        assertType('User|null', $model);
-
-        return ['string' => 'string'];
-    }));
-
     assertType('Illuminate\Database\Eloquent\Builder<User>', User::query());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->newQuery());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->withTrashed());


### PR DESCRIPTION
I imagine I'm gonna get roasted for this PR, but I'll give it a shot.

- passing arguments to the the `factory()` method is completely undocumented
- possibly/probably results in unnecessary calls to `count()` or `state()`
- is less intuitive/readable than its chained counterpart

Yes, this will cause a minor inconvenience on the major upgrade for some users, but I think it is better for long term health of the project. IMO having 1 well documented and descriptive way of accomplishing something is better than some of this variability.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
