### PR TITLE
[11.x] Fix Cache component to be aware of phpredis serialization and compression settings

### DIFF
--- a/src/Illuminate/Cache/LuaScripts.php
+++ b/src/Illuminate/Cache/LuaScripts.php
@@ -22,4 +22,20 @@ else
 end
 LUA;
     }
+
+    /**
+     * Get the Lua script that sets a key only when it does not yet exist.
+     *
+     * KEYS[1] - The name of the key
+     * ARGV[1] - Value of the key
+     * ARGV[2] - Time in seconds how long to keep the key
+     *
+     * @return string
+     */
+    public static function add()
+    {
+        return <<<'LUA'
+return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])
+LUA;
+    }
 }

--- a/src/Illuminate/Cache/LuaScripts.php
+++ b/src/Illuminate/Cache/LuaScripts.php
@@ -5,6 +5,22 @@ namespace Illuminate\Cache;
 class LuaScripts
 {
     /**
+     * Get the Lua script that sets a key only when it does not yet exist.
+     *
+     * KEYS[1] - The name of the key
+     * ARGV[1] - The value of the key
+     * ARGV[2] - The number of seconds the key should be valid
+     *
+     * @return string
+     */
+    public static function add()
+    {
+        return <<<'LUA'
+return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])
+LUA;
+    }
+
+    /**
      * Get the Lua script to atomically release a lock.
      *
      * KEYS[1] - The name of the lock
@@ -20,22 +36,6 @@ if redis.call("get",KEYS[1]) == ARGV[1] then
 else
     return 0
 end
-LUA;
-    }
-
-    /**
-     * Get the Lua script that sets a key only when it does not yet exist.
-     *
-     * KEYS[1] - The name of the key
-     * ARGV[1] - Value of the key
-     * ARGV[2] - Time in seconds how long to keep the key
-     *
-     * @return string
-     */
-    public static function add()
-    {
-        return <<<'LUA'
-return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])
 LUA;
     }
 }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -423,6 +423,28 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Prepare a value to be used with the Redis cache store when used by eval scripts.
