### PR TITLE
[11.x] Add `FormRequest::array($key)` and `Fluent::array($key)`

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -355,6 +355,17 @@ trait InteractsWithData
     }
 
     /**
+     * Retrieve data from the instance as an array.
+     *
+     * @param  array|string|null  $key
+     * @return array
+     */
+    public function array($key = null)
+    {
+        return (array) (is_array($key) ? $this->only($key) : $this->data($key));
+    }
+
+    /**
      * Retrieve data from the instance as a collection.
      *
      * @param  array|string|null  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -688,7 +688,7 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', [
             'users' => [1, 2, 3],
             'roles' => [4, 5, 6],
-            'email' => 'test@example.com'
+            'email' => 'test@example.com',
         ]);
 
         $this->assertEmpty($request->array('missing'));
@@ -700,7 +700,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals([
             'users' => [1, 2, 3],
             'roles' => [4, 5, 6],
-            'email' => 'test@example.com'
+            'email' => 'test@example.com',
         ], $request->array());
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -679,6 +679,31 @@ class HttpRequestTest extends TestCase
         $this->assertSame(0.0, $request->float('null', 123.456));
     }
 
+    public function testArrayMethod()
+    {
+        $request = Request::create('/', 'GET', []);
+        $this->assertIsArray($request->array());
+        $this->assertEmpty($request->array());
+
+        $request = Request::create('/', 'GET', [
+            'users' => [1, 2, 3],
+            'roles' => [4, 5, 6],
+            'email' => 'test@example.com'
+        ]);
+
+        $this->assertEmpty($request->array('missing'));
+        $this->assertEmpty($request->array(['missing']));
+        $this->assertEquals([1, 2, 3], $request->array('users'));
+        $this->assertEquals(['users' => [1, 2, 3]], $request->array(['users']));
+        $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $request->array(['users', 'email']));
+
+        $this->assertEquals([
+            'users' => [1, 2, 3],
+            'roles' => [4, 5, 6],
+            'email' => 'test@example.com'
+        ], $request->array());
+    }
+
     public function testCollectMethod()
     {
         $request = Request::create('/', 'GET', ['users' => [1, 2, 3]]);

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -243,6 +243,33 @@ class SupportFluentTest extends TestCase
         $this->assertSame(0.0, $fluent->float('null', 123.456));
     }
 
+    public function testArrayMethod()
+    {
+        $fluent = new Fluent(['users' => [1, 2, 3]]);
+
+        $this->assertIsArray($fluent->array('users'));
+        $this->assertEquals([1, 2, 3], $fluent->array('users'));
+        $this->assertEquals(['users' => [1, 2, 3]], $fluent->array());
+
+        $fluent = new Fluent(['text-payload']);
+        $this->assertEquals(['text-payload'], $fluent->array());
+
+        $fluent = new Fluent(['email' => 'test@example.com']);
+        $this->assertEquals(['test@example.com'], $fluent->array('email'));
+
+        $fluent = new Fluent([]);
+        $this->assertIsArray($fluent->array());
+        $this->assertEmpty($fluent->array());
+
+        $fluent = new Fluent(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com']);
+        $this->assertEmpty($fluent->array(['developers']));
+        $this->assertNotEmpty($fluent->array(['roles']));
+        $this->assertEquals(['roles' => [4, 5, 6]], $fluent->array(['roles']));
+        $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $fluent->array(['users', 'email']));
+        $this->assertEquals(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']], $fluent->array(['roles', 'foo']));
+        $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $fluent->array());
+    }
+
     public function testCollectMethod()
     {
         $fluent = new Fluent(['users' => [1, 2, 3]]);


### PR DESCRIPTION
### Description

This PR add an `array($key)` method to both the `FormRequest` and `Fluent` instance via the `InteractsWithDataTrait`.

Previously, to retrieve a value from either instance as an `array` you had to manually cast the result yourself:

```php
$fluent = new Fluent(['...']);

(array) $fluent->get('value');
```

Or use `->collect()->all()`:

```php
public function store(UserRequest $request)
{
    $values = $request->collect('...')->all();

    // ...
}
```

### Usage

This allows developers to always retrieve a value as an `array`:

```php
$fluent = new Fluent(['...']);

$values = $fluent->array('value');
```

```php
public function store(UserRequest $request)
{
    $values = $request->array('...');

    // ...
}
```