### PR TITLE
Improve exception renderer performance

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1269,6 +1269,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Get the path to the cached classmap.php file.
+     *
+     * @return string
+     */
+    public function getCachedClassmapPath()
+    {
+        return $this->normalizeCachePath('APP_CLASSMAP_CACHE', 'cache/classmap.php');
+    }
+
+    /**
      * Determine if the application configuration is cached.
      *
      * @return bool

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -65,5 +65,9 @@ class ComposerScripts
         if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
         }
+
+        if (is_file($classmapPath = $laravel->getCachedClassmapPath())) {
+            @unlink($classmapPath);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -37,6 +37,10 @@ class ClearCompiledCommand extends Command
             @unlink($packagesPath);
         }
 
-        $this->components->info('Compiled services and packages files removed successfully.');
+        if (is_file($classmapPath = $this->laravel->getCachedClassmapPath())) {
+            @unlink($classmapPath);
+        }
+
+        $this->components->info('Compiled services, packages and classmap files removed successfully.');
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Exceptions\Renderer;
 
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Exceptions\Renderer\Mappers\BladeMapper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -90,8 +91,12 @@ class Renderer
             $this->htmlErrorRenderer->render($throwable),
         );
 
+        $classmapPath = app()->getCachedClassmapPath();
+
         return $this->viewFactory->make('laravel-exceptions-renderer::show', [
-            'exception' => new Exception($flattenException, $request, $this->listener, $this->basePath),
+            'exception' => new Exception(
+                $flattenException, $request, $this->listener, new Filesystem, $this->basePath, $classmapPath
+            ),
         ])->render();
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -398,6 +398,7 @@ class FoundationApplicationTest extends TestCase
         $ds = DIRECTORY_SEPARATOR;
         $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/services.php', $app->getCachedServicesPath());
         $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/classmap.php', $app->getCachedClassmapPath());
         $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/config.php', $app->getCachedConfigPath());
         $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/routes-v7.php', $app->getCachedRoutesPath());
         $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/events.php', $app->getCachedEventsPath());
@@ -408,12 +409,14 @@ class FoundationApplicationTest extends TestCase
         $app = new Application('/base/path');
         $_SERVER['APP_SERVICES_CACHE'] = '/absolute/path/services.php';
         $_SERVER['APP_PACKAGES_CACHE'] = '/absolute/path/packages.php';
+        $_SERVER['APP_CLASSMAP_CACHE'] = '/absolute/path/classmap.php';
         $_SERVER['APP_CONFIG_CACHE'] = '/absolute/path/config.php';
         $_SERVER['APP_ROUTES_CACHE'] = '/absolute/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = '/absolute/path/events.php';
 
         $this->assertSame('/absolute/path/services.php', $app->getCachedServicesPath());
         $this->assertSame('/absolute/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/absolute/path/classmap.php', $app->getCachedClassmapPath());
         $this->assertSame('/absolute/path/config.php', $app->getCachedConfigPath());
         $this->assertSame('/absolute/path/routes.php', $app->getCachedRoutesPath());
         $this->assertSame('/absolute/path/events.php', $app->getCachedEventsPath());
@@ -421,6 +424,7 @@ class FoundationApplicationTest extends TestCase
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CLASSMAP_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
             $_SERVER['APP_EVENTS_CACHE']
@@ -432,6 +436,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application('/base/path');
         $_SERVER['APP_SERVICES_CACHE'] = 'relative/path/services.php';
         $_SERVER['APP_PACKAGES_CACHE'] = 'relative/path/packages.php';
+        $_SERVER['APP_CLASSMAP_CACHE'] = 'relative/path/classmap.php';
         $_SERVER['APP_CONFIG_CACHE'] = 'relative/path/config.php';
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
@@ -439,6 +444,7 @@ class FoundationApplicationTest extends TestCase
         $ds = DIRECTORY_SEPARATOR;
         $this->assertSame('/base/path'.$ds.'relative/path/services.php', $app->getCachedServicesPath());
         $this->assertSame('/base/path'.$ds.'relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/classmap.php', $app->getCachedClassmapPath());
         $this->assertSame('/base/path'.$ds.'relative/path/config.php', $app->getCachedConfigPath());
         $this->assertSame('/base/path'.$ds.'relative/path/routes.php', $app->getCachedRoutesPath());
         $this->assertSame('/base/path'.$ds.'relative/path/events.php', $app->getCachedEventsPath());
@@ -446,6 +452,7 @@ class FoundationApplicationTest extends TestCase
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CLASSMAP_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
             $_SERVER['APP_EVENTS_CACHE']
@@ -457,6 +464,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $_SERVER['APP_SERVICES_CACHE'] = 'relative/path/services.php';
         $_SERVER['APP_PACKAGES_CACHE'] = 'relative/path/packages.php';
+        $_SERVER['APP_CLASSMAP_CACHE'] = 'relative/path/classmap.php';
         $_SERVER['APP_CONFIG_CACHE'] = 'relative/path/config.php';
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
@@ -464,6 +472,7 @@ class FoundationApplicationTest extends TestCase
         $ds = DIRECTORY_SEPARATOR;
         $this->assertSame($ds.'relative/path/services.php', $app->getCachedServicesPath());
         $this->assertSame($ds.'relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame($ds.'relative/path/classmap.php', $app->getCachedClassmapPath());
         $this->assertSame($ds.'relative/path/config.php', $app->getCachedConfigPath());
         $this->assertSame($ds.'relative/path/routes.php', $app->getCachedRoutesPath());
         $this->assertSame($ds.'relative/path/events.php', $app->getCachedEventsPath());
@@ -471,6 +480,7 @@ class FoundationApplicationTest extends TestCase
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CLASSMAP_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
             $_SERVER['APP_EVENTS_CACHE']
@@ -483,12 +493,14 @@ class FoundationApplicationTest extends TestCase
         $app->addAbsoluteCachePathPrefix('C:');
         $_SERVER['APP_SERVICES_CACHE'] = 'C:\framework\services.php';
         $_SERVER['APP_PACKAGES_CACHE'] = 'C:\framework\packages.php';
+        $_SERVER['APP_CLASSMAP_CACHE'] = 'C:\framework\classmap.php';
         $_SERVER['APP_CONFIG_CACHE'] = 'C:\framework\config.php';
         $_SERVER['APP_ROUTES_CACHE'] = 'C:\framework\routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'C:\framework\events.php';
 
         $this->assertSame('C:\framework\services.php', $app->getCachedServicesPath());
         $this->assertSame('C:\framework\packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('C:\framework\classmap.php', $app->getCachedClassmapPath());
         $this->assertSame('C:\framework\config.php', $app->getCachedConfigPath());
         $this->assertSame('C:\framework\routes.php', $app->getCachedRoutesPath());
         $this->assertSame('C:\framework\events.php', $app->getCachedEventsPath());
@@ -496,6 +508,7 @@ class FoundationApplicationTest extends TestCase
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CLASSMAP_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
             $_SERVER['APP_EVENTS_CACHE']


### PR DESCRIPTION
# Description

This PR improves the rendering speed of the new exception renderer that was introduced in `11.x`. This is achieved by caching the classmap of Composer, which is used to properly show the stacktrace on the exceptions page.

# Reasoning
A detailed explanation about what is causing the slow rendering performance can be found in this issue:
- #54217 

### Summary
The exception renderer use Composer's `getClassMap()` and PHP's `realpath(...)` to map class names to "real" paths of the OS. Resolving thousands of paths can take multiple seconds. Without the use of a proprietary caching solution, this leads to render times of 5-10 seconds, every time the exception page is rendered.


### New findings
PHP has a built-in solution to mitigate this issue by putting resolved paths into a separate realpath cache. However, there are multiple limitations to this native cache:
1. The realpath cache is a **per-process cache**: Depending on the multi-processing-module of the webserver in use, PHP processes can either be long-running or "single-script-executing". If the module in question uses the latter, realpath cache will be discarded after every render of the exception page. 
2. The realpath cache **limited in size**: Currently defaulting to [`4096k`](https://github.com/php/php-src/blob/ad4cbf4e7f9c12be2e1d53f438eff6c56ddf8c32/main/main.c#L817), formerly defaulting to [`16k`](https://www.php.net/manual/en/ini.list.php#:~:text=realpath_cache_size) only, the realpath cache is simply too small to hold thousands of file paths.
3. All entries in the realpath cache have a **fixed "time-to-live"**. Currently defaulting to [`120s`](https://github.com/php/php-src/blob/ad4cbf4e7f9c12be2e1d53f438eff6c56ddf8c32/main/main.c#L818), the realpath cache gets invalidated rather quickly.
4. No **proper control** over the realpath cache: Setting size and ttl of the realpath cache can only be done directly in a system's `php.ini` file, because the options are [`INI_SYSTEM`](https://www.php.net/manual/en/info.constants.php#constant.ini-system). Note: Clearing the realpath cache _is_ possible by manually calling [`clearstatcache(true)`](https://www.php.net/manual/en/function.clearstatcache.php). However, the framework does not do this currently.

# Implemented solution
With this PR, after resolving all paths of the classmap with `realpath`, a separate cache file is created. I've implemented a custom caching logic that is similar to the existing solutions for `services.php` and `packages.php`. I've tried to keep it as consistent as possible, and in line with the existing code base. I've chosen to combine the logic of [ProviderRepository](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/ProviderRepository.php) and [PackageManifest](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/PackageManifest.php) and put it into [Exception](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php).

The cache is cleared post `install`/`update`/`autoload-dump` of Composer as well, so the list stays up to date with the actual packages.
