### PR TITLE
[11.x] Remove useless assignment in `CanBeOneOfMany`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -77,7 +77,7 @@ trait CanBeOneOfMany
 
         $keyName = $this->query->getModel()->getKeyName();
 
-        $columns = is_string($columns = $column) ? [
+        $columns = is_string($column) ? [
             $column => $aggregate,
             $keyName => $aggregate,
         ] : $column;


### PR DESCRIPTION
The variable `$columns` is assigned twice in the same line. Only the main assignment is necessary.