### PR TITLE
[11.x] Make tests pass on Herd

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+use function Illuminate\Support\artisan_binary;
 use function Illuminate\Support\php_binary;
 
 class Application extends SymfonyApplication implements ApplicationContract
@@ -95,7 +96,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public static function artisanBinary()
     {
-        return ProcessUtils::escapeArgument(defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan');
+        return ProcessUtils::escapeArgument(artisan_binary());
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Process;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Illuminate\Support\artisan_binary;
 use function Illuminate\Support\php_binary;
 
 #[AsCommand(name: 'install:api')]
@@ -68,7 +69,7 @@ class ApiInstallCommand extends Command
         if ($this->option('passport')) {
             Process::run(array_filter([
                 php_binary(),
-                defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+                artisan_binary(),
                 'passport:install',
                 $this->confirm('Would you like to use UUIDs for all client IDs?') ? '--uuids' : null,
             ]));
@@ -133,7 +134,7 @@ class ApiInstallCommand extends Command
         if (! $migrationPublished) {
             Process::run([
                 php_binary(),
-                defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+                artisan_binary(),
                 'vendor:publish',
                 '--provider',
                 'Laravel\\Sanctum\\SanctumServiceProvider',

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Process;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Illuminate\Support\artisan_binary;
 use function Illuminate\Support\php_binary;
 use function Laravel\Prompts\confirm;
 
@@ -156,7 +157,7 @@ class BroadcastingInstallCommand extends Command
 
         Process::run([
             php_binary(),
-            defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+            artisan_binary(),
             'reverb:install',
         ]);
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Closure;
 use Symfony\Component\Process\Process;
 
+use function Illuminate\Support\artisan_binary;
 use function Illuminate\Support\php_binary;
 
 class Listener
@@ -72,7 +73,7 @@ class Listener
      */
     protected function artisanBinary()
     {
-        return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
+        return artisan_binary();
     }
 
     /**

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -39,3 +39,15 @@ if (! function_exists('Illuminate\Support\php_binary')) {
         return (new PhpExecutableFinder)->find(false) ?: 'php';
     }
 }
+
+if (! function_exists('Illuminate\Support\artisan_binary')) {
+    /**
+     * Determine the PHP Binary.
+     *
+     * @return string
+     */
+    function artisan_binary()
+    {
+        return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
+    }
+}

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -42,7 +42,7 @@ if (! function_exists('Illuminate\Support\php_binary')) {
 
 if (! function_exists('Illuminate\Support\artisan_binary')) {
     /**
-     * Determine the PHP Binary.
+     * Determine the proper Artisan executable.
      *
      * @return string
      */

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Console;
 
+use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\CacheEventMutex;
 use Illuminate\Console\Scheduling\CacheSchedulingMutex;
@@ -92,32 +93,28 @@ class ConsoleEventSchedulerTest extends TestCase
 
     public function testCommandCreatesNewArtisanCommand()
     {
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
-
         $schedule = $this->schedule;
         $schedule->command('queue:listen');
         $schedule->command('queue:listen --tries=3');
         $schedule->command('queue:listen', ['--tries' => 3]);
 
         $events = $schedule->events();
-        $binary = $escape.PHP_BINARY.$escape;
-        $artisan = $escape.'artisan'.$escape;
-        $this->assertEquals($binary.' '.$artisan.' queue:listen', $events[0]->command);
-        $this->assertEquals($binary.' '.$artisan.' queue:listen --tries=3', $events[1]->command);
-        $this->assertEquals($binary.' '.$artisan.' queue:listen --tries=3', $events[2]->command);
+        $phpBinary = Application::phpBinary();
+        $artisanBinary = Application::artisanBinary();
+        $this->assertEquals($phpBinary.' '.$artisanBinary.' queue:listen', $events[0]->command);
+        $this->assertEquals($phpBinary.' '.$artisanBinary.' queue:listen --tries=3', $events[1]->command);
+        $this->assertEquals($phpBinary.' '.$artisanBinary.' queue:listen --tries=3', $events[2]->command);
     }
 
     public function testCreateNewArtisanCommandUsingCommandClass()
     {
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
-
         $schedule = $this->schedule;
         $schedule->command(ConsoleCommandStub::class, ['--force']);
 
         $events = $schedule->events();
-        $binary = $escape.PHP_BINARY.$escape;
-        $artisan = $escape.'artisan'.$escape;
-        $this->assertEquals($binary.' '.$artisan.' foo:bar --force', $events[0]->command);
+        $phpBinary = Application::phpBinary();
+        $artisanBinary = Application::artisanBinary();
+        $this->assertEquals($phpBinary.' '.$artisanBinary.' foo:bar --force', $events[0]->command);
     }
 
     public function testItUsesCommandDescriptionAsEventDescription()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
-use Illuminate\Console\Application;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Support\Str;

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
+use Illuminate\Console\Application;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
+use function Illuminate\Support\php_binary;
 
 class EventTest extends TestCase
 {
@@ -42,7 +44,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
+        $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".php_binary()."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
     }
 
     #[RequiresOperatingSystem('Windows')]
@@ -53,7 +55,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame('start /b cmd /v:on /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
+        $this->assertSame('start /b cmd /v:on /c "(php -i & '.php_binary().' artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
+
 use function Illuminate\Support\php_binary;
 
 class EventTest extends TestCase

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -49,13 +49,12 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
-        $phpBinary = php_binary();
         $artisanBinary = artisan_binary();
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.$phpBinary.$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape}", $process->getCommandLine());
+        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWithAnEnvironmentSpecified()
@@ -68,13 +67,12 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
-        $phpBinary = php_binary();
         $artisanBinary = artisan_binary();
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.$phpBinary.$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWhenTheConnectionIsNotSpecified()
@@ -87,12 +85,11 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess(null, 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
-        $phpBinary = php_binary();
         $artisanBinary = artisan_binary();
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.$phpBinary.$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+        $this->assertEquals($escape.php_binary().$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Queue;
 
+use Illuminate\Console\Application;
 use Illuminate\Queue\Listener;
 use Illuminate\Queue\ListenerOptions;
 use Mockery as m;
@@ -46,10 +47,13 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
+        $phpBinary = Application::phpBinary();
+        $artisanBinary = Application::artisanBinary();
+
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape}", $process->getCommandLine());
+        $this->assertEquals("{$phpBinary} {$artisanBinary} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWithAnEnvironmentSpecified()
@@ -62,10 +66,13 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
+        $phpBinary = Application::phpBinary();
+        $artisanBinary = Application::artisanBinary();
+
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+        $this->assertEquals("{$phpBinary} {$artisanBinary} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWhenTheConnectionIsNotSpecified()
@@ -78,9 +85,12 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess(null, 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
+        $phpBinary = Application::phpBinary();
+        $artisanBinary = Application::artisanBinary();
+
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.PHP_BINARY.$escape." {$escape}artisan{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+        $this->assertEquals("{$phpBinary} {$artisanBinary} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Illuminate\Console\Application;
 use Illuminate\Queue\Listener;
 use Illuminate\Queue\ListenerOptions;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
+
+use function Illuminate\Support\artisan_binary;
+use function Illuminate\Support\php_binary;
 
 class QueueListenerTest extends TestCase
 {
@@ -47,13 +49,13 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
-        $phpBinary = Application::phpBinary();
-        $artisanBinary = Application::artisanBinary();
+        $phpBinary = php_binary();
+        $artisanBinary = artisan_binary();
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals("{$phpBinary} {$artisanBinary} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape}", $process->getCommandLine());
+        $this->assertEquals($escape.$phpBinary.$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWithAnEnvironmentSpecified()
@@ -66,13 +68,13 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess('connection', 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
-        $phpBinary = Application::phpBinary();
-        $artisanBinary = Application::artisanBinary();
+        $phpBinary = php_binary();
+        $artisanBinary = artisan_binary();
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals("{$phpBinary} {$artisanBinary} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+        $this->assertEquals($escape.$phpBinary.$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}connection{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 
     public function testMakeProcessCorrectlyFormatsCommandLineWhenTheConnectionIsNotSpecified()
@@ -85,12 +87,12 @@ class QueueListenerTest extends TestCase
         $process = $listener->makeProcess(null, 'queue', $options);
         $escape = '\\' === DIRECTORY_SEPARATOR ? '' : '\'';
 
-        $phpBinary = Application::phpBinary();
-        $artisanBinary = Application::artisanBinary();
+        $phpBinary = php_binary();
+        $artisanBinary = artisan_binary();
 
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals("{$phpBinary} {$artisanBinary} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
+        $this->assertEquals($escape.$phpBinary.$escape." {$escape}{$artisanBinary}{$escape} {$escape}queue:work{$escape} {$escape}--once{$escape} {$escape}--name=default{$escape} {$escape}--queue=queue{$escape} {$escape}--backoff=1{$escape} {$escape}--memory=2{$escape} {$escape}--sleep=3{$escape} {$escape}--tries=1{$escape} {$escape}--env=test{$escape}", $process->getCommandLine());
     }
 }

--- a/tests/Support/SupportComposerTest.php
+++ b/tests/Support/SupportComposerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Composer;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
+use function Illuminate\Support\php_binary;
 
 class SupportComposerTest extends TestCase
 {
@@ -24,7 +25,7 @@ class SupportComposerTest extends TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommandWhenCustomComposerPharIsPresent()
     {
-        $expectedProcessArguments = [PHP_BINARY,  'composer.phar', 'dump-autoload'];
+        $expectedProcessArguments = [php_binary(),  'composer.phar', 'dump-autoload'];
         $customComposerPhar = true;
 
         $composer = $this->mockComposer($expectedProcessArguments, $customComposerPhar);

--- a/tests/Support/SupportComposerTest.php
+++ b/tests/Support/SupportComposerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Composer;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
+
 use function Illuminate\Support\php_binary;
 
 class SupportComposerTest extends TestCase


### PR DESCRIPTION
### Fix Test Compatibility with Herd by Standardizing Binary Handling

This PR fixes tests that use `PHP_BINARY` and therefore fail when running via Herd.

It standardizes the handling of `PHP` and `Artisan` binaries via the existing `php_binary` function (or `Application::phpBinary()` for console operations) and the newly added `artisan_binary` function.

#### Key Changes:
- Ensured compatibility with Herd by centralizing binary handling.
- Added the `artisan_binary` helper in `Illuminate\Support\functions.php` to standardize access to the Artisan binary path.
- Refactored core framework files and test cases to use the `artisan_binary` helper, replacing inline checks like `defined('ARTISAN_BINARY')`.

#### Benefits:
- Tests now pass reliably under Herd.
- Cleaner and more maintainable binary handling across the framework.
- Backward-compatible refactor with no breaking changes.

Tests have been updated and verified to maintain existing behavior while ensuring compatibility with Herd. This change focuses on improving developer experience in environments using Herd.
