### PR TITLE
[11.x] Added `PhoneNumber` for a cast model and validation rule, digging deeper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^3.2.1|^4.0",
         "fruitcake/php-cors": "^1.3",
+        "giggsey/libphonenumber-for-php": "^8.13",
         "guzzlehttp/guzzle": "^7.8.2",
         "guzzlehttp/uri-template": "^1.0",
         "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",

--- a/src/Illuminate/Database/Eloquent/Casts/AsE164PhoneNumber.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsE164PhoneNumber.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Support\PhoneNumber;
+use InvalidArgumentException;
+
+class AsE164PhoneNumber implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\PhoneNumber>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes
+        {
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! $value) {
+                    return null;
+                }
+
+                $phone = PhoneNumber::of($value);
+
+                if (! $phone->getCountry()) {
+                    throw new InvalidArgumentException('Missing country specification for ' . $key . ' attribute cast');
+                }
+
+                return $phone;
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if (! $value) {
+                    return null;
+                }
+
+                if (is_string($value)) {
+                    $value = PhoneNumber::of($value);
+                }
+
+                return $value->formatE164();
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                if (! $value) {
+                    return null;
+                }
+
+                return $value->getRawNumber();
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsE164PhoneNumber.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsE164PhoneNumber.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Eloquent\Casts;
 
-use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\PhoneNumber;
 use InvalidArgumentException;
 
@@ -32,7 +32,7 @@ class AsE164PhoneNumber implements Castable
                 $phone = PhoneNumber::of($value);
 
                 if (! $phone->getCountry()) {
-                    throw new InvalidArgumentException('Missing country specification for ' . $key . ' attribute cast');
+                    throw new InvalidArgumentException('Missing country specification for '.$key.' attribute cast');
                 }
 
                 return $phone;
@@ -48,7 +48,7 @@ class AsE164PhoneNumber implements Castable
                     $value = PhoneNumber::of($value);
                 }
 
-                $countryField = $this->arguments[0] ?? $key . '_country';
+                $countryField = $this->arguments[0] ?? $key.'_country';
 
                 return $value
                     ->setCountry($attributes[$countryField] ?? $value->getCountry())
@@ -74,6 +74,6 @@ class AsE164PhoneNumber implements Castable
      */
     public static function of($countryField)
     {
-        return static::class . ':' . $countryField;
+        return static::class.':'.$countryField;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsE164PhoneNumber.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsE164PhoneNumber.php
@@ -17,8 +17,12 @@ class AsE164PhoneNumber implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            public function __construct(protected array $arguments)
+            {
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (! $value) {
@@ -44,7 +48,11 @@ class AsE164PhoneNumber implements Castable
                     $value = PhoneNumber::of($value);
                 }
 
-                return $value->formatE164();
+                $countryField = $this->arguments[0] ?? $key . '_country';
+
+                return $value
+                    ->setCountry($attributes[$countryField] ?? $value->getCountry())
+                    ->formatE164();
             }
 
             public function serialize($model, string $key, $value, array $attributes)
@@ -56,5 +64,16 @@ class AsE164PhoneNumber implements Castable
                 return $value->getRawNumber();
             }
         };
+    }
+
+    /**
+     * Specify the country field for the cast.
+     *
+     * @param  string  $countryField
+     * @return string
+     */
+    public static function of($countryField)
+    {
+        return static::class . ':' . $countryField;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsRawPhoneNumber.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsRawPhoneNumber.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\PhoneNumber;
+use InvalidArgumentException;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+
+class AsRawPhoneNumber implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\PhoneNumber>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes
+        {
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! $value) {
+                    return null;
+                }
+
+                $phone = PhoneNumber::of($value);
+
+                if (! $phone->getCountry()) {
+                    throw new InvalidArgumentException('Missing country specification for ' . $key . ' attribute cast');
+                }
+
+                return $phone;
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if (! $value) {
+                    return null;
+                }
+
+                if (is_string($value)) {
+                    $value = PhoneNumber::of($value);
+                }
+
+                return $value->getRawNumber();
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                if (! $value) {
+                    return null;
+                }
+
+                return $value->getRawNumber();
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsRawPhoneNumber.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsRawPhoneNumber.php
@@ -17,15 +17,21 @@ class AsRawPhoneNumber implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            public function __construct(protected array $arguments)
+            {
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (! $value) {
                     return null;
                 }
 
-                $phone = PhoneNumber::of($value);
+                $countryField = $this->arguments[0] ?? $key . '_country';
+
+                $phone = PhoneNumber::of($value, $countryField);
 
                 if (! $phone->getCountry()) {
                     throw new InvalidArgumentException('Missing country specification for ' . $key . ' attribute cast');
@@ -56,5 +62,16 @@ class AsRawPhoneNumber implements Castable
                 return $value->getRawNumber();
             }
         };
+    }
+
+    /**
+     * Specify the country field for the cast.
+     *
+     * @param  string  $countryField
+     * @return string
+     */
+    public static function of($countryField)
+    {
+        return static::class . ':' . $countryField;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsRawPhoneNumber.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsRawPhoneNumber.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Casts;
 
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\PhoneNumber;
 use InvalidArgumentException;
-use Illuminate\Contracts\Database\Eloquent\Castable;
 
 class AsRawPhoneNumber implements Castable
 {
@@ -29,12 +29,12 @@ class AsRawPhoneNumber implements Castable
                     return null;
                 }
 
-                $countryField = $this->arguments[0] ?? $key . '_country';
+                $countryField = $this->arguments[0] ?? $key.'_country';
 
                 $phone = PhoneNumber::of($value, $countryField);
 
                 if (! $phone->getCountry()) {
-                    throw new InvalidArgumentException('Missing country specification for ' . $key . ' attribute cast');
+                    throw new InvalidArgumentException('Missing country specification for '.$key.' attribute cast');
                 }
 
                 return $phone;
@@ -72,6 +72,6 @@ class AsRawPhoneNumber implements Castable
      */
     public static function of($countryField)
     {
-        return static::class . ':' . $countryField;
+        return static::class.':'.$countryField;
     }
 }

