### PR TITLE
support style file name hashes with query strings in manifest

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -800,7 +800,7 @@ class Vite implements Htmlable
      */
     protected function isCssPath($path)
     {
-        return preg_match('/\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/', $path) === 1;
+        return preg_match('/\.(css|less|sass|scss|styl|stylus|pcss|postcss)(\?[^\.]*)?$/', $path) === 1;
     }
 
     /**


### PR DESCRIPTION
support manifests with style file name hashes in query strings instead of file name (for example when using https://github.com/Infomaniak/vite-plugin-query-hash)
