### PR TITLE
[11.x] Add support for phpredis backoff and max retry config options

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -85,6 +85,22 @@ class PhpRedisConnector implements Connector
                 );
             }
 
+            if (array_key_exists('max_retries', $config)) {
+                $client->setOption(Redis::OPT_MAX_RETRIES, $config['max_retries']);
+            }
+
+            if (array_key_exists('backoff_algorithm', $config)) {
+                $client->setOption(Redis::OPT_BACKOFF_ALGORITHM, $config['backoff_algorithm']);
+            }
+
+            if (array_key_exists('backoff_base', $config)) {
+                $client->setOption(Redis::OPT_BACKOFF_BASE, $config['backoff_base']);
+            }
+
+            if (array_key_exists('backoff_cap', $config)) {
+                $client->setOption(Redis::OPT_BACKOFF_CAP, $config['backoff_cap']);
+            }
+
             $this->establishConnection($client, $config);
 
             if (! empty($config['password'])) {


### PR DESCRIPTION
This pull request adds support for the [phpredis backoff/retry](https://github.com/phpredis/phpredis?tab=readme-ov-file#retry-and-backoff) configs.

Those settings are crucial for high performance applications. Currently I am forced to overwrite the driver in many services to leverage those configs. It would be amazing if you can merge this to support those configs out of the box.

I have confirmed with the phpredis maintainer, that those settings are currently only available to the normal `Redis` class, not for `RedisCluster` yet, so I did not add them to the cluster setup.

### Reasoning

This has been added to phpredis by recommendation from an AWS blog post: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

Especially when using phpredis with AWS Serverless where auto scaling constantly drops connections, it is important to spread out the reconnect attempts. The default phpredis is a linear backoff approach, which is not ideal.