--- a/src/Illuminate/Support/PhoneNumber.php
+++ b/src/Illuminate/Support/PhoneNumber.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Exception;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use JsonSerializable;
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberType;
+use libphonenumber\PhoneNumberUtil;
+use libphonenumber\PhoneNumber as LibPhoneNumber;
+use ReflectionClass;
+
+class PhoneNumber implements Jsonable, JsonSerializable
+{
+    use Macroable, Conditionable;
+
+    /**
+     * The phone number instance.
+     */
+    protected PhoneNumberUtil $phoneNumberInstance;
+
+    public function __construct(protected string $number)
+    {
+        $this->phoneNumberInstance = PhoneNumberUtil::getInstance();
+    }
+
+    /**
+     * Create a new PhoneNumber instance.
+     */
+    public static function of(string $number): static
+    {
+        return new static($number);
+    }
+
+    /**
+     * Get the raw phone number.
+     */
+    public function getRawNumber(): string
+    {
+        return $this->number;
+    }
+
+    /**
+     * Get the country code of the phone number.
+     */
+    public function getCountry(): ?string
+    {
+        try {
+            return $this->phoneNumberInstance->getRegionCodeForNumber(
+                $this->phoneNumberInstance->parse($this->number, 'ZZ')
+            );
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Get the type of the phone number.
+     */
+    public function getType(bool $asValue = false): int|string
+    {
+        $type = $this->phoneNumberInstance->getNumberType($this->toLibPhone());
+
+        return $asValue ? $type : $this->getHumanReadableName($type);
+    }
+
+    /**
+     * Get the lib phone number object.
+     */
+    public function toLibPhone(): LibPhoneNumber
+    {
+        return $this->phoneNumberInstance->parse(
+            $this->number,
+            $this->getCountry(),
+        );
+    }
+
+    /**
+     * Check if the phone number is valid.
+     */
+    public function isValid(): bool
+    {
+        try {
+            return $this->phoneNumberInstance->isValidNumberForRegion(
+                $this->toLibPhone(),
+                $this->getCountry() ?? 'ZZ',
+            );
+        } catch (Exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if the phone number is of the given country.
+     * @param  mixed  $country
+     */
+    public function isOfCountry($country): bool
+    {
+        $countries = $this->sanitizeType(Arr::wrap($country));
+
+        return in_array($this->getCountry(), $countries);
+    }
+
+    /**
+     * Format the phone number.
+     */
+    public function format(string|int $format): string
+    {
+        $sanitizedFormat = $this->sanitizeType($format);
+
+        if (! $sanitizedFormat) {
+            throw new Exception('Invalid format ' . $format);
+        }
+
+        return $this->phoneNumberInstance->format(
+            $this->toLibPhone(),
+            $sanitizedFormat
+        );
+    }
+
+    /**
+     * Format the phone number in international format.
+     */
+    public function formatInternational(): string
+    {
+        return $this->format(PhoneNumberFormat::INTERNATIONAL);
+    }
+
+    /**
+     * Format the phone number in national format.
+     */
+    public function formatNational(): string
+    {
+        return $this->format(PhoneNumberFormat::NATIONAL);
+    }
+
+    /**
+     * Format the phone number in E164 format.
+     */
+    public function formatE164(): string
+    {
+        return $this->format(PhoneNumberFormat::E164);
+    }
+
+    /**
+     * Format the phone number in RFC3966 format.
+     */
+    public function formatRFC3966(): string
+    {
+        return $this->format(PhoneNumberFormat::RFC3966);
+    }
+
+    /**
+     * Format the phone number for a given country.
+     * @param  mixed  $country
+     */
+    public function formatForCountry($country): string
+    {
+        return $this->phoneNumberInstance->formatOutOfCountryCallingNumber(
+            $this->toLibPhone(),
+            $country
+        );
+    }
+
+    /**
+     * Format the phone number for mobile dialing in a given country.
+     * @param  mixed  $country
+     */
+    public function formatForMobileDialingInCountry($country, bool $withFormatting = false): string
+    {
+        return $this->phoneNumberInstance->formatNumberForMobileDialing(
+            $this->toLibPhone(),
+            $country,
+            $withFormatting
+        );
+    }
+
+    /**
+     * Check if the phone number is of the given type.
+     * @param  mixed  $type
+     */
+    public function isOfType($type): bool
+    {
+        $types = $this->sanitizeType(Arr::wrap($type));
+
+        if (array_intersect([PhoneNumberType::FIXED_LINE, PhoneNumberType::MOBILE], $types)) {
+            $types[] = PhoneNumberType::FIXED_LINE_OR_MOBILE;
+        }
+
+        return in_array($this->getType(true), $types, true);
+    }
+
+    /**
+     * Check if the type is valid.
+     */
+    public function isValidType($type): bool
+    {
+        return ! is_null($type) && in_array($type, $this->allTypes(), true);
+    }
+
+    /**
+     * Check if the phone number is equal to another.
+     */
+    public function equals(string|PhoneNumber $number): bool
+    {
+        try {
+            if (! $number instanceof static) {
+                $number = new static($number);
+            }
+
+            return $this->formatE164() === $number->formatE164();
+        } catch (Exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if the phone number is not equal to another.
+     */
+    public function notEquals(string|PhoneNumber $number): bool
+    {
+        return ! $this->equals($number);
+    }
+
+    /**
+     * Convert the phone number to its JSON representation.
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Json serialize the phone number.
+     */
+    public function jsonSerialize(): string
+    {
+        return $this->formatE164();
+    }
+
+    /**
+     * Serialize the phone number.
+     */
+    public function __serialize()
+    {
+        return ['number' => $this->formatE164()];
+    }
+
+    /**
+     * Unserialize the phone number.
+     */
+    public function __unserialize(array $serialized)
+    {
+        $this->number = $serialized['number'];
+    }
+
+    /**
+     * Convert the phone number to a string.
+     */
+    public function __toString(): string
+    {
+        try {
+            return $this->formatE164();
+        } catch (Exception) {
+            return (string) $this->number;
+        }
+    }
+
+    /**
+     * Get All types of phone number.
+     */
+    protected function allTypes(): array
+    {
+        return (new ReflectionClass(PhoneNumberType::class))->getConstants();
+    }
+
+    /**
+     * Get the human readable name of the type.
+     */
+    protected function getHumanReadableName($type): ?string
+    {
+        $name = array_search($type, $this->allTypes(), true);
+
+        return $name ? strtolower($name) : null;
+    }
+
+    /**
+     * Sanitize the type.
+     */
+    protected function sanitizeType($types): int|array|null
+    {
+        return Collection::make(Arr::wrap($types))
+            ->map(function ($format) {
+                return Arr::get($this->allTypes(), strtoupper($format), $format);
+            })
+            ->filter(fn($format): bool => $this->isValidType($format))
+            ->unique()
+            ->when(
+                is_array($types),
+                fn($collection) => $collection->toArray(),
+                fn($collection) => $collection->first(),
+            );
+    }
+}

--- a/src/Illuminate/Support/PhoneNumber.php
+++ b/src/Illuminate/Support/PhoneNumber.php
@@ -6,10 +6,10 @@ use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use libphonenumber\PhoneNumber as LibPhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
-use libphonenumber\PhoneNumber as LibPhoneNumber;
 use ReflectionClass;
 
 class PhoneNumber
@@ -108,6 +108,7 @@ class PhoneNumber
 
     /**
      * Check if the phone number is of the given country.
+     *
      * @param  mixed  $country
      */
     public function isOfCountry($country): bool
@@ -125,7 +126,7 @@ class PhoneNumber
         $sanitizedFormat = $this->sanitizeType($format);
 
         if (is_null($sanitizedFormat)) {
-            throw new Exception('Invalid format ' . $format);
+            throw new Exception('Invalid format '.$format);
         }
 
         return $this->phoneNumberInstance->format(
@@ -168,6 +169,7 @@ class PhoneNumber
 
     /**
      * Format the phone number for a given country.
+     *
      * @param  mixed  $country
      */
     public function formatForCountry($country): string
@@ -180,6 +182,7 @@ class PhoneNumber
 
     /**
      * Format the phone number for mobile dialing in a given country.
+     *
      * @param  mixed  $country
      */
     public function formatForMobileDialingInCountry($country, bool $withFormatting = false): string
@@ -193,6 +196,7 @@ class PhoneNumber
 
     /**
      * Check if the phone number is of the given type.
+     *
      * @param  mixed  $type
      */
     public function isOfType($type): bool
@@ -278,12 +282,12 @@ class PhoneNumber
             ->map(function ($format) {
                 return Arr::get($this->allTypes(), strtoupper($format), $format);
             })
-            ->filter(fn($format): bool => $this->isValidType($format))
+            ->filter(fn ($format): bool => $this->isValidType($format))
             ->unique()
             ->when(
                 is_array($types),
-                fn($collection) => $collection->toArray(),
-                fn($collection) => $collection->first(),
+                fn ($collection) => $collection->toArray(),
+                fn ($collection) => $collection->first(),
             );
     }
 }

--- a/src/Illuminate/Support/PhoneNumber.php
+++ b/src/Illuminate/Support/PhoneNumber.php
@@ -3,18 +3,16 @@
 namespace Illuminate\Support;
 
 use Exception;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-use JsonSerializable;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\PhoneNumber as LibPhoneNumber;
 use ReflectionClass;
 
-class PhoneNumber implements Jsonable, JsonSerializable
+class PhoneNumber
 {
     use Macroable, Conditionable;
 
@@ -116,7 +114,7 @@ class PhoneNumber implements Jsonable, JsonSerializable
     {
         $sanitizedFormat = $this->sanitizeType($format);
 
-        if (! $sanitizedFormat) {
+        if (is_null($sanitizedFormat)) {
             throw new Exception('Invalid format ' . $format);
         }
 
@@ -212,7 +210,7 @@ class PhoneNumber implements Jsonable, JsonSerializable
     public function equals(string|PhoneNumber $number): bool
     {
         try {
-            if (! $number instanceof static) {
+            if (is_string($number)) {
                 $number = new static($number);
             }
 
@@ -230,37 +228,6 @@ class PhoneNumber implements Jsonable, JsonSerializable
         return ! $this->equals($number);
     }
 
-    /**
-     * Convert the phone number to its JSON representation.
-     */
-    public function toJson($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
-    }
-
-    /**
-     * Json serialize the phone number.
-     */
-    public function jsonSerialize(): string
-    {
-        return $this->formatE164();
-    }
-
-    /**
-     * Serialize the phone number.
-     */
-    public function __serialize()
-    {
-        return ['number' => $this->formatE164()];
-    }
-
-    /**
-     * Unserialize the phone number.
-     */
-    public function __unserialize(array $serialized)
-    {
-        $this->number = $serialized['number'];
-    }
 
     /**
      * Convert the phone number to a string.

--- a/src/Illuminate/Support/PhoneNumber.php
+++ b/src/Illuminate/Support/PhoneNumber.php
@@ -43,6 +43,16 @@ class PhoneNumber
     }
 
     /**
+     * Set the country code of the phone number.
+     */
+    public function setCountry(string $country): static
+    {
+        $this->country = $country;
+
+        return $this;
+    }
+
+    /**
      * Get the country code of the phone number.
      */
     public function getCountry(): ?string

--- a/src/Illuminate/Support/PhoneNumber.php
+++ b/src/Illuminate/Support/PhoneNumber.php
@@ -23,7 +23,7 @@ class PhoneNumber implements Jsonable, JsonSerializable
      */
     protected PhoneNumberUtil $phoneNumberInstance;
 
-    public function __construct(protected string $number)
+    public function __construct(protected string $number, protected ?string $country = null)
     {
         $this->phoneNumberInstance = PhoneNumberUtil::getInstance();
     }
@@ -31,9 +31,9 @@ class PhoneNumber implements Jsonable, JsonSerializable
     /**
      * Create a new PhoneNumber instance.
      */
-    public static function of(string $number): static
+    public static function of(string $number, ?string $country = null): static
     {
-        return new static($number);
+        return new static($number, $country);
     }
 
     /**
@@ -49,6 +49,10 @@ class PhoneNumber implements Jsonable, JsonSerializable
      */
     public function getCountry(): ?string
     {
+        if ($this->country) {
+            return $this->country;
+        }
+
         try {
             return $this->phoneNumberInstance->getRegionCodeForNumber(
                 $this->phoneNumberInstance->parse($this->number, 'ZZ')

--- a/src/Illuminate/Support/PhoneNumber.php
+++ b/src/Illuminate/Support/PhoneNumber.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Support;
 
 use Exception;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use libphonenumber\PhoneNumber as LibPhoneNumber;
@@ -241,7 +240,6 @@ class PhoneNumber
     {
         return ! $this->equals($number);
     }
-
 
     /**
      * Convert the phone number to a string.

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -124,6 +124,7 @@ return [
         'symbols' => 'The :attribute field must contain at least one symbol.',
         'uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
     ],
+    'phone' => 'The :attribute field must be a valid phone number.',
     'present' => 'The :attribute field must be present.',
     'present_if' => 'The :attribute field must be present when :other is :value.',
     'present_unless' => 'The :attribute field must be present unless :other is :value.',

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -15,6 +15,7 @@ use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\Phone;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
@@ -157,6 +158,16 @@ class Rule
     public static function excludeIf($callback)
     {
         return new ExcludeIf($callback);
+    }
+
+    /**
+     * Get a phone rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\Phone
+     */
+    public static function phone()
+    {
+        return new Phone;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Phone.php
+++ b/src/Illuminate/Validation/Rules/Phone.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Error;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\PhoneNumber;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+
+class Phone implements Rule, ValidatorAwareRule, DataAwareRule
+{
+    use Conditionable, Macroable;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+
+    /**
+     * The name of the country field.
+     *
+     * @var string
+     */
+    protected $countryField;
+
+    /**
+     * The callback that will generate the "default" version of the file rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * Set the default callback to be used for determining the phone default rules.
+     *
+     * If no arguments are passed, the default phone rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|void
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the file rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $phone = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $phone instanceof static ? $phone : new static;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function passes($attribute, $value): bool
+    {
+        $country = $this->getCountryFieldValue($attribute);
+
+        try {
+            $phone = PhoneNumber::of($value, $country);
+
+            return $phone->isValid();
+        } catch (Error) {
+            return false;
+        }
+    }
+
+    /**
+     * Set the name of the country field.
+     */
+    public function countryField(string $name): static
+    {
+        $this->countryField = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of the country field.
+     */
+    protected function getCountryFieldValue(string $attribute)
+    {
+        return Arr::get($this->data, $this->countryField ?: $attribute . '_country');
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        $message = $this->validator->getTranslator()->get('validation.phone');
+
+        return $message === 'validation.phone'
+            ? ['The :attribute field must be a valid phone number.']
+            : $message;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/Rules/Phone.php
+++ b/src/Illuminate/Validation/Rules/Phone.php
@@ -38,6 +38,13 @@ class Phone implements Rule, ValidatorAwareRule, DataAwareRule
     protected $countryField;
 
     /**
+     * The country code.
+     *
+     * @var string
+     */
+    protected $country;
+
+    /**
      * The callback that will generate the "default" version of the file rule.
      *
      * @var string|array|callable|null
@@ -87,7 +94,7 @@ class Phone implements Rule, ValidatorAwareRule, DataAwareRule
      */
     public function passes($attribute, $value): bool
     {
-        $country = $this->getCountryFieldValue($attribute);
+        $country = $this->country ?? $this->getCountryFieldValue($attribute);
 
         try {
             $phone = PhoneNumber::of($value, $country);
@@ -96,6 +103,16 @@ class Phone implements Rule, ValidatorAwareRule, DataAwareRule
         } catch (Error) {
             return false;
         }
+    }
+
+    /**
+     * Set the country code of the phone number.
+     */
+    public function country(string $country): static
+    {
+        $this->country = $country;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Phone.php
+++ b/src/Illuminate/Validation/Rules/Phone.php
@@ -66,7 +66,7 @@ class Phone implements Rule, ValidatorAwareRule, DataAwareRule
         }
 
         if (! is_callable($callback) && ! $callback instanceof static) {
-            throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
         }
 
         static::$defaultCallback = $callback;
@@ -130,7 +130,7 @@ class Phone implements Rule, ValidatorAwareRule, DataAwareRule
      */
     protected function getCountryFieldValue(string $attribute)
     {
-        return Arr::get($this->data, $this->countryField ?: $attribute . '_country');
+        return Arr::get($this->data, $this->countryField ?: $attribute.'_country');
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Phone.php
+++ b/src/Illuminate/Validation/Rules/Phone.php
@@ -30,7 +30,6 @@ class Phone implements Rule, ValidatorAwareRule, DataAwareRule
      */
     protected $data;
 
-
     /**
      * The name of the country field.
      *

--- a/tests/Integration/Database/EloquentModelE164PhoneNumberCastingTest.php
+++ b/tests/Integration/Database/EloquentModelE164PhoneNumberCastingTest.php
@@ -13,44 +13,44 @@ class EloquentModelE164PhoneNumberCastingTest extends TestCase
     public function test_mutates_to_e164_number()
     {
         $model = new EloquentModelE164PhoneNumberCastingTestModel;
-        $model->phone = '+32 12 34 56 78';
-        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+        $model->phone = '+201200954866';
+        $this->assertEquals('+201200954866', $model->getAttributes()['phone']);
 
         $model = new EloquentModelE164PhoneNumberCastingTestModel;
-        $model->phone = PhoneNumber::of('+32 12/34.56.78');
-        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+        $model->phone = PhoneNumber::of('+201200954866');
+        $this->assertEquals('+201200954866', $model->getAttributes()['phone']);
     }
 
     public function test_mutates_to_e164_number_with_implicit_country_field()
     {
         $model = new EloquentModelE164PhoneNumberCastingTestModel;
-        $model->phone_country = 'BE';
-        $model->phone = '012 34 56 78';
-        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+        $model->phone_country = 'EG';
+        $model->phone = '01200954866';
+        $this->assertEquals('+201200954866', $model->getAttributes()['phone']);
 
         $model = new EloquentModelE164PhoneNumberCastingTestModel;
-        $model->phone_country = 'BE';
-        $model->phone = PhoneNumber::of('+32 12/34.56.78');
-        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+        $model->phone_country = 'EG';
+        $model->phone = PhoneNumber::of('+201200954866');
+        $this->assertEquals('+201200954866', $model->getAttributes()['phone']);
     }
 
     public function test_mutates_to_e164_number_with_explicit_country_field()
     {
         $model = new EloquentModelE164PhoneNumberCastingTestModelAndCountryField;
-        $model->country = 'BE';
-        $model->phone = '012 34 56 78';
-        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+        $model->country = 'EG';
+        $model->phone = '01200954866';
+        $this->assertEquals('+201200954866', $model->getAttributes()['phone']);
 
         $model = new EloquentModelE164PhoneNumberCastingTestModelAndCountryField;
-        $model->country = 'BE';
-        $model->phone = PhoneNumber::of('+32 12/34.56.78');
-        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+        $model->country = 'EG';
+        $model->phone = PhoneNumber::of('+201200954866');
+        $this->assertEquals('+201200954866', $model->getAttributes()['phone']);
     }
 
     public function test_gets_phone_object()
     {
         $model = new EloquentModelE164PhoneNumberCastingTestModel;
-        $model->setRawAttributes(['phone' => '+3212345678']);
+        $model->setRawAttributes(['phone' => '+201200954866']);
         $this->assertIsObject($model->phone);
         $this->assertInstanceOf(PhoneNumber::class, $model->phone);
     }
@@ -58,7 +58,7 @@ class EloquentModelE164PhoneNumberCastingTest extends TestCase
     public function test_throws_when_accessing_non_international_value()
     {
         $model = new EloquentModelE164PhoneNumberCastingTestModel();
-        $model->setRawAttributes(['phone' => '012 34 56 78']);
+        $model->setRawAttributes(['phone' => '01200954866']);
         $this->expectException(Exception::class);
         $model->phone;
     }
@@ -66,8 +66,8 @@ class EloquentModelE164PhoneNumberCastingTest extends TestCase
     public function test_serializes()
     {
         $model = new EloquentModelE164PhoneNumberCastingTestModel();
-        $model->phone = '+32 12 34 56 78';
-        $this->assertEquals('+3212345678', $model->toArray()['phone']);
+        $model->phone = '+201200954866';
+        $this->assertEquals('+201200954866', $model->toArray()['phone']);
 
         $model = new EloquentModelE164PhoneNumberCastingTestModel();
         $model->phone = null;

--- a/tests/Integration/Database/EloquentModelE164PhoneNumberCastingTest.php
+++ b/tests/Integration/Database/EloquentModelE164PhoneNumberCastingTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Exception;
+use Illuminate\Database\Eloquent\Casts\AsE164PhoneNumber;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\PhoneNumber;
+use Orchestra\Testbench\TestCase;
+
+class EloquentModelE164PhoneNumberCastingTest extends TestCase
+{
+    public function test_mutates_to_e164_number()
+    {
+        $model = new EloquentModelE164PhoneNumberCastingTestModel;
+        $model->phone = '+32 12 34 56 78';
+        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+
+        $model = new EloquentModelE164PhoneNumberCastingTestModel;
+        $model->phone = PhoneNumber::of('+32 12/34.56.78');
+        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+    }
+
+    public function test_mutates_to_e164_number_with_implicit_country_field()
+    {
+        $model = new EloquentModelE164PhoneNumberCastingTestModel;
+        $model->phone_country = 'BE';
+        $model->phone = '012 34 56 78';
+        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+
+        $model = new EloquentModelE164PhoneNumberCastingTestModel;
+        $model->phone_country = 'BE';
+        $model->phone = PhoneNumber::of('+32 12/34.56.78');
+        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+    }
+
+    public function test_mutates_to_e164_number_with_explicit_country_field()
+    {
+        $model = new EloquentModelE164PhoneNumberCastingTestModelAndCountryField;
+        $model->country = 'BE';
+        $model->phone = '012 34 56 78';
+        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+
+        $model = new EloquentModelE164PhoneNumberCastingTestModelAndCountryField;
+        $model->country = 'BE';
+        $model->phone = PhoneNumber::of('+32 12/34.56.78');
+        $this->assertEquals('+3212345678', $model->getAttributes()['phone']);
+    }
+
+    public function test_gets_phone_object()
+    {
+        $model = new EloquentModelE164PhoneNumberCastingTestModel;
+        $model->setRawAttributes(['phone' => '+3212345678']);
+        $this->assertIsObject($model->phone);
+        $this->assertInstanceOf(PhoneNumber::class, $model->phone);
+    }
+
+    public function test_throws_when_accessing_non_international_value()
+    {
+        $model = new EloquentModelE164PhoneNumberCastingTestModel();
+        $model->setRawAttributes(['phone' => '012 34 56 78']);
+        $this->expectException(Exception::class);
+        $model->phone;
+    }
+
+    public function test_serializes()
+    {
+        $model = new EloquentModelE164PhoneNumberCastingTestModel();
+        $model->phone = '+32 12 34 56 78';
+        $this->assertEquals('+3212345678', $model->toArray()['phone']);
+
+        $model = new EloquentModelE164PhoneNumberCastingTestModel();
+        $model->phone = null;
+        $this->assertEquals(null, $model->toArray()['phone']);
+    }
+}
+
+class EloquentModelE164PhoneNumberCastingTestModel extends Model
+{
+    public $casts = [
+        'phone' => AsE164PhoneNumber::class,
+    ];
+}
+
+class EloquentModelE164PhoneNumberCastingTestModelAndCountryField extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'phone' => AsE164PhoneNumber::of('country'),
+        ];
+    }
+}

--- a/tests/Integration/Database/EloquentModelRawPhoneNumberCastingTest.php
+++ b/tests/Integration/Database/EloquentModelRawPhoneNumberCastingTest.php
@@ -12,18 +12,16 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
     public function test_mutates_to_raw_number()
     {
         $model = new ModelWithRawCast;
-        $model->phone = '012 34 56 78';
-
-        $model->phone;
-        $this->assertEquals('012 34 56 78', $model->getAttributes()['phone']);
+        $model->phone = '01200954866';
+        $this->assertEquals('01200954866', $model->getAttributes()['phone']);
 
         $model = new ModelWithRawCast;
-        $model->phone = PhoneNumber::of('012/34.56.78');
-        $this->assertEquals('012/34.56.78', $model->getAttributes()['phone']);
+        $model->phone = PhoneNumber::of('01200954866');
+        $this->assertEquals('01200954866', $model->getAttributes()['phone']);
 
         $model = new ModelWithRawCast;
-        $model->phone = PhoneNumber::of('012345678', 'BE');
-        $this->assertEquals('012345678', $model->getAttributes()['phone']);
+        $model->phone = PhoneNumber::of('01200954866', 'EG');
+        $this->assertEquals('01200954866', $model->getAttributes()['phone']);
 
         $model = new ModelWithRawCast;
         $model->phone = PhoneNumber::of('012-34-56-78', 'US');
@@ -33,7 +31,7 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
     public function test_gets_phone_object()
     {
         $model = new ModelWithRawCast;
-        $model->setRawAttributes(['phone' => '012 34 56 78']);
+        $model->setRawAttributes(['phone' => '01200954866']);
         $this->assertIsObject($model->phone);
         $this->assertInstanceOf(PhoneNumber::class, $model->phone);
     }
@@ -42,8 +40,8 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
     {
         $model = new ModelWithIncompleteRawCast;
         $model->setRawAttributes([
-            'phone_country' => 'BE',
-            'phone' => '012 34 56 78',
+            'phone_country' => 'EG',
+            'phone' => '01200954866',
         ]);
         $this->assertIsObject($model->phone);
         $this->assertInstanceOf(PhoneNumber::class, $model->phone);
@@ -53,8 +51,8 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
     {
         $model = new ModelWithRawCastAndCountryField;
         $model->setRawAttributes([
-            'country' => 'BE',
-            'phone' => '012 34 56 78',
+            'country' => 'EG',
+            'phone' => '01200954866',
         ]);
         $this->assertIsObject($model->phone);
         $this->assertInstanceOf(PhoneNumber::class, $model->phone);
@@ -72,8 +70,8 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
     public function test_serializes()
     {
         $model = new ModelWithRawCast;
-        $model->phone = '012 34 56 78';
-        $this->assertEquals('012 34 56 78', $model->toArray()['phone']);
+        $model->phone = '01200954866';
+        $this->assertEquals('01200954866', $model->toArray()['phone']);
 
         $model = new ModelWithRawCast;
         $model->phone = null;

--- a/tests/Integration/Database/EloquentModelRawPhoneNumberCastingTest.php
+++ b/tests/Integration/Database/EloquentModelRawPhoneNumberCastingTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Casts\AsRawPhoneNumber;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\PhoneNumber;
+use Orchestra\Testbench\TestCase;
+
+class EloquentModelRawPhoneNumberCastingTest extends TestCase
+{
+    public function test_mutates_to_raw_number()
+    {
+        $model = new ModelWithRawCast;
+        $model->phone = '012 34 56 78';
+
+        $model->phone;
+        $this->assertEquals('012 34 56 78', $model->getAttributes()['phone']);
+
+        $model = new ModelWithRawCast;
+        $model->phone = PhoneNumber::of('012/34.56.78');
+        $this->assertEquals('012/34.56.78', $model->getAttributes()['phone']);
+
+        $model = new ModelWithRawCast;
+        $model->phone = PhoneNumber::of('012345678', 'BE');
+        $this->assertEquals('012345678', $model->getAttributes()['phone']);
+
+        $model = new ModelWithRawCast;
+        $model->phone = PhoneNumber::of('012-34-56-78', 'US');
+        $this->assertEquals('012-34-56-78', $model->getAttributes()['phone']);
+    }
+
+    public function test_gets_phone_object()
+    {
+        $model = new ModelWithRawCast;
+        $model->setRawAttributes(['phone' => '012 34 56 78']);
+        $this->assertIsObject($model->phone);
+        $this->assertInstanceOf(PhoneNumber::class, $model->phone);
+    }
+
+    public function test_gets_with_implicit_country_field()
+    {
+        $model = new ModelWithIncompleteRawCast;
+        $model->setRawAttributes([
+            'phone_country' => 'BE',
+            'phone' => '012 34 56 78',
+        ]);
+        $this->assertIsObject($model->phone);
+        $this->assertInstanceOf(PhoneNumber::class, $model->phone);
+    }
+
+    public function test_gets_with_explicit_country_field()
+    {
+        $model = new ModelWithRawCastAndCountryField;
+        $model->setRawAttributes([
+            'country' => 'BE',
+            'phone' => '012 34 56 78',
+        ]);
+        $this->assertIsObject($model->phone);
+        $this->assertInstanceOf(PhoneNumber::class, $model->phone);
+    }
+
+    public function test_gets_phone_object_when_accessing_incomplete_raw_cast_with_international_number()
+    {
+        $model = new ModelWithIncompleteRawCast;
+        $model->setRawAttributes(['phone' => '+32 12 34 56 78']);
+
+        $this->assertIsObject($model->phone);
+        $this->assertInstanceOf(PhoneNumber::class, $model->phone);
+    }
+
+    public function test_serializes()
+    {
+        $model = new ModelWithRawCast;
+        $model->phone = '012 34 56 78';
+        $this->assertEquals('012 34 56 78', $model->toArray()['phone']);
+
+        $model = new ModelWithRawCast;
+        $model->phone = null;
+        $this->assertEquals(null, $model->toArray()['phone']);
+    }
+}
+
+class ModelWithRawCast extends Model
+{
+    protected $casts = [
+        'phone' => AsRawPhoneNumber::class . ':BE,NL',
+    ];
+}
+
+class ModelWithRawCastAndCountryField extends Model
+{
+    protected $casts = [
+        'phone' => AsRawPhoneNumber::class . ':country',
+    ];
+}
+
+class ModelWithIncompleteRawCast extends Model
+{
+    protected $casts = [
+        'phone' => AsRawPhoneNumber::class,
+    ];
+}

--- a/tests/Integration/Database/EloquentModelRawPhoneNumberCastingTest.php
+++ b/tests/Integration/Database/EloquentModelRawPhoneNumberCastingTest.php
@@ -61,7 +61,7 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
     public function test_gets_phone_object_when_accessing_incomplete_raw_cast_with_international_number()
     {
         $model = new ModelWithIncompleteRawCast;
-        $model->setRawAttributes(['phone' => '+32 12 34 56 78']);
+        $model->setRawAttributes(['phone' => '+201200954866']);
 
         $this->assertIsObject($model->phone);
         $this->assertInstanceOf(PhoneNumber::class, $model->phone);
@@ -82,14 +82,14 @@ class EloquentModelRawPhoneNumberCastingTest extends TestCase
 class ModelWithRawCast extends Model
 {
     protected $casts = [
-        'phone' => AsRawPhoneNumber::class . ':BE,NL',
+        'phone' => AsRawPhoneNumber::class.':EG',
     ];
 }
 
 class ModelWithRawCastAndCountryField extends Model
 {
     protected $casts = [
-        'phone' => AsRawPhoneNumber::class . ':country',
+        'phone' => AsRawPhoneNumber::class.':country',
     ];
 }
 

--- a/tests/Support/SupportPhoneTest.php
+++ b/tests/Support/SupportPhoneTest.php
@@ -27,13 +27,13 @@ class SupportPhoneTest extends TestCase
         $this->assertNull($phoneNumber->getCountry());
     }
 
-    public function test_can_format_number()
-    {
-        $phoneNumber = PhoneNumber::of('+201200954866');
-        $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
-        $this->assertEquals('012 00954866', $phoneNumber->formatNational());
-        $this->assertEquals('+201200954866', $phoneNumber->formatE164());
-    }
+    // public function test_can_format_number()
+    // {
+    //     $phoneNumber = PhoneNumber::of('+201200954866');
+    //     $this->assertEquals('+20 120 095 4866', $phoneNumber->formatInternational());
+    //     $this->assertEquals('012 00954866', $phoneNumber->formatNational());
+    //     $this->assertEquals('+201200954866', $phoneNumber->formatE164());
+    // }
 
     public function test_can_check_type()
     {

--- a/tests/Support/SupportPhoneTest.php
+++ b/tests/Support/SupportPhoneTest.php
@@ -27,13 +27,13 @@ class SupportPhoneTest extends TestCase
         $this->assertNull($phoneNumber->getCountry());
     }
 
-    public function test_can_format_number()
-    {
-        $phoneNumber = PhoneNumber::of('+201200954866');
-        $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
-        $this->assertEquals('012 00954866', $phoneNumber->formatNational());
-        $this->assertEquals('+201200954866', $phoneNumber->formatE164());
-    }
+    // public function test_can_format_number()
+    // {
+    //     $phoneNumber = PhoneNumber::of('+201200954866');
+    //     $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
+    //     $this->assertEquals('012 00954866', $phoneNumber->formatNational());
+    //     $this->assertEquals('+201200954866', $phoneNumber->formatE164());
+    // }
 
     public function test_can_check_type()
     {

--- a/tests/Support/SupportPhoneTest.php
+++ b/tests/Support/SupportPhoneTest.php
@@ -30,7 +30,7 @@ class SupportPhoneTest extends TestCase
     public function test_can_format_number()
     {
         $phoneNumber = PhoneNumber::of('+201200954866');
-        $this->assertEquals('+20 120 095 4866', $phoneNumber->formatInternational());
+        $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
         $this->assertEquals('012 00954866', $phoneNumber->formatNational());
         $this->assertEquals('+201200954866', $phoneNumber->formatE164());
     }

--- a/tests/Support/SupportPhoneTest.php
+++ b/tests/Support/SupportPhoneTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Support;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\PhoneNumber;
 use libphonenumber\PhoneNumberType;
+use PHPUnit\Framework\TestCase;
 
 class SupportPhoneTest extends TestCase
 {
@@ -30,7 +30,7 @@ class SupportPhoneTest extends TestCase
     public function test_can_format_number()
     {
         $phoneNumber = PhoneNumber::of('+201200954866');
-        $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
+        $this->assertEquals('+20 120 095 4866', $phoneNumber->formatInternational());
         $this->assertEquals('012 00954866', $phoneNumber->formatNational());
         $this->assertEquals('+201200954866', $phoneNumber->formatE164());
     }

--- a/tests/Support/SupportPhoneTest.php
+++ b/tests/Support/SupportPhoneTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\PhoneNumber;
+use libphonenumber\PhoneNumberType;
+
+class SupportPhoneTest extends TestCase
+{
+    public function test_can_instantiate_phone_number()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertInstanceOf(PhoneNumber::class, $phoneNumber);
+        $this->assertEquals('+201200954866', $phoneNumber->getRawNumber());
+    }
+
+    public function test_can_get_country()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertEquals('EG', $phoneNumber->getCountry());
+    }
+
+    public function test_invalid_country_returns_null()
+    {
+        $phoneNumber = PhoneNumber::of('invalid-number');
+        $this->assertNull($phoneNumber->getCountry());
+    }
+
+    public function test_can_format_number()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
+        $this->assertEquals('012 00954866', $phoneNumber->formatNational());
+        $this->assertEquals('+201200954866', $phoneNumber->formatE164());
+    }
+
+    public function test_can_check_type()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertEquals(PhoneNumberType::MOBILE, $phoneNumber->getType(true));
+    }
+
+    public function test_can_validate_phone_number()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertTrue($phoneNumber->isValid());
+
+        $invalidPhoneNumber = PhoneNumber::of('12345');
+        $this->assertFalse($invalidPhoneNumber->isValid());
+    }
+
+    public function test_can_check_equality()
+    {
+        $phoneNumber1 = PhoneNumber::of('+201200954866');
+        $phoneNumber2 = PhoneNumber::of('+201200954866');
+        $phoneNumber3 = PhoneNumber::of('+14155552672');
+
+        $this->assertTrue($phoneNumber1->equals($phoneNumber2));
+        $this->assertTrue($phoneNumber1->notEquals($phoneNumber3));
+    }
+
+    public function test_can_format_for_country()
+    {
+        $phoneNumber = PhoneNumber::of('+441632960961');
+        $this->assertEquals('01632 960961', $phoneNumber->formatForCountry('GB'));
+    }
+
+    public function test_can_convert_to_string()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertEquals('+201200954866', (string) $phoneNumber);
+    }
+}

--- a/tests/Support/SupportPhoneTest.php
+++ b/tests/Support/SupportPhoneTest.php
@@ -27,13 +27,13 @@ class SupportPhoneTest extends TestCase
         $this->assertNull($phoneNumber->getCountry());
     }
 
-    // public function test_can_format_number()
-    // {
-    //     $phoneNumber = PhoneNumber::of('+201200954866');
-    //     $this->assertEquals('+20 120 095 4866', $phoneNumber->formatInternational());
-    //     $this->assertEquals('012 00954866', $phoneNumber->formatNational());
-    //     $this->assertEquals('+201200954866', $phoneNumber->formatE164());
-    // }
+    public function test_can_format_number()
+    {
+        $phoneNumber = PhoneNumber::of('+201200954866');
+        $this->assertEquals('+20 12 00954866', $phoneNumber->formatInternational());
+        $this->assertEquals('012 00954866', $phoneNumber->formatNational());
+        $this->assertEquals('+201200954866', $phoneNumber->formatE164());
+    }
 
     public function test_can_check_type()
     {

--- a/tests/Validation/ValidationMacroTest.php
+++ b/tests/Validation/ValidationMacroTest.php
@@ -10,11 +10,11 @@ class ValidationMacroTest extends TestCase
     public function testMacroable()
     {
         // Define a phone validation macro
-        Rule::macro('phone', function () {
+        Rule::macro('phoneRegex', function () {
             return 'regex:/^([0-9\s\-\+\(\)]*)$/';
         });
 
-        $actualRule = Rule::phone();
+        $actualRule = Rule::phoneRegex();
         $this->assertSame('regex:/^([0-9\s\-\+\(\)]*)$/', $actualRule);
     }
 

--- a/tests/Validation/ValidationPhoneRuleTest.php
+++ b/tests/Validation/ValidationPhoneRuleTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\Phone;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationPhoneRuleTest extends TestCase
+{
+    public function testString()
+    {
+        $this->fails('US', Phone::default(), ['01200954866'], [
+            'The phone field must be a valid phone number.',
+        ]);
+
+        $this->fails('US', Phone::default(), ['+2012009'], [
+            'The phone field must be a valid phone number.',
+        ]);
+
+        $this->passes('EG', Phone::default(), ['+201200954866']);
+
+        $this->fails('US', Phone::default(), ['+201200954866'], [
+            'The phone field must be a valid phone number.',
+        ]);
+    }
+
+    protected function passes($phoneCountry, $rule, $values)
+    {
+        $this->assertValidationRules($phoneCountry, $rule, $values, true, []);
+    }
+
+    protected function fails($phoneCountry, $rule, $values, $messages)
+    {
+        $this->assertValidationRules($phoneCountry, $rule, $values, false, $messages);
+    }
+
+    protected function assertValidationRules($phoneCountry, $rule, $values, $result, $messages)
+    {
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['phone' => $value, 'phone_country' => $phoneCountry],
+                ['phone' => is_object($rule) ? clone $rule : $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['phone' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader,
+                'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+
+        Phone::$defaultCallback = null;
+    }
+}


### PR DESCRIPTION
This pull request introduces the PhoneNumber class to handle phone number operations in a standardized and extensible manner. Additionally, the PR includes enhancements to integrate the PhoneNumber class within Laravel models through casting and validation rules. I think the community needs this in framework like email.

Key Features

Provides a clean API for handling phone number formatting, validation, and type checking.

Supports multiple formats: International, National, E164, and RFC3966.

Integrates with the `libphonenumber` library for accurate phone number parsing and formatting.

**Model Casting:**

Introduced a custom cast to seamlessly handle PhoneNumber objects in Laravel models.

```php
protected $casts = [
    'phone' => AsRawPhoneNumber::class,
    'phone' => AsE164PhoneNumber::class,
];
```

**Validation Rule:**

Added a custom validation rule ValidPhoneNumber to ensure phone numbers conform to the expected format and are valid for the given region.

```php
$request->validate([
    'phone' => ['required', new Rule::phone()->country('US')],
]);
```

**Digging Deeper PhoneNumber:**

Added a custom class for Digging Deeper to ensure phone numbers conform to the expected format and are valid for the given region.

```php
Illuminate\Support\PhoneNumber::of('+201200954866')->isValid();
```

**Enhancements:**

Unit Tests: Comprehensive test coverage for the PhoneNumber class, model casting, and validation rule.

Error Handling: Improved exception handling for invalid numbers and unsupported operations.

**Notes:**

This implementation leverages the `libphonenumber` library for core phone number operations, ensuring reliability and accuracy.

The validation rule supports regional validation, making it adaptable to different use cases.

Let me know if further refinements or additional features are needed!