### PR TITLE
Implement mapByKey

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -644,6 +644,35 @@ class Arr
     }
 
     /**
+     * Run an associative map over each of the item's values filtered by their key.
+     *
+     * The callback should return the same resultset with the modified values of the given keys.
+     *
+     * @param  array  $array
+     * @param  string|array  $keys
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function mapByKey(array $array, $keys, callable $callback)
+    {
+        $result = [];
+
+        foreach ($array as $parentKey => $row) {
+            foreach ($row as $key => $value) {
+                if (! in_array($key, (array) $keys, true)) {
+                    $result[$parentKey][$key] = $value;
+
+                    continue;
+                }
+
+                $result[$parentKey][$key] = $callback($value, $key, $row);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Run a map over each nested chunk of items.
      *
      * @template TKey

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -844,6 +844,20 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Run an associative map over each of the item's values filtered by their key.
+     *
+     * The callback should return the same resultset with the modified values of the given keys.
+     *
+     * @param  string|array  $keys
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapByKey($keys, callable $callback)
+    {
+        return new static(Arr::mapByKey($this->items, $keys, $callback));
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -844,6 +844,20 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Run an associative map over each of the item's values filtered by their key.
+     *
+     * The callback should return the same resultset with the modified values of the given keys.
+     *
+     * @param  string|array  $keys
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapByKey($keys, callable $callback)
+    {
+        return $this->passthru('mapByKey', func_get_args());
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -6,6 +6,8 @@ use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Number;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -800,6 +802,60 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals(
             ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
+            $data
+        );
+    }
+
+    public function testMapByKey()
+    {
+        $invoices = [
+            ['recipient' => 'Dries', 'currency' => 'USD', 'amount' => 1],
+            ['recipient' => 'Taylor', 'currency' => 'USD', 'amount' => 25.67],
+            ['recipient' => 'Nuno', 'currency' => 'EUR', 'amount' => 123987],
+        ];
+
+        $invoices = Arr::mapByKey($invoices, 'amount', function ($value, $key, $row) {
+            return Number::currency($value, $row['currency']);
+        });
+
+        $this->assertEquals(
+            [
+                ['recipient' => 'Dries', 'currency' => 'USD', 'amount' => '$1.00'],
+                ['recipient' => 'Taylor', 'currency' => 'USD', 'amount' => '$25.67'],
+                ['recipient' => 'Nuno', 'currency' => 'EUR', 'amount' => '€123,987.00'],
+            ],
+            $invoices
+        );
+
+        $posts = [
+            ['title' => 'Hello World', 'body' => '# Hello World', 'preview' => 'Test *post*'],
+            ['title' => 'New Release', 'body' => '**New Release**', 'preview' => '**Release notes**'],
+        ];
+
+        $posts = Arr::mapByKey($posts, ['body', 'preview'], fn ($value) => Str::markdown($value));
+
+        $this->assertEquals(
+            [
+                ['title' => 'Hello World', 'body' => "<h1>Hello World</h1>\n", 'preview' => "<p>Test <em>post</em></p>\n"],
+                ['title' => 'New Release', 'body' => "<p><strong>New Release</strong></p>\n", 'preview' => "<p><strong>Release notes</strong></p>\n"],
+            ],
+            $posts
+        );
+
+        $data = [
+            ['foo' => 'Dries', 'bar' => 'Joe', 'baz' => 'Jess'],
+            ['foo' => 'Taylor', 'baz' => 'James'],
+            ['bar' => 'Nuno'],
+        ];
+
+        $data = Arr::mapByKey($data, ['bar', 'baz'], fn ($value) => Str::lower($value));
+
+        $this->assertEquals(
+            [
+                ['foo' => 'Dries', 'bar' => 'joe', 'baz' => 'jess'],
+                ['foo' => 'Taylor', 'baz' => 'james'],
+                ['bar' => 'nuno'],
+            ],
             $data
         );
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3054,6 +3054,27 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testMapByKey($collection)
+    {
+        $data = new $collection([
+            ['foo' => 'Dries', 'bar' => 'Joe', 'baz' => 'Jess'],
+            ['foo' => 'Taylor', 'baz' => 'James'],
+            ['bar' => 'Nuno'],
+        ]);
+
+        $data = $data->mapByKey(['bar', 'baz'], fn ($value) => Str::lower($value));
+
+        $this->assertEquals(
+            [
+                ['foo' => 'Dries', 'bar' => 'joe', 'baz' => 'jess'],
+                ['foo' => 'Taylor', 'baz' => 'james'],
+                ['bar' => 'nuno'],
+            ],
+            $data->all()
+        );
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testMapInto($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
This PR adds a new array helper and collection method called `mapByKey`. With this method instead of this:

```php
$result = Arr::map($array, function ($value, $key) {
    return in_array($key, ['foo', 'bar']) ? strtolower($value) : $value;
});
```

You can do:


```php
$result = Arr::mapByKey($array, ['foo', 'bar'], fn ($value) => strtolower($value));
```

So basically target any key in a given item on an array and manipulate it.

Things not added yet which I'd love to get some help with:

- Verify if LazyCollection support is implemented correctly 
- Generics in docblocks
- Deep nested key targeting with dot notation
- Enumerable contract method (can be added on master once it's merged upstream)