### PR TITLE
[11.x] Add IncrementOrCreate method to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -623,6 +623,23 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Create a record matching the attributes, or increment the existing record.
+     *
+     * @param  array  $attributes
+     * @param  string  $column
+     * @param  int  $default
+     * @return TModel
+     */
+    public function incrementOrCreate(array $attributes, string $column = 'count', $default = 1)
+    {
+        return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column) {
+           if (! $instance->wasRecentlyCreated) {
+               $instance->increment($column);
+           }
+        });
+    }
+
+    /**
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -627,14 +627,16 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  string  $column
-     * @param  int  $default
+     * @param  int|float  $default
+     * @param  int|float  $step
+     * @param  array  $extra
      * @return TModel
      */
-    public function incrementOrCreate(array $attributes, string $column = 'count', $default = 1)
+    public function incrementOrCreate(array $attributes, string $column = 'count', $default = 1, $step = 1, array $extra = [])
     {
-        return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column) {
-           if (! $instance->wasRecentlyCreated) {
-               $instance->increment($column);
+        return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column, $step, $extra) {
+            if (! $instance->wasRecentlyCreated) {
+                $instance->increment($column, $step, $extra);
            }
         });
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -637,7 +637,7 @@ class Builder implements BuilderContract
         return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column, $step, $extra) {
             if (! $instance->wasRecentlyCreated) {
                 $instance->increment($column, $step, $extra);
-           }
+            }
         });
     }
 

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -300,7 +300,8 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
-    public function testIncrementOrCreateMethodIncrementsExistingRecord(): void {
+    public function testIncrementOrCreateMethodIncrementsExistingRecord(): void
+    {
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
@@ -341,7 +342,8 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
-    public function testIncrementOrCreateMethodCreatesNewRecord(): void {
+    public function testIncrementOrCreateMethodCreatesNewRecord(): void
+    {
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite', [123]);
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
@@ -412,7 +414,8 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
-    public function testIncrementOrCreateMethodRetrievesRecordCreatedJustNow(): void {
+    public function testIncrementOrCreateMethodRetrievesRecordCreatedJustNow(): void
+    {
         $model = new EloquentBuilderCreateOrFirstTestModel();
         $this->mockConnectionForModel($model, 'SQLite');
         $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
@@ -437,7 +440,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
             ->andReturn([[
                 'id' => 123,
                 'attr' => 'foo',
-                'count' =>  1 ,
+                'count' => 1,
                 'created_at' => '2023-01-01 00:00:00',
                 'updated_at' => '2023-01-01 00:00:00',
             ]]);
@@ -446,7 +449,6 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
             ->expects('raw')
             ->with('"count" + 1')
             ->andReturn('2');
-
 
         $model->getConnection()
             ->expects('update')

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -300,6 +300,129 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
+    public function testIncrementOrCreateMethodIncrementsExistingRecord(): void {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'count' => 1,
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('raw')
+            ->with('"count" + 1')
+            ->andReturn('2');
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "count" = ?, "updated_at" = ? where "id" = ?',
+                ['2', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $result = $model->newQuery()->incrementOrCreate(['attr' => 'foo'], 'count');
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 2,
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testIncrementOrCreateMethodCreatesNewRecord(): void {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite', [123]);
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([]);
+
+        $model->getConnection()->expects('insert')->with(
+            'insert into "table" ("attr", "count", "updated_at", "created_at") values (?, ?, ?, ?)',
+            ['foo', '1', '2023-01-01 00:00:00', '2023-01-01 00:00:00'],
+        )->andReturnTrue();
+
+        $result = $model->newQuery()->incrementOrCreate(['attr' => 'foo']);
+        $this->assertTrue($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 1,
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testIncrementOrCreateMethodRetrievesRecordCreatedJustNow(): void {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([]);
+
+        $sql = 'insert into "table" ("attr", "count", "updated_at", "created_at") values (?, ?, ?, ?)';
+        $bindings = ['foo', '1', '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
+
+        $model->getConnection()
+            ->expects('insert')
+            ->with($sql, $bindings)
+            ->andThrow(new UniqueConstraintViolationException('sqlite', $sql, $bindings, new Exception()));
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], false)
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'count' =>  1 ,
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('raw')
+            ->with('"count" + 1')
+            ->andReturn('2');
+
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "count" = ?, "updated_at" = ? where "id" = ?',
+                ['2', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $result = $model->newQuery()->incrementOrCreate(['attr' => 'foo']);
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 2,
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
     protected function mockConnectionForModel(Model $model, string $database, array $lastInsertIds = []): void
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';


### PR DESCRIPTION
Laravel has methods like `updateOrCreate`, `firstOrCreate` and such. I think `incrementOrCreate` fits Eloquent, and to be fair I expected it existed already.

##### The use case: 
Let's imagine we are tracking the exceptions in our application, but we don't want to add a new record every time the same exception occurred but we want to update the number of times the exception happened.

```php
BackendException::incrementOrCreate(['name' => $name, 'file' => $file, 'line' => $line]);
```

This method will create a new model with ```['count' => 1]``` the first time the exception happens, and increment the `count` attribute for the next occurencies.

The column name and the default increment value can also be customized.

```php
BackendException::incrementOrCreate($attributes, 'occurrences', 0);
```

You can also pass [`increment()`](https://laravel.com/docs/11.x/queries#increment-and-decrement) `$step` and `$extra` parameters.

```php
BackendException::incrementOrCreate($attributes, step: 2, extra: ['trace' => $trace]);
```