### PR TITLE
[11.x] Add additional test cases for Arr helper to enhance coverage

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -39,6 +39,10 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
         $this->assertEquals([1 => 'hAz'], Arr::add([], 1, 'hAz'));
         $this->assertEquals([1 => [1 => 'hAz']], Arr::add([], 1.1, 'hAz'));
+
+        // Case where the key already exists
+        $this->assertEquals(['type' => 'Table'], Arr::add(['type' => 'Table'], 'type', 'Chair'));
+        $this->assertEquals(['category' => ['type' => 'Table']], Arr::add(['category' => ['type' => 'Table']], 'category.type', 'Chair'));
     }
 
     public function testCollapse()
@@ -48,8 +52,8 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
 
         // Case including numeric and string elements
-        $array = [[1], [2], [3], ['foo', 'bar'], collect(['baz', 'boom'])];
-        $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($array));
+        $array = [[1], [2], [3], ['foo', 'bar']];
+        $this->assertEquals([1, 2, 3, 'foo', 'bar'], Arr::collapse($array));
 
         // Case with empty two-dimensional arrays
         $emptyArray = [[], [], []];
@@ -504,6 +508,10 @@ class SupportArrTest extends TestCase
         $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', function () {
             return 'dayle';
         }));
+
+        // Test array has a null key
+        $this->assertSame('bar', Arr::get(['' => 'bar'], ''));
+        $this->assertSame('bar', Arr::get(['' => ['' => 'bar']], '.'));
     }
 
     public function testHas()
@@ -619,6 +627,9 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::isList([0 => 'foo', 'bar']));
         $this->assertTrue(Arr::isList([0 => 'foo', 1 => 'bar']));
 
+
+        $this->assertFalse(Arr::isList([-1 => 1]));
+        $this->assertFalse(Arr::isList([-1 => 1, 0 => 2]));
         $this->assertFalse(Arr::isList([1 => 'foo', 'bar']));
         $this->assertFalse(Arr::isList([1 => 'foo', 0 => 'bar']));
         $this->assertFalse(Arr::isList([0 => 'foo', 'bar' => 'baz']));
@@ -632,6 +643,17 @@ class SupportArrTest extends TestCase
         $array = Arr::only($array, ['name', 'price']);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
+
+        $this->assertEmpty(Arr::only($array, null));
+
+        // Test with array having numeric keys
+        $this->assertEquals(['foo'], Arr::only(['foo', 'bar', 'baz'], 0));
+        $this->assertEquals([1 => 'bar', 2 =>'baz'], Arr::only(['foo', 'bar', 'baz'], [1, 2]));
+        $this->assertEmpty(Arr::only(['foo', 'bar', 'baz'], [3]));
+
+        // Test with array having numeric key and string key
+        $this->assertEquals(['foo'], Arr::only(['foo', 'bar' => 'baz'], 0));
+        $this->assertEquals(['bar' => 'baz'], Arr::only(['foo', 'bar' => 'baz'], 'bar'));
     }
 
     public function testPluck()
@@ -1501,5 +1523,15 @@ class SupportArrTest extends TestCase
                 'name' => 'Abigail',
             ],
         ], Arr::select($array, 'name'));
+
+        $this->assertEquals([
+            [],
+            [],
+        ], Arr::select($array, 'nonExistingKey'));
+
+        $this->assertEquals([
+            [],
+            [],
+        ], Arr::select($array, null));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -627,7 +627,6 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::isList([0 => 'foo', 'bar']));
         $this->assertTrue(Arr::isList([0 => 'foo', 1 => 'bar']));
 
-
         $this->assertFalse(Arr::isList([-1 => 1]));
         $this->assertFalse(Arr::isList([-1 => 1, 0 => 2]));
         $this->assertFalse(Arr::isList([1 => 'foo', 'bar']));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -648,7 +648,7 @@ class SupportArrTest extends TestCase
 
         // Test with array having numeric keys
         $this->assertEquals(['foo'], Arr::only(['foo', 'bar', 'baz'], 0));
-        $this->assertEquals([1 => 'bar', 2 =>'baz'], Arr::only(['foo', 'bar', 'baz'], [1, 2]));
+        $this->assertEquals([1 => 'bar', 2 => 'baz'], Arr::only(['foo', 'bar', 'baz'], [1, 2]));
         $this->assertEmpty(Arr::only(['foo', 'bar', 'baz'], [3]));
 
         // Test with array having numeric key and string key


### PR DESCRIPTION
This PR adds new test cases for the ```Arr``` helper to improve test coverage. The changes include:

1. ```Arr::add()```: Add cases where key already exists
2. ```Arr::collapse()```: Remove duplicate case
3. ```Arr::get()```: Add cases where array has a empty key
4. ```Arr::isList()```: Add cases with negative keys
5. ```Arr::only()```: Add cases with numeric keys
6. ```Arr::select()```: Add cases with null / non-exists $keys