### PR TITLE
[11.x] Fix invokable validation rule return type

### DIFF
--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -64,7 +64,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
      * Create a new implicit or explicit Invokable validation rule.
      *
      * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule  $invokable
-     * @return \Illuminate\Contracts\Validation\Rule|\Illuminate\Validation\InvokableValidationRule
+     * @return \Illuminate\Validation\InvokableValidationRule
      */
     public static function make($invokable)
     {


### PR DESCRIPTION
`InvokableValidationRule::make()` always returns an instance of `InvokableValidationRule`, but the return type is documented as `Rule|InvokableValidationRule` (which tools like PHPStan simplify to `Rule`), this PR fixes that.