### PR TITLE
[12.x] Add query builder operator enums

### DIFF
--- a/src/Illuminate/Database/Enums/Comperator.php
+++ b/src/Illuminate/Database/Enums/Comperator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Database\Enums;
+
+enum Comperator: string
+{
+    case Equals = '=';
+    case LessThan = '<';
+    case GreaterThan = '>';
+    case LessThanOrEqual = '<=';
+    case GreaterThanOrEqual = '>=';
+    case NotEqual = '!=';
+    case AnsiNotEqual = '<>'; // same as Comperator::NotEqual
+    case Spaceship = '<=>'; // null-safe equal
+    case Like = 'like';
+    case LikeBinary = 'like binary';
+    case NotLike = 'not like';
+    case CaseInsensitiveLike = 'ilike';
+    case BitwiseAnd = '&';
+    case BitwiseOr = '|';
+    case Caret = '^';
+    case BitwiseShiftLeft = '<<';
+    case BitwiseShiftRight = '>>';
+    case BitwiseAndNot = '&~';
+    case Is = 'is';
+    case IsNot = 'is not';
+    case RegularExpressionLike = 'rlike';
+    case NotRegularExpressionLike = 'not rlike';
+    case RegularExpression = 'regexp';
+    case NotRegularExpression = 'not regexp';
+    case Match = '~';
+    case MatchCaseInsensitive = '~*';
+    case NotMatch = '!~';
+    case NotMatchCaseInsensitive = '!~*';
+    case SimilarTo = 'similar to';
+    case NotSimilarTo = 'not similar to';
+    case NotCaseInsensitiveLike = 'not ilike';
+    case MatchLikeCaseInsensitive = '~~*';
+    case NotMatchLikeCaseInsensitive = '!~~*';
+}

--- a/src/Illuminate/Database/Enums/LogicalOperator.php
+++ b/src/Illuminate/Database/Enums/LogicalOperator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Database\Enums;
+
+enum LogicalOperator: string
+{
+    case And = 'and';
+    case Or = 'or';
+}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -16,7 +16,6 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Enums\Comperator;
-use Illuminate\Database\Enums\LogicalOperator;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Pagination\Paginator;
@@ -953,7 +952,7 @@ class Builder implements BuilderContract
     {
         if ($useDefault) {
             return [$operator, '='];
-        } elseif (!($operator instanceof Comperator) && $this->invalidOperatorAndValue($operator, $value)) {
+        } elseif (! ($operator instanceof Comperator) && $this->invalidOperatorAndValue($operator, $value)) {
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Enums\Comperator;
+use Illuminate\Database\Enums\LogicalOperator;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Pagination\Paginator;
@@ -814,11 +816,13 @@ class Builder implements BuilderContract
      * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @param  string  $boolean
+     * @param  string|\Illuminate\Database\Enums\LogicalOperator  $boolean
      * @return $this
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+        $boolean = enum_value($boolean);
+
         if ($column instanceof ConditionExpression) {
             $type = 'Expression';
 
@@ -939,7 +943,7 @@ class Builder implements BuilderContract
      * Prepare the value and operator for a where clause.
      *
      * @param  string  $value
-     * @param  string  $operator
+     * @param  string|\Illuminate\Database\Enums\Comperator  $operator
      * @param  bool  $useDefault
      * @return array
      *
@@ -949,11 +953,11 @@ class Builder implements BuilderContract
     {
         if ($useDefault) {
             return [$operator, '='];
-        } elseif ($this->invalidOperatorAndValue($operator, $value)) {
+        } elseif (!($operator instanceof Comperator) && $this->invalidOperatorAndValue($operator, $value)) {
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        return [$value, $operator];
+        return [$value, enum_value($operator)];
     }
 
     /**

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -641,23 +641,23 @@ class QueryBuilderTest extends DatabaseTestCase
     }
 
     #[DataProvider('providesWhereOperators')]
-    public function testWhereOperatorEnums($value, $operator, $output)
+    public function testWhereOperatorEnums($value, $operator, $useDefault, $output)
     {
         $connection = DB::table('accounting')->getConnection();
         if ($output === false) {
             $this->expectException(InvalidArgumentException::class);
             $this->expectExceptionMessage('Illegal operator and value combination.');
         }
-        $this->assertSame($output, (new Builder($connection))->prepareValueAndOperator($value, $operator, $operator === null));
+        $this->assertSame($output, (new Builder($connection))->prepareValueAndOperator($value, $operator, $useDefault));
     }
 
     public static function providesWhereOperators()
     {
         return [
-            // 'simple where with default operator' => [ 'gibberish', null, [ 'gibberish', '=' ] ],
-            'simple where with explicit string operator' => [ 'gibberish', '=', [ 'gibberish', '=' ] ],
-            'simple where with non-nullable operator' => [ null, 'like', false ],
-            'simple where with explicit enum operator' => [ 'gibberish', Comperator::Equals, [ 'gibberish', '=' ] ],
+            'simple where with default operator' => [ 'gibberish', 'gibberish', true, [ 'gibberish', '=' ] ],
+            'simple where with explicit string operator' => [ 'gibberish', '=', false, [ 'gibberish', '=' ] ],
+            'simple where with non-nullable operator' => [ null, 'like', false, false ],
+            'simple where with explicit enum operator' => [ 'gibberish', Comperator::Equals, false, [ 'gibberish', '=' ] ],
         ];
     }
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -654,10 +654,10 @@ class QueryBuilderTest extends DatabaseTestCase
     public static function providesWhereOperators()
     {
         return [
-            'simple where with default operator' => [ 'gibberish', 'gibberish', true, [ 'gibberish', '=' ] ],
-            'simple where with explicit string operator' => [ 'gibberish', '=', false, [ 'gibberish', '=' ] ],
-            'simple where with non-nullable operator' => [ null, 'like', false, false ],
-            'simple where with explicit enum operator' => [ 'gibberish', Comperator::Equals, false, [ 'gibberish', '=' ] ],
+            'simple where with default operator' => ['gibberish', 'gibberish', true, ['gibberish', '=']],
+            'simple where with explicit string operator' => ['gibberish', '=', false, ['gibberish', '=']],
+            'simple where with non-nullable operator' => [null, 'like', false, false],
+            'simple where with explicit enum operator' => ['gibberish', Comperator::Equals, false, [ 'gibberish', '=']],
         ];
     }
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Enums\Comperator;
+use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
@@ -657,7 +657,7 @@ class QueryBuilderTest extends DatabaseTestCase
             'simple where with default operator' => ['gibberish', 'gibberish', true, ['gibberish', '=']],
             'simple where with explicit string operator' => ['gibberish', '=', false, ['gibberish', '=']],
             'simple where with non-nullable operator' => [null, 'like', false, false],
-            'simple where with explicit enum operator' => ['gibberish', Comperator::Equals, false, [ 'gibberish', '=']],
+            'simple where with explicit enum operator' => ['gibberish', Comperator::Equals, false, ['gibberish', '=']],
         ];
     }
 


### PR DESCRIPTION
**Comperator**
```php
use Illuminate\Database\Enums\Comperator;

DB::table('users')->where('name', Comperator::Equals, 'John Doe');
```
**LogicalOperator**
```php
use Illuminate\Database\Enums\LogicalOperator;

DB::table('users')->where('name', '=', 'John Doe', LogicalOperator::Or);
```