### PR TITLE
[11.x] Fix docblock for `PendingDispatch@getJob()`

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -179,7 +179,7 @@ class PendingDispatch
     /**
      * Get the underlying job instance.
      *
-     * @var mixed
+     * @return mixed
      */
     public function getJob()
     {


### PR DESCRIPTION
`@return` instead of `@var`