### PR TITLE
Allow scoped disks to be scoped from other scoped disks

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -298,7 +298,15 @@ class FilesystemManager implements FactoryContract
         return $this->build(tap(
             is_string($config['disk']) ? $this->getConfig($config['disk']) : $config['disk'],
             function (&$parent) use ($config) {
-                $parent['prefix'] = $config['prefix'];
+                if (empty($parent['prefix'])) {
+                    $parent['prefix'] = $config['prefix'];
+                } else {
+                    $separator = $parent['directory_separator'] ?? DIRECTORY_SEPARATOR;
+                    $parentPrefix = rtrim($parent['prefix'], $separator);
+                    $scopedPrefix = ltrim($config['prefix'], $separator);
+
+                    $parent['prefix'] = "{$parentPrefix}{$separator}{$scopedPrefix}";
+                }
 
                 if (isset($config['visibility'])) {
                     $parent['visibility'] = $config['visibility'];

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -302,6 +302,7 @@ class FilesystemManager implements FactoryContract
                     $parent['prefix'] = $config['prefix'];
                 } else {
                     $separator = $parent['directory_separator'] ?? DIRECTORY_SEPARATOR;
+
                     $parentPrefix = rtrim($parent['prefix'], $separator);
                     $scopedPrefix = ltrim($config['prefix'], $separator);
 


### PR DESCRIPTION
This allows a scoped disk to be scoped from another disk that is scoped itself. When working in nested sub-directories of a disk, this would allow nested on-demand disks to be created and make it much easier to keep track of the current path and avoid errors that can be introduced when building out paths manually for each call to methods like `put`, `get`, `files`, etc.