### PR TITLE
[11.x] Add support for filtering resource fields with 'only' method

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -20,7 +20,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     use ConditionallyLoadsAttributes, DelegatesToResource;
 
     /**
-     * The only fields that should be evaluated and returned when resource is displayed
+     * The only fields that should be evaluated and returned when resource is displayed.
      *
      * @var array
      */
@@ -126,9 +126,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Returns the default fields that define a resource, which will be filtered when 'only' filter is used
+     * Returns the default fields that define a resource, which will be filtered when 'only' filter is used.
      *
-     * @param Request $request
+     * @param  Request  $request
      * @return array
      */
     public function defaultToArray(Request $request)
@@ -144,7 +144,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray(Request $request)
     {
-        if (!empty($this->defaultToArray($request))) {
+        if (! empty($this->defaultToArray($request))) {
             return $this->applyOnlyFilter($this->defaultToArray($request));
         }
 
@@ -177,9 +177,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Set the only fields to be evaluated and returned when a resource is displayed
+     * Set the only fields to be evaluated and returned when a resource is displayed.
      *
-     * @param array $only
+     * @param  array  $only
      * @return $this
      */
     public function only(array $only)
@@ -293,17 +293,17 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Evaluates and returns only the desired fields from default fields when 'only' filter is used.
      *
-     * @param array $default_fields
+     * @param  array  $default_fields
      * @return array
      */
     public function applyOnlyFilter(array $default_fields): array
     {
         return array_map(
-            fn($item) => is_callable($item) ? $item() : $item,
-            !empty($this->only)
+            fn ($item) => is_callable($item) ? $item() : $item,
+            ! empty($this->only)
                 ? array_filter(
-                $default_fields,
-                fn($key) => in_array($key, $this->only ?? []), ARRAY_FILTER_USE_KEY)
+                    $default_fields,
+                    fn ($key) => in_array($key, $this->only ?? []), ARRAY_FILTER_USE_KEY)
                 : $default_fields
         );
     }

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -99,7 +99,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      */
     public function toArray(Request $request)
     {
-        return $this->collection->map->toArray($request)->all();
+        return $this->collection->map->only($this->only)->map->toArray($request)->all();
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/FilterableObjectResource.php
+++ b/tests/Integration/Http/Fixtures/FilterableObjectResource.php
@@ -9,9 +9,9 @@ class FilterableObjectResource extends JsonResource
     public function defaultToArray($request)
     {
         return [
-            'id'        => $this->id,
-            'full_name' => $this->first_name . ' ' . $this->last_name,
-            'address'   => $this->address,
+            'id' => $this->id,
+            'full_name' => $this->first_name.' '.$this->last_name,
+            'address' => $this->address,
         ];
     }
 }

--- a/tests/Integration/Http/Fixtures/FilterableObjectResource.php
+++ b/tests/Integration/Http/Fixtures/FilterableObjectResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FilterableObjectResource extends JsonResource
+{
+    public function defaultToArray($request)
+    {
+        return [
+            'id'        => $this->id,
+            'full_name' => $this->first_name . ' ' . $this->last_name,
+            'address'   => $this->address,
+        ];
+    }
+}

--- a/tests/Integration/Http/Fixtures/FilterableObjectResourceWithCallableFields.php
+++ b/tests/Integration/Http/Fixtures/FilterableObjectResourceWithCallableFields.php
@@ -10,9 +10,9 @@ class FilterableObjectResourceWithCallableFields extends JsonResource
     public function defaultToArray($request)
     {
         return [
-            'id'        => $this->id,
-            'full_name' => $this->first_name . ' ' . $this->last_name,
-            'addresses' => fn() => throw new Exception('This should be evaluated only if requested, like an eager relationship.'),
+            'id' => $this->id,
+            'full_name' => $this->first_name.' '.$this->last_name,
+            'addresses' => fn () => throw new Exception('This should be evaluated only if requested, like an eager relationship.'),
         ];
     }
 }

