### PR TITLE
[11.x] Remove redundant variable declarations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1934,7 +1934,7 @@ trait HasAttributes
     public function getOriginal($key = null, $default = null)
     {
         return (new static)->setRawAttributes(
-            $this->original, $sync = true
+            $this->original, true
         )->getOriginalWithoutRewindingModel($key, $default);
     }
 


### PR DESCRIPTION
Hello, I noticed that there is a `sync` variable declared but not used in the `getOriginal` method of `HasAttributes`. Perhaps it should be considered to be removed.