### PR TITLE
[11.x] Add fluent API support for random string operations

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1056,6 +1056,17 @@ class Str
     }
 
     /**
+     * Get a new stringable object from generated random string.
+     *
+     * @param  string  $string
+     * @return \Illuminate\Support\Stringable
+     */
+    public static function makeRandom($length = 16)
+    {
+        return new Stringable(Str::random($length));
+    }
+
+    /**
      * Set the callable that will be used to generate random strings.
      *
      * @param  callable|null  $factory

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1454,6 +1454,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Get a new stringable object from generated random string.
+     *
+     * @param  string  $string
+     * @return \Illuminate\Support\Stringable
+     */
+    public static function makeRandom($length = 16)
+    {
+        return new static(Str::random($length));
+    }
+
+    /**
      * Proxy dynamic properties onto methods.
      *
      * @param  string  $key

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,11 +5,11 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Str;
 
 class SupportStringableTest extends TestCase
 {
@@ -1372,7 +1372,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(16, $this->stringable()->makeRandom()->length());
         $this->assertSame(17, $this->stringable()->makeRandom(17)->length());
 
-        Str::createRandomStringsUsing(fn () =>'xyz');
+        Str::createRandomStringsUsing(fn () => 'xyz');
         $this->assertSame('XYZ', $this->stringable()->makeRandom(18)->upper()->toString());
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Stringable;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Str;
 
 class SupportStringableTest extends TestCase
 {
@@ -1364,5 +1365,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo', (string) $this->stringable(base64_encode('foo'))->fromBase64());
         $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
+    }
+
+    public function testRandom()
+    {
+        $this->assertSame(16, $this->stringable()->makeRandom()->length());
+        $this->assertSame(17, $this->stringable()->makeRandom(17)->length());
+
+        Str::createRandomStringsUsing(fn () =>'xyz');
+        $this->assertSame('XYZ', $this->stringable()->makeRandom(18)->upper()->toString());
     }
 }


### PR DESCRIPTION
This pull request adds `makeRandom` method to the `Stringable` class, providing a fluent API for random string operations.

Current:
```php
str(Str::random())->upper();
```

New:
```php
str()->makeRandom()->upper();
```