### PR TITLE
[11.x] Add applyAfterQueryCallbacks Support to Non-Mutator Cases in pluck Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -950,7 +950,7 @@ class Builder implements BuilderContract
         if (! $this->model->hasAnyGetMutator($column) &&
             ! $this->model->hasCast($column) &&
             ! in_array($column, $this->model->getDates())) {
-            return $results;
+            return $this->applyAfterQueryCallbacks($results);
         }
 
         return $this->applyAfterQueryCallbacks(


### PR DESCRIPTION
This PR modifies the pluck method to ensure that applyAfterQueryCallbacks is consistently applied, regardless of whether the column requires a mutator or casting.

Changes Made:
	•	Moved the applyAfterQueryCallbacks call to encompass non-mutator cases.
	•	Previously, applyAfterQueryCallbacks was only invoked when a mutator or cast was involved. With this change, it now applies to all results, providing more predictable and consistent behavior.

Benefits:
	•	Ensures that any callbacks registered with applyAfterQueryCallbacks are executed for all pluck results.
	•	Improves consistency in how pluck handles query results, regardless of column type or model-specific behavior.

Impact:
	•	Maintains backward compatibility with existing behavior.
	•	No breaking changes; the default functionality is preserved.