### PR TITLE
feat: add interactive migration selection for rollback command

### DIFF
--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -58,7 +58,8 @@ abstract class MigrationGeneratorCommand extends Command
         }
 
         $this->replaceMigrationPlaceholders(
-            $this->createBaseMigration($table), $table
+            $this->createBaseMigration($table),
+            $table
         );
 
         $this->components->info('Migration created successfully.');
@@ -75,7 +76,8 @@ abstract class MigrationGeneratorCommand extends Command
     protected function createBaseMigration($table)
     {
         return $this->laravel['migration.creator']->create(
-            'create_'.$table.'_table', $this->laravel->databasePath('/migrations')
+            'create_' . $table . '_table',
+            $this->laravel->databasePath('/migrations')
         );
     }
 
@@ -89,7 +91,9 @@ abstract class MigrationGeneratorCommand extends Command
     protected function replaceMigrationPlaceholders($path, $table)
     {
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get($this->migrationStubFile())
+            '{{table}}',
+            $table,
+            $this->files->get($this->migrationStubFile())
         );
 
         $this->files->put($path, $stub);
@@ -104,7 +108,7 @@ abstract class MigrationGeneratorCommand extends Command
     protected function migrationExists($table)
     {
         return count($this->files->glob(
-            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php')
+            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_' . $table . '_table.php')
         )) !== 0;
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -74,8 +74,8 @@ class RollbackCommand extends BaseCommand
                     'pretend' => $this->option('pretend'),
                     'step' => (int) $this->option('step'),
                     'batch' => (int) $this->option('batch'),
-                ],
-                $migrations
+                    'select' => $migrations,
+                ]
             );
         });
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -62,7 +62,7 @@ class RollbackCommand extends BaseCommand
 
         // if step or batch is not set, we need to rollback all migrations
         $migrations = [];
-        if (($this->option('step') == null && $this->option('batch') == null)) {
+        if (($this->option('select'))) {
             $migrations = $this->getMigrationsForRollback();
         }
 
@@ -97,6 +97,7 @@ class RollbackCommand extends BaseCommand
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted'],
             ['batch', null, InputOption::VALUE_REQUIRED, 'The batch of migrations (identified by their batch number) to be reverted'],
+            ['select', null, InputOption::VALUE_NONE, 'Select the migrations to rollback'],
         ];
     }
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -62,7 +62,7 @@ class RollbackCommand extends BaseCommand
 
         $migrations = [];
         if ($this->option('select')) {
-            $migrations = $this->getMigrationsForRollback();
+            $migrations = $this->getMigrationsForRollbacks();
         }
 
         $this->migrator->usingConnection($this->option('database'), function () use ($migrations) {
@@ -108,7 +108,8 @@ class RollbackCommand extends BaseCommand
      *
      * @return array<int, object> Returns an array of migration records, or empty array if no migrations exist
      */
-    private function getMigrationsForRollback()
+
+    private function getMigrationsForRollbacks()
     {
         $migrationsInstance = DB::table('migrations');
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -60,13 +60,11 @@ class RollbackCommand extends BaseCommand
             return 1;
         }
 
-        // if step or batch is not set, we need to rollback all migrations
         $migrations = [];
-        if (($this->option('select'))) {
+        if ($this->option('select')) {
             $migrations = $this->getMigrationsForRollback();
         }
 
-        // if step or batch is set, we need to rollback the migrations
         $this->migrator->usingConnection($this->option('database'), function () use ($migrations) {
             $this->migrator->setOutput($this->output)->rollback(
                 $this->getMigrationPaths(),
@@ -74,7 +72,7 @@ class RollbackCommand extends BaseCommand
                     'pretend' => $this->option('pretend'),
                     'step' => (int) $this->option('step'),
                     'batch' => (int) $this->option('batch'),
-                    'select' => $migrations,
+                    'selected' => $migrations ?: [],
                 ]
             );
         });
@@ -120,7 +118,7 @@ class RollbackCommand extends BaseCommand
                 options: $migrationsInstance->pluck('migration')->toArray(),
                 hint: 'Use the space bar to select options.',
                 scroll: 10,
-                required: false,
+                required: true,
             );
             return $migrationsInstance->whereIn('migration', $options)->get()->toArray();
         }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -115,11 +115,11 @@ class RollbackCommand extends BaseCommand
 
         if ($migrationsInstance->count() > 0) {
             $options = multiselect(
-                label: 'Which migrations would you like to rollback',
+                label: 'Which migrations would you like to rollback (leave blank to default behaviour)',
                 options: $migrationsInstance->pluck('migration')->toArray(),
                 hint: 'Use the space bar to select options.',
                 scroll: 10,
-                required: true,
+                required: false,
             );
             return $migrationsInstance->whereIn('migration', $options)->get()->toArray();
         }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -225,6 +225,7 @@ class Migrator
      * @param  string[]|string  $paths
      * @param  array<string, mixed>  $options
      * @return string[]
