### PR TITLE
[11.x] Add array response type

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -91,7 +91,7 @@ class Response implements ArrayAccess, Stringable
     /**
      * Get the JSON decoded body of the response as an object.
      *
-     * @return object|null
+     * @return object|array|null
      */
     public function object()
     {


### PR DESCRIPTION
Update the object method annotation in **Illuminate\Http\Client\Response** to include _array_ as a possible return type from json_decode.