### PR TITLE
[11.x] fix: Forcing DB Cache driver to always use the Write connection

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -431,7 +431,7 @@ class DatabaseStore implements LockProvider, Store
      */
     protected function table()
     {
-        return $this->connection->table($this->table);//->useWritePdo();
+        return $this->connection->table($this->table)->useWritePdo();
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -431,7 +431,7 @@ class DatabaseStore implements LockProvider, Store
      */
     protected function table()
     {
-        return $this->connection->table($this->table);//->useWritePdo();
+        return $this->connection->table($this->table); //->useWritePdo();
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -431,7 +431,7 @@ class DatabaseStore implements LockProvider, Store
      */
     protected function table()
     {
-        return $this->connection->table($this->table);
+        return $this->connection->table($this->table);//->useWritePdo();
     }
 
     /**

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -21,7 +21,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testNullIsReturnedWhenItemNotFound()
     {
         $store = $this->getStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
         $table->shouldReceive('get')->once()->andReturn(collect([]));
@@ -33,11 +33,11 @@ class CacheDatabaseStoreTest extends TestCase
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forgetIfExpired'])->setConstructorArgs($this->getMocks())->getMock();
 
-        $getQuery = m::mock(stdClass::class);
+        $getQuery = $this->getTableMock();
         $getQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($getQuery);
         $getQuery->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'expiration' => 1]]));
 
-        $deleteQuery = m::mock(stdClass::class);
+        $deleteQuery = $this->getTableMock();
         $deleteQuery->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($deleteQuery);
         $deleteQuery->shouldReceive('where')->once()->with('expiration', '<=', m::any())->andReturn($deleteQuery);
         $deleteQuery->shouldReceive('delete')->once()->andReturnNull();
@@ -50,7 +50,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecryptedValueIsReturnedWhenItemIsValid()
     {
         $store = $this->getStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
         $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 999999999999999]]));
@@ -61,7 +61,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testValueIsReturnedOnPostgres()
     {
         $store = $this->getPostgresStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
         $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]]));
@@ -72,7 +72,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testValueIsReturnedOnSqlite()
     {
         $store = $this->getSqliteStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo'])->andReturn($table);
         $table->shouldReceive('get')->once()->andReturn(collect([(object) ['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0bar\0")), 'expiration' => 999999999999999]]));
@@ -83,7 +83,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testValueIsUpserted()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
         $table->shouldReceive('upsert')->once()->with([['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61]], 'key')->andReturnTrue();
@@ -95,7 +95,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testValueIsUpsertedOnPostgres()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
         $table->shouldReceive('upsert')->once()->with([['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61]], 'key')->andReturn(1);
@@ -107,7 +107,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testValueIsUpsertedOnSqlite()
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getSqliteMocks())->getMock();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
         $table->shouldReceive('upsert')->once()->with([['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61]], 'key')->andReturn(1);
@@ -127,7 +127,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeRemovedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($table);
         $table->shouldReceive('delete')->once();
@@ -138,7 +138,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeFlushedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock();
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('delete')->once()->andReturn(2);
 
@@ -149,7 +149,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testIncrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock(4);
         $cache = m::mock(stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
@@ -188,7 +188,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock(stdClass::class);
+        $table = $this->getTableMock(4);
         $cache = m::mock(stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
@@ -252,5 +252,16 @@ class CacheDatabaseStoreTest extends TestCase
     protected function getSqliteMocks()
     {
         return [m::mock(SQLiteConnection::class), 'table', 'prefix'];
+    }
+
+    protected function getTableMock($times = 1)
+    {
+        $table = m::mock(stdClass::class);
+
+        $table->shouldReceive('useWritePdo')
+            ->times($times)
+            ->andReturnSelf();
+
+        return $table;
     }
 }


### PR DESCRIPTION
Similar to #54231

When using Cache with a "database" driver that uses a read/write config, it will use the "read" connection unless `DB_CACHE_CONNECTION=mysql::write` is used.

If the read database is lagging behind the write database, it can cause issues, especially for locks.

To test it we can use the following:

```php
// .env
CACHE_STORE=database

// routes/web.php
Route::get('/test-cache-connection', function () {
    \Illuminate\Support\Facades\Cache::has('some-key');
});

// config/database.php
        'mysql' => [
            'read' => [
                'host' => [
                    // If you see this error means it's using the "read" connection.
                    // Invalid Host. Fails with: SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo for some.invalid.host.invalid failed...
                    'some.invalid.host.invalid',
                ],
            ],

            'write' => [
                'host' => [
                    // Valid Host
                    '127.0.0.1',
                ],
            ],
            // 'host' => env('DB_HOST', '127.0.0.1'),
            // ...

```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
