### PR TITLE
[11.x] Improve `Email` validation rule custom translation messages

### DIFF
--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -2,12 +2,6 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Egulias\EmailValidator\EmailValidator;
-use Egulias\EmailValidator\Validation\DNSCheckValidation;
-use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
-use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
-use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
-use Egulias\EmailValidator\Validation\RFCValidation;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
@@ -17,7 +11,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Validation\Concerns\FilterEmailValidation;
 use InvalidArgumentException;
 
 class Email implements Rule, DataAwareRule, ValidatorAwareRule
@@ -199,27 +192,17 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             return false;
         }
 
-        $emailValidator = Container::getInstance()->make(EmailValidator::class);
+        $validator = Validator::make(
+            $this->data,
+            [$attribute => $this->buildValidationRules()],
+            $this->validator->customMessages,
+            $this->validator->customAttributes
+        );
 
-        $passes = $emailValidator->isValid((string) $value, new MultipleValidationWithAnd($this->buildValidationRules()));
-
-        if (! $passes) {
-            $this->messages = [trans('validation.email', ['attribute' => $attribute])];
+        if ($validator->fails()) {
+            $this->messages = array_merge($this->messages, $validator->messages()->all());
 
             return false;
-        }
-
-        if ($this->customRules) {
-            $validator = Validator::make(
-                $this->data,
-                [$attribute => $this->customRules],
-                $this->validator->customMessages,
-                $this->validator->customAttributes
-            );
-
-            if ($validator->fails()) {
-                return $this->fail($validator->messages()->all());
-            }
         }
 
         return true;
@@ -235,51 +218,36 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
         $rules = [];
 
         if ($this->rfcCompliant) {
-            $rules[] = new RFCValidation;
+            $rules[] = 'rfc';
         }
 
         if ($this->strictRfcCompliant) {
-            $rules[] = new NoRFCWarningsValidation;
+            $rules[] = 'strict';
         }
 
         if ($this->validateMxRecord) {
-            $rules[] = new DNSCheckValidation;
+            $rules[] = 'dns';
         }
 
         if ($this->preventSpoofing) {
-            $rules[] = new SpoofCheckValidation;
+            $rules[] = 'spoof';
         }
 
         if ($this->nativeValidation) {
-            $rules[] = new FilterEmailValidation;
+            $rules[] = 'filter';
         }
 
         if ($this->nativeValidationWithUnicodeAllowed) {
-            $rules[] = FilterEmailValidation::unicode();
+            $rules[] = 'filter_unicode';
         }
 
         if ($rules) {
-            return $rules;
+            $rules = ['email:'.implode(',', $rules)];
+        } else {
+            $rules = ['email'];
         }
 
-        return [new RFCValidation];
-    }
-
-    /**
-     * Adds the given failures, and return false.
-     *
-     * @param  array|string  $messages
-     * @return bool
-     */
-    protected function fail($messages)
-    {
-        $messages = Collection::wrap($messages)
-            ->map(fn ($message) => $this->validator->getTranslator()->get($message))
-            ->all();
-
-        $this->messages = array_merge($this->messages, $messages);
-
-        return false;
+        return array_merge(array_filter($rules), $this->customRules);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -2,12 +2,10 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -48,7 +48,7 @@ class ValidationEmailRuleTest extends TestCase
 
     /**
      * @param  mixed  $rule
-     * @param  string|array $values
+     * @param  string|array  $values
      * @param  array  $expectedMessages
      * @param  string|null  $customValidationMessage
      * @return void
@@ -90,8 +90,8 @@ class ValidationEmailRuleTest extends TestCase
     }
 
     /**
-     * @param mixed $rule
-     * @param string|array $values
+     * @param  mixed  $rule
+     * @param  string|array  $values
      * @return void
      */
     protected function passes($rule, $values)
@@ -481,7 +481,7 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             $spoofingEmail,
-            ["Please check the entered ".self::ATTRIBUTE_REPLACED.", it must be a valid email address, {$spoofingEmail} given."],
+            ['Please check the entered '.self::ATTRIBUTE_REPLACED.", it must be a valid email address, {$spoofingEmail} given."],
             'Please check the entered :attribute, it must be a valid email address, :input given.'
         );
 

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -15,17 +15,20 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationEmailRuleTest extends TestCase
 {
+    private const ATTRIBUTE = 'my_email';
+    private const ATTRIBUTE_REPLACED = 'my email';
+
     public function testBasic()
     {
         $this->fails(
             Email::default(),
             'foo',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
         $this->fails(
             Rule::email(),
             'foo',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -43,34 +46,57 @@ class ValidationEmailRuleTest extends TestCase
         $this->passes(Rule::email(), null);
     }
 
-    protected function fails($rule, $values, $messages)
+    /**
+     * @param  mixed  $rule
+     * @param  string|array $values
+     * @param  array  $expectedMessages
+     * @param  string|null  $customValidationMessage
+     * @return void
+     */
+    protected function fails($rule, $values, $expectedMessages, $customValidationMessage = null)
     {
-        $this->assertValidationRules($rule, $values, false, $messages);
+        $this->assertValidationRules($rule, $values, false, $expectedMessages, $customValidationMessage);
     }
 
-    protected function assertValidationRules($rule, $values, $result, $messages)
+    /**
+     * @param  mixed  $rule
+     * @param  string|array  $values
+     * @param  bool  $expectToPass
+     * @param  array  $expectedMessages
+     * @param  string|null  $customValidationMessage
+     * @return void
+     */
+    protected function assertValidationRules($rule, $values, $expectToPass, $expectedMessages = [], $customValidationMessage = null)
     {
         $values = Arr::wrap($values);
 
+        $translator = resolve('translator');
+
         foreach ($values as $value) {
             $v = new Validator(
-                resolve('translator'),
-                ['my_email' => $value],
-                ['my_email' => is_object($rule) ? clone $rule : $rule]
+                $translator,
+                [self::ATTRIBUTE => $value],
+                [self::ATTRIBUTE => is_object($rule) ? clone $rule : $rule],
+                $customValidationMessage ? [self::ATTRIBUTE.'.email' => $customValidationMessage] : []
             );
 
-            $this->assertSame($result, $v->passes());
+            $this->assertSame($expectToPass, $v->passes());
 
             $this->assertSame(
-                $result ? [] : ['my_email' => $messages],
+                $expectToPass ? [] : [self::ATTRIBUTE => $expectedMessages],
                 $v->messages()->toArray()
             );
         }
     }
 
+    /**
+     * @param mixed $rule
+     * @param string|array $values
+     * @return void
+     */
     protected function passes($rule, $values)
     {
-        $this->assertValidationRules($rule, $values, true, []);
+        $this->assertValidationRules($rule, $values, true);
     }
 
     public function testStrict()
@@ -78,25 +104,25 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->rfcCompliant(true),
             'invalid.@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(true),
             'invalid.@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             (new Email())->rfcCompliant(true),
             'username@sub..example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(true),
             'username@sub..example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -115,13 +141,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->validateMxRecord(),
             'plainaddress@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->validateMxRecord(),
             'plainaddress@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -140,26 +166,26 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->preventSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->preventSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
         $this->fails(
             (new Email())->preventSpoofing(),
             $spoofingEmail,
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->preventSpoofing(),
             $spoofingEmail,
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -188,13 +214,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->withNativeValidation(),
             'tést@domain.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->withNativeValidation(),
             'tést@domain.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -213,13 +239,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->withNativeValidation(true),
             'invalid.@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->withNativeValidation(true),
             'invalid.@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -248,25 +274,25 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->rfcCompliant(),
             'invalid.@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(),
             'invalid.@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             (new Email())->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -305,13 +331,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->rfcCompliant(true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
@@ -327,13 +353,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->preventSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->preventSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
@@ -351,13 +377,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->rfcCompliant()->preventSpoofing(),
             $spoofingEmail,
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
             Rule::email()->rfcCompliant()->preventSpoofing(),
             $spoofingEmail,
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
     }
 
@@ -408,7 +434,7 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             $spoofingEmail,
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         Email::defaults(function () {
@@ -427,7 +453,43 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             $spoofingEmail,
-            ['validation.email'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+        );
+    }
+
+    public function testValidationMessages()
+    {
+        Email::defaults(function () {
+            return Rule::email()->preventSpoofing();
+        });
+
+        $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
+
+        $this->fails(
+            Email::default(),
+            $spoofingEmail,
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+        );
+
+        $this->fails(
+            Email::default(),
+            $spoofingEmail,
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            'The :attribute must be a valid email address.',
+        );
+
+        $this->fails(
+            Email::default(),
+            $spoofingEmail,
+            ["Please check the entered ".self::ATTRIBUTE_REPLACED.", it must be a valid email address, {$spoofingEmail} given."],
+            'Please check the entered :attribute, it must be a valid email address, :input given.'
+        );
+
+        $this->fails(
+            Email::default(),
+            $spoofingEmail,
+            ['Plain text value'],
+            'Plain text value'
         );
     }
 
@@ -436,9 +498,15 @@ class ValidationEmailRuleTest extends TestCase
         $container = Container::getInstance();
 
         $container->bind('translator', function () {
-            return new Translator(
+            $translator = new Translator(
                 new ArrayLoader, 'en'
             );
+
+            $translator->addLines([
+                'validation.email' => 'The :attribute must be a valid email address.',
+            ], 'en');
+
+            return $translator;
         });
 
         Facade::setFacadeApplication($container);


### PR DESCRIPTION
Via #54067 we introduced the fluent `Email` validation rule. While implementing this new feature in our project I noticed that the existing custom validation message was not being used.

This PR adds tests that test custom validation messages, and makes changes to the `Email` class to make the tests pass. This change also 


This PR makes the following diff possible:

```diff
    public function rules(): array
    {
        return [
            'answer.email_address' => [
                'required',
                'string',
-                new class extends Email {
-                    public function message(): string
-                    {
-                        return __('check_answer.validation.email.invalid');
-                    }
-                },
+                Email::default(),
            ],
        ];
    }

    public function messages(): array
    {
        return [
            'answer.email_address.required' => __('check_answer.validation.email.required'),
            'answer.email_address.string' => __('check_answer.validation.email.invalid'),
            'answer.email_address.email' => __('check_answer.validation.email.invalid'),
        ];
    }
```

The `Email` class is quite some slimmer due to now converting to the old rules and then validating that, instead of implementing the different email validation classes. This way the email specific validation and the `customRules` can just be merged, similar to how the `File` rule works.

The `ValidationEmailRuleTest` (and `ValidationPasswordRuleTest` and `ValidationFileRuleTest`) are quite confusing, the helper methods are nice for simple tests, but complex tests/cases result in cognitive overload. I would be happy to see if we can simplify these tests, and also test more cases, e.g. the other existing rules don't test custom validation messages. 

The implementation of the `messages()` method in the different `Rule` classes in `Illuminate\Validation\Rules` also differ to a confusing extend. Let me know if you are open to receiving follow-up PRs to cleanup the framework in this area.