### PR TITLE
[11.x] Add ‘toDeepArray’ Collection method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1874,8 +1874,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         return $this->map(function ($value) {
             return match (true) {
                 $value instanceof Collection => $value->toDeepArray(), // Recursively convert nested collections
-                is_object($value) => collect($value)->toDeepArray(),  // Convert objects to arrays
-                is_array($value) => collect($value)->toDeepArray(),   // Process nested arrays
+                is_object($value) => (new static($value))->toDeepArray(),  // Convert objects to arrays
+                is_array($value) => (new static($value))->toDeepArray(),   // Process nested arrays
                 default => $value,                                   // Leave primitive values as-is
             };
         })->toArray();

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1865,6 +1865,23 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Recursively convert all nested objects and collections within this collection into arrays.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function toDeepArray()
+    {
+        return $this->map(function ($value) {
+            return match (true) {
+                $value instanceof Collection => $value->toDeepArray(), // Recursively convert nested collections
+                is_object($value) => collect($value)->toDeepArray(),  // Convert objects to arrays
+                is_array($value) => collect($value)->toDeepArray(),   // Process nested arrays
+                default => $value,                                   // Leave primitive values as-is
+            };
+        })->toArray();
+    }
+
+    /**
      * Determine if an item exists at an offset.
      *
      * @param  TKey  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1828,8 +1828,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         return $this->map(function ($value) {
             return match (true) {
                 $value instanceof Collection => $value->toDeepArray(), // Recursively convert nested collections
-                is_object($value) => collect($value)->toDeepArray(),  // Convert objects to arrays
-                is_array($value) => collect($value)->toDeepArray(),   // Process nested arrays
+                is_object($value) => (new static($value))->toDeepArray(),  // Convert objects to arrays
+                is_array($value) => (new static($value))->toDeepArray(),   // Process nested arrays
                 default => $value,                                   // Leave primitive values as-is
             };
         })->toArray();

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1819,6 +1819,23 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Recursively convert all nested objects and collections within this collection into arrays.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function toDeepArray()
+    {
+        return $this->map(function ($value) {
+            return match (true) {
+                $value instanceof Collection => $value->toDeepArray(), // Recursively convert nested collections
+                is_object($value) => collect($value)->toDeepArray(),  // Convert objects to arrays
+                is_array($value) => collect($value)->toDeepArray(),   // Process nested arrays
+                default => $value,                                   // Leave primitive values as-is
+            };
+        })->toArray();
+    }
+
+    /**
      * Make an iterator from the given source.
      *
      * @template TIteratorKey of array-key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5587,6 +5587,36 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testToDeepArrayOnNestedCollectionOfObjects($collection)
+    {
+        $data = (new $collection([
+            (object) [
+                'name' => 'taylor',
+                'email' => 'foo',
+                'posts' => [
+                    (object) [
+                        'id' => 1,
+                        'content' => 'Hello world',
+                    ],
+                    (object) [
+                        'id' => 2,
+                        'content' => 'Foo bar',
+                    ],
+                ],
+            ],
+            [
+                'name' => 'dayle',
+                'email' => 'bar',
+            ],
+        ]))->toDeepArray();
+
+        $this->assertIsArray($data[0]);
+        $this->assertIsArray($data[0]['posts'][0]);
+        $this->assertIsArray($data[0]['posts'][1]);
+        $this->assertIsArray($data[1]);
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
This PR introduces a new `toDeepArray` method for collections. Unlike the existing `toArray` method, which only converts elements implementing the `Illuminate\Support\Traits\Arrayable` interface, `toDeepArray` attempts to _force_ all objects/collections to be recursively converted to arrays.

This addition addresses two common scenarios developers might encounter:

1. **Working with the `DB::table` facade**: Elements returned as objects (e.g., instances of `\stdClass`) will now be converted to arrays.
2. **Handling mixed collections**: Collections that might be constructed with a mix of objects and arrays, created using collections can now be easily normalized into arrays.

This will also cover other cases where `Illuminate\Support\Collection` might be used with elements that don't implement the `Arrayable` interface but wish to be converted to array.

As this is a new method it shouldn't introduce any breaking changes.

### Examples of Usage

#### Using the `DB` Facade
```php
DB::table('users')->get()->toDeepArray();

// Returns an array of arrays (instead of the default array of objects):
// [
//     [
//         "id" => 1,
//         "name" => "Euna Kirlin",
//         "email" => "zlesch@example.net",
//         "email_verified_at" => "2025-01-10 22:25:33",
//         "password" => "$2y$12$Is9PRBP0HDcsJ2XSoH5kheGlwFZ9PfwlySGIYLiJ6y0hx3YU0o7tC",
//         "remember_token" => "eGXZ6D9EES",
//         "created_at" => "2025-01-10 22:25:33",
//         "updated_at" => "2025-01-10 22:25:33",
//     ],
// ]
```

#### Developer Built Collections
```php
$nestedArray = collect([
    (object) [
        'name' => 'taylor',
        'email' => 'foo',
        'posts' => [
            (object) [
                'id' => 1,
                'content' => 'Hello world',
            ],
            (object) [
                'id' => 2,
                'content' => 'Foo bar',
            ],
        ],
    ],
    [
        'name' => 'dayle',
        'email' => 'bar',
    ],
])->toDeepArray();

// Returns:
// [
//     [
//         'name' => 'taylor',
//         'email' => 'foo',
//         'posts' => [
//             [
//                 'id' => 1,
//                 'content' => 'Hello world',
//             ],
//             [
//                 'id' => 2,
//                 'content' => 'Foo bar',
//             ],
//         ],
//     ],
//     [
//         'name' => 'dayle',
//         'email' => 'bar',
//     ],
// ]
```