### PR TITLE
fix: `schedule:test` on commands using runInBackground

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -76,8 +76,10 @@ class ScheduleTestCommand extends Command
         $description = sprintf(
             'Running [%s]%s',
             $command,
-            $event->runInBackground ? ' in background' : '',
+            $event->runInBackground ? ' normally in background' : '',
         );
+
+        $event->runInBackground = false;
 
         $this->components->task($description, fn () => $event->run($this->laravel));
 


### PR DESCRIPTION
Force to run the selected command in the foreground.

The `artisan schedule:test` command exited immediately after invocation and the selected command did not start if it uses `->runInBackground()`. If `->withoutOverlapping()` is used too, the mutex would not be removed and blocks any further execution without any user facing notice.

# How to Reproduce

```sh
composer create-project <dir>
cd <dir
php artisan make:command TestCommand
```

Edit `app/Console/Commands/TestCommand.php`

```diff
     public function handle()
     {
-        //
+        Log::info("running");
     }
```

Edit `bootstrap/app.php`

```diff
+use App\Console\Commands\TestCommand;
+
 return Application::configure(basePath: dirname(__DIR__))
+    ->withSchedule(function (Schedule $schedule) {
+        $schedule->command(TestCommand::class)
+            ->everyMinute()
+            ->runInBackground()
+            ->withoutOverlapping();
+    })

```

Observe logs: `tail -f storage/logs/laravel.log`

Run the scheduled command: `php artisan schedule:test`
Compare against: `php artisan schedule:work`
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
