### PR TITLE
Remove unwanted comma in email.blade.php

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,7 +39,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards,')<br>
+@lang('Regards')<br>
 {{ config('app.name') }}
 @endif
 


### PR DESCRIPTION
Remove a comma preventing the string ‘Regards’ from being translated correctly when using a locale different form English

