### PR TITLE
Queue Integration Tests with Redis Cluster

### DIFF
--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -127,6 +127,54 @@ jobs:
           REDIS_CLIENT: ${{ matrix.client }}
           QUEUE_CONNECTION: redis
 
+  redis-cluster:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        client: ['phpredis', 'predis']
+
+    name: Redis Cluster (${{ matrix.client}}) Driver
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "11.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Create Redis Cluster
+        run: |
+          sudo apt-get install -y redis-server
+          sudo service redis-server stop
+          redis-server --daemonize yes --port 7000 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7000.conf
+          redis-server --daemonize yes --port 7001 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7001.conf
+          redis-server --daemonize yes --port 7002 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7002.conf
+          redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-replicas 0 --cluster-yes
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Queue
+        env:
+          REDIS_CLIENT: ${{ matrix.client }}
+          REDIS_CLUSTER_HOSTS_AND_PORTS: 127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002
+          REDIS_QUEUE: '{default}'
+
   beanstalkd:
     runs-on: ubuntu-24.04
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,3 +51,29 @@ services:
     ports:
       - "6379:6379"
     restart: always
+  # redis-cluster-0:
+  #   image: redis:7.0-alpine
+  #   ports:
+  #     - "7000:7000"
+  #   restart: always
+  #   command: redis-server --port 7000 --appendonly yes --cluster-enabled yes
+  # redis-cluster-1:
+  #   image: redis:7.0-alpine
+  #   ports:
+  #     - "7001:7001"
+  #   restart: always
+  #   command: redis-server --port 7001 --appendonly yes --cluster-enabled yes
+  # redis-cluster-2:
+  #   image: redis:7.0-alpine
+  #   ports:
+  #     - "7002:7002"
+  #   restart: always
+  #   command: redis-server --port 7002 --appendonly yes --cluster-enabled yes
+  # redis-cluster-creator:
+  #   image: redis:7.0-alpine
+  #   depends_on:
+  #     - redis-cluster-0
+  #     - redis-cluster-1
+  #     - redis-cluster-2
+  #   command: sh -c 'redis-cli --cluster create redis-cluster-0:7000 redis-cluster-1:7001 redis-cluster-2:7002 --cluster-replicas 0 --cluster-yes || true'
+  #   restart: no

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -8,6 +8,7 @@ use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\RateLimitedWithRedis;
@@ -21,6 +22,22 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 #[RequiresPhpExtension('redis')]
 class RateLimitedWithRedisTest extends TestCase
 {
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownRedis();
+
+        parent::tearDown();
+    }
+
     public function testUnlimitedJobsAreExecuted()
     {
         $rateLimiter = $this->app->make(RateLimiter::class);

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -9,6 +9,8 @@ use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Queue\RedisQueue;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -65,7 +67,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testExpiredJobsArePopped($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
 
         $jobs = [
             new RedisQueueIntegrationTestJob(0),
@@ -84,8 +87,8 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($jobs[3], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
         $this->assertNull($this->queue->pop());
 
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(3, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("queues:$default:delayed"));
+        $this->assertEquals(3, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
     }
 
     /**
@@ -99,13 +102,14 @@ class RedisQueueTest extends TestCase
     {
         $this->tearDownRedis();
 
+        $default = config('queue.connections.redis.queue', 'default');
         if ($pid = pcntl_fork() > 0) {
             $this->setUpRedis();
-            $this->setQueue($driver, 'default', null, 60, 10);
+            $this->setQueue($driver, $default, null, 60, 10);
             $this->assertEquals(12, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
         } elseif ($pid == 0) {
             $this->setUpRedis();
-            $this->setQueue('phpredis');
+            $this->setQueue('phpredis', $default);
             sleep(1);
             $this->queue->push(new RedisQueueIntegrationTestJob(12));
             exit;
@@ -120,13 +124,14 @@ class RedisQueueTest extends TestCase
     // #[DataProvider('redisDriverProvider')]
     // public function testMigrateMoreThan100Jobs($driver)
     // {
-    //     $this->setQueue($driver);
+    //     $default = config('queue.connections.redis.queue', 'default');
+    //     $this->setQueue($driver, $default);
     //     for ($i = -1; $i >= -201; $i--) {
     //         $this->queue->later($i, new RedisQueueIntegrationTestJob($i));
     //     }
     //     for ($i = -201; $i <= -1; $i++) {
     //         $this->assertEquals($i, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
-    //         $this->assertEquals(-$i - 1, $this->redis[$driver]->llen('queues:default:notify'));
+    //         $this->assertEquals(-$i - 1, $this->redis[$driver]->llen("queues:$default:notify"));
     //     }
     // }
 
@@ -136,7 +141,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testPopProperlyPopsJobOffOfRedis($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -155,8 +161,8 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($redisJob->getJobId(), json_decode($redisJob->getReservedJob())->id);
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
+        $result = $this->redis[$driver]->connection()->zrangebyscore("queues:$default:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -170,7 +176,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
         $this->queue->later(-10, $job);
@@ -181,8 +188,8 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
+        $result = $this->redis[$driver]->connection()->zrangebyscore("queues:$default:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -196,7 +203,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver)
     {
-        $this->setQueue($driver, 'default', null, null);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default, null, null);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -210,8 +218,8 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
+        $result = $this->redis[$driver]->connection()->zrangebyscore("queues:$default:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before);
@@ -225,7 +233,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testBlockingPopProperlyPopsJobOffOfRedis($driver)
     {
-        $this->setQueue($driver, 'default', null, 60, 5);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default, null, 60, 5);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -249,7 +258,8 @@ class RedisQueueTest extends TestCase
             return 'uuid';
         });
 
-        $this->setQueue($driver, 'default', null, 60, 5);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default, null, 60, 5);
 
         $jobs = [
             new RedisQueueIntegrationTestJob(0),
@@ -263,8 +273,8 @@ class RedisQueueTest extends TestCase
         $this->assertEquals($jobs[1], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
 
         $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default:notify'));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("queues:$default:delayed"));
+        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
 
         Str::createUuidsNormally();
     }
@@ -275,7 +285,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testNotExpireJobsWhenExpireNull($driver)
     {
-        $this->setQueue($driver, 'default', null, null);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default, null, null);
 
         // Make an expired reserved job
         $failed = new RedisQueueIntegrationTestJob(-20);
@@ -297,8 +308,8 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
+        $result = $this->redis[$driver]->connection()->zrangebyscore("queues:$default:reserved", -INF, INF, ['withscores' => true]);
 
         foreach ($result as $payload => $score) {
             $command = unserialize(json_decode($payload)->data->command);
@@ -323,7 +334,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testExpireJobsWhenExpireSet($driver)
     {
-        $this->setQueue($driver, 'default', null, 30);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default, null, 30);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -336,8 +348,8 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
+        $result = $this->redis[$driver]->connection()->zrangebyscore("queues:$default:reserved", -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = (int) $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 30);
@@ -351,7 +363,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testRelease($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
 
         // push a job into queue
         $job = new RedisQueueIntegrationTestJob(30);
@@ -365,9 +378,9 @@ class RedisQueueTest extends TestCase
         $after = $this->currentTime();
 
         // check the content of delayed queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard("queues:$default:delayed"));
 
-        $results = $this->redis[$driver]->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['withscores' => true]);
+        $results = $this->redis[$driver]->connection()->zrangebyscore("queues:$default:delayed", -INF, INF, ['withscores' => true]);
 
         $payload = array_keys($results)[0];
 
@@ -391,7 +404,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testReleaseInThePast($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
 
@@ -408,7 +422,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testDelete($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
 
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
@@ -418,9 +433,9 @@ class RedisQueueTest extends TestCase
 
         $redisJob->delete();
 
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default'));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("queues:$default:delayed"));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard("queues:$default:reserved"));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->llen("queues:$default"));
 
         $this->assertNull($this->queue->pop());
     }
@@ -431,7 +446,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testClear($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
 
         $job1 = new RedisQueueIntegrationTestJob(30);
         $job2 = new RedisQueueIntegrationTestJob(40);
@@ -450,7 +466,8 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testSize($driver)
     {
-        $this->setQueue($driver);
+        $default = config('queue.connections.redis.queue', 'default');
+        $this->setQueue($driver, $default);
         $this->assertEquals(0, $this->queue->size());
         $this->queue->push(new RedisQueueIntegrationTestJob(1));
         $this->assertEquals(1, $this->queue->size());
@@ -487,7 +504,8 @@ class RedisQueueTest extends TestCase
         $container->shouldReceive('bound')->with('events')->andReturn(true)->twice();
         $container->shouldReceive('offsetGet')->with('events')->andReturn($events)->twice();
 
-        $queue = new RedisQueue($this->redis[$driver]);
+        $default = config('queue.connections.redis.queue', 'default');
+        $queue = new RedisQueue($this->redis[$driver], $default);
         $queue->setContainer($container);
 
         $queue->push(new RedisQueueIntegrationTestJob(5));
@@ -499,6 +517,11 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testBulkJobQueuedEvent($driver)
     {
+        if ($this->redis[$driver]->connection() instanceof PhpRedisClusterConnection
+            || $this->redis[$driver]->connection() instanceof PredisClusterConnection
+        ) {
+            $this->markTestSkipped('RedisQueue::bulk currently does not support cluster connections');
+        }
         $events = m::mock(Dispatcher::class);
         $events->shouldReceive('dispatch')->with(m::type(JobQueueing::class))->andReturnNull()->times(3);
         $events->shouldReceive('dispatch')->with(m::type(JobQueued::class))->andReturnNull()->times(3);
@@ -507,7 +530,8 @@ class RedisQueueTest extends TestCase
         $container->shouldReceive('bound')->with('events')->andReturn(true)->times(6);
         $container->shouldReceive('offsetGet')->with('events')->andReturn($events)->times(6);
 
-        $queue = new RedisQueue($this->redis[$driver]);
+        $default = config('queue.connections.redis.queue', 'default');
+        $queue = new RedisQueue($this->redis[$driver], $default);
         $queue->setContainer($container);
 
         $queue->bulk([


### PR DESCRIPTION
Currently Laravel declares some support for Redis Cluster, but some features are not working (for example, job batches).
This PR adds Queue Integration Tests run with Redis Cluster (on both predis and phpredis). This will allow to check if new and existing features are compatible with Redis Cluster.

Some changes were made to run tests in new environment.
* InteractsWithRedis trait extended, to provide clustered config for redis, if REDIS_CLUSTER_HOSTS_AND_PORTS env variable is passed. This is considered backward compatible change, as currently env with this name is not described anywhere.
* InteractsWithRedis also sets RedisManager instance for application container. Without this change application in tests tries to use application configs leading to behaviour inconsistency (as config in InteractsWithRedis and in application differs). Added `cache` to config in InteractsWithRedis, to make configs in trait same as in app, and do not break tests, that previously used app configs. This change may be considered backward incompatible. On the other hand, behaviour of InteractsWithRedis is not described anywhere, and is intended to be used only in tests, and this change may be treated as not breaking contracts.
* InteractsWithRedis trait added to RateLimitedWithRedisTest (unlike other tests that interacts with redis, that test missed this trait).
* Redis cluster queue should use `{default}` queue name instead of `queue`. RedisQueueTest updated, to take queue name from config. This allow to pass right queue name when tested in cluster.
* testBulkJobQueuedEvent is skipped with redis cluster connection (fix for bulk with cluster and unskipping test will be in separate PR, simular to https://github.com/laravel/framework/pull/54205)
* redis-cluster example in docker-compose.yml to run local tests with cluster