### PR TITLE
[11.x] Fix line-ending mismatch in CliDumperTest::testArray and CliDumperTest::testObject

### DIFF
--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -68,7 +68,10 @@ class CliDumperTest extends TestCase
 
         EOF;
 
-        $this->assertSame($expected, $output);
+        $this->assertSame(
+            str_replace("\r\n", "\n", $expected),
+            str_replace("\r\n", "\n", $output)
+        );
     }
 
     public function testBoolean()
@@ -96,7 +99,10 @@ class CliDumperTest extends TestCase
 
         EOF;
 
-        $this->assertSame($expected, $output);
+        $this->assertSame(
+            str_replace("\r\n", "\n", $expected),
+            str_replace("\r\n", "\n", $output)
+        );
     }
 
     public function testNull()


### PR DESCRIPTION
Description
This PR resolves a platform-specific issue in the `CliDumperTest::testArray` and `CliDumperTest::testObject` test, where differences in line endings (\r\n vs. \n) between operating systems (Windows vs. Unix-based systems) caused the test to fail.

Problem
The test failed when running on systems with different line-ending.

Solution
Normalize line endings for both expected and actual output.