### PR TITLE
Correct return type to match functionality

### DIFF
--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -7,7 +7,7 @@ interface HasMiddleware
     /**
      * Get the middleware that should be assigned to the controller.
      *
-     * @return \Illuminate\Routing\Controllers\Middleware[]
+     * @return array<int,\Illuminate\Routing\Controllers\Middleware|\Closure|string>
      */
     public static function middleware();
 }


### PR DESCRIPTION
As discussed in https://github.com/laravel/framework/pull/50766#issuecomment-2566054522, the revised return type is still incorrect as it needs to include both string and closure in order to match all the functionality available.

I was fortunate enough to be upgrading a project where I ended up using all three types so I can confirm that phpstan is now happy with this particular combination.

[The docs](https://laravel.com/docs/11.x/controllers#controller-middleware) don't reference another type currently so this should be sufficient.