### PR TITLE
[12.x] Fix Session's `getCookieExpirationDate` incompatibility with Carbon 3

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -266,7 +266,7 @@ class StartSession
         $config = $this->manager->getSessionConfig();
 
         return $config['expire_on_close'] ? 0 : Date::instance(
-            Carbon::now()->addMinutes($config['lifetime'])
+            Carbon::now()->addMinutes((int) $config['lifetime'])
         );
     }
 


### PR DESCRIPTION

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
