### PR TITLE
[11.x] Add `hyphenate` string manipulation method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1056,6 +1056,47 @@ class Str
     }
 
     /**
+     * Add hyphens at specified position(s) in the string.
+     *
+     * @param  string  $value
+     * @param  array|int  $chunks
+     * @return string
+     */
+    public static function hyphenate(string $value, mixed ...$chunks)
+    {
+         $chunksArray = Arr::flatten($chunks);
+
+         if (count($chunksArray) === 1 && !is_array($chunksArray[0])) {
+             $chunkSize = (int)$chunksArray[0];
+             $totalChunks = ceil(strlen($value) / $chunkSize);
+             $chunksArray = array_fill(0, $totalChunks, $chunkSize);
+         }
+
+         $result = '';
+         $position = 0;
+
+         foreach ($chunksArray as $chunk) {
+             if ($position >= strlen($value)) {
+                 break;
+             }
+
+             if ($position > 0 && $position < strlen($value)) {
+                 $result .= '-';
+             }
+
+             $chunkSize = (int)$chunk;
+             $result .= substr($value, $position, $chunkSize);
+             $position += $chunkSize;
+         }
+
+         if ($position < strlen($value)) {
+             $result .= ($result ? '-' : '') . substr($value, $position);
+         }
+
+         return $result;
+    }
+
+    /**
      * Set the callable that will be used to generate random strings.
      *
      * @param  callable|null  $factory

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1454,6 +1454,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Add hyphens at specified position(s) in the string.
+     *
+     * @param  array|int  $chunks
+     * @return static
+     */
+    public function hyphenate(...$chunks)
+    {
+        return new static(Str::hyphenate($this->value, $chunks));
+    }
+
+    /**
      * Proxy dynamic properties onto methods.
      *
      * @param  string  $key

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1365,4 +1365,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
+
+    public function testHyphenate()
+    {
+        $this->assertSame('abc-123-xyz', (string) $this->stringable('abc123xyz')->hyphenate(3));
+        $this->assertSame('abc-12-3x', (string) $this->stringable('abc123x')->hyphenate(3, 2));
+        $this->assertSame('abc-12-3x', (string) $this->stringable('abc123x')->hyphenate([3, 2]));
+        $this->assertSame('abc-12', (string) $this->stringable('abc12')->hyphenate(3));
+        $this->assertSame('abc', (string) $this->stringable('abc')->hyphenate(4));
+        $this->assertSame('', (string) $this->stringable('', 4)->hyphenate());
+    }
 }


### PR DESCRIPTION
Adds new fluent `hyphenate` string manipulation method for adding hyphens

```php
str(387463627)->hyphenate(3)); // 387-463-627

str(Str::random(8))
    ->hyphenate(4)); // "VEVR-IqGIO"
```