### PR TITLE
[11.x] Make methods of `HasRelationships` generic

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -854,6 +854,7 @@ trait HasRelationships
      * Create a new model instance for a related model.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
      * @param  class-string<TRelatedModel>  $class
      * @return TRelatedModel
      */
@@ -870,6 +871,7 @@ trait HasRelationships
      * Create a new model instance for a related "through" model.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
      * @param  class-string<TRelatedModel>  $class
      * @return TRelatedModel
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -58,9 +58,11 @@ trait HasRelationships
     /**
      * Get the dynamic relation resolver if defined or inherited, or return null.
      *
-     * @param  string  $class
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  class-string<TRelatedModel>  $class
      * @param  string  $key
-     * @return mixed
+     * @return Closure|null
      */
     public function relationResolver($class, $key)
     {
@@ -851,8 +853,9 @@ trait HasRelationships
     /**
      * Create a new model instance for a related model.
      *
-     * @param  string  $class
-     * @return mixed
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TRelatedModel>  $class
+     * @return TRelatedModel
      */
     protected function newRelatedInstance($class)
     {
@@ -866,8 +869,9 @@ trait HasRelationships
     /**
      * Create a new model instance for a related "through" model.
      *
-     * @param  string  $class
-     * @return mixed
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TRelatedModel>  $class
+     * @return TRelatedModel
      */
     protected function newRelatedThroughInstance($class)
     {


### PR DESCRIPTION
This PR introduces generics to the `relationResolver`, `newRelatedInstance`, and `newRelatedThroughInstance` methods in the `HasRelationships` trait. By leveraging generics, these methods now provide stricter type checking for related models, improving developer experience and code predictability.

#### Key Changes:
- Added generics to the `relationResolver` method, refining the return type to `Closure|null`.
- Updated `newRelatedInstance` and `newRelatedThroughInstance` to ensure they return specific related model instances.
- Enhanced method annotations with `@template` and `@param` to enforce stricter type handling.

#### Benefits:
- Improved type safety for Eloquent relationships.
- Enhanced IDE support and fewer runtime type errors.
- Aligns with Laravel’s commitment to type clarity and maintainable code.

#### Before:
![image](https://github.com/user-attachments/assets/2555fdcc-9d33-4db4-92b7-ebfa0399fed2)

#### After:
![image](https://github.com/user-attachments/assets/7dc11c78-263f-4ed6-a7e4-a5c5e7ccb13b)


This change is backward-compatible, maintaining existing functionality while improving the reliability and clarity of type handling in Eloquent relation methods.
