### PR TITLE
[11.x] Implement Str::formatByPattern()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2005,7 +2005,7 @@ class Str
     }
 
     /**
-     * Formats the input string accodring to the pattern passed in
+     * Formats the input string accodring to the pattern passed in.
      *
      * @param  string  $string  the input string
      * @param  string  $pattern  asterisks will be replaced with the character
@@ -2018,14 +2018,14 @@ class Str
         if (strlen($string) !== substr_count($pattern, '*')) {
             throw new InvalidArgumentException('Number of placeholders must be the same as the length of the input string');
         }
-        
+
         $res = '';
         $index = 0;
-        
+
         for ($i = 0; $i < strlen($pattern); $i++) {
             $res .= $pattern[$i] === '*' ? $string[$index++] : $pattern[$i];
         }
-        
+
         return $res;
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use JsonException;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
@@ -2001,6 +2002,31 @@ class Str
         }
 
         return $ulid;
+    }
+
+    /**
+     * Formats the input string accodring to the pattern passed in
+     *
+     * @param  string  $string  the input string
+     * @param  string  $pattern  asterisks will be replaced with the character
+     *                           at the respective position of the input string
+     *                           while other characters will put inserted as
+     *                           is into the output string
+     */
+    public static function formatByPattern(string $string, string $pattern)
+    {
+        if (strlen($string) !== substr_count($pattern, '*')) {
+            throw new InvalidArgumentException('Number of placeholders must be the same as the length of the input string');
+        }
+        
+        $res = '';
+        $index = 0;
+        
+        for ($i = 0; $i < strlen($pattern); $i++) {
+            $res .= $pattern[$i] === '*' ? $string[$index++] : $pattern[$i];
+        }
+        
+        return $res;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1316,6 +1316,19 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Formats the input string accodring to the pattern passed in
+     *
+     * @param  string  $pattern  asterisks will be replaced with the character
+     *                           at the respective position of the input string
+     *                           while other characters will put inserted as
+     *                           is into the output string
+     */
+    public function formatByPattern(string $pattern)
+    {
+       return Str::formatByPattern($this->value, $pattern);
+    }
+
+    /**
      * Dump the string.
      *
      * @param  mixed  ...$args

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1316,7 +1316,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Formats the input string accodring to the pattern passed in
+     * Formats the input string accodring to the pattern passed in.
      *
      * @param  string  $pattern  asterisks will be replaced with the character
      *                           at the respective position of the input string
@@ -1325,7 +1325,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function formatByPattern(string $pattern)
     {
-       return Str::formatByPattern($this->value, $pattern);
+        return Str::formatByPattern($this->value, $pattern);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1635,6 +1635,22 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    #[DataProvider('providesFormatByPattern')]
+    public function testFormatByPattern(string $input, string $pattern, string $output)
+    {
+        $this->assertSame($output, Str::formatByPattern($input, $pattern));
+    }
+
+    public static function providesFormatByPattern()
+    {
+        return [
+            'hyphenated-triplets' => ['123456789', '***-***-***', '123-456-789'],
+            'slashed-triplets' => ['123456789', '***/***/***', '123/456/789'],
+            'uneven-hyphenated' => ['123456789', '**-*****-**', '12-34567-89'],
+            'different-delimiters' => ['123456789', '***;***,***', '123;456,789'],
+        ];
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
```php
$number = 123456789;
echo Str::formatByPattern((string)$number, '***-***-***'); // 123-456-789
echo Str::formatByPattern((string)$number, '***/***/***'); // 123/456/789
echo Str::formatByPattern((string)$number, '**-*****-**'); // 12-34567-89
echo Str::formatByPattern((string)$number, '***;***,***'); // 123;456,789
echo Str::formatByPattern('550e8400e29b41d4a716446655440000', '********-****-****-****-************'); // 550e8400-e29b-41d4-a716-446655440000
```