### PR TITLE
fix(broadcaster): incorrect channel matching because of dot in pattern

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -373,6 +373,7 @@ abstract class Broadcaster implements BroadcasterContract
     protected function channelNameMatchesPattern($channel, $pattern)
     {
         $pattern = str_replace('.', '\.', $pattern);
+
         return preg_match('/^'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -372,6 +372,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function channelNameMatchesPattern($channel, $pattern)
     {
+        $pattern = str_replace('.', '\.', $pattern);
         return preg_match('/^'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
     }
 

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -30,6 +30,19 @@ class UsePusherChannelsNamesTest extends TestCase
         );
     }
 
+    public function testChannelNamePatternMatching()
+    {
+        $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
+
+        $this->assertEquals(
+            0,
+            $broadcaster->testChannelNameMatchesPattern(
+                'TestChannel',
+                'Test.{id}'
+            )
+        );
+    }
+
     #[DataProvider('channelsProvider')]
     public function testIsGuardedChannel($requestChannelName, $_, $guarded)
     {
@@ -102,5 +115,10 @@ class FakeBroadcasterUsingPusherChannelsNames extends Broadcaster
     public function broadcast(array $channels, $event, array $payload = [])
     {
         //
+    }
+
+    public function testChannelNameMatchesPattern($channel, $pattern)
+    {
+        return $this->channelNameMatchesPattern($channel, $pattern);
     }
 }


### PR DESCRIPTION
**Issue:** Because of the dot in the pattern, Broadcaster can resolve an incorrect channel. For example, if we have two channels `orders.{id}` and `ordersShipment`, and `orders.{id}` was added earlier than `ordersShipment`, then when trying to authorize in the `ordersShipment` channel, the `orders.{id}` channel will be resolved, because in regular expressions `.` is any character