### PR TITLE
[11.x] Send  Artisan command uniquely

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -440,6 +440,18 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Queue the given console command uniquely.
+     *
+     * @param  string  $command
+     * @param  array  $parameters
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     */
+    public function queueUnique($command, array $parameters = [])
+    {
+        return QueuedUniqueCommand::dispatch(func_get_args());
+    }
+
+    /**
      * Get all of the commands registered with the console.
      *
      * @return array

--- a/src/Illuminate/Foundation/Console/QueuedUniqueCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedUniqueCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Console\Kernel as KernelContract;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class QueuedUniqueCommand extends QueuedCommand implements ShouldBeUnique
+{
+    /**
+     * The unique id for this job.
+     *
+     * @var string
+     */
+    protected $uniqueId;
+
+    /**
+     * The amount of seconds to keep the command unique.
+     *
+     * @var int
+     */
+    protected $uniqueFor;
+
+    /**
+     * The Cache repository where the lock should be acquired.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $via;
+
+    /**
+     * Sets the unique id for this command.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    public function setUniqueId($id)
+    {
+        $this->uniqueId = $id;
+    }
+
+    /**
+     * Sets the Cache repository where the lock should be acquired.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $via
+     * @return void
+     */
+    public function setUniqueVia($via)
+    {
+        $this->via = $via;
+    }
+
+    /**
+     * The amount of seconds to keep the command unique.
+     *
+     * @param  int  $amount
+     * @return void
+     */
+    public function setUniqueFor($amount)
+    {
+        $this->uniqueFor = $amount;
+    }
+
+    /**
+     * Get the unique ID for the job.
+     *
+     * @return  string
+     */
+    public function uniqueId()
+    {
+        return $this->uniqueId;
+    }
+
+    /**
+     * The number of seconds after which the job's unique lock will be released.
+     *
+     * @return  string
+     */
+    public function uniqueFor()
+    {
+        return $this->uniqueId;
+    }
+
+    /**
+     * Get the cache driver for the unique job lock.
+     *
+     * @return  \Illuminate\Contracts\Cache\Repository
+     */
+    public function uniqueVia()
+    {
+        return $this->via;
+    }
+}

--- a/src/Illuminate/Foundation/Console/QueuedUniqueCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedUniqueCommand.php
@@ -15,21 +15,14 @@ class QueuedUniqueCommand extends QueuedCommand implements ShouldBeUnique
      *
      * @var string
      */
-    protected $uniqueId;
+    public $uniqueId = __CLASS__;
 
     /**
      * The amount of seconds to keep the command unique.
      *
      * @var int
      */
-    protected $uniqueFor;
-
-    /**
-     * The Cache repository where the lock should be acquired.
-     *
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    protected $via;
+    public $uniqueFor = 0;
 
     /**
      * Sets the unique id for this command.
@@ -43,17 +36,6 @@ class QueuedUniqueCommand extends QueuedCommand implements ShouldBeUnique
     }
 
     /**
-     * Sets the Cache repository where the lock should be acquired.
-     *
-     * @param  \Illuminate\Contracts\Cache\Repository  $via
-     * @return void
-     */
-    public function setUniqueVia($via)
-    {
-        $this->via = $via;
-    }
-
-    /**
      * The amount of seconds to keep the command unique.
      *
      * @param  int  $amount
@@ -62,35 +44,5 @@ class QueuedUniqueCommand extends QueuedCommand implements ShouldBeUnique
     public function setUniqueFor($amount)
     {
         $this->uniqueFor = $amount;
-    }
-
-    /**
-     * Get the unique ID for the job.
-     *
-     * @return  string
-     */
-    public function uniqueId()
-    {
-        return $this->uniqueId;
-    }
-
-    /**
-     * The number of seconds after which the job's unique lock will be released.
-     *
-     * @return  string
-     */
-    public function uniqueFor()
-    {
-        return $this->uniqueId;
-    }
-
-    /**
-     * Get the cache driver for the unique job lock.
-     *
-     * @return  \Illuminate\Contracts\Cache\Repository
-     */
-    public function uniqueVia()
-    {
-        return $this->via;
     }
 }

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
  * @method static void registerCommand(\Symfony\Component\Console\Command\Command $command)
  * @method static int call(string $command, array $parameters = [], \Symfony\Component\Console\Output\OutputInterface|null $outputBuffer = null)
  * @method static \Illuminate\Foundation\Bus\PendingDispatch queue(string $command, array $parameters = [])
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch queueUnique(string $command, array $parameters = [])
  * @method static array all()
  * @method static string output()
  * @method static void bootstrap()


### PR DESCRIPTION
## What?

There is no way to push an Artisan command _uniquely_. The only way is to create a unique job and call the artisan command there.

This PR brings the `queueUnique` method to the Console Kernel, which allows the user to make the job unique.

```php
Artisan::queueUnique('foo:bar');
```

The uniqueness can be configured using `setUniqueId` and `setUniqueFor`. 

> [!WARNING]
>
> Because the Job is serialized, I didn't add an `setUniqueVia` because the closure would also have to be serialized (by being signed with the app key). It would probably break if the app changes key, as the queue wouldn't be able to deserialize the closure. I believe `Laravel\SerializableClosure` class doesn't support rotating app keys.

```php
Artisan::queueUnique('foo:bar')
    ->setUniqueId('unique-command')
    ->setUniqueFor(3000);
```

If this PR is approved, there should be a change on the Kernel Contract to enforce the `queueUnique` method for `12.x`, at the same time docs should be updated.
