### PR TITLE
[11.x] apply our new Pint rule to the `/tests` directory

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -3,7 +3,7 @@
     "rules": {
         "method_chaining_indentation": true
     },
-    "exclude": [
-        "tests"
+    "notPath": [
+        "tests/Foundation/fixtures/bad-syntax-strategy.php"
     ]
 }

--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -41,7 +41,7 @@ class AblyBroadcasterTest extends TestCase
         });
 
         $this->broadcaster->shouldReceive('validAuthenticationResponse')
-                          ->once();
+            ->once();
 
         $this->broadcaster->auth(
             $this->getMockRequestWithUserForChannel('private-test')
@@ -82,7 +82,7 @@ class AblyBroadcasterTest extends TestCase
         });
 
         $this->broadcaster->shouldReceive('validAuthenticationResponse')
-                          ->once();
+            ->once();
 
         $this->broadcaster->auth(
             $this->getMockRequestWithUserForChannel('presence-test')
@@ -125,17 +125,17 @@ class AblyBroadcasterTest extends TestCase
         $request->shouldReceive('all')->andReturn(['channel_name' => $channel, 'socket_id' => 'abcd.1234']);
 
         $request->shouldReceive('input')
-                ->with('callback', false)
-                ->andReturn(false);
+            ->with('callback', false)
+            ->andReturn(false);
 
         $user = m::mock('User');
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
-             ->andReturn(42);
+            ->andReturn(42);
         $user->shouldReceive('getAuthIdentifier')
-             ->andReturn(42);
+            ->andReturn(42);
 
         $request->shouldReceive('user')
-                ->andReturn($user);
+            ->andReturn($user);
 
         return $request;
     }
@@ -150,7 +150,7 @@ class AblyBroadcasterTest extends TestCase
         $request->shouldReceive('all')->andReturn(['channel_name' => $channel]);
 
         $request->shouldReceive('user')
-                ->andReturn(null);
+            ->andReturn(null);
 
         return $request;
     }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -206,9 +206,9 @@ class BroadcasterTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')
-                ->once()
-                ->withNoArgs()
-                ->andReturn(new DummyUser);
+            ->once()
+            ->withNoArgs()
+            ->andReturn(new DummyUser);
 
         $this->assertInstanceOf(
             DummyUser::class,
@@ -224,9 +224,9 @@ class BroadcasterTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')
-                ->once()
-                ->with('myguard')
-                ->andReturn(new DummyUser);
+            ->once()
+            ->with('myguard')
+            ->andReturn(new DummyUser);
 
         $this->assertInstanceOf(
             DummyUser::class,
@@ -245,14 +245,14 @@ class BroadcasterTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')
-                ->once()
-                ->with('myguard1')
-                ->andReturn(null);
+            ->once()
+            ->with('myguard1')
+            ->andReturn(null);
         $request->shouldReceive('user')
-                ->twice()
-                ->with('myguard2')
-                ->andReturn(new DummyUser)
-                ->ordered('user');
+            ->twice()
+            ->with('myguard2')
+            ->andReturn(new DummyUser)
+            ->ordered('user');
 
         $this->assertInstanceOf(
             DummyUser::class,
@@ -273,11 +273,11 @@ class BroadcasterTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')
-                ->once()
-                ->with('myguard')
-                ->andReturn(null);
+            ->once()
+            ->with('myguard')
+            ->andReturn(null);
         $request->shouldNotReceive('user')
-                ->withNoArgs();
+            ->withNoArgs();
 
         $this->broadcaster->retrieveUser($request, 'somechannel');
     }
@@ -290,15 +290,15 @@ class BroadcasterTest extends TestCase
 
         $request = m::mock(Request::class);
         $request->shouldReceive('user')
-                ->once()
-                ->with('myguard1')
-                ->andReturn(null);
+            ->once()
+            ->with('myguard1')
+            ->andReturn(null);
         $request->shouldReceive('user')
-                ->once()
-                ->with('myguard2')
-                ->andReturn(null);
+            ->once()
+            ->with('myguard2')
+            ->andReturn(null);
         $request->shouldNotReceive('user')
-                ->withNoArgs();
+            ->withNoArgs();
 
         $this->broadcaster->retrieveUser($request, 'somechannel');
     }

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -32,7 +32,7 @@ class PusherBroadcasterTest extends TestCase
         });
 
         $this->broadcaster->shouldReceive('validAuthenticationResponse')
-                          ->once();
+            ->once();
 
         $this->broadcaster->auth(
             $this->getMockRequestWithUserForChannel('private-test')
@@ -73,7 +73,7 @@ class PusherBroadcasterTest extends TestCase
         });
 
         $this->broadcaster->shouldReceive('validAuthenticationResponse')
-                          ->once();
+            ->once();
 
         $this->broadcaster->auth(
             $this->getMockRequestWithUserForChannel('presence-test')
@@ -115,8 +115,8 @@ class PusherBroadcasterTest extends TestCase
         ];
 
         $this->pusher->shouldReceive('socket_auth')
-                     ->once()
-                     ->andReturn(json_encode($data));
+            ->once()
+            ->andReturn(json_encode($data));
 
         $this->assertEquals(
             $data,
@@ -137,8 +137,8 @@ class PusherBroadcasterTest extends TestCase
         ];
 
         $this->pusher->shouldReceive('presence_auth')
-                     ->once()
-                     ->andReturn(json_encode($data));
+            ->once()
+            ->andReturn(json_encode($data));
 
         $this->assertEquals(
             $data,
@@ -181,17 +181,17 @@ class PusherBroadcasterTest extends TestCase
         $request->shouldReceive('all')->andReturn(['channel_name' => $channel, 'socket_id' => 'abcd.1234']);
 
         $request->shouldReceive('input')
-                ->with('callback', false)
-                ->andReturn(false);
+            ->with('callback', false)
+            ->andReturn(false);
 
         $user = m::mock('User');
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
-             ->andReturn(42);
+            ->andReturn(42);
         $user->shouldReceive('getAuthIdentifier')
-             ->andReturn(42);
+            ->andReturn(42);
 
         $request->shouldReceive('user')
-                ->andReturn($user);
+            ->andReturn($user);
 
         return $request;
     }
