### PR TITLE
[11.x] Conditional Validation for Fluent Email Rules

### DIFF
--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -17,27 +17,27 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     use Conditionable, Macroable;
 
     /**
-     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     * @var bool|\Closure(string $attribute, mixed $value): bool
      */
     public bool|Closure $validateMxRecord = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     * @var bool|\Closure(string $attribute, mixed $value): bool
      */
     public bool|Closure $preventSpoofing = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     * @var bool|\Closure(string $attribute, mixed $value): bool
      */
     public bool|Closure $nativeValidation = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     * @var bool|\Closure(string $attribute, mixed $value): bool
      */
     public bool|Closure $nativeValidationWithUnicodeAllowed = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     * @var bool|\Closure(string $attribute, mixed $value): bool
      */
     public bool|Closure $rfcCompliant = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     * @var bool|\Closure(string $attribute, mixed $value): bool
      */
     public bool|Closure $strictRfcCompliant = false;
 
@@ -115,7 +115,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * Ensure that the email is an RFC compliant email address.
      *
      * @param  bool  $strict
-     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
+     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
      * @return $this
      */
     public function rfcCompliant(bool $strict = false, bool|Closure $condition = true)
@@ -132,7 +132,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Ensure that the email is a strictly enforced RFC compliant email address.
      *
-     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
+     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
      * @return $this
      */
     public function strict(bool|Closure $condition = true)
@@ -145,7 +145,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * Requires the PHP intl extension.
      *
-     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
+     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
      * @return $this
      */
     public function validateMxRecord(bool|Closure $condition = true)
@@ -158,7 +158,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Ensure that the email address is not attempting to spoof another email address using invalid unicode characters.
      *
-     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool $condition
+     * @param  bool|\Closure(string $attribute, mixed $value): bool $condition
      * @return $this
      */
     public function preventSpoofing(bool|Closure $condition = true)
@@ -172,7 +172,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * Ensure the email address is valid using PHP's native email validation functions.
      *
      * @param  bool  $allowUnicode
-     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
+     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
      * @return $this
      */
     public function withNativeValidation(bool $allowUnicode = false, bool|Closure $condition = true)

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -17,27 +17,27 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     use Conditionable, Macroable;
 
     /**
-     * @var bool|\Closure(string $attribute, mixed $value): bool
+     * @var bool|\Closure(string, mixed): bool
      */
     public bool|Closure $validateMxRecord = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value): bool
+     * @var bool|\Closure(string, mixed): bool
      */
     public bool|Closure $preventSpoofing = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value): bool
+     * @var bool|\Closure(string, mixed): bool
      */
     public bool|Closure $nativeValidation = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value): bool
+     * @var bool|\Closure(string, mixed): bool
      */
     public bool|Closure $nativeValidationWithUnicodeAllowed = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value): bool
+     * @var bool|\Closure(string, mixed): bool
      */
     public bool|Closure $rfcCompliant = false;
     /**
-     * @var bool|\Closure(string $attribute, mixed $value): bool
+     * @var bool|\Closure(string, mixed): bool
      */
     public bool|Closure $strictRfcCompliant = false;
 
@@ -115,7 +115,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * Ensure that the email is an RFC compliant email address.
      *
      * @param  bool  $strict
-     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
+     * @param  bool|\Closure(string, mixed): bool  $condition
      * @return $this
      */
     public function rfcCompliant(bool $strict = false, bool|Closure $condition = true)
@@ -132,7 +132,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Ensure that the email is a strictly enforced RFC compliant email address.
      *
-     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
+     * @param  bool|\Closure(string, mixed): bool  $condition
      * @return $this
      */
     public function strict(bool|Closure $condition = true)
@@ -145,7 +145,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * Requires the PHP intl extension.
      *
-     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
+     * @param  bool|\Closure(string, mixed): bool  $condition
      * @return $this
      */
     public function validateMxRecord(bool|Closure $condition = true)
@@ -158,7 +158,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Ensure that the email address is not attempting to spoof another email address using invalid unicode characters.
      *
