### PR TITLE
pass options to migration events

### DIFF
--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -14,13 +14,22 @@ abstract class MigrationsEvent implements MigrationEventContract
     public $method;
 
     /**
+     * The options provided when the migration method was invoked.
+     *
+     * @var array<string, mixed>
+     */
+    public $options;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $method
+     * @param  array<string, mixed>  $options
      * @return void
      */
-    public function __construct($method)
+    public function __construct($method, $options)
     {
         $this->method = $method;
+        $this->options = $options;
     }
 }

--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -27,7 +27,7 @@ abstract class MigrationsEvent implements MigrationEventContract
      * @param  array<string, mixed>  $options
      * @return void
      */
-    public function __construct($method, $options)
+    public function __construct($method, array $options = [])
     {
         $this->method = $method;
         $this->options = $options;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -169,7 +169,7 @@ class Migrator
 
         $step = $options['step'] ?? false;
 
-        $this->fireMigrationEvent(new MigrationsStarted('up'));
+        $this->fireMigrationEvent(new MigrationsStarted('up', $options));
 
         $this->write(Info::class, 'Running migrations.');
 
@@ -184,7 +184,7 @@ class Migrator
             }
         }
 
-        $this->fireMigrationEvent(new MigrationsEnded('up'));
+        $this->fireMigrationEvent(new MigrationsEnded('up', $options));
 
         $this->output?->writeln('');
     }
@@ -278,7 +278,7 @@ class Migrator
 
         $this->requireFiles($files = $this->getMigrationFiles($paths));
 
-        $this->fireMigrationEvent(new MigrationsStarted('down'));
+        $this->fireMigrationEvent(new MigrationsStarted('down', $options));
 
         $this->write(Info::class, 'Rolling back migrations.');
 
@@ -302,7 +302,7 @@ class Migrator
             );
         }
 
-        $this->fireMigrationEvent(new MigrationsEnded('down'));
+        $this->fireMigrationEvent(new MigrationsEnded('down', $options));
 
         return $rolledBack;
     }


### PR DESCRIPTION
As discussed in https://github.com/laravel/framework/discussions/48801

> You can run php artisan migrate --pretend which outputs the raw SQL from the migrations rather than executing them.

> The problem is this extra context is not added to the events issued 

> This means if you have database-altering code relying on these events, they could throw exceptions or cause errors in production.

I passed through the whole `$options` array to make it slightly more future proof in case there are other options added in the future.

I had a few issues writing tests for it which is why `testMigrationEventsContainTheOptionsAndPretendTrue` is a bit shorter but I also figure that the rollback event is tested in `testMigrationEventsContainTheOptionsAndPretendFalse` so doesn't necessarily need a duplicated test.

I would also be interested in changing the base event for php 8 constructor property promotion which I can see being used in a few other classes in the framework but I didn't want to just jump into that bit without confirming it was okay.