+     *
+     * @param  mixed  $value
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @return mixed
+     */
+    protected function pack($value, $connection)
+    {
+        if ($connection instanceof PhpRedisConnection) {
+            if ($connection->serialized()) {
+                return $connection->pack([$value])[0];
+            }
+
+            if ($connection->compressed()) {
+                return $connection->pack([$this->serialize($value)])[0];
+            }
+        }
+
+        return $this->serialize($value);
+    }
+
+    /**
      * Serialize the value.
      *
      * @param  mixed  $value
@@ -445,29 +467,7 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Prepares a value to be used with the redis cache store when used with eval scripts.
-     *
-     * @param  mixed  $value
-     * @param  \Illuminate\Redis\Connections\Connection  $connection
-     * @return mixed
-     */
-    protected function pack($value, $connection)
-    {
-        if ($connection instanceof PhpRedisConnection) {
-            if ($connection->serialized()) {
-                return $connection->pack([$value])[0];
-            }
-
-            if ($connection->compressed()) {
-                return $connection->pack([$this->serialize($value)])[0];
-            }
-        }
-
-        return $this->serialize($value);
-    }
-
-    /**
-     * Does connection specific considerations when a value needs to be serialized.
+     * Handle connection specific considerations when a value needs to be serialized.
      *
      * @param  mixed  $value
      * @param  \Illuminate\Redis\Connections\Connection  $connection
@@ -483,7 +483,7 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Does connection specific considerations when a value needs to be unserialized.
+     * Handle connection specific considerations when a value needs to be unserialized.
      *
      * @param  mixed  $value
      * @param  \Illuminate\Redis\Connections\Connection  $connection

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -68,9 +68,11 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function get($key)
     {
-        $value = $this->connection()->get($this->prefix.$key);
+        $connection = $this->connection();
 
-        return ! is_null($value) ? $this->unserialize($value) : null;
+        $value = $connection->get($this->prefix.$key);
+
+        return ! is_null($value) ? $this->connectionAwareUnserialize($value, $connection) : null;
     }
 
     /**
@@ -89,12 +91,14 @@ class RedisStore extends TaggableStore implements LockProvider
 
         $results = [];
 
-        $values = $this->connection()->mget(array_map(function ($key) {
+        $connection = $this->connection();
+
+        $values = $connection->mget(array_map(function ($key) {
             return $this->prefix.$key;
         }, $keys));
 
         foreach ($values as $index => $value) {
-            $results[$keys[$index]] = ! is_null($value) ? $this->unserialize($value) : null;
+            $results[$keys[$index]] = ! is_null($value) ? $this->connectionAwareUnserialize($value, $connection) : null;
         }
 
         return $results;
@@ -110,8 +114,10 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function put($key, $value, $seconds)
     {
-        return (bool) $this->connection()->setex(
-            $this->prefix.$key, (int) max(1, $seconds), $this->serialize($value)
+        $connection = $this->connection();
+
+        return (bool) $connection->setex(
+            $this->prefix.$key, (int) max(1, $seconds), $this->connectionAwareSerialize($value, $connection)
         );
     }
 
@@ -165,10 +171,10 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function add($key, $value, $seconds)
     {
-        $lua = "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])";
+        $connection = $this->connection();
 
-        return (bool) $this->connection()->eval(
-            $lua, 1, $this->prefix.$key, $this->serialize($value), (int) max(1, $seconds)
+        return (bool) $connection->eval(
+            LuaScripts::add(), 1, $this->prefix.$key, $this->pack($value, $connection), (int) max(1, $seconds)
         );
     }
 
@@ -205,7 +211,9 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function forever($key, $value)
     {
-        return (bool) $this->connection()->set($this->prefix.$key, $this->serialize($value));
+        $connection = $this->connection();
+
+        return (bool) $connection->set($this->prefix.$key, $this->connectionAwareSerialize($value, $connection));
     }
 
     /**
@@ -434,5 +442,59 @@ class RedisStore extends TaggableStore implements LockProvider
     protected function unserialize($value)
     {
         return is_numeric($value) ? $value : unserialize($value);
+    }
+
+    /**
+     * Prepares a value to be used with the redis cache store when used with eval scripts.
+     *
+     * @param  mixed  $value
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @return mixed
+     */
+    protected function pack($value, $connection)
+    {
+        if ($connection instanceof PhpRedisConnection) {
+            if ($connection->serialized()) {
+                return $connection->pack([$value])[0];
+            }
+
+            if ($connection->compressed()) {
+                return $connection->pack([$this->serialize($value)])[0];
+            }
+        }
+
+        return $this->serialize($value);
+    }
+
+    /**
+     * Does connection specific considerations when a value needs to be serialized.
+     *
+     * @param  mixed  $value
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @return mixed
+     */
+    protected function connectionAwareSerialize($value, $connection)
+    {
+        if ($connection instanceof PhpRedisConnection && $connection->serialized()) {
+            return $value;
+        }
+
+        return $this->serialize($value);
+    }
+
+    /**
+     * Does connection specific considerations when a value needs to be unserialized.
+     *
+     * @param  mixed  $value
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @return mixed
+     */
+    protected function connectionAwareUnserialize($value, $connection)
+    {
+        if ($connection instanceof PhpRedisConnection && $connection->serialized()) {
+            return $value;
+        }
+
+        return $this->unserialize($value);
     }
 }

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -83,6 +83,17 @@ trait PacksPhpRedisValues
     }
 
     /**
+     * Determine if serialization is enabled.
+     *
+     * @return bool
+     */
+    public function serialized(): bool
+    {
+        return defined('Redis::OPT_SERIALIZER') &&
+               $this->client->getOption(Redis::OPT_SERIALIZER) !== Redis::SERIALIZER_NONE;
+    }
+
+    /**
      * Determine if compression is enabled.
      *
      * @return bool


### PR DESCRIPTION
### Summary

Fix **Cache** component to be aware of phpredis's serialization and compression settings.

--No breaking changes-- as the Cache component never worked properly with those settings enabled. If those settings are disabled, code path is the same as before.

### Detailed Description

Three years ago, support for phpredis serialization and compression settings was added, working seamlessly with the **Redis** component. However, the **Cache** component is unaware of these settings and fails when they are set to anything other than `NONE`.

Issues:

1. Double Serialization:
The Cache component serializes/unserializes data before sending it to Redis. When phpredis serialization is enabled, this results in redundant serialization, causing inefficiency. **Solution**: Skip Cache-level serialization if phpredis serialization is enabled.

2. EVAL Parameter Mismatch:
EVAL scripts require parameter values to be prepared client-side, which differs from the serialized/compressed values stored in Redis. Without proper preparation, scripts may fail. **Solution**: Use phpredis’s internal `pack` method to ensure EVAL parameters are consistent with stored values.

### Evidence

Screenshots demonstrate the issue when running existing tests using MSGPACK (serialization) and ZSTD (compression) enabled. Before the fix, the Cache component incorrectly php-serializes values, leaving them uncompressed and mismatched with stored values. After the fix, the EVAL parameters are smaller, correctly compressed, and match Redis-stored values.

![Screenshot from 2025-01-16 22-37-11](https://github.com/user-attachments/assets/f8c44937-7e39-4ac1-9ebe-10a5b26b4fd0)
![Screenshot from 2025-01-16 22-38-05](https://github.com/user-attachments/assets/cdfc71a2-71df-4325-aab4-b570c8d79e33)


