### PR TITLE
[11.x] feat: Create missing pgsql database when running migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -276,8 +276,6 @@ class MigrateCommand extends BaseCommand implements Isolatable
             ), function () {
                 $this->laravel['db']->purge();
             });
-        } catch (Throwable $e) {
-            dd($e);
         } finally {
             $this->laravel['config']->set("database.connections.{$connection->getName()}.database", $connection->getDatabaseName());
         }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -191,7 +191,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
             || (
                 ($e->getPrevious()->errorInfo[0] ?? null) == '08006'
                 && $connection->getDriverName() == 'pgsql'
-                && Str::contains($e->getPrevious()->getMessage(), '"'.$connection->getDatabaseName().'" does not exist')
+                && Str::contains($e->getPrevious()->getMessage(), '"'.$connection->getDatabaseName().'"')
             )
         ) {
             return $this->createMissingMySqlOrPgsqlDatabase($connection);

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -173,8 +173,10 @@ class MigrateCommand extends BaseCommand implements Isolatable
 
     /**
      * Attempt to create the database if it's missing.
+     *
+     * @return bool
      */
-    protected function handleMissingDatabase(Throwable $e): bool
+    protected function handleMissingDatabase(Throwable $e)
     {
         if ($e instanceof SQLiteDatabaseDoesNotExistException) {
             return $this->createMissingSqliteDatabase($e->path);

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -172,8 +172,9 @@ class MigrateCommand extends BaseCommand implements Isolatable
     }
 
     /**
-     * Attempt to create the database if it's missing.
+     * Attempt to create the database if it is missing.
      *
+     * @param  \Throwable  $e
      * @return bool
      */
     protected function handleMissingDatabase(Throwable $e)
@@ -188,14 +189,10 @@ class MigrateCommand extends BaseCommand implements Isolatable
             return false;
         }
 
-        if (
-            ($e->getCode() === 1049 && in_array($connection->getDriverName(), ['mysql', 'mariadb']))
-            || (
-                ($e->errorInfo[0] ?? null) == '08006'
-                && $connection->getDriverName() == 'pgsql'
-                && Str::contains($e->getMessage(), '"'.$connection->getDatabaseName().'"')
-            )
-        ) {
+        if (($e->getCode() === 1049 && in_array($connection->getDriverName(), ['mysql', 'mariadb'])) ||
+            (($e->errorInfo[0] ?? null) == '08006' &&
+              $connection->getDriverName() == 'pgsql' &&
+              Str::contains($e->getMessage(), '"'.$connection->getDatabaseName().'"'))) {
             return $this->createMissingMySqlOrPgsqlDatabase($connection);
         }
 
@@ -234,6 +231,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     /**
      * Create a missing MySQL or Postgres database.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @return bool
      *
      * @throws \RuntimeException


### PR DESCRIPTION
This PR is the MySQL counterpart to #44153 
Create missing pgsql database like we do for MySQL(and SQLite) when running migrations

When creating a fresh Laravel install, it will fail
![image](https://github.com/user-attachments/assets/f9e67353-9a58-4e31-8499-303806d6847d)

