### PR TITLE
[11.x] feat: Adding catch callback to Pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -42,7 +42,7 @@ class Pipeline implements PipelineContract
     protected $method = 'handle';
 
     /**
-     * The catch callback to be executed when an exception is thrown
+     * The catch callback to be executed when an exception is thrown.
      *
      * @var \Closure|null
      */


### PR DESCRIPTION
Adding a catch callback to the Pipeline

```php
(new Pipeline(new Container))
    ->send($std)
    ->through([
        function ($std, $next) {
            return $next($std);
        },
        function ($std) {
            throw new Exception('My Exception: '.$std->value);
        },
    ])->catch(function ($std, Throwable $e) {
        $std->value = 100;

        return $std;
    })
    ->then(function ($std) {
        return $std;
    });
```

