### PR TITLE
[12.x] Filesystems config - S3 - Add root and visibility as env options

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -52,6 +52,8 @@ return [
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
+            'root' => env('AWS_ROOT'),
+            'visibility' => env('AWS_VISIBILITY'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,
         ],


### PR DESCRIPTION
Most of use who've used the same bucket across multiple environments have used these options, so to reduce unnecessary overrides introduced by Laravel 11 I've added them to the base config - it's not a breaking change.