### PR TITLE
[11.x] fix `times()` calls

### DIFF
--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -233,7 +233,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_multiple_model_attributes_can_be_created()
     {
-        $posts = FactoryTestPostFactory::new()->times(10)->raw();
+        $posts = FactoryTestPostFactory::times(10)->raw();
         $this->assertIsArray($posts);
 
         $this->assertCount(10, $posts);

--- a/tests/Integration/Support/OnceHelperTest.php
+++ b/tests/Integration/Support/OnceHelperTest.php
@@ -17,8 +17,8 @@ class OnceHelperTest extends TestCase
 
     protected function afterRefreshingDatabase()
     {
-        UserFactory::new()->times(3)->create();
-        UserFactory::new()->times(2)->unverified()->create();
+        UserFactory::times(3)->create();
+        UserFactory::times(2)->unverified()->create();
     }
 
     public function testItCanCacheStaticMethodWithoutParameters()


### PR DESCRIPTION
`times()` is a static method on the factory, and should be called as such, not as an instance method.

`times()` also already calls `new()` so no reason to do it twice.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
