### PR TITLE
draft: fix: Don't release lock for ShouldBeUniqueUntilProcessing Job that gets released

### DIFF
--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -40,9 +40,11 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         $lockKey = DB::table('cache_locks')->first()->key;
         $this->assertNotNull($lockKey);
         $this->runQueueWorkerCommand(['--once' => true]);
+        $this->assertFalse(UniqueUntilProcessingJobThatReleases::$handled);
         $this->assertTrue(UniqueUntilProcessingJobThatReleases::$released);
         $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key ?? null;
         $this->assertNotNull($lockKey);
+
 
         UniqueUntilProcessingJobThatReleases::dispatch();
         $this->assertDatabaseCount('jobs', 1);
@@ -55,6 +57,12 @@ class UniqueTestJobThatDoesNotRelease implements ShouldQueue, ShouldBeUniqueUnti
 
     public static $handled = false;
     public static $released = false;
+
+    public function __construct()
+    {
+        static::$handled = false;
+        static::$released = false;
+    }
 
     public function handle()
     {

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -52,24 +52,21 @@ class UniqueTestJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
     public static $handled = false;
     public static $released = false;
 
-
     public function handle()
     {
         static::$handled = true;
     }
 }
 
-
 class UniqueUntilProcessingJob extends UniqueTestJob
 {
-
     public function middleware()
     {
         return [
             function ($job) {
                 static::$released = true;
                 $job->release(30);
-            }
+            },
         ];
     }
 

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -77,7 +77,7 @@ class UniqueUntilProcessingJobThatReleases extends UniqueTestJobThatDoesNotRelea
         return [
             function ($job) {
                 static::$released = true;
-                $job->release(30);
+                return $job->release(30);
             },
         ];
     }

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -45,7 +45,6 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key ?? null;
         $this->assertNotNull($lockKey);
 
-
         UniqueUntilProcessingJobThatReleases::dispatch();
         $this->assertDatabaseCount('jobs', 1);
     }

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -33,6 +33,7 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         $this->assertFalse(UniqueTestJobThatDoesNotRelease::$released);
         $lockKey = DB::table('cache_locks')->first()->key ?? null;
         $this->assertNull($lockKey);
+        $this->assertDatabaseCount('jobs', 0);
 
         // Job that releases and does not get processed
         UniqueUntilProcessingJobThatReleases::dispatch();

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('cache')]
+#[WithMigration('queue')]
+class UniqueUntilProcessingJobTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+        $app['config']->set('queue.default', 'database');
+        $app['config']->set('cache.default', 'database');
+        $this->driver = 'database';
+    }
+
+    public function testShouldBeUniqueUntilProcessingReleasesLockWhenJobIsReleasedByAMiddleware()
+    {
+        // Job that does not release and gets processed
+        UniqueTestJob::dispatch();
+        $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key;
+        $this->assertNotNull($lockKey);
+        $this->runQueueWorkerCommand(['--once' => true]);
+        $this->assertFalse(UniqueTestJob::$released);
+        $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key ?? null;
+        $this->assertNull($lockKey);
+
+        // Job that releases and does not get processed
+        UniqueUntilProcessingJob::dispatch();
+        $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key;
+        $this->assertNotNull($lockKey);
+        $this->runQueueWorkerCommand(['--once' => true]);
+        $this->assertTrue(UniqueUntilProcessingJob::$released);
+        $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key ?? null;
+        $this->assertNotNull($lockKey);
+    }
+}
+
+class UniqueTestJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+
+    public static $handled = false;
+    public static $released = false;
+
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+}
+
+
+class UniqueUntilProcessingJob extends UniqueTestJob
+{
+
+    public function middleware()
+    {
+        return [
+            function ($job) {
+                static::$released = true;
+                $job->release(30);
+            }
+        ];
+    }
+
+    public function uniqueId()
+    {
+        return 100;
+    }
+}

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -30,7 +30,7 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key;
         $this->assertNotNull($lockKey);
         $this->runQueueWorkerCommand(['--once' => true]);
-        $this->assertFalse(UniqueTestJob::$released);
+        $this->assertFalse(UniqueTestJobThatDoesNotRelease::$released);
         $lockKey = DB::table('cache_locks')->first()->key ?? null;
         $this->assertNull($lockKey);
 
@@ -61,7 +61,7 @@ class UniqueTestJobThatDoesNotRelease implements ShouldQueue, ShouldBeUniqueUnti
     }
 }
 
-class UniqueUntilProcessingJobThatReleases extends UniqueTestJob
+class UniqueUntilProcessingJobThatReleases extends UniqueTestJobThatDoesNotRelease
 {
     public function middleware()
     {

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -31,17 +31,20 @@ class UniqueUntilProcessingJobTest extends QueueTestCase
         $this->assertNotNull($lockKey);
         $this->runQueueWorkerCommand(['--once' => true]);
         $this->assertFalse(UniqueTestJob::$released);
-        $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key ?? null;
+        $lockKey = DB::table('cache_locks')->first()->key ?? null;
         $this->assertNull($lockKey);
 
         // Job that releases and does not get processed
         UniqueUntilProcessingJob::dispatch();
-        $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key;
+        $lockKey = DB::table('cache_locks')->first()->key;
         $this->assertNotNull($lockKey);
         $this->runQueueWorkerCommand(['--once' => true]);
         $this->assertTrue(UniqueUntilProcessingJob::$released);
         $lockKey = DB::table('cache_locks')->orderBy('id')->first()->key ?? null;
         $this->assertNotNull($lockKey);
+
+        UniqueUntilProcessingJob::dispatch();
+        $this->assertDatabaseCount('jobs', 1);
     }
 }
 

--- a/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
+++ b/tests/Integration/Queue/UniqueUntilProcessingJobTest.php
@@ -76,6 +76,7 @@ class UniqueUntilProcessingJobThatReleases extends UniqueTestJobThatDoesNotRelea
         return [
             function ($job) {
                 static::$released = true;
+
                 return $job->release(30);
             },
         ];


### PR DESCRIPTION
When a job that is `ShouldBeUniqueUntilProcessing` is released, it releases the `UniqueLock` causing multiple Jobs to be present in the queue when it should be only a single one

