### PR TITLE
[11.x] Fix line-ending mismatch in `BladeComponentTagCompilerTest` under `Illuminate\Tests\View\Blade`

### DIFF
--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -21,7 +21,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, []) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, []) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testInlineSlotsCanBeCompiled()
@@ -30,7 +33,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot:foo>
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, []) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, []) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testDynamicSlotsCanBeCompiled()
@@ -39,7 +45,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot :name="$foo">
 </x-slot>');
 
-        $this->assertSame("@slot(\$foo, null, []) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot(\$foo, null, []) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testDynamicSlotsCanBeCompiledWithKeyOfObjects()
@@ -48,7 +57,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot :name="$foo->name">
 </x-slot>');
 
-        $this->assertSame("@slot(\$foo->name, null, []) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot(\$foo->name, null, []) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testSlotsWithAttributesCanBeCompiled()
@@ -57,7 +69,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" class="font-bold">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testInlineSlotsWithAttributesCanBeCompiled()
@@ -66,7 +81,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot:foo class="font-bold">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testSlotsWithDynamicAttributesCanBeCompiled()
@@ -75,7 +93,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" :class="$classes">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$classes)]) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$classes)]) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testSlotsWithClassDirectiveCanBeCompiled()
@@ -84,7 +105,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" @class($classes)>
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssClasses(\$classes))]) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssClasses(\$classes))]) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testSlotsWithStyleDirectiveCanBeCompiled()
@@ -93,7 +117,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" @style($styles)>
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, ['style' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssStyles(\$styles))]) \n".' @endslot', trim($result));
+        $this->assertSame(
+            "@slot('foo', null, ['style' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssStyles(\$styles))]) \n".' @endslot',
+            str_replace("\r\n", "\n", trim($result))
+        );
     }
 
     public function testBasicComponentParsing()


### PR DESCRIPTION
Problem
The test failed when running on systems with different line-ending.

Solution
Normalize line endings for both expected and actual output.

continuation of #54222