### PR TITLE
add lineCount method to string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1808,6 +1808,24 @@ class Str
     }
 
     /**
+     * Counts the number of lines in the input string.
+     *
+     * @param  string  $string
+     * @param  bool  $withNoContentLines
+     * @return int
+     */
+    public static function lineCount(string $string, bool $withNoContentLines = true): int
+    {
+        $string = str_replace(["\r\n", "\r"], "\n", $string);
+
+        if ($withNoContentLines) {
+            return substr_count($string, "\n") + 1;
+        }
+
+        return count(array_filter(explode("\n", $string), 'mb_trim'));
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1261,6 +1261,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Counts the number of lines in the input string.
+     *
+     * @param  bool  $withEmptyLines
+     * @return int
+     */
+    public function lineCount(bool $withEmptyLines = true)
+    {
+        return Str::lineCount($this->value, $withEmptyLines);
+    }
+
+    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $before

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1289,6 +1289,37 @@ class SupportStrTest extends TestCase
         $this->assertEquals('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
     }
 
+    public function testLineCount()
+    {
+        $this->assertEquals(4, Str::lineCount('Line 1
+                                                              Line 2
+
+                                                              Line 3'));
+        $this->assertEquals(3, Str::lineCount('Line 1
+                                                              Line 2
+
+                                                              Line 3', false));
+
+        $this->assertEquals(5, Str::lineCount("Line 1\n\nLine 2\nLine 3\n"));
+        $this->assertEquals(3, Str::lineCount("Line 1\n\nLine 2\nLine 3\n", false));
+
+        $this->assertEquals(4, Str::lineCount("\n\n\n"));
+        $this->assertEquals(0, Str::lineCount("\n\n\n", false));
+
+        $this->assertEquals(1, Str::lineCount('Single line string'));
+        $this->assertEquals(1, Str::lineCount('Single line string', false));
+
+        $this->assertEquals(1, Str::lineCount(''));
+        $this->assertEquals(0, Str::lineCount('', false));
+
+        $this->assertEquals(3, Str::lineCount("Line 1\r\nLine 2\r\nLine 3"));
+
+        $this->assertEquals(0, Str::lineCount("   \n\n   \n", false));
+
+        $this->assertEquals(5, Str::lineCount("Line 1\n   \nLine 2\n\n"));
+        $this->assertEquals(2, Str::lineCount("Line 1\n   \nLine 2\n\n", false));
+    }
+
     public static function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1247,6 +1247,14 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
 
+    public function testLineCount()
+    {
+        $this->assertEquals(5, $this->stringable("Line 1\n\nLine 2\nLine 3\n")->lineCount());
+        $this->assertEquals(4, $this->stringable("\n\n\n")->lineCount());
+        $this->assertEquals(3, $this->stringable("Line 1\r\nLine 2\r\nLine 3")->lineCount());
+
+    }
+
     public function testWrap()
     {
         $this->assertEquals('This is me!', $this->stringable('is')->wrap('This ', ' me!'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1252,7 +1252,6 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(5, $this->stringable("Line 1\n\nLine 2\nLine 3\n")->lineCount());
         $this->assertEquals(4, $this->stringable("\n\n\n")->lineCount());
         $this->assertEquals(3, $this->stringable("Line 1\r\nLine 2\r\nLine 3")->lineCount());
-
     }
 
     public function testWrap()


### PR DESCRIPTION
This PR adds the ```lineCount``` method to string helper. It can count lines, supports a param to include/exclude blank lines and handle mixed line endings between Windows, MacOS and Linux