+     * @param  array  $userChosenMigrations
      */
     public function rollback($paths = [], array $options = [], array $userChosenMigrations = [])
     {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -231,7 +231,7 @@ class Migrator
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
-        $migrations = count($options['selected']) > 0 ? $options['selected'] : $this->getMigrationsForRollback($options);
+        $migrations = isset($options['selected']) && count($options['selected']) > 0 ? $options['selected'] : $this->getMigrationsForRollback($options);
 
         if (count($migrations) === 0) {
             $this->fireMigrationEvent(new NoPendingMigrations('down'));

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -758,4 +758,32 @@ class Migrator
     {
         $this->events?->dispatch($event);
     }
+
+    protected function getMigrationBatches($migrations)
+    {
+        $options = $this->resolveOptions($migrations);
+        $selected = $options['selected'] ?? [];
+
+        if (count($selected) > 0) {
+            return collect($selected)->map(function ($migration) {
+                return (object) $migration;
+            })->pluck('batch', 'migration')->all();
+        }
+
+        return $this->repository->getRan();
+    }
+
+    protected function resolveOptions($migrations)
+    {
+        if (is_array($migrations)) {
+            return $migrations;
+        }
+
+        return [
+            'pretend' => false,
+            'step' => 0,
+            'batch' => 0,
+            'selected' => [],
+        ];
+    }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -225,14 +225,13 @@ class Migrator
      * @param  string[]|string  $paths
      * @param  array<string, mixed>  $options
      * @return string[]
-     * @param  array  $userChosenMigrations
      */
-    public function rollback($paths = [], array $options = [], array $userChosenMigrations = [])
+    public function rollback($paths = [], array $options = [])
     {
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
-        $migrations = count($userChosenMigrations) > 0 ? $userChosenMigrations : $this->getMigrationsForRollback($options);
+        $migrations = count($options['select']) > 0 ? $options['select'] : $this->getMigrationsForRollback($options);
 
         if (count($migrations) === 0) {
             $this->fireMigrationEvent(new NoPendingMigrations('down'));

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -231,7 +231,7 @@ class Migrator
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
-        $migrations = count($options['select']) > 0 ? $options['select'] : $this->getMigrationsForRollback($options);
+        $migrations = count($options['selected']) > 0 ? $options['selected'] : $this->getMigrationsForRollback($options);
 
         if (count($migrations) === 0) {
             $this->fireMigrationEvent(new NoPendingMigrations('down'));

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0, 'selected' => []]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0, 'selected' => []]);
 
         $this->runCommand($command);
     }
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0, 'selected' => []]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0, 'selected' => []]);
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -60,7 +60,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], true);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
@@ -69,14 +69,14 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
     {
         $command = new RollbackCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
-        $app->useDatabasePath(__DIR__);`
+        $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0, 'selected' => []]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0, 'selected' => []]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2, '--select' => true]);
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0]);
 
         $this->runCommand($command);
     }
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0]);
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -60,7 +60,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], true);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
@@ -76,7 +76,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
     }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -78,7 +78,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0, 'selected' => []]);
 
-        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2, '--select' => true]);
+        $this->runCommand($command, ['--pretend' => true, '--step' => 2]);
     }
 
     protected function runCommand($command, $input = [])

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0, 'selected' => []]);
 
         $this->runCommand($command);
     }
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0, 'selected' => []]);
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -60,7 +60,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], true);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
@@ -69,16 +69,16 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
     {
         $command = new RollbackCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
-        $app->useDatabasePath(__DIR__);
+        $app->useDatabasePath(__DIR__);`
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__ . DIRECTORY_SEPARATOR . 'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0, 'selected' => []]);
 
-        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2, '--select' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
# Interactive Migration Selection for Rollback Command

## Description
This PR enhances the `migrate:rollback` command by adding an interactive multi-select prompt when no step or batch options are provided. Users can now selectively choose which migrations they want to rollback, providing more fine-grained control over the database migration process.

## Features
- Interactive multi-select prompt for migration rollback
- Users can select multiple migrations using spacebar
- Scrollable interface when there are many migrations (limited to 10 visible at a time)
- Maintains existing step/batch functionality when those options are provided

## Usage
When running `php artisan migrate:rollback --select` add `--select` options:

<img width="609" alt="image" src="https://github.com/user-attachments/assets/790c3ba6-006a-4687-8392-cbda7c79baf2" />


## Why
Previously, users could only rollback migrations by batch or step numbers, which sometimes led to rolling back more migrations than intended. This feature provides more precise control over which migrations to rollback, especially useful in development environments where you might want to rollback specific migrations without affecting others.

## Testing
- [x] Tested with multiple migrations
- [x] Verified behavior when no migrations exist
- [x] Confirmed compatibility with existing step/batch options
- [x] Tested scrolling behavior with >10 migrations

## Notes
- This feature is particularly useful during development and testing
- The interactive prompt only appears when neither step nor batch options are provided
- Maintains backward compatibility with all existing rollback functionality