@@ -206,7 +206,7 @@ class PusherBroadcasterTest extends TestCase
         $request->shouldReceive('all')->andReturn(['channel_name' => $channel]);
 
         $request->shouldReceive('user')
-                ->andReturn(null);
+            ->andReturn(null);
 
         return $request;
     }

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -41,7 +41,7 @@ class RedisBroadcasterTest extends TestCase
         });
 
         $this->broadcaster->shouldReceive('validAuthenticationResponse')
-                          ->once();
+            ->once();
 
         $this->broadcaster->auth(
             $this->getMockRequestWithUserForChannel('private-test')
@@ -82,7 +82,7 @@ class RedisBroadcasterTest extends TestCase
         });
 
         $this->broadcaster->shouldReceive('validAuthenticationResponse')
-                          ->once();
+            ->once();
 
         $this->broadcaster->auth(
             $this->getMockRequestWithUserForChannel('presence-test')
@@ -172,12 +172,12 @@ class RedisBroadcasterTest extends TestCase
 
         $user = m::mock('User');
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
-             ->andReturn(42);
+            ->andReturn(42);
         $user->shouldReceive('getAuthIdentifier')
-             ->andReturn(42);
+            ->andReturn(42);
 
         $request->shouldReceive('user')
-                ->andReturn($user);
+            ->andReturn($user);
 
         return $request;
     }
@@ -192,7 +192,7 @@ class RedisBroadcasterTest extends TestCase
         $request->shouldReceive('all')->andReturn(['channel_name' => $channel]);
 
         $request->shouldReceive('user')
-                ->andReturn(null);
+            ->andReturn(null);
 
         return $request;
     }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -101,8 +101,8 @@ class BusBatchTest extends TestCase
         };
 
         $queue->shouldReceive('connection')->once()
-                        ->with('test-connection')
-                        ->andReturn($connection = m::mock(stdClass::class));
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
 
         $connection->shouldReceive('bulk')->once()->with(m::on(function ($args) use ($job, $secondJob) {
             return
@@ -191,8 +191,8 @@ class BusBatchTest extends TestCase
         };
 
         $queue->shouldReceive('connection')->once()
-                        ->with('test-connection')
-                        ->andReturn($connection = m::mock(stdClass::class));
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
 
         $connection->shouldReceive('bulk')->once();
 
@@ -231,8 +231,8 @@ class BusBatchTest extends TestCase
         };
 
         $queue->shouldReceive('connection')->once()
-                        ->with('test-connection')
-                        ->andReturn($connection = m::mock(stdClass::class));
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
 
         $connection->shouldReceive('bulk')->once();
 
@@ -273,8 +273,8 @@ class BusBatchTest extends TestCase
         };
 
         $queue->shouldReceive('connection')->once()
-                        ->with('test-connection')
-                        ->andReturn($connection = m::mock(stdClass::class));
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
 
         $connection->shouldReceive('bulk')->once();
 
@@ -472,26 +472,26 @@ class BusBatchTest extends TestCase
         $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
 
         $pendingBatch = (new PendingBatch(new Container, collect()))
-                            ->progress(function (Batch $batch) {
-                                $_SERVER['__progress.batch'] = $batch;
-                                $_SERVER['__progress.count']++;
-                            })
-                            ->then(function (Batch $batch) {
-                                $_SERVER['__then.batch'] = $batch;
-                                $_SERVER['__then.count']++;
-                            })
-                            ->catch(function (Batch $batch, $e) {
-                                $_SERVER['__catch.batch'] = $batch;
-                                $_SERVER['__catch.exception'] = $e;
-                                $_SERVER['__catch.count']++;
-                            })
-                            ->finally(function (Batch $batch) {
-                                $_SERVER['__finally.batch'] = $batch;
-                                $_SERVER['__finally.count']++;
-                            })
-                            ->allowFailures($allowFailures)
-                            ->onConnection('test-connection')
-                            ->onQueue('test-queue');
+            ->progress(function (Batch $batch) {
+                $_SERVER['__progress.batch'] = $batch;
+                $_SERVER['__progress.count']++;
+            })
+            ->then(function (Batch $batch) {
+                $_SERVER['__then.batch'] = $batch;
+                $_SERVER['__then.count']++;
+            })
+            ->catch(function (Batch $batch, $e) {
+                $_SERVER['__catch.batch'] = $batch;
+                $_SERVER['__catch.exception'] = $e;
+                $_SERVER['__catch.count']++;
+            })
+            ->finally(function (Batch $batch) {
+                $_SERVER['__finally.batch'] = $batch;
+                $_SERVER['__finally.count']++;
+            })
+            ->allowFailures($allowFailures)
+            ->onConnection('test-connection')
+            ->onQueue('test-queue');
 
         return $repository->store($pendingBatch);
     }

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -75,17 +75,17 @@ class ComponentsTest extends TestCase
         $output = m::mock(OutputStyle::class);
 
         $output->shouldReceive('confirm')
-               ->with('Question?', false)
-               ->once()
-               ->andReturnTrue();
+            ->with('Question?', false)
+            ->once()
+            ->andReturnTrue();
 
         $result = with(new Components\Confirm($output))->render('Question?');
         $this->assertTrue($result);
 
         $output->shouldReceive('confirm')
-               ->with('Question?', true)
-               ->once()
-               ->andReturnTrue();
+            ->with('Question?', true)
+            ->once()
+            ->andReturnTrue();
 
         $result = with(new Components\Confirm($output))->render('Question?', true);
         $this->assertTrue($result);
@@ -96,9 +96,9 @@ class ComponentsTest extends TestCase
         $output = m::mock(OutputStyle::class);
 
         $output->shouldReceive('askQuestion')
