### PR TITLE
Add whenGrouped to query builders.

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -590,6 +590,6 @@ trait BuildsQueries
      */
     public function whenGrouped($value = null, ?callable $callback = null, ?callable $default = null)
     {
-        return $this->where(fn($query) => $query->when($value, $callback, $default));
+        return $this->where(fn ($query) => $query->when($value, $callback, $default));
     }
 }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -576,4 +576,20 @@ trait BuildsQueries
 
         return $this;
     }
+
+    /**
+     * Apply the callback inside a grouped where if the given "value" is (or resolves to) truthy.
+     *
+     * @template TWhenParameter
+     * @template TWhenReturnType
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function whenGrouped($value = null, ?callable $callback = null, ?callable $default = null)
+    {
+        return $this->where(fn($query) => $query->when($value, $callback, $default));
+    }
 }


### PR DESCRIPTION
# Purpose of this PR
The Laravel query builder supports both the helpful `when` method for conditionally modifying the query, and also nested `where` calls for grouping conditions.

However, if you want to combine these two method you end up with a difficult to read boilerplate chain of `fn(Builder $query) => $query->where(fn(Builder $query) => $query->...)` E.g.
```php
$query
  ->where('column_a', 'value_a')
  ->when($condition, fn(Builder $query) => $query->where(fn(Builder $query) => $query
    ->where('column_b', 'value_b')
    ->orWhere('column_c', 'value_c')
  ));
```

This PR adds a new `whenGrouped` method to allow the above to become
```php
$query
  ->where('column_a', 'value_a')
  ->whenGrouped($condition, fn(Builder $query) => $query
    ->where('column_b', 'value_b')
    ->orWhere('column_c', 'value_c')
  );
```

We could change the name of this method, e.g. maybe `whenWhere` might be better?

# Tests?
I investigated adding tests for this, but concluded that there's really nothing to test here as we're just adding some syntactic sugar.