### PR TITLE
[11.x] Fix unique jobs that have a uniqueVia method

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -638,7 +638,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return string|null
      */
-    protected function getName()
+    public function getName()
     {
         return $this->config['store'] ?? null;
     }

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Exception;
 use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
@@ -49,6 +50,14 @@ class UniqueJobTest extends QueueTestCase
         $this->assertFalse(
             $this->app->get(Cache::class)->lock($this->getLockKey(UniqueTestJob::class), 10)->get()
         );
+    }
+
+    public function testUniqueJobWithViaDispatched()
+    {
+        Bus::fake();
+
+        UniqueViaJob::dispatch();
+        Bus::assertDispatched(UniqueViaJob::class);
     }
 
     public function testLockIsReleasedForSuccessfulJobs()
@@ -220,5 +229,13 @@ class UniqueTestSerializesModelsJob extends UniqueTestJob
 
     public function __construct(public User $user)
     {
+    }
+}
+
+class UniqueViaJob extends UniqueTestJob
+{
+    public function uniqueVia(): Cache
+    {
+        return Container::getInstance()->make(Cache::class);
     }
 }


### PR DESCRIPTION
This pertains to issue #54293.

Adds a test for a unique job that has a `uniqueVia` method and makes `Illuminate\Cache\Repository::getName()` public.