-               ->with(m::type(ChoiceQuestion::class))
-               ->once()
-               ->andReturn('a');
+            ->with(m::type(ChoiceQuestion::class))
+            ->once()
+            ->andReturn('a');
 
         $result = with(new Components\Choice($output))->render('Question?', ['a', 'b']);
         $this->assertSame('a', $result);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -516,13 +516,13 @@ class ContainerTest extends TestCase
     public function testMakeWithMethodIsAnAliasForMakeMethod()
     {
         $mock = $this->getMockBuilder(Container::class)
-                     ->onlyMethods(['make'])
-                     ->getMock();
+            ->onlyMethods(['make'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('make')
-             ->with(ContainerDefaultValueStub::class, ['default' => 'laurence'])
-             ->willReturn(new stdClass);
+            ->method('make')
+            ->with(ContainerDefaultValueStub::class, ['default' => 'laurence'])
+            ->willReturn(new stdClass);
 
         $result = $mock->makeWith(ContainerDefaultValueStub::class, ['default' => 'laurence']);
 
@@ -672,8 +672,8 @@ class ContainerTest extends TestCase
         $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
 
         $container->when(ContainerContextualBindingCallTarget::class)
-                ->needs(IContainerContractStub::class)
-                ->give(ContainerImplementationStub::class);
+            ->needs(IContainerContractStub::class)
+            ->give(ContainerImplementationStub::class);
 
         $result = $container->call([new ContainerContextualBindingCallTarget, 'work']);
 

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -138,9 +138,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
             ->posts()->createMany([
-                                     ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                                     ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-                                 ]);
+                ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+            ]);
 
         $country = HasManyThroughTestCountry::first();
         $post = $country->posts()->find(1);
@@ -157,9 +157,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
             ->posts()->createMany([
-                                     ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                                     ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-                                 ]);
+                ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+            ]);
 
         $country = HasManyThroughTestCountry::first();
 
@@ -238,9 +238,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
             ->posts()->createMany([
-                                     ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                                     ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-                                 ]);
+                ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+            ]);
 
         $result = HasManyThroughTestCountry::first()->posts()->findOr([1, 2], fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
@@ -265,9 +265,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
             ->posts()->createMany([
-                                     ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                                     ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-                                 ]);
+                ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+            ]);
 
         $result = HasManyThroughTestCountry::first()->posts()->findOr(new Collection([1, 2]), fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
@@ -502,9 +502,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
             ->posts()->createMany([
-                                     ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                                     ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-                                 ]);
+                ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+            ]);
     }
 
     protected function seedDataExtended()
