### PR TITLE
[11.x] Call driver factories from Manager.php class through the container to allow DI

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -103,7 +103,7 @@ abstract class Manager
         $method = 'create'.Str::studly($driver).'Driver';
 
         if (method_exists($this, $method)) {
-            return $this->$method();
+            return $this->container->call($this->$method(...));
         }
 
         throw new InvalidArgumentException("Driver [$driver] not supported.");

--- a/tests/Integration/Support/Fixtures/TestManager.php
+++ b/tests/Integration/Support/Fixtures/TestManager.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Support\Fixtures;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Manager;
+
+class TestManager extends Manager
+{
+    public function getDefaultDriver()
+    {
+        return 'test';
+    }
+
+    protected function createTestDriver()
+    {
+        return fn () => 'test';
+    }
+
+    protected function createNullDriver()
+    {
+        return fn () => null;
+    }
+
+    protected function createParametersDriver(Container $container)
+    {
+        return fn () => $container;
+    }
+}

--- a/tests/Integration/Support/ManagerTest.php
+++ b/tests/Integration/Support/ManagerTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Support;
 
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Tests\Integration\Support\Fixtures\NullableManager;
+use Illuminate\Tests\Integration\Support\Fixtures\TestManager;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
@@ -13,5 +15,14 @@ class ManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new NullableManager($this->app))->driver();
+    }
+
+    public function testParametersCanBeInjectedToDriverCreator()
+    {
+        $manager = app(TestManager::class);
+
+        $callback = $manager->driver('parameters');
+
+        $this->assertInstanceOf(Container::class, $callback());
     }
 }


### PR DESCRIPTION
This PR makes use of the Container to call drivers' factories in the Manager.php class rather than calling it directly. This allows devs to use dependency injection to reduce the boilerplate of their code:

Before:

```
class MyManager extends \Illuminate\Support\Manager
{
    public function defaultDriver()
    {
        return 'something';
    }
    
    public function makeSomethingDriver()
    {
        return new Something(
            d1: $this->container->make(Dependency1::class),
            d2: $this->container->make(Dependency2::class),
            custom: 'customParam',
        );
    }
    
    public function makeSimpleDriver()
    {
        return $this->container->make(SimpleDriver::class);
    }
}
```

After:

```
class MyManager extends \Illuminate\Support\Manager
{
    public function defaultDriver()
    {
        return 'something';
    }
    
    public function makeSomethingDriver(Dependency1 $d1, Dependency2 $d2)
    {
        return new Something(d1: $d1, d2: $d2, custom: 'customParam');
    }
    
    public function makeSimpleDriver(SimpleDriver $driver)
    {
        reutnr $driver;
    }
}
```
