### PR TITLE
Add QueryException message handling without replacing bindings.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -816,14 +816,15 @@ class Connection implements ConnectionInterface
         // message to include the bindings with SQL, which will make this exception a
         // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
+            $maskBindings = Arr::get($this->config, 'mask_bindings_on_exception_message', false);
             if ($this->isUniqueConstraintError($e)) {
                 throw new UniqueConstraintViolationException(
-                    $this->getName(), $query, $this->prepareBindings($bindings), $e
+                    $this->getName(), $query, $this->prepareBindings($bindings), $e, $maskBindings
                 );
             }
 
             throw new QueryException(
-                $this->getName(), $query, $this->prepareBindings($bindings), $e
+                $this->getName(), $query, $this->prepareBindings($bindings), $e, $maskBindings
             );
         }
     }

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -38,7 +38,7 @@ class QueryException extends PDOException
      * @param  \Throwable  $previous
      * @return void
      */
-    public function __construct($connectionName, $sql, array $bindings, Throwable $previous)
+    public function __construct($connectionName, $sql, array $bindings, Throwable $previous, bool $maskBindings = false)
     {
         parent::__construct('', 0, $previous);
 
@@ -46,7 +46,7 @@ class QueryException extends PDOException
         $this->sql = $sql;
         $this->bindings = $bindings;
         $this->code = $previous->getCode();
-        $this->message = $this->formatMessage($connectionName, $sql, $bindings, $previous);
+        $this->message = $this->formatMessage($connectionName, $sql, $bindings, $previous, $maskBindings);
 
         if ($previous instanceof PDOException) {
             $this->errorInfo = $previous->errorInfo;
@@ -60,11 +60,16 @@ class QueryException extends PDOException
      * @param  string  $sql
      * @param  array  $bindings
      * @param  \Throwable  $previous
+     * @param  bool  $maskBindings
      * @return string
      */
-    protected function formatMessage($connectionName, $sql, $bindings, Throwable $previous)
+    protected function formatMessage($connectionName, $sql, $bindings, Throwable $previous, bool $maskBindings)
     {
-        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+        if (! $maskBindings) {
+            $sql = Str::replaceArray('?', $bindings, $sql);
+        }
+
+        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.$sql.')';
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As mentioned in the discussion https://github.com/laravel/framework/discussions/41920, QueryException message that bind real SQL values is useful for development. But there is security risk, e.g. unintended personal information(email, user name, tel, ...) logging.

This pull request adds support for QueryException message handling with/without replacing bindings.
If we put `mask: true` parameters to database config, `?` masking is not replacing with real SQL value.
I think this pull request help Laravel application more secure.

## Example

config/database.php
```php
<?php

return [
    'connections' => [
        'mysql' => [
            'driver' => 'mysql',
            // ...
            'mask' => true,
        ],
```

mask: true
```
(Connection: , SQL: SELECT * FROM users WHERE id = ?)
```

mask: false
```
(Connection: , SQL: SELECT * FROM users WHERE id = 1)
```