@@ -535,9 +535,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughDefaultTestCountry::create(['id' => 1, 'name' => 'United States of America'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
             ->posts()->createMany([
-                                            ['title' => 'A title', 'body' => 'A body'],
-                                            ['title' => 'Another title', 'body' => 'Another body'],
-                                        ]);
+                ['title' => 'A title', 'body' => 'A body'],
+                ['title' => 'Another title', 'body' => 'Another body'],
+            ]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -136,8 +136,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindMethod()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->createMany([
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->createMany([
                                      ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
                                      ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
                                  ]);
@@ -155,8 +155,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindManyMethod()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->createMany([
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->createMany([
                                      ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
                                      ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
                                  ]);
@@ -184,7 +184,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 
         HasManyThroughTestCountry::first()->posts()->findOrFail(1);
     }
@@ -195,8 +195,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
 
         HasManyThroughTestCountry::first()->posts()->findOrFail([1, 2]);
     }
@@ -207,8 +207,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
 
         HasManyThroughTestCountry::first()->posts()->findOrFail(new Collection([1, 2]));
     }
@@ -216,8 +216,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrMethod()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
 
         $result = HasManyThroughTestCountry::first()->posts()->findOr(1, fn () => 'callback result');
         $this->assertInstanceOf(HasManyThroughTestPost::class, $result);
@@ -236,8 +236,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrMethodWithMany()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->createMany([
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->createMany([
                                      ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
                                      ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
                                  ]);
@@ -263,8 +263,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrMethodWithManyUsingCollection()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->createMany([
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->createMany([
                                      ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
                                      ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
                                  ]);
@@ -500,8 +500,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     protected function seedData()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
-                                 ->posts()->createMany([
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->createMany([
                                      ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
                                      ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
                                  ]);
@@ -533,8 +533,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     protected function seedDefaultData()
     {
         HasManyThroughDefaultTestCountry::create(['id' => 1, 'name' => 'United States of America'])
-                                        ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
-                                        ->posts()->createMany([
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
+            ->posts()->createMany([
                                             ['title' => 'A title', 'body' => 'A body'],
                                             ['title' => 'Another title', 'body' => 'Another body'],
                                         ]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1175,7 +1175,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
 
         $user->posts()->create(['name' => 'Post 2'])
-             ->photos()->create(['name' => 'photo.jpg']);
+            ->photos()->create(['name' => 'photo.jpg']);
 
         $query = EloquentTestUser::has('postWithPhotos');
 
@@ -2322,7 +2322,7 @@ class EloquentTestUserWithCustomFriendPivot extends EloquentTestUser
     public function friends()
     {
         return $this->belongsToMany(EloquentTestUser::class, 'friends', 'user_id', 'friend_id')
-                        ->using(EloquentTestFriendPivot::class)->withPivot('user_id', 'friend_id', 'friend_level_id');
+            ->using(EloquentTestFriendPivot::class)->withPivot('user_id', 'friend_id', 'friend_level_id');
     }
 }
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -28,8 +28,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
-                ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
     }
@@ -44,8 +44,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
-                ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
     }
@@ -60,8 +60,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
-                ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
     }
@@ -76,8 +76,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
-                ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
@@ -92,8 +92,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
-                ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
+            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
 
         $this->runCommand($command, ['name' => 'create_users_table']);
     }
@@ -108,8 +108,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
-                ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
+            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
+            ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
     }
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -99,9 +99,9 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $mockVariables = [];
 
         $schemaState = $this->getMockBuilder(MySqlSchemaState::class)
-                            ->disableOriginalConstructor()
-                            ->onlyMethods(['makeProcess'])
-                            ->getMock();
+            ->disableOriginalConstructor()
+            ->onlyMethods(['makeProcess'])
+            ->getMock();
 
         $schemaState->method('makeProcess')->willReturn($mockProcess);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3578,9 +3578,9 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder()->select('*')->from('users')->where('email', '=', function ($q) {
             $q->select(new Raw('max(id)'))
-              ->from('users')->where('email', '=', 'bar')
-              ->orderByRaw('email like ?', '%.com')
-              ->groupBy('id')->having('id', '=', 4);
+                ->from('users')->where('email', '=', 'bar')
+                ->orderByRaw('email like ?', '%.com')
+                ->groupBy('id')->having('id', '=', 4);
         })->orWhere('id', '=', 'foo')->groupBy('id')->having('id', '=', 5);
         $this->assertEquals([0 => 'bar', 1 => 4, 2 => '%.com', 3 => 'foo', 4 => 5], $builder->getBindings());
     }
@@ -4075,9 +4075,9 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')
             ->join('orders', function ($join) {
                 $join->on('users.id', '=', 'orders.user_id')
-                   ->where('users.id', '=', 1);
+                    ->where('users.id', '=', 1);
             })->where('name', 'baz')
-           ->updateFrom(['email' => 'foo', 'name' => 'bar']);
+            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
     }
 
@@ -4427,11 +4427,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
-                    ->method('update')
-                    ->with(
-                        'update `users` set `name` = json_set(`name`, \'$."first_name"\', ?), `name` = json_set(`name`, \'$."last_name"\', ?) where `active` = ?',
-                        ['John', 'Doe', 1]
-                    );
+            ->method('update')
+            ->with(
+                'update `users` set `name` = json_set(`name`, \'$."first_name"\', ?), `name` = json_set(`name`, \'$."last_name"\', ?) where `active` = ?',
+                ['John', 'Doe', 1]
+            );
 
         $builder = new Builder($connection, $grammar, $processor);
 
@@ -4445,11 +4445,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
-                    ->method('update')
-                    ->with(
-                        'update `users` set `meta` = json_set(`meta`, \'$."name"."first_name"\', ?), `meta` = json_set(`meta`, \'$."name"."last_name"\', ?) where `active` = ?',
-                        ['John', 'Doe', 1]
-                    );
+            ->method('update')
+            ->with(
+                'update `users` set `meta` = json_set(`meta`, \'$."name"."first_name"\', ?), `meta` = json_set(`meta`, \'$."name"."last_name"\', ?) where `active` = ?',
+                ['John', 'Doe', 1]
+            );
 
         $builder = new Builder($connection, $grammar, $processor);
 
@@ -4463,16 +4463,16 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
-                    ->method('update')
-                    ->with(
-                        'update `users` set `options` = ?, `meta` = json_set(`meta`, \'$."tags"\', cast(? as json)), `group_id` = 45, `created_at` = ? where `active` = ?',
-                        [
-                            json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
-                            json_encode(['white', 'large']),
-                            new DateTime('2019-08-06'),
-                            1,
-                        ]
-                    );
+            ->method('update')
+            ->with(
+                'update `users` set `options` = ?, `meta` = json_set(`meta`, \'$."tags"\', cast(? as json)), `group_id` = 45, `created_at` = ? where `active` = ?',
+                [
+                    json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
+                    json_encode(['white', 'large']),
+                    new DateTime('2019-08-06'),
+                    1,
+                ]
+            );
 
         $builder = new Builder($connection, $grammar, $processor);
         $builder->from('users')->where('active', 1)->update([
@@ -4490,14 +4490,14 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
-                    ->method('update')
-                    ->with(
-                        'update `users` set `options` = json_set(`options`, \'$[1]."2fa"\', false), `meta` = json_set(`meta`, \'$."tags"[0][2]\', ?) where `active` = ?',
-                        [
-                            'large',
-                            1,
-                        ]
-                    );
+            ->method('update')
+            ->with(
+                'update `users` set `options` = json_set(`options`, \'$[1]."2fa"\', false), `meta` = json_set(`meta`, \'$."tags"[0][2]\', ?) where `active` = ?',
+                [
+                    'large',
+                    1,
+                ]
+            );
 
         $builder = new Builder($connection, $grammar, $processor);
         $builder->from('users')->where('active', 1)->update([
@@ -4513,11 +4513,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $connection = m::mock(ConnectionInterface::class);
         $connection->shouldReceive('update')
-                    ->once()
-                    ->with(
-                        'update `users` set `options` = json_set(`options`, \'$."enable"\', false), `updated_at` = ? where `id` = ?',
-                        ['2015-05-26 22:02:06', 0]
-                    );
+            ->once()
+            ->with(
+                'update `users` set `options` = json_set(`options`, \'$."enable"\', false), `updated_at` = ? where `id` = ?',
+                ['2015-05-26 22:02:06', 0]
+            );
         $builder = new Builder($connection, $grammar, $processor);
         $builder->from('users')->where('id', '=', 0)->update(['options->enable' => false, 'updated_at' => '2015-05-26 22:02:06']);
 

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -57,7 +57,7 @@ class RouteListCommandTest extends TestCase
         $router->get('/sub-example', function () {
             return 'Hello World';
         })->domain('sub')
-        ->middleware('exampleMiddleware');
+            ->middleware('exampleMiddleware');
 
         $router->get('/example-group', function () {
             return 'Hello Group';

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -272,7 +272,7 @@ class FoundationFormRequestTest extends TestCase
         $request = $class::create('/', 'GET', $payload);
 
         return $request->setRedirector($this->createMockRedirector($request))
-                       ->setContainer($container);
+            ->setContainer($container);
     }
 
     /**
@@ -284,7 +284,7 @@ class FoundationFormRequestTest extends TestCase
     protected function createValidationFactory($container)
     {
         $translator = m::mock(Translator::class)->shouldReceive('get')
-                       ->zeroOrMoreTimes()->andReturn('error')->getMock();
+            ->zeroOrMoreTimes()->andReturn('error')->getMock();
 
         return new ValidationFactory($translator, $container);
     }
@@ -300,13 +300,13 @@ class FoundationFormRequestTest extends TestCase
         $redirector = $this->mocks['redirector'] = m::mock(Redirector::class);
 
         $redirector->shouldReceive('getUrlGenerator')->zeroOrMoreTimes()
-                   ->andReturn($generator = $this->createMockUrlGenerator());
+            ->andReturn($generator = $this->createMockUrlGenerator());
 
         $redirector->shouldReceive('to')->zeroOrMoreTimes()
-                   ->andReturn($this->createMockRedirectResponse());
+            ->andReturn($this->createMockRedirectResponse());
 
         $generator->shouldReceive('previous')->zeroOrMoreTimes()
-                  ->andReturn('previous');
+            ->andReturn('previous');
 
         return $redirector;
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -727,7 +727,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->attach('foo', 'data', 'file.txt', ['X-Test-Header' => 'foo'])
-                ->post('http://foo.com/file');
+            ->post('http://foo.com/file');
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/file' &&

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -164,7 +164,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $this->assertCount(
             1,
             $anotherQuery->cursorPaginate(5, ['*'], 'cursor', new Cursor(['id' => 3]))
-                        ->items()
+                ->items()
         );
     }
 
@@ -239,7 +239,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $this->assertCount(
             4,
             $anotherQuery->cursorPaginate(10, ['*'], 'cursor', new Cursor(['user_id' => 2]))
-                        ->items()
+                ->items()
         );
     }
 

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -164,7 +164,7 @@ class PivotSerializationTestProject extends Model
     public function tags()
     {
         return $this->morphToMany(PivotSerializationTestTag::class, 'taggable', 'taggables', 'taggable_id', 'tag_id')
-                ->using(PivotSerializationTestTagAttachment::class);
+            ->using(PivotSerializationTestTagAttachment::class);
     }
 }
 
@@ -175,7 +175,7 @@ class PivotSerializationTestTag extends Model
     public function projects()
     {
         return $this->morphedByMany(PivotSerializationTestProject::class, 'taggable', 'taggables', 'tag_id', 'taggable_id')
-                    ->using(PivotSerializationTestTagAttachment::class);
+            ->using(PivotSerializationTestTagAttachment::class);
     }
 }
 

--- a/tests/Integration/Database/EloquentPivotTest.php
+++ b/tests/Integration/Database/EloquentPivotTest.php
@@ -91,17 +91,17 @@ class PivotTestUser extends Model
     public function activeSubscriptions()
     {
         return $this->belongsToMany(PivotTestProject::class, 'subscriptions', 'user_id', 'project_id')
-                    ->withPivotValue('status', 'active')
-                    ->withPivot('status')
-                    ->using(PivotTestSubscription::class);
+            ->withPivotValue('status', 'active')
+            ->withPivot('status')
+            ->using(PivotTestSubscription::class);
     }
 
     public function inactiveSubscriptions()
     {
         return $this->belongsToMany(PivotTestProject::class, 'subscriptions', 'user_id', 'project_id')
-                    ->withPivotValue('status', 'inactive')
-                    ->withPivot('status')
-                    ->using(PivotTestSubscription::class);
+            ->withPivotValue('status', 'inactive')
+            ->withPivot('status')
+            ->using(PivotTestSubscription::class);
     }
 }
 
@@ -114,7 +114,7 @@ class PivotTestProject extends Model
         return $this->belongsToMany(
             PivotTestUser::class, 'collaborators', 'project_id', 'user_id'
         )->withPivot('permissions')
-        ->using(PivotTestCollaborator::class);
+            ->using(PivotTestCollaborator::class);
     }
 
     public function contributors()

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -73,24 +73,24 @@ class ArtisanCommandTest extends TestCase
     public function test_console_command_that_passes_with_output()
     {
         $this->artisan('survey')
-             ->expectsQuestion('What is your name?', 'Taylor Otwell')
-             ->expectsQuestion('Which language do you prefer?', 'PHP')
-             ->expectsOutput('Your name is Taylor Otwell and you prefer PHP.')
-             ->doesntExpectOutput('Your name is Taylor Otwell and you prefer Ruby.')
-             ->assertExitCode(0);
+            ->expectsQuestion('What is your name?', 'Taylor Otwell')
+            ->expectsQuestion('Which language do you prefer?', 'PHP')
+            ->expectsOutput('Your name is Taylor Otwell and you prefer PHP.')
+            ->doesntExpectOutput('Your name is Taylor Otwell and you prefer Ruby.')
+            ->assertExitCode(0);
     }
 
     public function test_console_command_that_passes_with_repeating_output()
     {
         $this->artisan('slim')
-             ->expectsQuestion('Who?', 'Taylor')
-             ->expectsQuestion('What?', 'Taylor')
-             ->expectsQuestion('Huh?', 'Taylor')
-             ->expectsOutput('Taylor')
-             ->doesntExpectOutput('Otwell')
-             ->expectsOutput('Taylor')
-             ->expectsOutput('Taylor')
-             ->assertExitCode(0);
+            ->expectsQuestion('Who?', 'Taylor')
+            ->expectsQuestion('What?', 'Taylor')
+            ->expectsQuestion('Huh?', 'Taylor')
+            ->expectsOutput('Taylor')
+            ->doesntExpectOutput('Otwell')
+            ->expectsOutput('Taylor')
+            ->expectsOutput('Taylor')
+            ->assertExitCode(0);
     }
 
     public function test_console_command_that_fails_from_unexpected_output()
@@ -99,10 +99,10 @@ class ArtisanCommandTest extends TestCase
         $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was printed.');
 
         $this->artisan('survey')
-             ->expectsQuestion('What is your name?', 'Taylor Otwell')
-             ->expectsQuestion('Which language do you prefer?', 'PHP')
-             ->doesntExpectOutput('Your name is Taylor Otwell and you prefer PHP.')
-             ->assertExitCode(0);
+            ->expectsQuestion('What is your name?', 'Taylor Otwell')
+            ->expectsQuestion('Which language do you prefer?', 'PHP')
+            ->doesntExpectOutput('Your name is Taylor Otwell and you prefer PHP.')
+            ->assertExitCode(0);
     }
 
     public function test_console_command_that_fails_from_unexpected_output_substring()
@@ -111,8 +111,8 @@ class ArtisanCommandTest extends TestCase
         $this->expectExceptionMessage('Output "Taylor Otwell" was printed.');
 
         $this->artisan('contains')
-             ->doesntExpectOutputToContain('Taylor Otwell')
-             ->assertExitCode(0);
+            ->doesntExpectOutputToContain('Taylor Otwell')
+            ->assertExitCode(0);
     }
 
     public function test_console_command_that_fails_from_missing_output()
@@ -122,10 +122,10 @@ class ArtisanCommandTest extends TestCase
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('survey')
-                 ->expectsQuestion('What is your name?', 'Taylor Otwell')
-                 ->expectsQuestion('Which language do you prefer?', 'Ruby')
-                 ->expectsOutput('Your name is Taylor Otwell and you prefer PHP.')
-                 ->assertExitCode(0);
+                ->expectsQuestion('What is your name?', 'Taylor Otwell')
+                ->expectsQuestion('Which language do you prefer?', 'Ruby')
+                ->expectsOutput('Your name is Taylor Otwell and you prefer PHP.')
+                ->assertExitCode(0);
         });
     }
 
@@ -135,9 +135,9 @@ class ArtisanCommandTest extends TestCase
         $this->expectExceptionMessage('Expected status code 1 but received 0.');
 
         $this->artisan('survey')
-             ->expectsQuestion('What is your name?', 'Taylor Otwell')
-             ->expectsQuestion('Which language do you prefer?', 'PHP')
-             ->assertExitCode(1);
+            ->expectsQuestion('What is your name?', 'Taylor Otwell')
+            ->expectsQuestion('Which language do you prefer?', 'PHP')
+            ->assertExitCode(1);
     }
 
     public function test_console_command_that_fails_from_unordered_output()
@@ -146,21 +146,21 @@ class ArtisanCommandTest extends TestCase
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('slim')
-                 ->expectsQuestion('Who?', 'Taylor')
-                 ->expectsQuestion('What?', 'Danger')
-                 ->expectsQuestion('Huh?', 'Otwell')
-                 ->expectsOutput('Taylor')
-                 ->expectsOutput('Otwell')
-                 ->expectsOutput('Danger')
-                 ->assertExitCode(0);
+                ->expectsQuestion('Who?', 'Taylor')
+                ->expectsQuestion('What?', 'Danger')
+                ->expectsQuestion('Huh?', 'Otwell')
+                ->expectsOutput('Taylor')
+                ->expectsOutput('Otwell')
+                ->expectsOutput('Danger')
+                ->assertExitCode(0);
         });
     }
 
     public function test_console_command_that_passes_if_the_output_contains()
     {
         $this->artisan('contains')
-             ->expectsOutputToContain('Taylor Otwell')
-             ->assertExitCode(0);
+            ->expectsOutputToContain('Taylor Otwell')
+            ->assertExitCode(0);
     }
 
     public function test_console_command_that_passes_if_outputs_something()
@@ -270,8 +270,8 @@ class ArtisanCommandTest extends TestCase
 
         $this->ignoringMockOnceExceptions(function () {
             $this->artisan('contains')
-                 ->expectsOutputToContain('Otwell Taylor')
-                 ->assertExitCode(0);
+                ->expectsOutputToContain('Otwell Taylor')
+                ->assertExitCode(0);
         });
     }
 

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -24,7 +24,7 @@ class MailMailableDataTest extends TestCase
         $mailable = new MailableStub;
         $mailable->build(function ($m) use ($testData) {
             $m->view('view', $testData)
-              ->text('text-view');
+                ->text('text-view');
         });
         $this->assertSame($testData, $mailable->buildViewData());
     }

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1209,7 +1209,7 @@ class WelcomeMailableStub extends Mailable
     public function build()
     {
         $this->with('first_name', 'Taylor')
-             ->withLastName('Otwell');
+            ->withLastName('Otwell');
     }
 }
 

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -75,7 +75,7 @@ class NotificationMailMessageTest extends TestCase
 
         $message = new MailMessage;
         $message->cc('test@example.com')
-                ->cc('test@example.com', 'Test');
+            ->cc('test@example.com', 'Test');
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->cc);
 
@@ -94,7 +94,7 @@ class NotificationMailMessageTest extends TestCase
 
         $message = new MailMessage;
         $message->bcc('test@example.com')
-                ->bcc('test@example.com', 'Test');
+            ->bcc('test@example.com', 'Test');
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->bcc);
 
@@ -113,7 +113,7 @@ class NotificationMailMessageTest extends TestCase
 
         $message = new MailMessage;
         $message->replyTo('test@example.com')
-                ->replyTo('test@example.com', 'Test');
+            ->replyTo('test@example.com', 'Test');
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->replyTo);
 

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -20,11 +20,11 @@ class PipelineTest extends TestCase
         };
 
         $result = (new Pipeline(new Container))
-                    ->send('foo')
-                    ->through([PipelineTestPipeOne::class, $pipeTwo])
-                    ->then(function ($piped) {
-                        return $piped;
-                    });
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class, $pipeTwo])
+            ->then(function ($piped) {
+                return $piped;
+            });
 
         $this->assertSame('foo', $result);
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);
@@ -235,9 +235,9 @@ class PipelineTest extends TestCase
     public function testPipelineThenReturnMethodRunsPipelineThenReturnsPassable()
     {
         $result = (new Pipeline(new Container))
-                    ->send('foo')
-                    ->through([PipelineTestPipeOne::class])
-                    ->thenReturn();
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class])
+            ->thenReturn();
 
         $this->assertSame('foo', $result);
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -319,8 +319,8 @@ class ProcessTest extends TestCase
 
         $factory->fake([
             'ls *' => $factory->sequence()
-                        ->push('ls command 1')
-                        ->push('ls command 2'),
+                ->push('ls command 1')
+                ->push('ls command 2'),
             'cat *' => 'cat command',
         ]);
 
@@ -340,9 +340,9 @@ class ProcessTest extends TestCase
 
         $factory->fake([
             'ls *' => $factory->sequence()
-                        ->push('ls command 1')
-                        ->push('ls command 2')
-                        ->dontFailWhenEmpty(),
+                ->push('ls command 1')
+                ->push('ls command 2')
+                ->dontFailWhenEmpty(),
         ]);
 
         $result = $factory->run('ls -la');
@@ -363,8 +363,8 @@ class ProcessTest extends TestCase
 
         $factory->fake([
             'ls *' => $factory->sequence()
-                        ->push('ls command 1')
-                        ->push('ls command 2'),
+                ->push('ls command 1')
+                ->push('ls command 2'),
         ]);
 
         $result = $factory->run('ls -la');
@@ -716,10 +716,10 @@ class ProcessTest extends TestCase
 
         $factory->fake(function () use ($factory) {
             return $factory->describe()
-                    ->output('ONE')
-                    ->output('TWO')
-                    ->output('THREE')
-                    ->runsFor(iterations: 3);
+                ->output('ONE')
+                ->output('TWO')
+                ->output('THREE')
+                ->runsFor(iterations: 3);
         });
 
         $process = $factory->start('echo "ONE"; sleep 1; echo "TWO"; sleep 1; echo "THREE"; sleep 1;');

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -816,9 +816,9 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->resource('users', RouteRegistrarControllerStub::class)
             ->only('create', 'store')->names([
-                         'create' => 'user.build',
-                         'store' => 'user.save',
-                     ]);
+                'create' => 'user.build',
+                'store' => 'user.save',
+            ]);
 
         $this->router->resource('posts', RouteRegistrarControllerStub::class)
             ->only('create', 'destroy')

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -246,7 +246,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterRouteWithControllerAction()
     {
         $this->router->middleware('controller-middleware')
-                     ->get('users', RouteRegistrarControllerStub::class.'@index');
+            ->get('users', RouteRegistrarControllerStub::class.'@index');
 
         $this->seeResponse('controller', Request::create('users', 'GET'));
         $this->seeMiddleware('controller-middleware');
@@ -255,7 +255,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterRouteWithControllerActionArray()
     {
         $this->router->middleware('controller-middleware')
-                     ->get('users', [RouteRegistrarControllerStub::class, 'index']);
+            ->get('users', [RouteRegistrarControllerStub::class, 'index']);
 
         $this->seeResponse('controller', Request::create('users', 'GET'));
         $this->seeMiddleware('controller-middleware');
@@ -519,7 +519,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterResource()
     {
         $this->router->middleware('resource-middleware')
-                     ->resource('users', RouteRegistrarControllerStub::class);
+            ->resource('users', RouteRegistrarControllerStub::class);
 
         $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
         $this->seeMiddleware('resource-middleware');
@@ -611,8 +611,8 @@ class RouteRegistrarTest extends TestCase
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
     {
         $resource = $this->router->middleware('resource-middleware')
-                     ->resource('users', RouteRegistrarControllerStub::class)
-                     ->register();
+            ->resource('users', RouteRegistrarControllerStub::class)
+            ->register();
 
         $this->assertCount(7, $resource->getRoutes());
 
@@ -628,7 +628,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanLimitMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->only('index', 'show', 'destroy');
+            ->only('index', 'show', 'destroy');
 
         $this->assertCount(3, $this->router->getRoutes());
 
@@ -640,7 +640,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanExcludeMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->except(['index', 'create', 'store', 'show', 'edit']);
+            ->except(['index', 'create', 'store', 'show', 'edit']);
 
         $this->assertCount(2, $this->router->getRoutes());
 
@@ -651,8 +651,8 @@ class RouteRegistrarTest extends TestCase
     public function testCanLimitAndExcludeMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->only('index', 'show', 'destroy')
-                     ->except('destroy');
+            ->only('index', 'show', 'destroy')
+            ->except('destroy');
 
         $this->assertCount(2, $this->router->getRoutes());
 
@@ -700,7 +700,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanExcludeMethodsOnRegisteredApiResource()
     {
         $this->router->apiResource('users', RouteRegistrarControllerStub::class)
-                     ->except(['index', 'show', 'store']);
+            ->except(['index', 'show', 'store']);
 
         $this->assertCount(2, $this->router->getRoutes());
 
@@ -812,18 +812,18 @@ class RouteRegistrarTest extends TestCase
     public function testCanNameRoutesOnRegisteredResource()
     {
         $this->router->resource('comments', RouteRegistrarControllerStub::class)
-                     ->only('create', 'store')->names('reply');
+            ->only('create', 'store')->names('reply');
 
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->only('create', 'store')->names([
+            ->only('create', 'store')->names([
                          'create' => 'user.build',
                          'store' => 'user.save',
                      ]);
 
         $this->router->resource('posts', RouteRegistrarControllerStub::class)
-                    ->only('create', 'destroy')
-                    ->name('create', 'posts.make')
-                    ->name('destroy', 'posts.remove');
+            ->only('create', 'destroy')
+            ->name('create', 'posts.make')
+            ->name('destroy', 'posts.remove');
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('reply.create'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('reply.store'));
@@ -836,10 +836,10 @@ class RouteRegistrarTest extends TestCase
     public function testCanOverrideParametersOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->parameters(['users' => 'admin_user']);
+            ->parameters(['users' => 'admin_user']);
 
         $this->router->resource('posts', RouteRegistrarControllerStub::class)
-                     ->parameter('posts', 'topic');
+            ->parameter('posts', 'topic');
 
         $this->assertStringContainsString('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
         $this->assertStringContainsString('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
@@ -848,7 +848,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetMiddlewareOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->middleware(RouteRegistrarMiddlewareStub::class);
+            ->middleware(RouteRegistrarMiddlewareStub::class);
 
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
@@ -856,10 +856,10 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                    ->middleware('default')
-                    ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
-                    ->middlewareFor(['create', 'store'], 'one')
-                    ->middlewareFor(['edit'], ['one', 'two']);
+            ->middleware('default')
+            ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
+            ->middlewareFor(['create', 'store'], 'one')
+            ->middlewareFor(['edit'], ['one', 'two']);
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
@@ -870,10 +870,10 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
 
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
-                ->middlewareFor(['create', 'store'], 'one')
-                ->middlewareFor(['edit'], ['one', 'two'])
-                ->middleware('default');
+            ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
+            ->middlewareFor(['create', 'store'], 'one')
+            ->middlewareFor(['edit'], ['one', 'two'])
+            ->middleware('default');
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
@@ -887,9 +887,9 @@ class RouteRegistrarTest extends TestCase
     public function testResourceWithoutMiddlewareRegistration()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->only('index')
-                     ->middleware(['one', 'two'])
-                     ->withoutMiddleware('one');
+            ->only('index')
+            ->middleware(['one', 'two'])
+            ->withoutMiddleware('one');
 
         $this->seeResponse('controller', Request::create('users', 'GET'));
 
@@ -899,10 +899,10 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetExcludedMiddlewareForSpecifiedMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                    ->withoutMiddleware('one')
-                    ->withoutMiddlewareFor('index', 'two')
-                    ->withoutMiddlewareFor(['create', 'store'], 'three')
-                    ->withoutMiddlewareFor(['edit'], ['four', 'five']);
+            ->withoutMiddleware('one')
+            ->withoutMiddlewareFor('index', 'two')
+            ->withoutMiddlewareFor(['create', 'store'], 'three')
+            ->withoutMiddlewareFor(['edit'], ['four', 'five']);
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->excludedMiddleware(), ['one', 'two']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->excludedMiddleware(), ['one', 'three']);
@@ -924,9 +924,9 @@ class RouteRegistrarTest extends TestCase
         };
 
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->only('index')
-                     ->middleware([$one, 'two'])
-                     ->withoutMiddleware('one');
+            ->only('index')
+            ->middleware([$one, 'two'])
+            ->withoutMiddleware('one');
 
         $this->seeResponse('controller', Request::create('users', 'GET'));
 
@@ -942,7 +942,7 @@ class RouteRegistrarTest extends TestCase
         ];
 
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->where($wheres);
+            ->where($wheres);
 
         /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
@@ -1398,12 +1398,12 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredSingletonResource()
     {
         $this->router->singleton('users', RouteRegistrarControllerStub::class)
-                    ->creatable()
-                    ->destroyable()
-                    ->middleware('default')
-                    ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
-                    ->middlewareFor(['create', 'store'], 'one')
-                    ->middlewareFor(['edit'], ['one', 'two']);
+            ->creatable()
+            ->destroyable()
+            ->middleware('default')
+            ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
+            ->middlewareFor(['create', 'store'], 'one')
+            ->middlewareFor(['edit'], ['one', 'two']);
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
@@ -1413,12 +1413,12 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals($this->router->getRoutes()->getByName('users.destroy')->gatherMiddleware(), ['default']);
 
         $this->router->singleton('users', RouteRegistrarControllerStub::class)
-                ->creatable()
-                ->destroyable()
-                ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
-                ->middlewareFor(['create', 'store'], 'one')
-                ->middlewareFor(['edit'], ['one', 'two'])
-                ->middleware('default');
+            ->creatable()
+            ->destroyable()
+            ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
+            ->middlewareFor(['create', 'store'], 'one')
+            ->middlewareFor(['edit'], ['one', 'two'])
+            ->middleware('default');
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);
@@ -1431,12 +1431,12 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetExcludedMiddlewareForSpecifiedMethodsOnRegisteredSingletonResource()
     {
         $this->router->singleton('users', RouteRegistrarControllerStub::class)
-                    ->creatable()
-                    ->destroyable()
-                    ->withoutMiddleware('one')
-                    ->withoutMiddlewareFor('show', 'two')
-                    ->withoutMiddlewareFor(['create', 'store'], 'three')
-                    ->withoutMiddlewareFor(['edit'], ['four', 'five']);
+            ->creatable()
+            ->destroyable()
+            ->withoutMiddleware('one')
+            ->withoutMiddlewareFor('show', 'two')
+            ->withoutMiddlewareFor(['create', 'store'], 'three')
+            ->withoutMiddlewareFor(['edit'], ['four', 'five']);
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->excludedMiddleware(), ['one', 'three']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->excludedMiddleware(), ['one', 'three']);

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -152,7 +152,7 @@ class SleepTest extends TestCase
         Sleep::fake();
 
         $sleep = Sleep::for(1)->second()
-                      ->and(500)->microseconds();
+            ->and(500)->microseconds();
 
         $this->assertSame((float) $sleep->duration->totalMicroseconds, 1000500.0);
     }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1583,7 +1583,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make(['a' => 0])->concat(
             $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]])
-                 ->mapInto(stdClass::class)
+                ->mapInto(stdClass::class)
         );
 
         $this->assertDoesNotEnumerateCollection($data, function ($collection) {

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -396,7 +396,7 @@ class MailableStub extends Mailable
     public function build()
     {
         $this->with('first_name', 'Taylor')
-             ->withLastName('Otwell');
+            ->withLastName('Otwell');
     }
 }
 
@@ -414,7 +414,7 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
     public function build()
     {
         $this->with('first_name', 'Taylor')
-             ->withLastName('Otwell');
+            ->withLastName('Otwell');
     }
 }
 

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -64,8 +64,8 @@ class ValidationFactoryTest extends TestCase
         $factory = m::mock(Factory::class.'[make]', [$translator]);
 
         $factory->shouldReceive('make')->once()
-                ->with(['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'required'], [], [])
-                ->andReturn($validator);
+            ->with(['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'required'], [], [])
+            ->andReturn($validator);
 
         $validator->shouldReceive('validate')->once()->andReturn(['foo' => 'bar']);
 


### PR DESCRIPTION
I originally omitted these files to keep the PR smaller, but adding back now for consistent styling throughout repo. these are purely indentation whitespace changes.

the `bad-syntax-strategy.php` file is not valid PHP so we need to omit it, or it throws a Pint error.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
