### PR TITLE
[11.x] Add multiple method signatures for where in PHPDoc block

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -38,7 +38,7 @@ use function Illuminate\Support\enum_value;
  * @method self where(\Closure(): mixed)
  * @method self where(array<string, mixed> $column)
  * @method self where((array{string, 'and'|'or', mixed}|array{string, mixed}|array{column: string, operator?: 'and'|'or', value: mixed})[] $column)
- * @method self where(\Closure|string|array|\Illuminate\Contracts\Database\Query\Expression $column, mixed $operator, mixed $value, string $boolean)
+ * @method self where(\Closure|string|array|\Illuminate\Contracts\Database\Query\Expression $column, mixed $operator  null, mixed $value = null, string $boolean = 'and')
  */
 class Builder implements BuilderContract
 {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -31,6 +31,14 @@ use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 
+/**
+ * @method self where(string $column, $value)
+ * @method self where(string $column, string $operator, $value)
+ * @method self where(string $column, string $operator, $value, 'and'|'or' $boolean)
+ * @method self where(\Closure(): mixed)
+ * @method self where(array<string, mixed> $column)
+ * @method self where((array{string, 'and'|'or', mixed}|array{string, mixed}|array{column: string, operator?: 'and'|'or', value: mixed})[] $column)
+ */
 class Builder implements BuilderContract
 {
     /** @use \Illuminate\Database\Concerns\BuildsQueries<object> */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -38,6 +38,7 @@ use function Illuminate\Support\enum_value;
  * @method self where(\Closure(): mixed)
  * @method self where(array<string, mixed> $column)
  * @method self where((array{string, 'and'|'or', mixed}|array{string, mixed}|array{column: string, operator?: 'and'|'or', value: mixed})[] $column)
+ * @method self where(\Closure|string|array|\Illuminate\Contracts\Database\Query\Expression $column, mixed $operator, mixed $value, string $boolean)
  */
 class Builder implements BuilderContract
 {


### PR DESCRIPTION
Looks something like this in the IDE:
![grafik](https://github.com/user-attachments/assets/6c44d863-6fde-4c56-977c-8bc16c3e7dd2)
