### PR TITLE
[11.x] Add array response type

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -91,7 +91,7 @@ class Response implements ArrayAccess, Stringable
     /**
      * Get the JSON decoded body of the response as an object.
      *
-     * @return object|null
+     * @return object|array|null
      */
     public function object()
     {


### PR DESCRIPTION
Update object method annotation in Illuminate\Http\Client\Response to include array as a possible return type from json_decode.

I’m reopening this PR because I have a file using an API that returns an array of objects. The current method assumes only objects are returned, which is causing an error in my pipeline.

For example, if `$this->body() returns something like:

```php
$bar = '[
    {
        "key": "value"
    }
]';
```

The actual implementation of **object** allows an array as response

```php
public function object()
{
     return json_decode($this->body(), false);
}
```

Therefore, the annotation needs to be updated to reflect that an array can also be returned.