-     * @param  bool|\Closure(string $attribute, mixed $value): bool $condition
+     * @param  bool|\Closure(string, mixed): bool  $condition
      * @return $this
      */
     public function preventSpoofing(bool|Closure $condition = true)
@@ -172,7 +172,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * Ensure the email address is valid using PHP's native email validation functions.
      *
      * @param  bool  $allowUnicode
-     * @param  bool|\Closure(string $attribute, mixed $value): bool  $condition
+     * @param  bool|\Closure(string, mixed): bool  $condition
      * @return $this
      */
     public function withNativeValidation(bool $allowUnicode = false, bool|Closure $condition = true)

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -16,11 +16,29 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 {
     use Conditionable, Macroable;
 
+    /**
+     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     */
     public bool|Closure $validateMxRecord = false;
+    /**
+     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     */
     public bool|Closure $preventSpoofing = false;
+    /**
+     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     */
     public bool|Closure $nativeValidation = false;
+    /**
+     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     */
     public bool|Closure $nativeValidationWithUnicodeAllowed = false;
+    /**
+     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     */
     public bool|Closure $rfcCompliant = false;
+    /**
+     * @var bool|\Closure(string $attribute, mixed $value, static $rule): bool
+     */
     public bool|Closure $strictRfcCompliant = false;
 
     /**
@@ -97,6 +115,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * Ensure that the email is an RFC compliant email address.
      *
      * @param  bool  $strict
+     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
      * @return $this
      */
     public function rfcCompliant(bool $strict = false, bool|Closure $condition = true)
@@ -113,6 +132,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Ensure that the email is a strictly enforced RFC compliant email address.
      *
+     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
      * @return $this
      */
     public function strict(bool|Closure $condition = true)
@@ -125,6 +145,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * Requires the PHP intl extension.
      *
+     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
      * @return $this
      */
     public function validateMxRecord(bool|Closure $condition = true)
@@ -137,6 +158,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Ensure that the email address is not attempting to spoof another email address using invalid unicode characters.
      *
+     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool $condition
      * @return $this
      */
     public function preventSpoofing(bool|Closure $condition = true)
@@ -150,6 +172,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      * Ensure the email address is valid using PHP's native email validation functions.
      *
      * @param  bool  $allowUnicode
+     * @param  bool|\Closure(string $attribute, mixed $value, static $rule): bool  $condition
      * @return $this
      */
     public function withNativeValidation(bool $allowUnicode = false, bool|Closure $condition = true)

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -210,8 +210,8 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Build the array of underlying validation rules based on the current state.
      *
-     * @param string $attribute
-     * @param mixed $value
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return array
      */
     public function buildValidationRules($attribute, $value)


### PR DESCRIPTION
### Add Conditional Validation for Fluent Email Rules

This PR enhances the `Email` validation rule in Laravel by introducing conditional validation capabilities. It allows developers to dynamically enable or disable specific email validation rules, making the validation logic more flexible and adaptable to specific use cases.

#### Key Features:
- **Unset Default Rules:** Developers can now unset default `Email::default()` rules, such as disabling MX record validation for certain routes. This is particularly useful for cases like Single Sign-On (SSO) emails without inboxes.
- **Dynamic Rule Application:** Rules can now be conditionally applied using closures, enabling context-specific validation logic, such as skipping DNS checks for whitelisted email domains.

#### Key Changes:
- Updated the `Email` class to accept `bool|Closure` conditions for rules like `rfcCompliant`, `validateMxRecord`, `preventSpoofing`, and `withNativeValidation`.
- Modified the `buildValidationRules` method to evaluate conditions dynamically based on the provided attribute and value.
- Added extensive tests in `ValidationEmailRuleTest` to ensure the new functionality works as intended for various scenarios.

#### Benefits:
- **Increased Flexibility:** Developers can customize email validation rules based on the context, such as bypassing specific checks for certain email patterns or routes.
- **Enhanced Use Case Support:** Scenarios like SSO emails or whitelisting specific domains are now easier to handle.
- **Backward Compatibility:** Existing behavior remains unchanged unless conditional logic is explicitly applied.

This update aligns with Laravel's focus on making validation rules expressive and adaptable while maintaining backward compatibility.
