### PR TITLE
feat: Support custom attributes for controller

### DIFF
--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Routing\Concerns;
+
+use Illuminate\Support\Collection;
+use ReflectionAttribute;
+use ReflectionMethod;
+
+trait HasCustomAttributes
+{
+    public function callAction($method, $parameters)
+    {
+        $reflection = new ReflectionMethod($this, $method);
+
+        $attributes = $this->gteCustomAttributes($reflection);
+
+        $attributes->each(function (ReflectionAttribute $attribute) {
+            $instance = $attribute->newInstance();
+
+            if(method_exists($instance, 'handle')) {
+                $attribute->newInstance()->handle(...$attribute->getArguments());
+            }
+        });
+
+        return parent::callAction($method, $parameters);
+    }
+
+    private function gteCustomAttributes(ReflectionMethod $reflection): Collection
+    {
+        return collect($reflection->getAttributes())
+            ->filter(fn(ReflectionAttribute $attr) => $attr->newInstance() instanceof ICustomAttribute);
+    }
+}

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -7,7 +7,7 @@ use ReflectionAttribute;
 use ReflectionMethod;
 
 /**
- * Trait HasCustomAttributes
+ * Trait HasCustomAttributes.
  *
  * This trait allows Laravel controllers to handle custom PHP attributes on controller methods.
  * Attributes are metadata annotations that can be added to classes, methods, or properties.
@@ -33,8 +33,8 @@ trait HasCustomAttributes
     /**
      * Call a controller action with custom attribute handling.
      *
-     * @param string $method
-     * @param array $parameters
+     * @param  string  $method
+     * @param  array  $parameters
      * @return mixed
      */
     public function callAction($method, $parameters)

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -6,6 +6,28 @@ use Illuminate\Support\Collection;
 use ReflectionAttribute;
 use ReflectionMethod;
 
+/**
+ * Trait HasCustomAttributes
+ *
+ * This trait allows Laravel controllers to handle custom PHP attributes on controller methods.
+ * Attributes are metadata annotations that can be added to classes, methods, or properties.
+ * They provide additional context or functionality and can be retrieved at runtime using reflection.
+ *
+ * This trait specifically retrieves attributes from controller methods and invokes their `handle` method (if it exists)
+ * before executing the controller action. Attributes must implement the `ICustomAttribute` interface to be processed.
+ *
+ * For more information on PHP attributes, see the official documentation:
+ * @link https://www.php.net/manual/en/language.attributes.overview.php
+ *
+ * Example usage:
+ * ```php
+ * #[SomeCustomAttribute]
+ * public function myControllerMethod()
+ * {
+ *     // Action logic here
+ * }
+ * ```
+ */
 trait HasCustomAttributes
 {
     /**

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -19,7 +19,7 @@ trait HasCustomAttributes
     {
         $reflection = new ReflectionMethod($this, $method);
 
-        $attributes = $this->gteCustomAttributes($reflection);
+        $attributes = $this->getCustomAttributes($reflection);
 
         $attributes->each(function (ReflectionAttribute $attribute) {
             $instance = $attribute->newInstance();

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -17,7 +17,7 @@ trait HasCustomAttributes
         $attributes->each(function (ReflectionAttribute $attribute) {
             $instance = $attribute->newInstance();
 
-            if(method_exists($instance, 'handle')) {
+            if (method_exists($instance, 'handle')) {
                 $attribute->newInstance()->handle(...$attribute->getArguments());
             }
         });
@@ -28,6 +28,6 @@ trait HasCustomAttributes
     private function gteCustomAttributes(ReflectionMethod $reflection): Collection
     {
         return collect($reflection->getAttributes())
-            ->filter(fn(ReflectionAttribute $attr) => $attr->newInstance() instanceof ICustomAttribute);
+            ->filter(fn (ReflectionAttribute $attr) => $attr->newInstance() instanceof ICustomAttribute);
     }
 }

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -17,6 +17,7 @@ use ReflectionMethod;
  * before executing the controller action. Attributes must implement the `ICustomAttribute` interface to be processed.
  *
  * For more information on PHP attributes, see the official documentation:
+ *
  * @link https://www.php.net/manual/en/language.attributes.overview.php
  *
  * Example usage:

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -54,7 +54,7 @@ trait HasCustomAttributes
         return parent::callAction($method, $parameters);
     }
 
-    private function gteCustomAttributes(ReflectionMethod $reflection): Collection
+    private function getCustomAttributes(ReflectionMethod $reflection): Collection
     {
         return collect($reflection->getAttributes())
             ->filter(fn (ReflectionAttribute $attr) => $attr->newInstance() instanceof ICustomAttribute);

--- a/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
+++ b/src/Illuminate/Routing/Concerns/HasCustomAttributes.php
@@ -8,6 +8,13 @@ use ReflectionMethod;
 
 trait HasCustomAttributes
 {
+    /**
+     * Call a controller action with custom attribute handling.
+     *
+     * @param string $method
+     * @param array $parameters
+     * @return mixed
+     */
     public function callAction($method, $parameters)
     {
         $reflection = new ReflectionMethod($this, $method);

--- a/src/Illuminate/Routing/Concerns/ICustomAttribute.php
+++ b/src/Illuminate/Routing/Concerns/ICustomAttribute.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Routing\Concerns;
+
+interface ICustomAttribute
+{
+    //
+}


### PR DESCRIPTION
This feature introduces the ability for Laravel users to create their own PHP attributes as needed.

For example, I have created an attribute called Authorize. This attribute internally calls the Gate facade.


 
![Screenshot 2025-01-18 at 1 25 44 AM](https://github.com/user-attachments/assets/70884cd7-9355-4121-9790-29a7d220ff83)
![Screenshot 2025-01-18 at 1 25 56 AM](https://github.com/user-attachments/assets/ae792dae-30bb-4e68-b16e-414c8598d9b3)
