### PR TITLE
[11.x] Adds support to allow specifying number of days to keep failed jobs in DynamoDB

### DIFF
--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -48,7 +48,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      * @param  int  $expireDays
      * @return void
      */
-    public function __construct(DynamoDbClient $dynamo, $applicationName, $table, $expireDays)
+    public function __construct(DynamoDbClient $dynamo, $applicationName, $table, $expireDays = 3)
     {
         $this->table = $table;
         $this->dynamo = $dynamo;

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -33,18 +33,27 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     protected $table;
 
     /**
+     * The number of days a failed job should be retained.
+     *
+     * @var string
+     */
+    protected $expireDays;
+
+    /**
      * Create a new DynamoDb failed job provider.
      *
      * @param  \Aws\DynamoDb\DynamoDbClient  $dynamo
      * @param  string  $applicationName
      * @param  string  $table
+     * @param  string  $expireDays
      * @return void
      */
-    public function __construct(DynamoDbClient $dynamo, $applicationName, $table)
+    public function __construct(DynamoDbClient $dynamo, $applicationName, $table, $expireDays)
     {
         $this->table = $table;
         $this->dynamo = $dynamo;
         $this->applicationName = $applicationName;
+        $this->expireDays = (int) $expireDays;
     }
 
     /**
@@ -72,7 +81,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
                 'payload' => ['S' => $payload],
                 'exception' => ['S' => (string) $exception],
                 'failed_at' => ['N' => (string) $failedAt->getTimestamp()],
-                'expires_at' => ['N' => (string) $failedAt->addDays(3)->getTimestamp()],
+                'expires_at' => ['N' => (string) $failedAt->addDays($this->expireDays)->getTimestamp()],
             ],
         ]);
 

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -35,7 +35,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     /**
      * The number of days a failed job should be retained.
      *
-     * @var string
+     * @var int
      */
     protected $expireDays;
 
@@ -45,7 +45,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      * @param  \Aws\DynamoDb\DynamoDbClient  $dynamo
      * @param  string  $applicationName
      * @param  string  $table
-     * @param  string  $expireDays
+     * @param  int  $expireDays
      * @return void
      */
     public function __construct(DynamoDbClient $dynamo, $applicationName, $table, $expireDays)
@@ -53,7 +53,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
         $this->table = $table;
         $this->dynamo = $dynamo;
         $this->applicationName = $applicationName;
-        $this->expireDays = (int) $expireDays;
+        $this->expireDays = $expireDays;
     }
 
     /**

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -324,7 +324,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         return new DynamoDbFailedJobProvider(
             new DynamoDbClient($dynamoConfig),
             $this->app['config']['app.name'],
-            $config['table']
+            $config['table'],
+            $config['expire_days'] ?? '3'
         );
     }
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -325,7 +325,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             new DynamoDbClient($dynamoConfig),
             $this->app['config']['app.name'],
             $config['table'],
-            $config['expire_days'] ?? '3'
+            $config['expire_days'] ?? 3
         );
     }
 

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -47,7 +47,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
 
         $provider->log('connection', 'queue', json_encode(['uuid' => (string) $uuid]), $exception);
 
@@ -83,7 +83,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
 
         $response = $provider->all();
 
@@ -124,7 +124,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
 
         $response = $provider->find('id');
 
@@ -152,7 +152,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ])->andReturn([]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
 
         $response = $provider->find('id');
 
@@ -171,7 +171,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ])->andReturn([]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
 
         $provider->forget('id');
     }

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -47,7 +47,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', 3);
 
         $provider->log('connection', 'queue', json_encode(['uuid' => (string) $uuid]), $exception);
 
@@ -83,7 +83,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', 3);
 
         $response = $provider->all();
 
@@ -124,7 +124,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', 3);
 
         $response = $provider->find('id');
 
@@ -152,7 +152,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ])->andReturn([]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', 3);
 
         $response = $provider->find('id');
 
@@ -171,7 +171,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             ],
         ])->andReturn([]);
 
-        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', '3');
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table', 3);
 
         $provider->forget('id');
     }


### PR DESCRIPTION
This PR adds a new config option for queue.failed (when using DynamoDB): `expire_days` 

Story: 3 days seems awfully short, depending on the size of your company, as there may be designated periods of time where failed jobs are triaged and handled. 

This allows controlling the expires_at value for jobs that are inserted into DynamoDB, defaulted to 3 for consistency.

___

This pull request introduces changes to the `DynamoDbFailedJobProvider` class to make the expiration period for failed jobs configurable. The main modifications include adding a new property for expiration days, updating the constructor to accept this new parameter, and adjusting the tests to accommodate this change.

Key changes:

### Configuration of Expiration Days:
* [`src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php`](diffhunk://#diff-6564c27ed10f68bdd2785962c4dea912445d4eeb10a44cf942093aa13cee1b8bR35-R56): Added a new protected property `expireDays`, updated the constructor to accept `expireDays` as a parameter, and modified the `log` method to use the configurable expiration period. [[1]](diffhunk://#diff-6564c27ed10f68bdd2785962c4dea912445d4eeb10a44cf942093aa13cee1b8bR35-R56) [[2]](diffhunk://#diff-6564c27ed10f68bdd2785962c4dea912445d4eeb10a44cf942093aa13cee1b8bL75-R84)

### Service Provider Adjustment:
* [`src/Illuminate/Queue/QueueServiceProvider.php`](diffhunk://#diff-04e8885d3921a29da5b539057c3f2a18df92c38a353053aec8435bd731681614L327-R328): Updated the `dynamoFailedJobProvider` method to pass the `expire_days` configuration value, defaulting to '3' if not provided.

### Test Updates:
* [`tests/Queue/DynamoDbFailedJobProviderTest.php`](diffhunk://#diff-010487d864635ab0c867c9b6afec4507475084b7738b9893372213ccf0751d16L50-R50): Updated multiple test methods to include the `expireDays` parameter when creating `DynamoDbFailedJobProvider` instances. [[1]](diffhunk://#diff-010487d864635ab0c867c9b6afec4507475084b7738b9893372213ccf0751d16L50-R50) [[2]](diffhunk://#diff-010487d864635ab0c867c9b6afec4507475084b7738b9893372213ccf0751d16L86-R86) [[3]](diffhunk://#diff-010487d864635ab0c867c9b6afec4507475084b7738b9893372213ccf0751d16L127-R127) [[4]](diffhunk://#diff-010487d864635ab0c867c9b6afec4507475084b7738b9893372213ccf0751d16L155-R155) [[5]](diffhunk://#diff-010487d864635ab0c867c9b6afec4507475084b7738b9893372213ccf0751d16L174-R174)