### PR TITLE
Normalise rate limiting argument order

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -74,11 +74,11 @@ class Limit
     /**
      * Create a new rate limit using minutes as decay time.
      *
-     * @param  int  $decayMinutes
      * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
      * @return static
      */
-    public static function perMinutes($decayMinutes, $maxAttempts)
+    public static function perMinutes($maxAttempts, $decayMinutes)
     {
         return new static('', $maxAttempts, 60 * $decayMinutes);
     }

--- a/tests/Cache/LimitTest.php
+++ b/tests/Cache/LimitTest.php
@@ -30,7 +30,7 @@ class LimitTest extends TestCase
         $this->assertSame(240, $limit->decaySeconds);
         $this->assertSame(3, $limit->maxAttempts);
 
-        $limit = Limit::perMinutes(2, 3);
+        $limit = Limit::perMinutes(3, 2);
         $this->assertSame(120, $limit->decaySeconds);
         $this->assertSame(3, $limit->maxAttempts);
 


### PR DESCRIPTION
Currently, `perSecond()`, `perMinute()`, `perHour()` `perDay()` all use the order `$maxAttempts, $decayX`, whereas `perMinutes()` uses `$decayX, $maxAttempts`.

This normalises the order of the arguments for consistency.

I've read the discussion from 2021 in [this PR](https://github.com/laravel/framework/pull/36568#issuecomment-797508806) but think it's worth considering again.

This is a breaking change so is targeting master.