### PR TITLE
[11.x] switch Collection::make() for new Collection()

### DIFF
--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -21,7 +21,7 @@ class HttpClientTest extends TestCase
         Http::get('laravel.com');
 
         Event::assertDispatched(RequestSending::class, function (RequestSending $event) {
-            return Collection::make($event->request->header('User-Agent'))->contains('Facade/1.0');
+            return (new Collection($event->request->header('User-Agent')))->contains('Facade/1.0');
         });
     }
 

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -101,7 +101,7 @@ class CursorPaginatorTest extends TestCase
     {
         $cursor = new Cursor(['id' => 25], true);
 
-        $p = new CursorPaginator(Collection::make(), 25, $cursor, [
+        $p = new CursorPaginator(new Collection(), 25, $cursor, [
             'path' => 'http://website.com/test',
             'cursorName' => 'cursor',
             'parameters' => ['id'],


### PR DESCRIPTION
make() is essentially just a static alias to the constructor. it performs no logic.

removing the middleman to simplify the call stack.

continuation of #54216