### PR TITLE
fix: collapseWithKeys on empty collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -149,7 +149,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function collapseWithKeys()
     {
         if (! $this->items) {
-            return $this;
+            return new static;
         }
 
         $results = [];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -148,6 +148,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function collapseWithKeys()
     {
+        if(! $this->items){
+            return $this;
+        }
+
         $results = [];
 
         foreach ($this->items as $key => $values) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -148,7 +148,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function collapseWithKeys()
     {
-        if(! $this->items){
+        if (! $this->items) {
             return $this;
         }
 


### PR DESCRIPTION
This goes with issue  #54289 .
Early returns out of the function collapseWithKeys to avoid an ArgumentCountError when called on an empty collection
