### PR TITLE
[11.x] Add ability to create raw unique indexes for postgresql

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -717,6 +717,18 @@ class Blueprint
     }
 
     /**
+     * Specify a raw unique index for the table.
+     *
+     * @param  string  $expression
+     * @param  string  $name
+     * @return \Illuminate\Database\Schema\IndexDefinition
+     */
+    public function rawUnique($expression, $name)
+    {
+        return $this->unique([new Expression($expression)], $name);
+    }
+
+    /**
      * Specify a foreign key for the table.
      *
      * @param  string|array  $columns

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -314,6 +314,14 @@ class PostgresGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
+        if ($command->useCreateIndex) {
+            return sprintf('create unique index %s on %s (%s)',
+                $this->wrap($command->index),
+                $this->wrapTable($blueprint),
+                $this->columnize($command->columns),
+            );
+        }
+
         $sql = sprintf('alter table %s add constraint %s unique (%s)',
             $this->wrapTable($blueprint),
             $this->wrap($command->index),

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Fluent;
  * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
+ * @method $this useCreateIndex(bool $value = true) Specify if the unique index will be created using CREATE UNIQUE INDEX (PostgreSQL)
  */
 class IndexDefinition extends Fluent
 {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -274,6 +274,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyViaUseCreateIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->unique('foo', 'bar')->useCreateIndex();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint('users');
@@ -362,6 +372,26 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
+    }
+
+    public function testAddingRawUniqueKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawUnique('foo,bar', 'baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "baz" unique (foo,bar)', $statements[0]);
+    }
+
+    public function testAddingRawUniqueKeyViaUseCreateIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawUnique('function(column)', 'baz')->useCreateIndex();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "baz" on "users" (function(column))', $statements[0]);
     }
 
     public function testAddingIncrementingID()


### PR DESCRIPTION
This PR adds a way for people to create unique keys on **postgres** with a value of `LOWER(column)` (or any other transformative sql function) into their unique key. 

Example of an index statement this would now allow:
`create unique index "username_unique" on "users" (LOWER(username))`

This feature is fully backwards compatible since it is only enabled upon a function call and as such can be merged in 11.x.

Let me know if you require any changes!

(Also let me know if you want me to re-target this on master for 12.x instead)