### PR TITLE
[11.x] Solidify `Rule::email()` tests

### DIFF
--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -565,13 +565,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Rule::email()->withNativeValidation(),
             $email,
-            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(),
             $email,
-            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
     }
 
@@ -610,7 +610,7 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Rule::email()->rfcCompliant(true),
             $email,
-            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
     }
 
@@ -622,7 +622,7 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Rule::email()->withNativeValidation(),
             $email,
-            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
@@ -664,13 +664,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Rule::email()->withNativeValidation(),
             $email,
-            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(true),
             $email,
-            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
     }
 

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -23,22 +23,23 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             'foo',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
+
         $this->fails(
             Rule::email(),
             'foo',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             Email::default(),
-            'taylor@laravel.com',
+            'taylor@laravel.com'
         );
 
         $this->passes(
             Rule::email(),
-            'taylor@laravel.com',
+            'taylor@laravel.com'
         );
 
         $this->passes(Email::default(), null);
@@ -109,35 +110,35 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->rfcCompliant(strict: true),
             $emailThatPassesNonStrictButFailsInStrict,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(strict: true),
             $emailThatPassesNonStrictButFailsInStrict,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             (new Email())->rfcCompliant(strict: true),
             $emailThatFailsBothNonStrictButFailsInStrict,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(strict: true),
             $emailThatFailsBothNonStrictButFailsInStrict,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->rfcCompliant(strict: true),
-            $emailThatPassesBothNonStrictAndInStrict,
+            $emailThatPassesBothNonStrictAndInStrict
         );
 
         $this->passes(
             Rule::email()->rfcCompliant(strict: true),
-            $emailThatPassesBothNonStrictAndInStrict,
+            $emailThatPassesBothNonStrictAndInStrict
         );
     }
 
@@ -146,23 +147,23 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->validateMxRecord(),
             'plainaddress@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->validateMxRecord(),
             'plainaddress@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->validateMxRecord(),
-            'taylor@laravel.com',
+            'taylor@laravel.com'
         );
 
         $this->passes(
             Rule::email()->validateMxRecord(),
-            'taylor@laravel.com',
+            'taylor@laravel.com'
         );
     }
 
@@ -171,46 +172,46 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->preventSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->preventSpoofing(),
             'admin@examрle.com',// Contains a Cyrillic 'р' (U+0440), not a Latin 'p'
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
         $this->fails(
             (new Email())->preventSpoofing(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->preventSpoofing(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->preventSpoofing(),
-            'admin@example.com',
+            'admin@example.com'
         );
 
         $this->passes(
             Rule::email()->preventSpoofing(),
-            'admin@example.com',
+            'admin@example.com'
         );
 
         $this->passes(
             (new Email())->preventSpoofing(),
-            'test👨‍💻@domain.com',
+            'test👨‍💻@domain.com'
         );
 
         $this->passes(
             Rule::email()->preventSpoofing(),
-            'test👨‍💻@domain.com',
+            'test👨‍💻@domain.com'
         );
     }
 
@@ -219,23 +220,23 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->withNativeValidation(),
             'tést@domain.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->withNativeValidation(),
             'tést@domain.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->withNativeValidation(),
-            'admin@example.com',
+            'admin@example.com'
         );
 
         $this->passes(
             Rule::email()->withNativeValidation(),
-            'admin@example.com',
+            'admin@example.com'
         );
     }
 
@@ -244,33 +245,33 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->withNativeValidation(allowUnicode: true),
             'invalid.@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->withNativeValidation(allowUnicode: true),
             'invalid.@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->withNativeValidation(allowUnicode: true),
-            'tést@domain.com',
+            'tést@domain.com'
         );
 
         $this->passes(
             Rule::email()->withNativeValidation(allowUnicode: true),
-            'tést@domain.com',
+            'tést@domain.com'
         );
 
         $this->passes(
             (new Email())->withNativeValidation(allowUnicode: true),
-            'admin@example.com',
+            'admin@example.com'
         );
 
         $this->passes(
             Rule::email()->withNativeValidation(allowUnicode: true),
-            'admin@example.com',
+            'admin@example.com'
         );
     }
 
