### PR TITLE
[11.x]  Fix job not logged in failed_jobs table if timeout occurs within database transaction

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -319,7 +319,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function rollBack()
     {
-        $this->connection->rollBack();
+        $this->connection->rollBack(toLevel: 0);
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -204,11 +204,9 @@ abstract class Job
             }
         }
 
-        // If the job times out and has an open database transaction on the same connection as
-        // the failed jobs table, we need to rollback that transaction to ensure the failed job
-        // can be properly logged. Otherwise, the current transaction will never commit.
         if ($e instanceof TimeoutExceededException &&
             ($failedJobConnectionName = $this->container['config']['queue.failed.database']) &&
+            in_array($this->container['config']['queue.failed.driver'], ['database', 'database-uuids']) &&
             $this->container->bound('db')) {
             $this->container->make('db')->connection($failedJobConnectionName)->rollBack(toLevel: 0);
         }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -209,7 +209,7 @@ abstract class Job
         // If the job times out and has an open database transaction on the same connection as
         // the failed jobs table, we need to rollback that transaction to ensure the failed job
         // can be properly logged. Otherwise, the current transaction will never commit.
-        if ($e instanceof TimeoutExceededException && 
+        if ($e instanceof TimeoutExceededException &&
             ! is_null($failedJobConnectionName) &&
             $this->container->bound('db')) {
             $this->container->make('db')->connection($failedJobConnectionName)->rollBack(toLevel: 0);

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -204,13 +204,11 @@ abstract class Job
             }
         }
 
-        $failedJobConnectionName = $this->container['config']['queue.failed.database'];
-
         // If the job times out and has an open database transaction on the same connection as
         // the failed jobs table, we need to rollback that transaction to ensure the failed job
         // can be properly logged. Otherwise, the current transaction will never commit.
         if ($e instanceof TimeoutExceededException &&
-            ! is_null($failedJobConnectionName) &&
+            ($failedJobConnectionName = $this->container['config']['queue.failed.database']) &&
             $this->container->bound('db')) {
             $this->container->make('db')->connection($failedJobConnectionName)->rollBack(toLevel: 0);
         }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -212,7 +212,7 @@ abstract class Job
         if ($e instanceof TimeoutExceededException && 
             ! is_null($failedJobConnectionName) &&
             $this->container->bound('db')) {
-            $this->container->make('db')->connection($failedJobConnectionName)->rollBack();
+            $this->container->make('db')->connection($failedJobConnectionName)->rollBack(toLevel: 0);
         }
 
         try {

--- a/tests/Integration/Database/Queue/Fixtures/TimeOutJobWithNestedTransactions.php
+++ b/tests/Integration/Database/Queue/Fixtures/TimeOutJobWithNestedTransactions.php
@@ -2,20 +2,23 @@
 
 namespace Illuminate\Tests\Integration\Database\Queue\Fixtures;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\DB;
 
-class TimeOutNonBatchableJobWithTransaction implements ShouldQueue
+class TimeOutJobWithNestedTransactions implements ShouldQueue
 {
-    use InteractsWithQueue, Queueable;
+    use InteractsWithQueue, Queueable, Batchable;
 
     public int $tries = 1;
     public int $timeout = 2;
 
     public function handle(): void
     {
-        DB::transaction(fn () => sleep(20));
+        DB::transaction(function () {
+            DB::transaction(fn () => sleep(20));
+        });
     }
 }

--- a/tests/Integration/Database/Queue/Fixtures/TimeOutJobWithTransaction.php
+++ b/tests/Integration/Database/Queue/Fixtures/TimeOutJobWithTransaction.php
@@ -17,6 +17,8 @@ class TimeOutJobWithTransaction implements ShouldQueue
 
     public function handle(): void
     {
-        DB::transaction(fn () => sleep(20));
+        DB::transaction(function () {
+            DB::transaction(fn () => sleep(20));
+        });
     }
 }

--- a/tests/Integration/Database/Queue/Fixtures/TimeOutJobWithTransaction.php
+++ b/tests/Integration/Database/Queue/Fixtures/TimeOutJobWithTransaction.php
@@ -17,8 +17,6 @@ class TimeOutJobWithTransaction implements ShouldQueue
 
     public function handle(): void
     {
-        DB::transaction(function () {
-            DB::transaction(fn () => sleep(20));
-        });
+        DB::transaction(fn () => sleep(20));
     }
 }

