### PR TITLE
Simplify hasEvenNumberOfParentheses()

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -605,24 +605,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function hasEvenNumberOfParentheses(string $expression)
     {
-        $tokens = token_get_all('<?php '.$expression);
-
-        if (Arr::last($tokens) !== ')') {
-            return false;
-        }
-
-        $opening = 0;
-        $closing = 0;
-
-        foreach ($tokens as $token) {
-            if ($token == ')') {
-                $closing++;
-            } elseif ($token == '(') {
-                $opening++;
-            }
-        }
-
-        return $opening === $closing;
+        return substr_count($expression, '(') === substr_count($expression, ')');
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -605,6 +605,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function hasEvenNumberOfParentheses(string $expression)
     {
+        if (substr($expression, -1) !== ')') {
+            return false;
+        }
+
         return substr_count($expression, '(') === substr_count($expression, ')');
     }
 


### PR DESCRIPTION
This should be faster and is for sure easier to read.