### PR TITLE
Add method ```lineCount()``` string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1793,7 +1793,11 @@ class Str
             return substr_count($string, "\n") + 1;
         }
 
-        return count(array_filter(explode("\n", $string), 'mb_strlen'));
+        $lines = preg_match_all(
+            '/(?(DEFINE)(?<lineBreak>\r\n|\r|\n))(.+)(?P>lineBreak)/',
+            $string
+        );
+        return $lines === 0 && $string !== '' ? 1 : $lines;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1790,7 +1790,7 @@ class Str
         $string = str_replace("\r\n", "\n", $string);
 
         if ($withEmptyLines) {
-            return count(explode("\n", $string));
+            return substr_count($string, "\n") + 1;
         }
 
         return count(array_filter(explode("\n", $string), 'mb_strlen'));

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1779,6 +1779,24 @@ class Str
     }
 
     /**
+     * Counts the number of lines in the input string.
+     *
+     * @param  string  $string
+     * @param  bool  $withEmptyLines
+     * @return int
+     */
+    public static function lineCount(string $string, bool $withEmptyLines = true): int
+    {
+        $string = str_replace("\r\n", "\n", $string);
+
+        if ($withEmptyLines) {
+            return count(explode("\n", $string));
+        }
+
+        return count(array_filter(explode("\n", $string), 'mb_strlen'));
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1261,6 +1261,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Counts the number of lines in the input string.
+     *
+     * @param  bool  $withEmptyLines
+     * @return int
+     */
+    public function lineCount(bool $withEmptyLines = true)
+    {
+        return Str::lineCount($this->value, $withEmptyLines);
+    }
+
+    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $before

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1237,6 +1237,28 @@ class SupportStrTest extends TestCase
         $this->assertEquals('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
     }
 
+    public function testLineCount()
+    {
+        $this->assertEquals(5, Str::lineCount("Line 1\n\nLine 2\nLine 3\n"));
+        $this->assertEquals(3, Str::lineCount("Line 1\n\nLine 2\nLine 3\n", false));
+
+        $this->assertEquals(4, Str::lineCount("\n\n\n"));
+        $this->assertEquals(0, Str::lineCount("\n\n\n", false));
+
+        $this->assertEquals(1, Str::lineCount("Single line string"));
+        $this->assertEquals(1, Str::lineCount("Single line string", false));
+
+        $this->assertEquals(1, Str::lineCount(""));
+        $this->assertEquals(0, Str::lineCount("", false));
+
+        $this->assertEquals(3, Str::lineCount("Line 1\r\nLine 2\r\nLine 3"));
+
+        $this->assertEquals(2, Str::lineCount("   \n\n   \n", false));
+
+        $this->assertEquals(5, Str::lineCount("Line 1\n   \nLine 2\n\n"));
+        $this->assertEquals(3, Str::lineCount("Line 1\n   \nLine 2\n\n", false));
+    }
+
     public static function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1215,6 +1215,14 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
 
+    public function testLineCount()
+    {
+        $this->assertEquals(5, $this->stringable("Line 1\n\nLine 2\nLine 3\n")->lineCount());
+        $this->assertEquals(4, $this->stringable("\n\n\n")->lineCount());
+        $this->assertEquals(3, $this->stringable("Line 1\r\nLine 2\r\nLine 3")->lineCount());
+
+    }
+
     public function testWrap()
     {
         $this->assertEquals('This is me!', $this->stringable('is')->wrap('This ', ' me!'));


### PR DESCRIPTION
This PR adds the ```lineCount``` method to string helper. It can count lines, supports a param to include/exclude empty lines and handle mixed line endings between Windows and Linux