### PR TITLE
[11.x] Replace string class names with ::class constants

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -250,8 +250,8 @@ class RouteListCommand extends Command
     protected function isFrameworkController(Route $route)
     {
         return in_array($route->getControllerClass(), [
-            '\Illuminate\Routing\RedirectController',
-            '\Illuminate\Routing\ViewController',
+            \Illuminate\Routing\RedirectController::class,
+            \Illuminate\Routing\ViewController::class,
         ], true);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -258,7 +258,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        return $this->any($uri, '\Illuminate\Routing\RedirectController')
+        return $this->any($uri, \Illuminate\Routing\RedirectController::class)
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);
     }
@@ -287,7 +287,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function view($uri, $view, $data = [], $status = 200, array $headers = [])
     {
-        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
+        return $this->match(['GET', 'HEAD'], $uri, \Illuminate\Routing\ViewController::class)
                 ->setDefaults([
                     'view' => $view,
                     'data' => $data,


### PR DESCRIPTION
Replace string class names with ::class constants to be consistent with the rest of the codebase.

This change:
- Improves type safety
- Makes refactoring easier
- Maintains consistency with Laravel's coding style