### PR TITLE
Handle unique validation conflicts caused by soft-deleted records

### DIFF
--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -75,14 +75,19 @@ class Unique implements Stringable
     }
 
     /**
-     * Exclude soft-deleted records from the unique check.
+     * Apply a condition to exclude soft-deleted records.
      *
+     * @param Model|null $model
      * @return $this
      */
-    public function withSoftDeletes()
+    public function withSoftDeletes(?Model $model = null): static
     {
-        $this->where(function ($query) {
-            $query->whereNull('deleted_at');
+        $this->where(function ($query) use ($model) {
+            $deletedAtColumn = $model && method_exists($model, 'getDeletedAtColumn')
+                ? $model->getDeletedAtColumn()
+                : 'deleted_at';
+
+            $query->whereNull($deletedAtColumn);
         });
 
         return $this;

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -73,4 +73,18 @@ class Unique implements Stringable
             $this->formatWheres()
         ), ',');
     }
+
+    /**
+     * Exclude soft-deleted records from the unique check.
+     *
+     * @return $this
+     */
+    public function withSoftDeletes()
+    {
+        $this->where(function ($query) {
+            $query->whereNull('deleted_at');
+        });
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Hi Laravel Team 👋,

During my experience working on various projects, I’ve encountered a recurring issue when validating the uniqueness of a field while using Soft Deletes. Specifically, when using Rule::unique for validation, it often leads to unintended conflicts because soft-deleted records are still considered in the validation check. This has caused confusion and bugs in projects where certain records are logically “deleted” but still exist in the database.

To address this issue, I’ve introduced a new method called withSoftDeletes to the Rule::unique class. This method allows developers to exclude soft-deleted records from the unique validation check. By explicitly opting in to this behavior, it ensures that the framework remains opinionated and avoids introducing any breaking changes.

I believe this addition can improve the developer experience by:

1. “**Explicit is better than implicit**” — This method makes the behavior clear and opt-in, avoiding unexpected side effects.
2. “**Don’t repeat yourself (DRY)**” — It reduces the repetitive task of manually adding conditions for soft-deleted records.

**Usage Example:**
Here’s an example of how this method can be used:
```
use Illuminate\Validation\Rule;

$request->validate([
    'email' => [
        'required',
        'email',
        Rule::unique('users', 'email')->withSoftDeletes(),
    ],
]);
```

Thank you for considering this PR! 😊

Looking forward to your feedback and suggestions.