### PR TITLE
feat: add interactive migration selection for rollback command

### DIFF
--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -58,7 +58,8 @@ abstract class MigrationGeneratorCommand extends Command
         }
 
         $this->replaceMigrationPlaceholders(
-            $this->createBaseMigration($table), $table
+            $this->createBaseMigration($table),
+            $table
         );
 
         $this->components->info('Migration created successfully.');
@@ -75,7 +76,8 @@ abstract class MigrationGeneratorCommand extends Command
     protected function createBaseMigration($table)
     {
         return $this->laravel['migration.creator']->create(
-            'create_'.$table.'_table', $this->laravel->databasePath('/migrations')
+            'create_' . $table . '_table',
+            $this->laravel->databasePath('/migrations')
         );
     }
 
@@ -89,7 +91,9 @@ abstract class MigrationGeneratorCommand extends Command
     protected function replaceMigrationPlaceholders($path, $table)
     {
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get($this->migrationStubFile())
+            '{{table}}',
+            $table,
+            $this->files->get($this->migrationStubFile())
         );
 
         $this->files->put($path, $stub);
@@ -104,7 +108,7 @@ abstract class MigrationGeneratorCommand extends Command
     protected function migrationExists($table)
     {
         return count($this->files->glob(
-            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php')
+            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_' . $table . '_table.php')
         )) !== 0;
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -115,11 +115,11 @@ class RollbackCommand extends BaseCommand
 
         if ($migrationsInstance->count() > 0) {
             $options = multiselect(
-                label: 'Which migrations would you like to rollback',
+                label: 'Which migrations would you like to rollback (leave blank to default behaviour)',
                 options: $migrationsInstance->pluck('migration')->toArray(),
                 hint: 'Use the space bar to select options.',
                 scroll: 10,
-                required: true,
+                required: false,
             );
             return $migrationsInstance->whereIn('migration', $options)->get()->toArray();
         }


### PR DESCRIPTION
# Interactive Migration Selection for Rollback Command

## Description
This PR enhances the `migrate:rollback` command by adding an interactive multi-select prompt when no step or batch options are provided. Users can now selectively choose which migrations they want to rollback, providing more fine-grained control over the database migration process.

## Features
- Interactive multi-select prompt for migration rollback
- Users can select multiple migrations using spacebar
- Scrollable interface when there are many migrations (limited to 10 visible at a time)
- Maintains existing step/batch functionality when those options are provided

## Usage
When running `php artisan migrate:rollback` without `--step` or `--batch` options:


## Why
Previously, users could only rollback migrations by batch or step numbers, which sometimes led to rolling back more migrations than intended. This feature provides more precise control over which migrations to rollback, especially useful in development environments where you might want to rollback specific migrations without affecting others.

## Testing
- [x] Tested with multiple migrations
- [x] Verified behavior when no migrations exist
- [x] Confirmed compatibility with existing step/batch options
- [x] Tested scrolling behavior with >10 migrations

## Notes
- This feature is particularly useful during development and testing
- The interactive prompt only appears when neither step nor batch options are provided
- Maintains backward compatibility with all existing rollback functionality

<img width="469" alt="image" src="https://github.com/user-attachments/assets/195d8b77-2325-4cd6-99aa-385cc6778944" />

