### PR TITLE
Encode cache values for SQLite with base64 to prevent failing on \0 characters

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Cache\Store;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -487,7 +488,7 @@ class DatabaseStore implements LockProvider, Store
     {
         $result = serialize($value);
 
-        if ($this->connection instanceof PostgresConnection && str_contains($result, "\0")) {
+        if (($this->connection instanceof PostgresConnection || $this->connection instanceof SQLiteConnection) && str_contains($result, "\0")) {
             $result = base64_encode($result);
         }
 
@@ -502,7 +503,7 @@ class DatabaseStore implements LockProvider, Store
      */
     protected function unserialize($value)
     {
-        if ($this->connection instanceof PostgresConnection && ! Str::contains($value, [':', ';'])) {
+        if (($this->connection instanceof PostgresConnection || $this->connection instanceof SQLiteConnection) && ! Str::contains($value, [':', ';'])) {
             $value = base64_decode($value);
         }
 


### PR DESCRIPTION
Fixes a Cache serialization issue when the cache store is sqlite3 and the cached/serialized object contains any private or protected methods/properties.

It also handles reading non-encoded (previous) cache from SQLite - if it doesn't detect `:` or `;`, it doesn't to try to `base64_decode` and just serializes the value.

Fixes https://github.com/laravel/framework/issues/54082