### PR TITLE
Fix breaking change - Revert "[11.x] Replace string class names with ::class constants"

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -250,8 +250,8 @@ class RouteListCommand extends Command
     protected function isFrameworkController(Route $route)
     {
         return in_array($route->getControllerClass(), [
-            \Illuminate\Routing\RedirectController::class,
-            \Illuminate\Routing\ViewController::class,
+            '\Illuminate\Routing\RedirectController',
+            '\Illuminate\Routing\ViewController',
         ], true);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -258,7 +258,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        return $this->any($uri, \Illuminate\Routing\RedirectController::class)
+        return $this->any($uri, '\Illuminate\Routing\RedirectController')
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);
     }
@@ -287,7 +287,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function view($uri, $view, $data = [], $status = 200, array $headers = [])
     {
-        return $this->match(['GET', 'HEAD'], $uri, \Illuminate\Routing\ViewController::class)
+        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
                 ->setDefaults([
                     'view' => $view,
                     'data' => $data,

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -344,6 +344,15 @@ class RouteRegistrarTest extends TestCase
             'App\Http\Controllers\UsersController@index',
             $this->getRoute()->getAction()['uses']
         );
+
+        $this->router->namespace('App\Http\Controllers')->group(function ($router) {
+            $router->redirect('users', '/');
+        });
+
+        $this->assertSame(
+            '\Illuminate\Routing\RedirectController@__invoke',
+            $this->getRoute()->getAction()['uses']
+        );
     }
 
     public function testCanRegisterGroupWithPrefix()


### PR DESCRIPTION
Reverts laravel/framework#54134

fixed #54184

@taylorotwell I think this is a breaking change on the old route namespacing eg
```
Route::namespace('Admin')

    ->group(function (): void {

        Route::view('dashboard', 'admin.dashboard');

    });
```

this now throws `Invalid route action: [App\Http\Controllers\Admin\Illuminate\Routing\ViewController].` because the namespace in this PR was changed from `\Illuminate\Routing\ViewController` to `Illuminate\Routing\ViewController` I think.

![image](https://github.com/user-attachments/assets/9288de84-749c-4af5-8318-052eb8bde62f)