--- a/tests/Integration/Http/Fixtures/FilterableObjectResourceWithCallableFields.php
+++ b/tests/Integration/Http/Fixtures/FilterableObjectResourceWithCallableFields.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Exception;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FilterableObjectResourceWithCallableFields extends JsonResource
+{
+    public function defaultToArray($request)
+    {
+        return [
+            'id'        => $this->id,
+            'full_name' => $this->first_name . ' ' . $this->last_name,
+            'addresses' => fn() => throw new Exception('This should be evaluated only if requested, like an eager relationship.'),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1858,7 +1858,7 @@ class ResourceTest extends TestCase
     public function testResourceFieldsCanBeFiltered()
     {
         Route::get('/', function () {
-            return FilterableObjectResource::make((object)['id' => 32, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud', 'address' => 'somewhere'])->only(['id', 'address']);
+            return FilterableObjectResource::make((object) ['id' => 32, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud', 'address' => 'somewhere'])->only(['id', 'address']);
         });
 
         $this->withoutExceptionHandling()
@@ -1866,7 +1866,7 @@ class ResourceTest extends TestCase
             ->assertStatus(200)
             ->assertExactJson([
                 'data' => [
-                    'id'      => 32,
+                    'id' => 32,
                     'address' => 'somewhere',
                 ],
             ]);
@@ -1876,8 +1876,8 @@ class ResourceTest extends TestCase
     {
         Route::get('/', function () {
             $objects = [
-                (object)['id' => 1, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud', 'address' => 'somewhere here'],
-                (object)['id' => 2, 'first_name' => 'Mahfoud', 'last_name' => 'Mouhcine', 'address' => 'somewhere there'],
+                (object) ['id' => 1, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud', 'address' => 'somewhere here'],
+                (object) ['id' => 2, 'first_name' => 'Mahfoud', 'last_name' => 'Mouhcine', 'address' => 'somewhere there'],
             ];
 
             return FilterableObjectResource::collection($objects)->only(['full_name']);
@@ -1894,13 +1894,12 @@ class ResourceTest extends TestCase
             ]);
     }
 
-
     public function testResourceCollectionFieldsAreAllReturnedWhenNoFiltersAreSpecified()
     {
         Route::get('/', function () {
             $objects = [
-                (object)['id' => 1, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud', 'address' => 'somewhere here'],
-                (object)['id' => 2, 'first_name' => 'Mahfoud', 'last_name' => 'Mouhcine', 'address' => 'somewhere there'],
+                (object) ['id' => 1, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud', 'address' => 'somewhere here'],
+                (object) ['id' => 2, 'first_name' => 'Mahfoud', 'last_name' => 'Mouhcine', 'address' => 'somewhere there'],
             ];
 
             return FilterableObjectResource::collection($objects);
@@ -1920,7 +1919,7 @@ class ResourceTest extends TestCase
     public function testResourceFieldsAreEvaluatedWhenIncludedInOnlyFilter()
     {
         Route::get('/', function () {
-            return FilterableObjectResourceWithCallableFields::make((object)['id' => 32, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud'])->only(['id', 'full_name', 'addresses']);
+            return FilterableObjectResourceWithCallableFields::make((object) ['id' => 32, 'first_name' => 'Mouhcine', 'last_name' => 'Mahfoud'])->only(['id', 'full_name', 'addresses']);
         });
 
         $this->expectExceptionMessage('This should be evaluated only if requested, like an eager relationship.');


### PR DESCRIPTION
# Add support for filtering resource fields with 'only' method

This PR introduces a new `only()` method for API Resources that allows selective field filtering when transforming resources to JSON responses. This feature is particularly useful when you want to:

- Reduce payload size by returning only specific fields
- Customize resource output based on different API endpoints
- Optimize performance by avoiding evaluation of expensive fields when not needed

## Usage Examples

### Basic Resource Field Filtering

```php
class UserResource extends JsonResource
{
    public function defaultToArray($request)
    {
        return [
            'id' => $this->id,
            'full_name' => $this->first_name . ' ' . $this->last_name,
            'email' => $this->email,
            'address' => $this->address,
            'created_at' => $this->created_at
        ];
    }
}

// In your controller, return only specific fields
return UserResource::make($user)->only(['id', 'full_name']);
// Returns: { "data": { "id": 1, "full_name": "John Doe" } }
```

### Resource Collection Filtering

```php
// Filter fields for an entire collection
return UserResource::collection($users)->only(['id', 'email']);
```

### Lazy Evaluation of Fields

The feature supports lazy evaluation of expensive operations, only executing them when the field is actually requested:

```php
class UserResource extends JsonResource
{
    public function defaultToArray($request)
    {
        return [
            'id' => $this->id,
            'name' => $this->name,
            'posts' => fn() => PostResource::collection($this->whenLoaded('posts')),
            'activity_stats' => fn() => $this->calculateActivityStats() // Expensive operation
        ];
    }
}

// Only id and name will be evaluated
return UserResource::make($user)->only(['id', 'name']);

// posts and activity_stats will be evaluated only when explicitly requested
return UserResource::make($user)->only(['id', 'posts', 'activity_stats']);
```

### Using with Inertia.js

The `only()` method is particularly useful when working with Inertia.js to optimize page data:

```php
// In your UserResource
class UserResource extends JsonResource
{
    public function defaultToArray($request)
    {
        return [
            'id' => $this->id,
            'name' => $this->name,
            'email' => $this->email,
            'profile' => fn() => new ProfileResource($this->profile),
            'permissions' => fn() => $this->permissions,
            'activity_log' => fn() => ActivityLogResource::collection($this->activities),
            'notifications' => fn() => NotificationResource::collection($this->notifications),
        ];
    }
}

// In your controllers, customize data per page:

// User list page - minimal data
public function index()
{
    return Inertia::render('Users/Index', [
        'users' => UserResource::collection(User::paginate())
            ->only(['id', 'name', 'email'])
    ]);
}

// User profile page - more detailed data
public function show(User $user)
{
    return Inertia::render('Users/Show', [
        'user' => UserResource::make($user)
            ->only(['id', 'name', 'email', 'profile', 'permissions'])
    ]);
}

// User activity page - focus on activity data
public function activity(User $user)
{
    return Inertia::render('Users/Activity', [
        'user' => UserResource::make($user)
            ->only(['id', 'name', 'activity_log'])
    ]);
}

// Notification center - only notification related data
public function notifications(User $user)
{
    return Inertia::render('Users/Notifications', [
        'user' => UserResource::make($user)
            ->only(['id', 'notifications'])
    ]);
}
```

This approach with Inertia.js provides several benefits:
- Reduces initial page load size by including only necessary data
- Prevents overfetching of expensive relationships
- Makes it clear which data is required for each page
- Allows for easy modification of included fields per route

## Benefits

- **Performance**: Avoid evaluating expensive computations or relationships when not needed
- **Bandwidth**: Reduce response payload size by including only necessary fields
- **Flexibility**: Easily customize resource output based on context or client needs
- **Maintainability**: Define all possible fields in one place, filter as needed

This implementation is backward compatible and doesn't affect existing resource implementations.