### PR TITLE
[11.x] Helper methods to dump responses of the Laravel HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
 use Stringable;
+use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * @mixin \Psr\Http\Message\ResponseInterface
@@ -300,6 +301,68 @@ class Response implements ArrayAccess, Stringable
         if ($this->failed()) {
             return new RequestException($this);
         }
+    }
+
+    /**
+     * Dump the content from the response.
+     *
+     * @param  string|null  $key
+     * @return $this
+     */
+    public function dump($key = null)
+    {
+        $content = $this->body();
+
+        $json = json_decode($content);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $content = $json;
+        }
+
+        if (! is_null($key)) {
+            dump(data_get($content, $key));
+        } else {
+            dump($content);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Dump the content from the response and end the script.
+     *
+     * @param  string|null  $key
+     * @return never
+     */
+    public function dd($key = null)
+    {
+        $this->dump($key);
+
+        exit(1);
+    }
+
+    /**
+     * Dump the headers from the response.
+     *
+     * @return $this
+     */
+    public function dumpHeaders()
+    {
+        dump($this->headers());
+
+        return $this;
+    }
+
+    /**
+     * Dump the headers from the response and end the script.
+     *
+     * @return never
+     */
+    public function ddHeaders()
+    {
+        $this->dumpHeaders();
+
+        exit(1);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
 use Stringable;
-use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * @mixin \Psr\Http\Message\ResponseInterface

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -303,68 +303,6 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Dump the content from the response.
-     *
-     * @param  string|null  $key
-     * @return $this
-     */
-    public function dump($key = null)
-    {
-        $content = $this->body();
-
-        $json = json_decode($content);
-
-        if (json_last_error() === JSON_ERROR_NONE) {
-            $content = $json;
-        }
-
-        if (! is_null($key)) {
-            dump(data_get($content, $key));
-        } else {
-            dump($content);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Dump the content from the response and end the script.
-     *
-     * @param  string|null  $key
-     * @return never
-     */
-    public function dd($key = null)
-    {
-        $this->dump($key);
-
-        exit(1);
-    }
-
-    /**
-     * Dump the headers from the response.
-     *
-     * @return $this
-     */
-    public function dumpHeaders()
-    {
-        dump($this->headers());
-
-        return $this;
-    }
-
-    /**
-     * Dump the headers from the response and end the script.
-     *
-     * @return never
-     */
-    public function ddHeaders()
-    {
-        $this->dumpHeaders();
-
-        exit(1);
-    }
-
-    /**
      * Throw an exception if a server or client error occurred.
      *
      * @return $this
@@ -456,6 +394,68 @@ class Response implements ArrayAccess, Stringable
     public function throwIfServerError()
     {
         return $this->serverError() ? $this->throw() : $this;
+    }
+
+    /**
+     * Dump the content from the response.
+     *
+     * @param  string|null  $key
+     * @return $this
+     */
+    public function dump($key = null)
+    {
+        $content = $this->body();
+
+        $json = json_decode($content);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $content = $json;
+        }
+
+        if (! is_null($key)) {
+            dump(data_get($content, $key));
+        } else {
+            dump($content);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Dump the content from the response and end the script.
+     *
+     * @param  string|null  $key
+     * @return never
+     */
+    public function dd($key = null)
+    {
+        $this->dump($key);
+
+        exit(1);
+    }
+
+    /**
+     * Dump the headers from the response.
+     *
+     * @return $this
+     */
+    public function dumpHeaders()
+    {
+        dump($this->headers());
+
+        return $this;
+    }
+
+    /**
+     * Dump the headers from the response and end the script.
+     *
+     * @return never
+     */
+    public function ddHeaders()
+    {
+        $this->dumpHeaders();
+
+        exit(1);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1606,6 +1606,63 @@ class HttpClientTest extends TestCase
         VarDumper::setHandler(null);
     }
 
+    public function testResponseCanDump()
+    {
+        $dumped = [];
+
+        VarDumper::setHandler(function ($value) use (&$dumped) {
+            $dumped[] = $value;
+        });
+
+        $this->factory->fake([
+            '200.com' => $this->factory::response('hello', 200),
+        ]);
+
+        $this->factory->get('http://200.com')->dump();
+
+        $this->assertSame('hello', $dumped[0]);
+
+        VarDumper::setHandler(null);
+    }
+
+    public function testResponseCanDumpWithKey()
+    {
+        $dumped = [];
+
+        VarDumper::setHandler(function ($value) use (&$dumped) {
+            $dumped[] = $value;
+        });
+
+        $this->factory->fake([
+            '200.com' => $this->factory::response(['hello' => 'world'], 200),
+        ]);
+
+        $this->factory->get('http://200.com')->dump('hello');
+
+        $this->assertSame('world', $dumped[0]);
+
+        VarDumper::setHandler(null);
+    }
+
+    public function testResponseCanDumpHeaders()
+    {
+        $dumped = [];
+
+        VarDumper::setHandler(function ($value) use (&$dumped) {
+            $dumped[] = $value;
+        });
+
+        $this->factory->fake([
+            '200.com' => $this->factory::response('hello', 200, ['hello' => 'world']),
+        ]);
+
+        $this->factory->get('http://200.com')->dumpHeaders();
+
+        $this->assertSame(['hello' => ['world']], $dumped[0]);
+
+        VarDumper::setHandler(null);
+    }
+
     public function testResponseSequenceIsMacroable()
     {
         ResponseSequence::macro('customMethod', function () {


### PR DESCRIPTION
Similar to #36466 this PR adds methods to the `Response` object returned by the HTTP Client. 

The method signatures follow the methods from the `TestResponse` class for consistency.

```php
Http::get($url)->dump($key = null);
Http::get($url)->dd($key = null);
Http::get($url)->dumpHeaders();
Http::get($url)->ddHeaders();
```