@@ -279,45 +280,45 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             (new Email())->rfcCompliant(),
             'invalid.@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(),
             'invalid.@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             (new Email())->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->rfcCompliant(),
-            'admin@example.com',
+            'admin@example.com'
         );
 
         $this->passes(
             Rule::email()->rfcCompliant(),
-            'admin@example.com',
+            'admin@example.com'
         );
 
         $this->passes(
             (new Email())->rfcCompliant(),
-            'tést@domain.com',
+            'tést@domain.com'
         );
 
         $this->passes(
             Rule::email()->rfcCompliant(),
-            'tést@domain.com',
+            'tést@domain.com'
         );
     }
 
@@ -339,13 +340,13 @@ class ValidationEmailRuleTest extends TestCase
         foreach ($emailsThatPassOnRfcCompliantButFailOnStrict as $email) {
             $this->passes(
                 Rule::email()->rfcCompliant(),
-                $email,
+                $email
             );
 
             $this->fails(
                 Rule::email()->rfcCompliant(strict: true),
                 $email,
-                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
 
@@ -370,12 +371,12 @@ class ValidationEmailRuleTest extends TestCase
         foreach ($emailsThatPassOnBothRfcCompliantAndOnStrict as $email) {
             $this->passes(
                 Rule::email()->rfcCompliant(),
-                $email,
+                $email
             );
 
             $this->passes(
                 Rule::email()->rfcCompliant(strict: true),
-                $email,
+                $email
             );
         }
 
@@ -403,13 +404,13 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->rfcCompliant(),
                 $email,
-                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
 
             $this->fails(
                 Rule::email()->rfcCompliant(strict: true),
                 $email,
-                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
 
@@ -423,12 +424,12 @@ class ValidationEmailRuleTest extends TestCase
         foreach ($emailsThatPassOnBoth as $email) {
             $this->passes(
                 Rule::email()->rfcCompliant(),
-                $email,
+                $email
             );
 
             $this->passes(
                 Rule::email()->rfcCompliant(strict: true),
-                $email,
+                $email
             );
         }
     }
@@ -447,12 +448,12 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->withNativeValidation(),
                 $email,
-                ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
 
             $this->passes(
                 Rule::email()->withNativeValidation(allowUnicode: true),
-                $email,
+                $email
             );
         }
 
@@ -473,13 +474,13 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->withNativeValidation(),
                 $email,
-                ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
 
             $this->fails(
                 Rule::email()->withNativeValidation(allowUnicode: true),
                 $email,
-                ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
 
@@ -499,12 +500,12 @@ class ValidationEmailRuleTest extends TestCase
         foreach ($emailsThatPassOnBoth as $email) {
             $this->passes(
                 Rule::email()->withNativeValidation(),
-                $email,
+                $email
             );
 
             $this->passes(
                 Rule::email()->withNativeValidation(allowUnicode: true),
-                $email,
+                $email
             );
         }
     }
@@ -524,7 +525,7 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->rfcCompliant(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
 
@@ -550,7 +551,7 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->withNativeValidation(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
 
             $this->passes(
@@ -561,7 +562,6 @@ class ValidationEmailRuleTest extends TestCase
 
         /**
          * Addresses that pass both withNativeValidation() and rfcCompliant().
-         * (Standard ASCII emails with no unusual syntax or domain issues.)
          */
         $emailsThatPassBoth = [
             'plainaddress@example.com',
@@ -617,12 +617,13 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->withNativeValidation(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
+
             $this->fails(
                 Rule::email()->rfcCompliant(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
     }
@@ -646,7 +647,7 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->rfcCompliant(true),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
 
@@ -660,7 +661,7 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->withNativeValidation(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
 
             $this->passes(
@@ -706,13 +707,13 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->withNativeValidation(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
 
             $this->fails(
                 Rule::email()->rfcCompliant(true),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
             );
         }
     }
@@ -721,70 +722,70 @@ class ValidationEmailRuleTest extends TestCase
     {
         $this->passes(
             (new Email())->rfcCompliant(strict: true)->preventSpoofing(),
-            'test@example.com',
+            'test@example.com'
         );
 
         $this->passes(
             Rule::email()->rfcCompliant(strict: true)->preventSpoofing(),
-            'test@example.com',
+            'test@example.com'
         );
 
         $this->fails(
             (new Email())->rfcCompliant(strict: true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant(strict: true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(
             (new Email())->preventSpoofing(),
-            'test👨‍💻@domain.com',
+            'test👨‍💻@domain.com'
         );
 
         $this->passes(
             Rule::email()->preventSpoofing(),
-            'test👨‍💻@domain.com',
+            'test👨‍💻@domain.com'
         );
 
         $this->fails(
             (new Email())->preventSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->preventSpoofing()->rfcCompliant(),
             'test👨‍💻@domain.com',
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $spoofingEmail = 'admin@exam'."\u{0440}".'le.com';
 
         $this->passes(
             (new Email())->rfcCompliant(),
-            $spoofingEmail,
+            $spoofingEmail
         );
 
         $this->passes(
             Rule::email()->rfcCompliant(),
-            $spoofingEmail,
+            $spoofingEmail
         );
 
         $this->fails(
             (new Email())->rfcCompliant()->preventSpoofing(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email()->rfcCompliant()->preventSpoofing(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
     }
 
@@ -808,12 +809,12 @@ class ValidationEmailRuleTest extends TestCase
 
         $this->passes(
             Email::laravelEmployee(),
-            'taylor@laravel.com',
+            'taylor@laravel.com'
         );
 
         $this->passes(
             Rule::email()->laravelEmployee(),
-            'taylor@laravel.com',
+            'taylor@laravel.com'
         );
     }
 
@@ -825,7 +826,7 @@ class ValidationEmailRuleTest extends TestCase
 
         $this->passes(
             Email::default(),
-            $spoofingEmail,
+            $spoofingEmail
         );
 
         Email::defaults(function () {
@@ -835,7 +836,7 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         Email::defaults(function () {
@@ -844,7 +845,7 @@ class ValidationEmailRuleTest extends TestCase
 
         $this->passes(
             Email::default(),
-            $spoofingEmail,
+            $spoofingEmail
         );
 
         Email::defaults(function () {
@@ -854,7 +855,7 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
     }
 
@@ -869,28 +870,28 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
-            Email::default(),
-            $spoofingEmail,
-            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
-            'The :attribute must be a valid email address.',
+            rule: Email::default(),
+            values: $spoofingEmail,
+            expectedMessages: ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
+            customValidationMessage: 'The :attribute must be a valid email address.'
         );
 
         $this->fails(
-            Email::default(),
-            $spoofingEmail,
-            ['Please check the entered '.self::ATTRIBUTE_REPLACED.", it must be a valid email address, {$spoofingEmail} given."],
-            'Please check the entered :attribute, it must be a valid email address, :input given.'
+            rule: Email::default(),
+            values: $spoofingEmail,
+            expectedMessages: ['Please check the entered '.self::ATTRIBUTE_REPLACED.", it must be a valid email address, {$spoofingEmail} given."],
+            customValidationMessage: 'Please check the entered :attribute, it must be a valid email address, :input given.'
         );
 
         $this->fails(
-            Email::default(),
-            $spoofingEmail,
-            ['Plain text value'],
-            'Plain text value'
+            rule: Email::default(),
+            values: $spoofingEmail,
+            expectedMessages: ['Plain text value'],
+            customValidationMessage: 'Plain text value'
         );
     }
 

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -345,7 +345,7 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->rfcCompliant(strict: true),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.'],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
             );
         }
 
@@ -403,13 +403,13 @@ class ValidationEmailRuleTest extends TestCase
             $this->fails(
                 Rule::email()->rfcCompliant(),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.'],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
             );
 
             $this->fails(
                 Rule::email()->rfcCompliant(strict: true),
                 $email,
-                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.'],
+                ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
             );
         }
 
@@ -457,7 +457,7 @@ class ValidationEmailRuleTest extends TestCase
         }
 
         /**
-         * Emails that fail both ASCII and Unicode modes
+         * Emails that fail both ASCII and Unicode modes.
          */
         $emailsThatFailOnBoth = [
             'test@üñîçødé.com',  // Unicode domain
@@ -512,7 +512,7 @@ class ValidationEmailRuleTest extends TestCase
     public function testNativeValidationVsRfcCompliant()
     {
         $emailsThatPassNativeFailRfc = [
-           // none I could find
+            // none I could find
         ];
 
         foreach ($emailsThatPassNativeFailRfc as $email) {
@@ -529,9 +529,8 @@ class ValidationEmailRuleTest extends TestCase
         }
 
         /**
-         * Addresses that fail withNativeValidation (ASCII-only)
-         * but pass rfcCompliant().
-         * (Typical scenario for emails with accented or Unicode local parts.)
+         * Addresses that fail withNativeValidation (ASCII-only) but pass rfcCompliant().
+         * Typical scenario for emails with accented or Unicode local parts.
          */
         $emailsThatFailNativePassRfc = [
             'some(comment)@example.com',        // Comment in local part
@@ -601,7 +600,6 @@ class ValidationEmailRuleTest extends TestCase
 
         /**
          * Addresses that fail both native validation and rfcCompliant.
-         * (Truly invalid syntax or domain usage.)
          */
         $emailsThatFailBoth = [
             'test@@example.com',        // Multiple @

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -242,34 +242,34 @@ class ValidationEmailRuleTest extends TestCase
     public function testWithNativeValidationAllowUnicode()
     {
         $this->fails(
-            (new Email())->withNativeValidation(true),
+            (new Email())->withNativeValidation(allowUnicode: true),
             'invalid.@example.com',
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
-            Rule::email()->withNativeValidation(true),
+            Rule::email()->withNativeValidation(allowUnicode: true),
             'invalid.@example.com',
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
-            (new Email())->withNativeValidation(true),
+            (new Email())->withNativeValidation(allowUnicode: true),
             'tést@domain.com',
         );
 
         $this->passes(
-            Rule::email()->withNativeValidation(true),
+            Rule::email()->withNativeValidation(allowUnicode: true),
             'tést@domain.com',
         );
 
         $this->passes(
-            (new Email())->withNativeValidation(true),
+            (new Email())->withNativeValidation(allowUnicode: true),
             'admin@example.com',
         );
 
         $this->passes(
-            Rule::email()->withNativeValidation(true),
+            Rule::email()->withNativeValidation(allowUnicode: true),
             'admin@example.com',
         );
     }
@@ -451,7 +451,7 @@ class ValidationEmailRuleTest extends TestCase
             );
 
             $this->passes(
-                Rule::email()->withNativeValidation(true),
+                Rule::email()->withNativeValidation(allowUnicode: true),
                 $email,
             );
         }
@@ -477,7 +477,7 @@ class ValidationEmailRuleTest extends TestCase
             );
 
             $this->fails(
-                Rule::email()->withNativeValidation(true),
+                Rule::email()->withNativeValidation(allowUnicode: true),
                 $email,
                 ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
             );
@@ -503,7 +503,7 @@ class ValidationEmailRuleTest extends TestCase
             );
 
             $this->passes(
-                Rule::email()->withNativeValidation(true),
+                Rule::email()->withNativeValidation(allowUnicode: true),
                 $email,
             );
         }

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -335,6 +335,7 @@ class ValidationEmailRuleTest extends TestCase
             'user@[IPv6:::1]',                      // Domain-literal with unusual IPv6 short form
             'a@[IPv6:2001:db8::1]',                 // Domain-literal with normal IPv6
             'user@[IPv6:::]',                       // invalid shorthand IPv6
+            '"ab\\(c"@example.com',
         ];
 
         foreach ($emailsThatPassOnRfcCompliantButFailOnStrict as $email) {

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -80,11 +80,12 @@ class ValidationEmailRuleTest extends TestCase
                 $customValidationMessage ? [self::ATTRIBUTE.'.email' => $customValidationMessage] : []
             );
 
-            $this->assertSame($expectToPass, $v->passes());
+            $this->assertSame($expectToPass, $v->passes(), 'Expected email input '.$value.' to '.($expectToPass ? 'pass' : 'fail').'.');
 
             $this->assertSame(
                 $expectToPass ? [] : [self::ATTRIBUTE => $expectedMessages],
-                $v->messages()->toArray()
+                $v->messages()->toArray(),
+                'Expected different message for email input '.$value,
             );
         }
     }
@@ -99,44 +100,48 @@ class ValidationEmailRuleTest extends TestCase
         $this->assertValidationRules($rule, $values, true);
     }
 
-    public function testStrict()
+    public function testRfcCompliantStrict()
     {
+        $emailThatFailsBothNonStrictButFailsInStrict = 'username@sub..example.com';
+        $emailThatPassesNonStrictButFailsInStrict = '"has space"@example.com';
+        $emailThatPassesBothNonStrictAndInStrict = 'plainaddress@example.com';
+
         $this->fails(
-            (new Email())->rfcCompliant(true),
-            'invalid.@example.com',
+            (new Email())->rfcCompliant(strict: true),
+            $emailThatPassesNonStrictButFailsInStrict,
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliant(true),
-            'invalid.@example.com',
+            Rule::email()->rfcCompliant(strict: true),
+            $emailThatPassesNonStrictButFailsInStrict,
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
-            (new Email())->rfcCompliant(true),
-            'username@sub..example.com',
+            (new Email())->rfcCompliant(strict: true),
+            $emailThatFailsBothNonStrictButFailsInStrict,
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliant(true),
-            'username@sub..example.com',
+            Rule::email()->rfcCompliant(strict: true),
+            $emailThatFailsBothNonStrictButFailsInStrict,
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->passes(
-            (new Email())->rfcCompliant(true),
-            'plainaddress@example.com',
+            (new Email())->rfcCompliant(strict: true),
+            $emailThatPassesBothNonStrictAndInStrict,
         );
 
         $this->passes(
-            Rule::email()->rfcCompliant(true),
-            'plainaddress@example.com',
+            Rule::email()->rfcCompliant(strict: true),
+            $emailThatPassesBothNonStrictAndInStrict,
         );
     }
 
-    public function testDns()
+    public function testValidateMxRecord()
     {
         $this->fails(
             (new Email())->validateMxRecord(),
@@ -161,7 +166,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testSpoof()
+    public function testPreventSpoofing()
     {
         $this->fails(
             (new Email())->preventSpoofing(),
@@ -209,7 +214,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testFilter()
+    public function testWithNativeValidation()
     {
         $this->fails(
             (new Email())->withNativeValidation(),
@@ -234,7 +239,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testFilterUnicode()
+    public function testWithNativeValidationAllowUnicode()
     {
         $this->fails(
             (new Email())->withNativeValidation(true),
@@ -269,7 +274,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testRfc()
+    public function testRfcCompliantNonStrict()
     {
         $this->fails(
             (new Email())->rfcCompliant(),
@@ -314,28 +319,426 @@ class ValidationEmailRuleTest extends TestCase
             Rule::email()->rfcCompliant(),
             'tést@domain.com',
         );
+    }
+
+    public function testPassesRfcCompliantButNotRfcCompliantStrict()
+    {
+        $emailsThatPassOnRfcCompliantButFailOnStrict = [
+            '"has space"@example.com',              // Quoted local part with space
+            'some(comment)@example.com',            // Comment in local part
+            'abc."test"@example.com',               // Mixed quoted/unquoted local part
+            '"escaped\\\"quote"@example.com',       // Escaped quote inside quoted local part
+            'test@example',                         // Domain without TLD
+            'test@localhost',                       // Domain without TLD
+            'name@[127.0.0.1]',                     // Local-part with domain-literal IPv4 address
+            'user@[IPv6:::1]',                      // Domain-literal with unusual IPv6 short form
+            'a@[IPv6:2001:db8::1]',                 // Domain-literal with normal IPv6
+            'user@[IPv6:::]',                       // invalid shorthand IPv6
+        ];
+
+        foreach ($emailsThatPassOnRfcCompliantButFailOnStrict as $email) {
+            $this->passes(
+                Rule::email()->rfcCompliant(),
+                $email,
+            );
+
+            $this->fails(
+                Rule::email()->rfcCompliant(strict: true),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.'],
+            );
+        }
+
+        $emailsThatPassOnBothRfcCompliantAndOnStrict = [
+            'plainaddress@example.com',
+            'joe.smith@example.io',
+            'custom-tag+dev@example.org',
+            'hyphens--@example.org',
+            'underscore_name@example.co.uk',
+            'underscores__@example.org',
+            'user@subdomain.example.com',
+            'numbers123@domain.com',
+            'john-doe@some-domain.com',
+            'UPPERlower@example.org',
+            'dots.ok@sub.domain.io',
+            'some_email+tag@domain.dev',
+            'a@b.c',
+            'user@xn--bcher-kva.example',
+            'user@bücher.example',
+        ];
+
+        foreach ($emailsThatPassOnBothRfcCompliantAndOnStrict as $email) {
+            $this->passes(
+                Rule::email()->rfcCompliant(),
+                $email,
+            );
+
+            $this->passes(
+                Rule::email()->rfcCompliant(strict: true),
+                $email,
+            );
+        }
+
+        $emailsThatFailOnBoth = [
+            'invalid.@example.com',
+            'invalid@.example.com',
+            '.invalid@example.com',
+            'invalid@example.com.',
+            'some..dots@example.com',
+            'username@sub..example.com',
+            'test@example..com',
+            'test@@example.com',
+            'test👨‍💻@domain.com',
+            'username@domain-with-hyphen-.com',
+            '()<>[]:,;@example.com',
+            '@example.com',
+            '[test]@example.com',
+            'user@example.com:3000',
+            '"unescaped"quote@example.com',
+            'https://example.com',
+            'with\\escape@example.com',
+        ];
+
+        foreach ($emailsThatFailOnBoth as $email) {
+            $this->fails(
+                Rule::email()->rfcCompliant(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.'],
+            );
+
+            $this->fails(
+                Rule::email()->rfcCompliant(strict: true),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.'],
+            );
+        }
+
+        $emailsThatPassOnBoth = [
+            'plainaddress@example.com',
+            'tést@example.com',
+            'user@üñîçødé.com',
+            'test@xn--bcher-kva.com',
+        ];
+
+        foreach ($emailsThatPassOnBoth as $email) {
+            $this->passes(
+                Rule::email()->rfcCompliant(),
+                $email,
+            );
+
+            $this->passes(
+                Rule::email()->rfcCompliant(strict: true),
+                $email,
+            );
+        }
+    }
+
+    public function testWithNativeValidationAsciiVsUnicode()
+    {
+        /**
+         * Emails that fail ASCII-only native validation but pass with Unicode turned on.
+         */
+        $emailsThatFailOnAsciiButPassOnUnicode = [
+            'déjà@example.com',  // Accented local part
+            '测试@example.com',   // Chinese local part
+        ];
+
+        foreach ($emailsThatFailOnAsciiButPassOnUnicode as $email) {
+            $this->fails(
+                Rule::email()->withNativeValidation(),
+                $email,
+                ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
+            );
+
+            $this->passes(
+                Rule::email()->withNativeValidation(true),
+                $email,
+            );
+        }
+
+        /**
+         * Emails that fail both ASCII and Unicode modes
+         */
+        $emailsThatFailOnBoth = [
+            'test@üñîçødé.com',  // Unicode domain
+            'user@domain..com',     // Double dots in domain
+            'test@.example.com',    // Domain starts with a dot
+            'username@domain-with-hyphen-.com',
+            'пример@пример.рф',
+            '例子@例子.公司',
+            'name@123.123.123.123',
+        ];
+
+        foreach ($emailsThatFailOnBoth as $email) {
+            $this->fails(
+                Rule::email()->withNativeValidation(),
+                $email,
+                ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
+            );
+
+            $this->fails(
+                Rule::email()->withNativeValidation(true),
+                $email,
+                ["The " . self::ATTRIBUTE_REPLACED . " must be a valid email address."],
+            );
+        }
+
+        /**
+         * Emails that pass both ASCII-only and Unicode modes.
+         * Typically straightforward addresses with no special chars,
+         * or punycode that is valid under both validations.
+         */
+        $emailsThatPassOnBoth = [
+            'user@example.com',
+            'user.name+tag@example.co.uk',
+            'joe_smith@example.org',
+            'user@[IPv6:2001:db8:1ff::a0b:dbd0]',
+            'test@xn--bcher-kva.com', // Punycode for bücher.com
+        ];
+
+        foreach ($emailsThatPassOnBoth as $email) {
+            $this->passes(
+                Rule::email()->withNativeValidation(),
+                $email,
+            );
+
+            $this->passes(
+                Rule::email()->withNativeValidation(true),
+                $email,
+            );
+        }
+    }
+
+    public function testNativeValidationVsRfcCompliant()
+    {
+        $emailsThatPassNativeFailRfc = [
+           // none I could find
+        ];
+
+        foreach ($emailsThatPassNativeFailRfc as $email) {
+            $this->passes(
+                Rule::email()->withNativeValidation(),
+                $email
+            );
+
+            $this->fails(
+                Rule::email()->rfcCompliant(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+        }
+
+        /**
+         * Addresses that fail withNativeValidation (ASCII-only)
+         * but pass rfcCompliant().
+         * (Typical scenario for emails with accented or Unicode local parts.)
+         */
+        $emailsThatFailNativePassRfc = [
+            'some(comment)@example.com',        // Comment in local part
+            'tést@example.com',                 // Accented local part
+            'user@üñîçødé.com',                 // Unicode domain
+            'user@bücher.example',              // Unicode domain
+            '"has space"@example.com',          // Quoted local part with space
+            '"escaped\\\"quote"@example.com',   // Escaped quote inside quoted local part
+            'test@localhost',                   // Domain without TLD
+            'test@example',                     // Domain without TLD
+            'пример@пример.рф',
+            '例子@例子.公司',
+            'name@123.123.123.123',
+        ];
+
+        foreach ($emailsThatFailNativePassRfc as $email) {
+            $this->fails(
+                Rule::email()->withNativeValidation(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+
+            $this->passes(
+                Rule::email()->rfcCompliant(),
+                $email
+            );
+        }
+
+        /**
+         * Addresses that pass both withNativeValidation() and rfcCompliant().
+         * (Standard ASCII emails with no unusual syntax or domain issues.)
+         */
+        $emailsThatPassBoth = [
+            'plainaddress@example.com',
+            'joe.smith@example.io',
+            'custom-tag+dev@example.org',
+            'hyphens--@example.org',
+            'underscore_name@example.co.uk',
+            'underscores__@example.org',
+            'user@subdomain.example.com',
+            'numbers123@domain.com',
+            'john-doe@some-domain.com',
+            'UPPERlower@example.org',
+            'dots.ok@sub.domain.io',
+            'some_email+tag@domain.dev',
+            'a@b.c',
+            'user@xn--bcher-kva.example',    // Punycode for user@bücher.example
+            'user_name+tag@example.io',      // Underscore + plus tag, standard TLD
+            'UPPERCASE@EXAMPLE.IO',          // All uppercase local + domain
+            'abc."test"@example.com',        // Mixed quoted/unquoted local part
+            'name@[127.0.0.1]',              // Local-part with domain-literal IPv4 address
+            'user@[IPv6:::1]',               // Domain-literal with unusual IPv6 short form
+            'a@[IPv6:2001:db8::1]',          // Domain-literal with normal IPv6
+            'user@[IPv6:2001:db8:1ff::a0b:dbd0]',
+        ];
+
+        foreach ($emailsThatPassBoth as $email) {
+            $this->passes(
+                Rule::email()->withNativeValidation(),
+                $email
+            );
+            $this->passes(
+                Rule::email()->rfcCompliant(),
+                $email
+            );
+        }
+
+        /**
+         * Addresses that fail both native validation and rfcCompliant.
+         * (Truly invalid syntax or domain usage.)
+         */
+        $emailsThatFailBoth = [
+            'test@@example.com',        // Multiple @
+            'user@domain..com',         // Double dots in domain
+            '.leadingdot@example.com',  // Leading dot in local part
+            'with\\escape@example.com', // Backslash in local part
+            '@example.com',             // Missing local part
+            'some)@example.com',        // Unmatched parenthesis in local part
+            ' space@domain.com',        // Leading space in local part
+            'user@domain:port.com',     // Colon in domain (mimics a port)
+            'username@domain-with-hyphen-.com',
+        ];
+
+        foreach ($emailsThatFailBoth as $email) {
+            $this->fails(
+                Rule::email()->withNativeValidation(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+            $this->fails(
+                Rule::email()->rfcCompliant(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+        }
+    }
+
+    public function testNativeValidationVsRfcCompliantStrict()
+    {
+        $emailsThatPassNativeFailStrict = [
+            'abc."test"@example.com',      // Mixed quotes in local part
+            'name@[127.0.0.1]',            // Local-part with domain-literal IPv4 address
+            'user@[IPv6:2001:db8::1]',     // Domain-literal with normal IPv6
+            'user@[IPv6:2001:db8:1ff::a0b:dbd0]',
+            '"ab\\(c"@example.com',
+        ];
+
+        foreach ($emailsThatPassNativeFailStrict as $email) {
+            $this->passes(
+                Rule::email()->withNativeValidation(),
+                $email
+            );
+
+            $this->fails(
+                Rule::email()->rfcCompliant(true),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+        }
+
+        $emailsThatFailNativePassStrict = [
+            'пример@пример.рф',
+            '例子@例子.公司',
+            'name@123.123.123.123',
+        ];
+
+        foreach ($emailsThatFailNativePassStrict as $email) {
+            $this->fails(
+                Rule::email()->withNativeValidation(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+
+            $this->passes(
+                Rule::email()->rfcCompliant(true),
+                $email
+            );
+        }
+
+        $emailsThatPassBoth = [
+            'user@example.com',
+            'joe.smith+dev@example.co.uk',
+            'user!#$%&\'*+/=?^_`{|}~@example.com', // Unusual valid characters in local part
+        ];
+
+        foreach ($emailsThatPassBoth as $email) {
+            $this->passes(
+                Rule::email()->withNativeValidation(),
+                $email
+            );
+
+            $this->passes(
+                Rule::email()->rfcCompliant(true),
+                $email
+            );
+        }
+
+        $emailsThatFailBoth = [
+            'test@@example.com',          // Multiple @
+            '.leadingdot@example.com',    // Leading dot in local part
+            'user@domain..com',           // Double dots in domain
+            'test@',                      // Missing domain
+            'abc"quote@example.com',
+            'some(comment)@example.com',   // Local part comment
+            '"has space"@example.com',     // Quoted local part with space
+            'user@domain(comment)',
+            'user@[127.0.0.1(comment)]',
+            'some((double))comment@example.com',
+            '"test\\\"quote"@example.com',     // Escaped quote in quoted local part
+            '" leading.space"@example.com',    // Leading space in quoted local part
+        ];
+
+        foreach ($emailsThatFailBoth as $email) {
+            $this->fails(
+                Rule::email()->withNativeValidation(),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+
+            $this->fails(
+                Rule::email()->rfcCompliant(true),
+                $email,
+                ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+            );
+        }
     }
 
     public function testCombiningRules()
     {
         $this->passes(
-            (new Email())->rfcCompliant(true)->preventSpoofing(),
+            (new Email())->rfcCompliant(strict: true)->preventSpoofing(),
             'test@example.com',
         );
 
         $this->passes(
-            Rule::email()->rfcCompliant(true)->preventSpoofing(),
+            Rule::email()->rfcCompliant(strict: true)->preventSpoofing(),
             'test@example.com',
         );
 
         $this->fails(
-            (new Email())->rfcCompliant(true)->preventSpoofing()->validateMxRecord(),
+            (new Email())->rfcCompliant(strict: true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );
 
         $this->fails(
-            Rule::email()->rfcCompliant(true)->preventSpoofing()->validateMxRecord(),
+            Rule::email()->rfcCompliant(strict: true)->preventSpoofing()->validateMxRecord(),
             'test@example.com',
             ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.'],
         );


### PR DESCRIPTION
While working on https://github.com/laravel/docs/pull/10112 I tested quite some different emails to find which email passes/fails on which rule to create a good set of examples and use cases. This PR adds those tests to the framework to be able to track future regressions or changes that require docs updates. 

