### PR TITLE
No explicit `USE database` statement

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -24,7 +24,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
         $connection = $this->createConnection($dsn, $config, $options);
 
         if (! empty($config['database']) && 
-            (! isset($config['use_db_after_connecting']) || 
+            (! isset($config['use_db_after_connecting']) ||
              $config['use_db_after_connecting'])) {
             $connection->exec("use `{$config['database']}`;");
         }

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -23,6 +23,11 @@ class MySqlConnector extends Connector implements ConnectorInterface
         // connection's behavior, and some might be specified by the developers.
         $connection = $this->createConnection($dsn, $config, $options);
 
+        // Allow skipping of explicit `USE database` statement.
+        if (! empty($config['database']) && (! isset($config['explicit_use_db']) || $config['explicit_use_db'])) {
+            $connection->exec("use `{$config['database']}`;");
+        }
+
         $this->configureConnection($connection, $config);
 
         return $connection;

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -23,10 +23,6 @@ class MySqlConnector extends Connector implements ConnectorInterface
         // connection's behavior, and some might be specified by the developers.
         $connection = $this->createConnection($dsn, $config, $options);
 
-        if (! empty($config['database'])) {
-            $connection->exec("use `{$config['database']}`;");
-        }
-
         $this->configureConnection($connection, $config);
 
         return $connection;

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -23,8 +23,9 @@ class MySqlConnector extends Connector implements ConnectorInterface
         // connection's behavior, and some might be specified by the developers.
         $connection = $this->createConnection($dsn, $config, $options);
 
-        // Allow skipping of explicit `USE database` statement.
-        if (! empty($config['database']) && (! isset($config['explicit_use_db']) || $config['explicit_use_db'])) {
+        if (! empty($config['database']) && 
+            (! isset($config['use_db_after_connecting']) || 
+             $config['use_db_after_connecting'])) {
             $connection->exec("use `{$config['database']}`;");
         }
 


### PR DESCRIPTION
No need to explicitly send a `USE database` statement. The database is already selected via the DSN string.

Multiple reasons for this:
- One less round trip per connection
- No connection pinning when used with a proxy (e.g. [RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html#rds-proxy-pinning.mysql-tracked-vars)).
- No other drivers are doing that (again, database is already selected via the DSN string).