### PR TITLE
Add support for naming additional database connections

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -91,7 +91,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        $name = $name ?: $this->getDefaultConnection();
+        $name = $this->mapConnectionName($name);
 
         [$database, $type] = $this->parseConnectionName($name);
 
@@ -167,6 +167,19 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
+     * Map the given connection name to its configuration name or default if not provided.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function mapConnectionName($name)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        return $this->app['config']['database.' . $name] ??= $name;
+    }
+
+    /**
      * Parse the connection into an array of the name and read / write type.
      *
      * @param  string  $name
@@ -174,7 +187,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     protected function parseConnectionName($name)
     {
-        $name = $name ?: $this->getDefaultConnection();
+        $name = $this->mapConnectionName($name);
 
         return Str::endsWith($name, ['::read', '::write'])
                             ? explode('::', $name, 2) : [$name, null];
@@ -217,7 +230,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     protected function configuration($name)
     {
-        $name = $name ?: $this->getDefaultConnection();
+        $name = $this->mapConnectionName($name);
 
         $connections = $this->app['config']['database.connections'];
 
@@ -304,7 +317,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function purge($name = null)
     {
-        $name = $name ?: $this->getDefaultConnection();
+        $name = $this->mapConnectionName($name);
 
         $this->disconnect($name);
 

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -176,7 +176,7 @@ class DatabaseManager implements ConnectionResolverInterface
     {
         $name = $name ?: $this->getDefaultConnection();
 
-        return $this->app['config']['database.' . $name] ??= $name;
+        return $this->app['config']['database.'.$name] ??= $name;
     }
 
     /**


### PR DESCRIPTION
This pull request introduces the ability to name multiple database connections, improving the developer experience when working with multiple databases. By providing meaningful names for each connection, it becomes more intuitive to switch between different databases.

This feature adds an abstraction layer that decouples the database implementation from your code by allowing you to define multiple named connections in the database configuration:
```
/*
|--------------------------------------------------------------------------
| Default Database Connection Name
|--------------------------------------------------------------------------
|
| Here you may specify which of the database connections below you wish
| to use as your default connection for database operations. This is
| the connection which will be utilized unless another connection
| is explicitly specified when you execute a query / statement.
|
*/

'default' => env('DB_CONNECTION', 'sqlite'),
'other' => env('DB_CONNECTION_OTHER', 'mysql'),
```
Models can then specify which connection to use via the $connection property:
```
class Order extends Model
{
    protected $connection = 'other'; // Equals to mysql
```
Or you can use the connection directly in queries:
```
$orders = DB::connection('other')->table('orders')->get();
```