### PR TITLE
Make Notification and Make Mail Consistency

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function Laravel\Prompts\select;
+use function Laravel\Prompts\confirm;
 
 #[AsCommand(name: 'make:mail')]
 class MailMakeCommand extends GeneratorCommand
@@ -143,8 +143,9 @@ class MailMakeCommand extends GeneratorCommand
         if (! $view) {
             $name = str_replace('\\', '/', $this->argument('name'));
 
-            $view = 'mail.'.(new Collection(explode('/', $name)))
-                ->map(fn ($part) => Str::kebab($part))
+            $view = (new Collection(explode('/', $name)))
+                ->map(fn ($path) => Str::kebab($path))
+                ->prepend('mail')
                 ->implode('.');
         }
 
@@ -194,20 +195,6 @@ class MailMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists'],
-            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable', false],
-            ['view', null, InputOption::VALUE_OPTIONAL, 'Create a new Blade template for the mailable', false],
-        ];
-    }
-
-    /**
      * Interact further with the user if they were prompted for missing arguments.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
@@ -220,14 +207,24 @@ class MailMakeCommand extends GeneratorCommand
             return;
         }
 
-        $type = select('Would you like to create a view?', [
-            'markdown' => 'Markdown View',
-            'view' => 'Empty View',
-            'none' => 'No View',
-        ]);
+        $wantsMarkdownView = confirm('Would you like to create a markdown view?');
 
-        if ($type !== 'none') {
-            $input->setOption($type, null);
+        if ($wantsMarkdownView) {
+            $input->setOption('markdown', $this->getView());
         }
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists'],
+            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable', false],
+            ['view', null, InputOption::VALUE_OPTIONAL, 'Create a new Blade template for the mailable', false],
+        ];
     }
 }

--- a/tests/Integration/Generators/MailMakeCommandTest.php
+++ b/tests/Integration/Generators/MailMakeCommandTest.php
@@ -128,29 +128,18 @@ class MailMakeCommandTest extends TestCase
     {
         $this->artisan('make:mail')
             ->expectsQuestion('What should the mailable be named?', 'FooMail')
-            ->expectsQuestion('Would you like to create a view?', 'none')
+            ->expectsQuestion('Would you like to create a markdown view?', false)
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/FooMail.php');
         $this->assertFilenameDoesNotExists('resources/views/mail/foo-mail.blade.php');
     }
 
-    public function testItCanGenerateMailWithViewWithNoInitialInput()
-    {
-        $this->artisan('make:mail')
-            ->expectsQuestion('What should the mailable be named?', 'MyFooMail')
-            ->expectsQuestion('Would you like to create a view?', 'view')
-            ->assertExitCode(0);
-
-        $this->assertFilenameExists('app/Mail/MyFooMail.php');
-        $this->assertFilenameExists('resources/views/mail/my-foo-mail.blade.php');
-    }
-
     public function testItCanGenerateMailWithMarkdownViewWithNoInitialInput()
     {
         $this->artisan('make:mail')
             ->expectsQuestion('What should the mailable be named?', 'FooMail')
-            ->expectsQuestion('Would you like to create a view?', 'markdown')
+            ->expectsQuestion('Would you like to create a markdown view?', true)
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Mail/FooMail.php');

--- a/tests/Integration/Generators/NotificationMakeCommandTest.php
+++ b/tests/Integration/Generators/NotificationMakeCommandTest.php
@@ -68,10 +68,9 @@ class NotificationMakeCommandTest extends TestCase
         $this->artisan('make:notification')
             ->expectsQuestion('What should the notification be named?', 'FooNotification')
             ->expectsQuestion('Would you like to create a markdown view?', true)
-            ->expectsQuestion('What should the markdown view be named?', 'foo-notification')
             ->assertExitCode(0);
 
         $this->assertFilenameExists('app/Notifications/FooNotification.php');
-        $this->assertFilenameExists('resources/views/foo-notification.blade.php');
+        $this->assertFilenameExists('resources/views/mail/foo-notification.blade.php');
     }
 }


### PR DESCRIPTION
There is no consistency between `make:notification` and `make:mail` without arguments.

**make:notification asks about:**

1- The name of the notification.
2- Whether to create a markdown view or not.
3- What is the name of the view.

**While make:mail  asks about:**

1- The name of the mail.
2- Whether to create a view or an empty view or not.

**I have noticed a few things:**

1- There is no need to ask about the name of the view while creating the `notification` because our command should use naming conventions to guess it.

2- There is no need to ask about creating an empty view while creating the `mail`, It should only ask about whether to create a markdown view or not.

3- getOptions() method used in both of them but in different places in the classes.

4- getView() method is written in one class but the other uses it's content inside another method.

These things are important for consistency.

According to PR #52355 and #52057