--- a/tests/Integration/Database/Queue/Fixtures/TimeOutNonBatchableJobWithNestedTransactions.php
+++ b/tests/Integration/Database/Queue/Fixtures/TimeOutNonBatchableJobWithNestedTransactions.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\DB;
 
-class TimeOutNonBatchableJobWithTransaction implements ShouldQueue
+class TimeOutNonBatchableJobWithNestedTransactions implements ShouldQueue
 {
     use InteractsWithQueue, Queueable;
 
@@ -16,6 +16,8 @@ class TimeOutNonBatchableJobWithTransaction implements ShouldQueue
 
     public function handle(): void
     {
-        DB::transaction(fn () => sleep(20));
+        DB::transaction(function () {
+            DB::transaction(fn () => sleep(20));
+        });
     }
 }

--- a/tests/Integration/Database/Queue/Fixtures/TimeOutNonBatchableJobWithTransaction.php
+++ b/tests/Integration/Database/Queue/Fixtures/TimeOutNonBatchableJobWithTransaction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Queue\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\DB;
+
+class TimeOutNonBatchableJobWithTransaction implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable;
+
+    public int $tries = 1;
+    public int $timeout = 2;
+
+    public function handle(): void
+    {
+        DB::transaction(fn () => sleep(20));
+    }
+}

--- a/tests/Integration/Database/Queue/Fixtures/TimeOutNonBatchableJobWithTransaction.php
+++ b/tests/Integration/Database/Queue/Fixtures/TimeOutNonBatchableJobWithTransaction.php
@@ -16,6 +16,8 @@ class TimeOutNonBatchableJobWithTransaction implements ShouldQueue
 
     public function handle(): void
     {
-        DB::transaction(fn () => sleep(20));
+        DB::transaction(function () {
+            DB::transaction(fn () => sleep(20));
+        });
     }
 }

--- a/tests/Integration/Database/Queue/QueueTransactionTest.php
+++ b/tests/Integration/Database/Queue/QueueTransactionTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Throwable;
@@ -29,9 +30,10 @@ class QueueTransactionTest extends DatabaseTestCase
         }
     }
 
-    public function testItCanHandleTimeoutJob()
+    #[DataProvider('timeoutJobs')]
+    public function testItCanHandleTimeoutJob($job)
     {
-        dispatch(new Fixtures\TimeOutJobWithTransaction);
+        dispatch($job);
 
         $this->assertSame(1, DB::table('jobs')->count());
         $this->assertSame(0, DB::table('failed_jobs')->count());
@@ -48,5 +50,13 @@ class QueueTransactionTest extends DatabaseTestCase
 
         $this->assertSame(0, DB::table('jobs')->count());
         $this->assertSame(1, DB::table('failed_jobs')->count());
+    }
+
+    public static function timeoutJobs(): array
+    {
+        return [
+            [new Fixtures\TimeOutJobWithTransaction()],
+            [new Fixtures\TimeOutNonBatchableJobWithTransaction()],
+        ];
     }
 }

--- a/tests/Integration/Database/Queue/QueueTransactionTest.php
+++ b/tests/Integration/Database/Queue/QueueTransactionTest.php
@@ -56,7 +56,9 @@ class QueueTransactionTest extends DatabaseTestCase
     {
         return [
             [new Fixtures\TimeOutJobWithTransaction()],
+            [new Fixtures\TimeOutJobWithNestedTransactions()],
             [new Fixtures\TimeOutNonBatchableJobWithTransaction()],
+            [new Fixtures\TimeOutNonBatchableJobWithNestedTransactions()],
         ];
     }
 }


### PR DESCRIPTION
This PR attempts to address https://github.com/laravel/framework/issues/49389

When a job times out with an open database transaction on the same connection as the failed jobs table, rolling back the transaction ensures the failed job is logged correctly. Without this rollback, the transaction remains uncommitted. As a result, database updates are rolled back when the worker process is terminated, preventing the failed job from being saved.

Additionally, this PR ensures that any open database transactions are rolled back to the root level. This guarantees that nested transactions are also properly rolled back; otherwise, the failed job might not be logged in the database.

