### PR TITLE
[11.x] Fixes wrong `@mixin` on `SoftDeletes` trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -11,8 +11,6 @@ use Illuminate\Support\Collection as BaseCollection;
  * @method static \Illuminate\Database\Eloquent\Builder<static> withoutTrashed()
  * @method static static restoreOrCreate(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
  * @method static static createOrRestore(array<string, mixed> $attributes = [], array<string, mixed> $values = [])
- *
- * @mixin \Illuminate\Database\Eloquent\Model
  */
 trait SoftDeletes
 {


### PR DESCRIPTION
Seems that PHPStan / Larastan are unable to pick any model's casts if this `@mixin` annotation is present. Unsure about the reason, so as quick fix we may remove it.