### PR TITLE
[11.x]Add fluent helper to initialize pipeline processing

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -5,6 +5,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Pipeline;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Once;
@@ -526,3 +527,18 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('flow')) {
+    /**
+     * Sets the object to be processed through the pipeline.
+     *
+     * @param  mixed  $passable
+     * @return \Illuminate\Pipeline\Pipeline
+     */
+    function flow($passable = null)
+    {
+        return Pipeline::send($passable);
+    }
+}
+
+

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -540,5 +540,3 @@ if (! function_exists('flow')) {
         return Pipeline::send($passable);
     }
 }
-
-


### PR DESCRIPTION
This PR introduces the `flow()` helper, which sets the object to be processed through the pipeline. It provides a fluent syntax to streamline the use of Laravel's pipeline feature.

### Helper Function:
`flow($passable)` sets the initial object for pipeline processing.

### Usage:
```php
flow($data)
    ->through([...])
    ->thenReturn();