### PR TITLE
[11.x] Add `inCents` parameter to Number::currency helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -143,7 +143,7 @@ class Number
      */
     public static function currency(int|float $number, string $in = '', ?string $locale = null, bool $inCents = false )
     {
-        if ($inCents){
+        if ($inCents) {
             $number /= 100;
         }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -138,7 +138,7 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
-     * @param bool $inCents
+     * @param bool  $inCents
      * @return string|false
      */
     public static function currency(int|float $number, string $in = '', ?string $locale = null, bool $inCents = false)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -138,7 +138,7 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
-     * @param bool  $inCents
+     * @param  bool  $inCents
      * @return string|false
      */
     public static function currency(int|float $number, string $in = '', ?string $locale = null, bool $inCents = false)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -138,10 +138,10 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
-     * @param  bool $inCents
+     * @param bool $inCents
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null, bool $inCents = false )
+    public static function currency(int|float $number, string $in = '', ?string $locale = null, bool $inCents = false)
     {
         if ($inCents) {
             $number /= 100;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -138,10 +138,15 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
+     * @param  bool $inCents
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null)
+    public static function currency(int|float $number, string $in = '', ?string $locale = null, bool $inCents = false )
     {
+        if ($inCents){
+            $number /= 100;
+        }
+
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -165,6 +165,11 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
     }
 
+    public function testToCurrencyInCents()
+    {
+        $this->assertSame('$15.00', Number::currency(1500, 'USD', 'en', true));
+    }
+
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::fileSize(0));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -169,6 +169,10 @@ class SupportNumberTest extends TestCase
     public function testToCurrencyInCents()
     {
         $this->assertSame('$15.00', Number::currency(1500, 'USD', 'en', true));
+        $this->assertSame('$15.50', Number::currency(1550, 'USD', 'en', true));
+        $this->assertSame('15,00 €', Number::currency(1500, 'EUR', 'fr', true));
+        $this->assertSame('$15.00', Number::currency(1500, '', 'en', true));
+        $this->assertSame('-$15.00', Number::currency(-1500, 'USD', 'en', true));
     }
 
     public function testBytesToHuman()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -165,6 +165,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testToCurrencyInCents()
     {
         $this->assertSame('$15.00', Number::currency(1500, 'USD', 'en', true));


### PR DESCRIPTION
This pull request adds an `inCents` parameter to the `Number::currency` method, allowing us to specify whether the `$number` parameter is in cents. This makes it easier to format currency values without having to convert them beforehand.

As Stripe and many other payment gateways use cents-based amounts for prices, this addition simplifies the display of prices in applications.

Before:
```php
// With a price of 1500 cents from Stripe
$price = $stripePrice / 100;
Number::currency($price); // outputs "$15.00"
```
After:
```php
// With a price of 1500 cents from Stripe
Number::currency($stripePrice, inCents: true); // outputs "$15.00"
```