### PR TITLE
Add action filter to route:list

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -264,6 +264,7 @@ class RouteListCommand extends Command
     protected function filterRoute(array $route)
     {
         if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||
+            ($this->option('action')&& ! Str::contains($route['action'], $this->option('action'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
             ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||
@@ -496,6 +497,7 @@ class RouteListCommand extends Command
         return [
             ['json', null, InputOption::VALUE_NONE, 'Output the route list as JSON'],
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
+            ['action', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by action'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -264,7 +264,7 @@ class RouteListCommand extends Command
     protected function filterRoute(array $route)
     {
         if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||
-            ($this->option('action') && ! Str::contains($route['action'], $this->option('action'))) ||
+            ($this->option('action') && isset($route['action']) && is_string($route['action']) && ! Str::contains($route['action'], $this->option('action'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
             ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -264,7 +264,7 @@ class RouteListCommand extends Command
     protected function filterRoute(array $route)
     {
         if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||
-            ($this->option('action')&& ! Str::contains($route['action'], $this->option('action'))) ||
+            ($this->option('action') && ! Str::contains($route['action'], $this->option('action'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
             ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -119,6 +119,27 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('');
     }
 
+    public function testRouteCanBeFilteredByAction()
+    {
+        $this->withoutDeprecationHandling();
+
+        $this->router->get('/', function () {
+            //
+        });
+        $this->router->get('foo/{user}', [FooController::class, 'show']);
+
+        $this->artisan(RouteListCommand::class, ['--action' => 'FooController'])
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput(
+                '  GET|HEAD       foo/{user} Illuminate\Tests\Testing\Console\FooController@show'
+            )->expectsOutput('')
+            ->expectsOutput(
+                '                                                  Showing [1] routes'
+            )
+            ->expectsOutput('');
+    }
+
     public function testDisplayRoutesExceptVendor()
     {
         $this->router->get('foo/{user}', [FooController::class, 'show']);


### PR DESCRIPTION
Add filter option for route:list that filters on the action string.

Can be used to find the routes using a specific controller, eg `route:list --action=TestController`