### PR TITLE
[11.x] Add transaction attempts config variable

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -116,6 +116,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database Transactions
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the behavior of database transactions. The attempts
+    | value is the number of times the transaction will be attempted before
+    | an exception is thrown. The default value is 1, but can be any positive integer set from .env
+    |
+    */
+
+    'transactions' => [
+        'attempts' => (int) env('DB_TRANSACTION_ATTEMPTS', 1),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Migration Repository Table
     |--------------------------------------------------------------------------
     |

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Concerns;
 
 use Closure;
 use Illuminate\Database\DeadlockException;
+use Illuminate\Support\Arr;
 use RuntimeException;
 use Throwable;
 
@@ -20,8 +21,12 @@ trait ManagesTransactions
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1)
+    public function transaction(Closure $callback, $attempts = null)
     {
+        if (is_null($attempts)) {
+            $attempts = Arr::get($this->config, 'transactions.attempts', 1);
+        }
+
         for ($currentAttempt = 1; $currentAttempt <= $attempts; $currentAttempt++) {
             $this->beginTransaction();
 

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -227,6 +227,10 @@ class DatabaseManager implements ConnectionResolverInterface
             throw new InvalidArgumentException("Database connection [{$name}] not configured.");
         }
 
+        if ($transactions = $this->app['config']['database.transactions'] ?? null) {
+            $config['transactions'] = $transactions;
+        }
+
         return (new ConfigurationUrlParser)
                     ->parseConfiguration($config);
     }


### PR DESCRIPTION
In systems with a large codebase and a high number of active users, transaction deadlocks can occasionally occur. To address this, it might be necessary to adjust the default number of transaction retry attempts globally for all transactions. Introducing a `.env` variable, like `DB_TRANSACTION_ATTEMPTS` can be very helpful in such cases.