### PR TITLE
Added support in DB::prohibitDestructiveCommands to preventing destructive Rollback…

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,7 +11,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand('migrate:rollback')]
 class RollbackCommand extends BaseCommand
 {
-    use ConfirmableTrait;
+    use ConfirmableTrait, Prohibitable;
 
     /**
      * The console command name.
@@ -53,8 +54,9 @@ class RollbackCommand extends BaseCommand
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
-            return 1;
+        if ($this->isProhibited() ||
+            ! $this->confirmToProceed()) {
+            return Command::FAILURE;
         }
 
         $this->migrator->usingConnection($this->option('database'), function () {

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\Migrations\Migrator;

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Database\Console\Migrations\FreshCommand;
 use Illuminate\Database\Console\Migrations\RefreshCommand;
 use Illuminate\Database\Console\Migrations\ResetCommand;
+use Illuminate\Database\Console\Migrations\RollbackCommand;
 use Illuminate\Database\Console\WipeCommand;
 
 /**
@@ -132,6 +133,7 @@ class DB extends Facade
         FreshCommand::prohibit($prohibit);
         RefreshCommand::prohibit($prohibit);
         ResetCommand::prohibit($prohibit);
+        RollbackCommand::prohibit($prohibit);
         WipeCommand::prohibit($prohibit);
     }
 


### PR DESCRIPTION
This PR prevents the destructive RollbackCommand if DB::prohibitDestructiveCommands  is set to true. 