### PR TITLE
[11.x] fix declaration issue with `HasMiddleware` interface in controllers

### DIFF
--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -9,5 +9,5 @@ interface HasMiddleware
      *
      * @return array<int,\Illuminate\Routing\Controllers\Middleware|\Closure|string>
      */
-    public static function middleware();
+    public static function setMiddleware(): array;
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1138,7 +1138,7 @@ class Route
      */
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
     {
-        return (new Collection($class::middleware()))->map(function ($middleware) {
+        return (new Collection($class::setMiddleware()))->map(function ($middleware) {
             return $middleware instanceof Middleware
                 ? $middleware
                 : new Middleware($middleware);

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Routing\Controller;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
 use Illuminate\Support\Facades\Route;
@@ -19,7 +20,7 @@ class HasMiddlewareTest extends TestCase
     }
 }
 
-class HasMiddlewareTestController implements HasMiddleware
+class HasMiddlewareTestController extends Controller implements HasMiddleware
 {
     public static function middleware()
     {

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -22,7 +22,7 @@ class HasMiddlewareTest extends TestCase
 
 class HasMiddlewareTestController extends Controller implements HasMiddleware
 {
-    public static function middleware()
+    public static function setMiddleware(): array
     {
         return [
             new Middleware('all'),


### PR DESCRIPTION
After checking [this issue](https://github.com/laravel/framework/issues/54181) I realized that the original test for `src/Illuminate/Routing/Controllers/HasMiddleware.php` is not correct. It missed inheriting the `Controller` class. There is a declaration conflict between `Controller::middleware` and `HasMiddleware::middleware` methods. The whole `HasMiddleware` feature didn't work properly from the beginning. This PR fixes the issue and the test,