### PR TITLE
[11.x] Simplify Codebase by Using `qualifyColumn` Helper Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1729,12 +1729,8 @@ class Builder implements BuilderContract
     {
         return [explode(':', $name)[0], static function ($query) use ($name) {
             $query->select(array_map(static function ($column) use ($query) {
-                if (str_contains($column, '.')) {
-                    return $column;
-                }
-
                 return $query instanceof BelongsToMany
-                        ? $query->getRelated()->getTable().'.'.$column
+                        ? $query->getRelated()->qualifyColumn($column)
                         : $column;
             }, explode(',', explode(':', $name)[1])));
         }];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -110,7 +110,7 @@ trait HasRelationships
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newHasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+        return $this->newHasOne($instance->newQuery(), $this, $instance->qualifyColumn($foreignKey), $localKey);
     }
 
     /**
@@ -198,11 +198,9 @@ trait HasRelationships
 
         [$type, $id] = $this->getMorphs($name, $type, $id);
 
-        $table = $instance->getTable();
-
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newMorphOne($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+        return $this->newMorphOne($instance->newQuery(), $this, $instance->qualifyColumn($type), $instance->qualifyColumn($id), $localKey);
     }
 
     /**
@@ -431,7 +429,7 @@ trait HasRelationships
         $localKey = $localKey ?: $this->getKeyName();
 
         return $this->newHasMany(
-            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey
+            $instance->newQuery(), $this, $instance->qualifyColumn($foreignKey), $localKey
         );
     }
 
@@ -527,11 +525,9 @@ trait HasRelationships
         // get the table and create the relationship instances for the developers.
         [$type, $id] = $this->getMorphs($name, $type, $id);
 
-        $table = $instance->getTable();
-
         $localKey = $localKey ?: $this->getKeyName();
 
-        return $this->newMorphMany($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+        return $this->newMorphMany($instance->newQuery(), $this, $instance->qualifyColumn($type), $instance->qualifyColumn($id), $localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2134,7 +2134,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         if ($relationship instanceof HasManyThrough ||
             $relationship instanceof BelongsToMany) {
-            $field = $relationship->getRelated()->getTable().'.'.$field;
+            $field = $relationship->getRelated()->qualifyColumn($field);
         }
 
         return $relationship instanceof Model

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -892,7 +892,7 @@ class BelongsToMany extends Relation
     protected function shouldSelect(array $columns = ['*'])
     {
         if ($columns == ['*']) {
-            $columns = [$this->related->getTable().'.*'];
+            $columns = [$this->related->qualifyColumn('*')];
         }
 
         return array_merge($columns, $this->aliasedPivotColumns());

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -297,7 +297,7 @@ trait CanBeOneOfMany
      */
     protected function qualifyRelatedColumn($column)
     {
-        return str_contains($column, '.') ? $column : $this->query->getModel()->getTable().'.'.$column;
+        return $this->query->getModel()->qualifyColumn($column);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -501,7 +501,7 @@ abstract class HasOneOrManyThrough extends Relation
     protected function shouldSelect(array $columns = ['*'])
     {
         if ($columns == ['*']) {
-            $columns = [$this->related->getTable().'.*'];
+            $columns = [$this->related->qualifyColumn('*')];
         }
 
         return array_merge($columns, [$this->getQualifiedFirstKeyName().' as laravel_through_key']);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -162,7 +162,7 @@ class MorphTo extends BelongsTo
         $whereIn = $this->whereInMethod($instance, $ownerKey);
 
         return $query->{$whereIn}(
-            $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type, $instance->getKeyType())
+            $instance->qualifyColumn($ownerKey), $this->gatherKeysByType($type, $instance->getKeyType())
         )->get();
     }
 


### PR DESCRIPTION
### Simplify Codebase by Using `qualifyColumn` Helper Method

This PR simplifies the Laravel codebase by replacing repetitive string concatenations for qualifying column names with the `qualifyColumn` helper method. This change improves readability, reduces code duplication, and aligns with Laravel’s focus on clean and maintainable code.

#### Key Changes:
- Replaced direct string concatenations (e.g., `$table . '.' . $column`) with the `qualifyColumn` method in various parts of the Eloquent ORM.
- Updated relationship methods (`hasOne`, `hasMany`, `morphOne`, `morphMany`, etc.) in `HasRelationships` to use `qualifyColumn`.
- Adjusted logic in Eloquent builders, relations, and traits to ensure consistent and efficient column qualification.

#### Benefits:
- Improved readability and maintainability of the codebase.
- Reduced potential for errors when qualifying column names.
- Encourages consistent use of helper methods across the framework.
