### PR TITLE
[11.x] Add `Dispatchable::newPendingDispatch()`

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -53,12 +53,12 @@ trait Dispatchable
         if ($boolean instanceof Closure) {
             $dispatchable = new static(...$arguments);
 
-            return !value($boolean, $dispatchable)
+            return ! value($boolean, $dispatchable)
                 ? static::createPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
-        return !value($boolean)
+        return ! value($boolean)
             ? static::createPendingDispatch(new static(...$arguments))
             : new Fluent;
     }

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -16,7 +16,7 @@ trait Dispatchable
      */
     public static function dispatch(...$arguments)
     {
-        return new PendingDispatch(new static(...$arguments));
+        return static::createPendingDispatch(new static(...$arguments));
     }
 
     /**
@@ -32,12 +32,12 @@ trait Dispatchable
             $dispatchable = new static(...$arguments);
 
             return value($boolean, $dispatchable)
-                ? new PendingDispatch($dispatchable)
+                ? static::createPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
         return value($boolean)
-            ? new PendingDispatch(new static(...$arguments))
+            ? static::createPendingDispatch(new static(...$arguments))
             : new Fluent;
     }
 
@@ -53,13 +53,13 @@ trait Dispatchable
         if ($boolean instanceof Closure) {
             $dispatchable = new static(...$arguments);
 
-            return ! value($boolean, $dispatchable)
-                ? new PendingDispatch($dispatchable)
+            return !value($boolean, $dispatchable)
+                ? static::createPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
-        return ! value($boolean)
-            ? new PendingDispatch(new static(...$arguments))
+        return !value($boolean)
+            ? static::createPendingDispatch(new static(...$arguments))
             : new Fluent;
     }
 
@@ -96,5 +96,16 @@ trait Dispatchable
     public static function withChain($chain)
     {
         return new PendingChain(static::class, $chain);
+    }
+
+    /**
+     * Prepare a pending job dispatch.
+     *
+     * @param  mixed  $job
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     */
+    protected static function createPendingDispatch($job)
+    {
+        return new PendingDispatch($job);
     }
 }

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -16,7 +16,7 @@ trait Dispatchable
      */
     public static function dispatch(...$arguments)
     {
-        return static::createPendingDispatch(new static(...$arguments));
+        return static::newPendingDispatch(new static(...$arguments));
     }
 
     /**
@@ -32,12 +32,12 @@ trait Dispatchable
             $dispatchable = new static(...$arguments);
 
             return value($boolean, $dispatchable)
-                ? static::createPendingDispatch($dispatchable)
+                ? static::newPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
         return value($boolean)
-            ? static::createPendingDispatch(new static(...$arguments))
+            ? static::newPendingDispatch(new static(...$arguments))
             : new Fluent;
     }
 
@@ -54,12 +54,12 @@ trait Dispatchable
             $dispatchable = new static(...$arguments);
 
             return ! value($boolean, $dispatchable)
-                ? static::createPendingDispatch($dispatchable)
+                ? static::newPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
         return ! value($boolean)
-            ? static::createPendingDispatch(new static(...$arguments))
+            ? static::newPendingDispatch(new static(...$arguments))
             : new Fluent;
     }
 
@@ -99,12 +99,12 @@ trait Dispatchable
     }
 
     /**
-     * Prepare a pending job dispatch.
+     * Create a new pending job dispatch instance.
      *
      * @param  mixed  $job
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    protected static function createPendingDispatch($job)
+    protected static function newPendingDispatch($job)
     {
         return new PendingDispatch($job);
     }


### PR DESCRIPTION
This consolidates the creation of a PendingDispatch. It does not however consolidate for the `dispatch()` helper method.

## Why
Ultimately, what I would like to be able to do is call `TwSync::dispatch($team)` and be able to universally set the queue/connection without having to write it repeatedly. We would just "extend" the Dispatchable trait and modify the newPendingDispatch function so it calls another function on the job before instantiating the PendingDispatch. That would be something like this in userland code:

```php
protected static function newPendingDispatch($job)
{
    return parent::newPendingDispatch($job->prepareForDispatch());
}
```

We are essentially creating a post-job instantiation, pre-PendingDispatching hook.

We have Horizon set up with 3 connections and 3-4 queues each, so it's easy to mismatch, and there's a lot of duplicative code in our job constructors where we set the queue/connection. Easy to forget to do and then find out you've been dispatching a job to connection that doesn't handle a particular queue (so the job just sits in queued job purgatory).

## Alternate solution
Add a `if method_exists($job, 'prepareForDispatch') { ... }` clause _somewhere_, not sure if that would be the dispatcher or the PendingDispatch constructor.