### PR TITLE
fix: Don't set newLineWritten to true unless verbosity allows output

### DIFF
--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -80,8 +80,10 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     #[\Override]
     public function writeln(string|iterable $messages, int $type = self::OUTPUT_NORMAL): void
     {
-        $this->newLinesWritten = $this->trailingNewLineCount($messages) + 1;
-        $this->newLineWritten = true;
+        if ($this->output->getVerbosity() >= $type) {
+            $this->newLinesWritten = $this->trailingNewLineCount($messages) + 1;
+            $this->newLineWritten = true;
+        }
 
         parent::writeln($messages, $type);
     }

--- a/tests/Console/OutputStyleTest.php
+++ b/tests/Console/OutputStyleTest.php
@@ -54,4 +54,21 @@ class OutputStyleTest extends TestCase
         $style->writeln('Foo');
         $this->assertTrue($style->newLineWritten());
     }
+
+    public function testDetectsNewLineOnlyOnOutput()
+    {
+        $bufferedOutput = new BufferedOutput();
+
+        $style = new OutputStyle(new ArrayInput([]), $bufferedOutput);
+
+        $style->setVerbosity(OutputStyle::VERBOSITY_NORMAL);
+
+        $style->writeln('Foo', OutputStyle::VERBOSITY_VERBOSE);
+        $this->assertFalse($style->newLineWritten());
+
+        $style->setVerbosity(OutputStyle::VERBOSITY_VERBOSE);
+
+        $style->writeln('Foo', OutputStyle::VERBOSITY_VERBOSE);
+        $this->assertTrue($style->newLineWritten());
+    }
 }


### PR DESCRIPTION
This PR fixes the following spacing issue in command output when using NewLineAware output.

This simple command has two info outputs
```
    public function handle(): void
    {
        $this->components->info('Foo', OutputInterface::VERBOSITY_VERBOSE);
        $this->components->info('Bar', OutputInterface::VERBOSITY_NORMAL);
    }
```

If it is ran with normal verbosity the spacing will be wrong
```
 $ artisan foo
   INFO  Bar.

```

While with verbose it looks like this:
```
 $ artisan foo -v

   INFO  Foo.

   INFO  Bar.

```