### PR TITLE
[11.x] Fix deprecation warnings in `optimize:clear` and `optimize`

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -34,7 +34,7 @@ class OptimizeClearCommand extends Command
     {
         $this->components->info('Clearing cached bootstrap files.');
 
-        $exceptions = Collection::wrap(explode(',', $this->option('except')))
+        $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
             ->map(fn ($except) => trim($except))
             ->filter()
             ->unique()

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -34,7 +34,7 @@ class OptimizeCommand extends Command
     {
         $this->components->info('Caching framework bootstrap, configuration, and metadata.');
 
-        $exceptions = Collection::wrap(explode(',', $this->option('except')))
+        $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
             ->map(fn ($except) => trim($except))
             ->filter()
             ->unique()

--- a/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeClearCommandTest.php
@@ -15,6 +15,8 @@ class OptimizeClearCommandTest extends TestCase
 
     public function testCanListenToOptimizingEvent(): void
     {
+        $this->withoutDeprecationHandling();
+
         $this->artisan('optimize:clear')
             ->assertSuccessful()
             ->expectsOutputToContain('ServiceProviderWithOptimizeClear');

--- a/tests/Integration/Foundation/Console/OptimizeCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeCommandTest.php
@@ -23,6 +23,8 @@ class OptimizeCommandTest extends TestCase
 
     public function testCanListenToOptimizingEvent(): void
     {
+        $this->withoutDeprecationHandling();
+
         $this->artisan('optimize')
             ->assertSuccessful()
             ->expectsOutputToContain('my package');


### PR DESCRIPTION
To resolve https://github.com/laravel/framework/issues/54190

Passing null to `explode()` produces a deprecation warning. I coalesced the option to a blank string, and modified the tests so the tests will fail if there's a deprecation warning.