### PR TITLE
[11.x] Fix line-ending mismatch on Windows

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -838,7 +838,10 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');
-        $this->assertSame("This is a story about something that happened long ago when your grandfather was a child.\n", $response->body());
+        $this->assertSame(
+            "This is a story about something that happened long ago when your grandfather was a child.\n",
+            str_replace("\r\n", "\n", $response->body())
+        );
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -145,7 +145,7 @@ class MailMailerTest extends TestCase
         rendered.view
         Text;
 
-        $this->assertStringContainsString($expected, $sentMessage->toString());
+        $this->assertStringContainsString(str_replace("\r\n", "\n", $expected), $sentMessage->toString());
 
         $expected = <<<Text
         Content-Type: text/plain; charset=utf-8\r
@@ -154,7 +154,7 @@ class MailMailerTest extends TestCase
         rendered.plain
         Text;
 
-        $this->assertStringContainsString($expected, $sentMessage->toString());
+        $this->assertStringContainsString(str_replace("\r\n", "\n", $expected), $sentMessage->toString());
     }
 
     public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit()
@@ -177,7 +177,7 @@ class MailMailerTest extends TestCase
         rendered.view
         Text;
 
-        $this->assertStringContainsString($expected, $sentMessage->toString());
+        $this->assertStringContainsString(str_replace("\r\n", "\n", $expected), $sentMessage->toString());
 
         $expected = <<<Text
         Content-Type: text/plain; charset=utf-8\r
@@ -186,7 +186,7 @@ class MailMailerTest extends TestCase
         rendered.plain
         Text;
 
-        $this->assertStringContainsString($expected, $sentMessage->toString());
+        $this->assertStringContainsString(str_replace("\r\n", "\n", $expected), $sentMessage->toString());
     }
 
     public function testToAllowsEmailAndName()

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -16,12 +16,12 @@ class BladeComponentsTest extends AbstractBladeTestCase
 
     public function testClassComponentsAreCompiled()
     {
-        $this->assertSame('<?php if (isset($component)) { $__componentOriginal2dda3d2f2f9b76bd400bf03f0b84e87f = $component; } ?>
+        $this->assertSame(str_replace("\r\n", "\n", '<?php if (isset($component)) { $__componentOriginal2dda3d2f2f9b76bd400bf03f0b84e87f = $component; } ?>
 <?php if (isset($attributes)) { $__attributesOriginal2dda3d2f2f9b76bd400bf03f0b84e87f = $attributes; } ?>
 <?php $component = Illuminate\Tests\View\Blade\ComponentStub::class::resolve(["foo" => "bar"] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
 <?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Illuminate\Tests\View\Blade\ComponentStub::class\', \'test\', ["foo" => "bar"])'));
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>'), $this->compiler->compileString('@component(\'Illuminate\Tests\View\Blade\ComponentStub::class\', \'test\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()
@@ -35,7 +35,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
     {
         $this->compiler->newComponentHash('foo');
 
-        $this->assertSame('<?php echo $__env->renderComponent(); ?>
+        $this->assertSame(str_replace("\r\n", "\n", '<?php echo $__env->renderComponent(); ?>
 <?php endif; ?>
 <?php if (isset($__attributesOriginal79aef92e83454121ab6e5f64077e7d8a)): ?>
 <?php $attributes = $__attributesOriginal79aef92e83454121ab6e5f64077e7d8a; ?>
@@ -44,7 +44,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php if (isset($__componentOriginal79aef92e83454121ab6e5f64077e7d8a)): ?>
 <?php $component = $__componentOriginal79aef92e83454121ab6e5f64077e7d8a; ?>
 <?php unset($__componentOriginal79aef92e83454121ab6e5f64077e7d8a); ?>
-<?php endif; ?>', $this->compiler->compileString('@endcomponentClass'));
+<?php endif; ?>'), $this->compiler->compileString('@endcomponentClass'));
     }
 
     public function testSlotsAreCompiled()


### PR DESCRIPTION
Problem
The test failed when running on systems with different line-ending.

Solution
Normalize line endings for both expected and actual output.

continuation of #54233