### PR TITLE
[12.x] Allow queueing Mails by default

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -89,6 +89,13 @@ class Mailer implements MailerContract, MailQueueContract
     protected $queue;
 
     /**
+     * Indicates if mails should be queued by default.
+     * 
+     * @var bool
+     */
+    protected $queueMailsByDefault = false;
+
+    /**
      * Create a new Mailer instance.
      *
      * @param  string  $name
@@ -349,7 +356,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function sendMailable(MailableContract $mailable)
     {
-        return $mailable instanceof ShouldQueue
+        return ($mailable instanceof ShouldQueue || $this->queueMailsByDefault)
                         ? $mailable->mailer($this->name)->queue($this->queue)
                         : $mailable->mailer($this->name)->send($this);
     }
@@ -459,6 +466,17 @@ class Mailer implements MailerContract, MailQueueContract
 
         $message->forgetCc();
         $message->forgetBcc();
+    }
+
+    /**
+     * Indicate that all mailables should be queued by default.
+     * 
+     * @param  bool  $queue
+     * @return void
+     */
+    public function queueMailsByDefault(bool $shouldQueue = true)
+    {
+        $this->queueMailsByDefault = $shouldQueue;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -57,6 +57,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static bool hasSent(string $mailable)
  * @method static \Illuminate\Support\Collection queued(string|\Closure $mailable, callable|null $callback = null)
  * @method static bool hasQueued(string $mailable)
+ * @method static void queueMailsByDefault(bool $shouldQueue = true)
  *
  * @see \Illuminate\Mail\MailManager
  * @see \Illuminate\Support\Testing\Fakes\MailFake

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -48,6 +48,13 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     protected $queuedMailables = [];
 
     /**
+     * Indicates if mails should be queued by default.
+     * 
+     * @var bool
+     */
+    protected $queueMailsByDefault = false;
+
+    /**
      * Create a new mail fake.
      *
      * @param  MailManager  $manager
@@ -476,7 +483,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      */
     public function send($view, array $data = [], $callback = null)
     {
-        return $this->sendMail($view, $view instanceof ShouldQueue);
+        return $this->sendMail($view, ($view instanceof ShouldQueue || $this->queueMailsByDefault));
     }
 
     /**
@@ -514,6 +521,17 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
         $this->currentMailer = null;
 
         $this->mailables[] = $view;
+    }
+
+    /**
+     * Indicate that all mailables should be queued by default.
+     * 
+     * @param  bool  $queue
+     * @return void
+     */
+    public function queueMailsByDefault(bool $shouldQueue = true)
+    {
+        $this->queueMailsByDefault = $shouldQueue;
     }
 
     /**

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -310,6 +310,22 @@ class SupportTestingMailFakeTest extends TestCase
         }
     }
 
+    public function testSendQueuesAMailableThatShouldBeQueuedByDefault()
+    {
+        $this->fake->queueMailsByDefault();
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class);
+
+        try {
+            $this->fake->assertSent(MailableStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.', $e->getMessage());
+        }
+    }
+
     public function testAssertNothingSent()
     {
         $this->fake->assertNothingSent();


### PR DESCRIPTION
This PR adds the ability to automatically queue all outgoing mailables by default, no matter if they implement the `ShouldQueue` interface or not.

I think this method can be beneficial to prevent performance degradation (and application errors) by accidentally sending out mails synchronously that should always be sent via the queue.

The API works in a similar way to the `DB::prohibitDestructiveCommands()` method.

Usage (for example in your service provider):

```php
<?php
class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Mail::queueMailsByDefault();
    }
}
```

Now, calling `send` will always queue the mail, regardless of the implemented interface.
Of course, calling `sendNow` remains unaffected.