### PR TITLE
Add self to HasCollection type param in Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -38,7 +38,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\GuardsAttributes,
         Concerns\PreventsCircularRecursion,
         ForwardsCalls;
-    /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static>> */
+    /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
 
     /**


### PR DESCRIPTION
# Summary
Psalm is giving me this error when trying to extend the Model class.
`Extended template param TModel of Illuminate\Database\Eloquent\Collection<array-key, static> expects type Illuminate\Database\Eloquent\Model, type static given (see https://psalm.dev/183)`

The proposed change solves the error by indicating that whatever type resolved by `static` should also resolve as `self` AKA Model, according to the Collection template requirement.

My composer.json has:
```
        "php": "^8.3",
        "laravel/framework": "^11.0",
...
        "vimeo/psalm": "5.26.1",
        "psalm/plugin-laravel": "^2.11"
```