### PR TITLE
[11.x] `addPath()` Allow adding new path for translation loader.

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -185,7 +185,7 @@ class FileLoader implements Loader
     /**
      * Add a new path to the loader.
      *
-     * @param  string|array  $path
+     * @param  string  $path
      * @return void
      */
     public function addPath($path)

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -185,12 +185,12 @@ class FileLoader implements Loader
     /**
      * Add a new path to the loader.
      *
-     * @param  string  $path
+     * @param  string|array  $path
      * @return void
      */
     public function addPath($path)
     {
-        $this->paths[] = $hint;
+        $this->paths[] = $path;
     }
 
     /**

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -183,12 +183,12 @@ class FileLoader implements Loader
     }
 
     /**
-     * Add a new namespace to the loader.
+     * Add a new path to the loader.
      *
      * @param  string  $path
      * @return void
      */
-    public function addLocation($path)
+    public function addPath($path)
     {
         $this->paths[] = $hint;
     }

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -183,6 +183,17 @@ class FileLoader implements Loader
     }
 
     /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addLocation($path)
+    {
+        $this->paths[] = $hint;
+    }
+
+    /**
      * Add a new JSON path to the loader.
      *
      * @param  string  $path


### PR DESCRIPTION
It was not possible to add a new directory directly without a namespace for the translation loader. This method makes it possible to load translation lines by including a new directory directly in the loader without a namespace.