### PR TITLE
adds four new Blade directives: @url, @route, @asset, and @old

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -19,7 +19,7 @@ trait CompilesHelpers
     /**
      * Compile the "dd" statements into valid PHP.
      *
-     * @param  string  $arguments
+     * @param string $arguments
      * @return string
      */
     protected function compileDd($arguments)
@@ -30,7 +30,7 @@ trait CompilesHelpers
     /**
      * Compile the "dump" statements into valid PHP.
      *
-     * @param  string  $arguments
+     * @param string $arguments
      * @return string
      */
     protected function compileDump($arguments)
@@ -41,7 +41,7 @@ trait CompilesHelpers
     /**
      * Compile the method statements into valid PHP.
      *
-     * @param  string  $method
+     * @param string $method
      * @return string
      */
     protected function compileMethod($method)
@@ -50,9 +50,57 @@ trait CompilesHelpers
     }
 
     /**
+     * Compile the "url" statements into valid PHP.
+     *
+     * @param string $arguments
+     * @return string
+     */
+
+    protected function compileUrl($arguments)
+    {
+        return "<?php echo url{$arguments}; ?>";
+    }
+
+    /**
+     * Compile the "route" statements into valid PHP.
+     *
+     * @param string $arguments
+     * @return string
+     */
+
+    protected function compileRoute($arguments)
+    {
+        return "<?php echo route{$arguments}; ?>";
+    }
+
+    /**
+     * Compile the "assets" statements into valid PHP.
+     *
+     * @param string $arguments
+     * @return string
+     */
+
+    protected function compileAsset($arguments)
+    {
+        return "<?php echo asset{$arguments}; ?>";
+    }
+
+    /**
+     * Compile the "old" statements into valid PHP.
+     *
+     * @param string $arguments
+     * @return string
+     */
+
+    protected function compileOld($arguments)
+    {
+        return "<?php echo old{$arguments}; ?>";
+    }
+
+    /**
      * Compile the "vite" statements into valid PHP.
      *
-     * @param  string|null  $arguments
+     * @param string|null $arguments
      * @return string
      */
     protected function compileVite($arguments)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -55,7 +55,6 @@ trait CompilesHelpers
      * @param  string  $arguments
      * @return string
      */
-
     protected function compileUrl($arguments)
     {
         return "<?php echo url{$arguments}; ?>";
@@ -67,7 +66,6 @@ trait CompilesHelpers
      * @param  string  $arguments
      * @return string
      */
-
     protected function compileRoute($arguments)
     {
         return "<?php echo route{$arguments}; ?>";
@@ -79,7 +77,6 @@ trait CompilesHelpers
      * @param  string  $arguments
      * @return string
      */
-
     protected function compileAsset($arguments)
     {
         return "<?php echo asset{$arguments}; ?>";
@@ -91,7 +88,6 @@ trait CompilesHelpers
      * @param  string  $arguments
      * @return string
      */
-
     protected function compileOld($arguments)
     {
         return "<?php echo old{$arguments}; ?>";

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -19,7 +19,7 @@ trait CompilesHelpers
     /**
      * Compile the "dd" statements into valid PHP.
      *
-     * @param string $arguments
+     * @param  string  $arguments
      * @return string
      */
     protected function compileDd($arguments)
@@ -30,7 +30,7 @@ trait CompilesHelpers
     /**
      * Compile the "dump" statements into valid PHP.
      *
-     * @param string $arguments
+     * @param  string  $arguments
      * @return string
      */
     protected function compileDump($arguments)
@@ -41,7 +41,7 @@ trait CompilesHelpers
     /**
      * Compile the method statements into valid PHP.
      *
-     * @param string $method
+     * @param  string  $method
      * @return string
      */
     protected function compileMethod($method)
@@ -52,7 +52,7 @@ trait CompilesHelpers
     /**
      * Compile the "url" statements into valid PHP.
      *
-     * @param string $arguments
+     * @param  string  $arguments
      * @return string
      */
 
@@ -64,7 +64,7 @@ trait CompilesHelpers
     /**
      * Compile the "route" statements into valid PHP.
      *
-     * @param string $arguments
+     * @param  string  $arguments
      * @return string
      */
 
@@ -76,7 +76,7 @@ trait CompilesHelpers
     /**
      * Compile the "assets" statements into valid PHP.
      *
-     * @param string $arguments
+     * @param  string  $arguments
      * @return string
      */
 
@@ -88,7 +88,7 @@ trait CompilesHelpers
     /**
      * Compile the "old" statements into valid PHP.
      *
-     * @param string $arguments
+     * @param  string  $arguments
      * @return string
      */
 
@@ -100,7 +100,7 @@ trait CompilesHelpers
     /**
      * Compile the "vite" statements into valid PHP.
      *
-     * @param string|null $arguments
+     * @param  string|null  $arguments
      * @return string
      */
     protected function compileVite($arguments)

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -16,5 +16,12 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')([\'resources/js/app.js\']); ?>', $this->compiler->compileString('@vite([\'resources/js/app.js\'])'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')->reactRefresh(); ?>', $this->compiler->compileString('@viteReactRefresh'));
+        $this->assertSame('<?php echo url(\'/home\'); ?>', $this->compiler->compileString('@url(\'/home\')'));
+        $this->assertSame('<?php echo url(\'/home\', [1]); ?>', $this->compiler->compileString('@url(\'/home\', [1])'));
+        $this->assertSame('<?php echo route(\'home.index\'); ?>', $this->compiler->compileString('@route(\'home.index\')'));
+        $this->assertSame('<?php echo route(\'user.profile\', [\'id\' => 1]); ?>', $this->compiler->compileString('@route(\'user.profile\', [\'id\' => 1])'));
+        $this->assertSame('<?php echo old(\'name\'); ?>', $this->compiler->compileString('@old(\'name\')'));
+        $this->assertSame('<?php echo old(\'name\', \'test\'); ?>', $this->compiler->compileString('@old(\'name\', \'test\')'));
+        $this->assertSame('<?php echo asset(\'/css/style.css\'); ?>', $this->compiler->compileString('@asset(\'/css/style.css\')'));
     }
 }


### PR DESCRIPTION
This PR adds four new Blade directives: @url, @route, @asset, and @old.

- **@url:** Outputs the URL helper function.
- **@route:** Outputs the route helper function.
- **@asset:** Outputs the asset helper function.
- **@old:** Outputs the old helper function.

### Why?
These directives simplify the usage of commonly used Laravel helpers in Blade templates, making the syntax cleaner and more readable.

### Examples:
```php
@url('/home') // Compiles to: <?php echo url('/home'); ?>
@route('home.index') // Compiles to: <?php echo route('home.index'); ?>
@asset('css/style.css') // Compiles to: <?php echo asset('css/style.css'); ?>
@old('name') // Compiles to: <?php echo old('name'); ?>