### PR TITLE
[12.x] Prevent XSS vulnerabilities by excluding SVGs by default in image validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1387,11 +1387,18 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<int, string>  $parameters
      * @return bool
      */
-    public function validateImage($attribute, $value)
+    public function validateImage($attribute, $value, $parameters)
     {
-        return $this->validateMimes($attribute, $value, ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp']);
+        $mimes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
+
+        if (! $parameters || ! in_array('without_svg', $parameters)) {
+            $mimes[] = 'svg';
+        }
+
+        return $this->validateMimes($attribute, $value, $mimes);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1390,11 +1390,11 @@ trait ValidatesAttributes
      * @param  array<int, string>  $parameters
      * @return bool
      */
-    public function validateImage($attribute, $value, $parameters)
+    public function validateImage($attribute, $value, $parameters = [])
     {
         $mimes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
 
-        if (! $parameters || ! in_array('without_svg', $parameters)) {
+        if (is_array($parameters) && in_array('allow_svg', $parameters)) {
             $mimes[] = 'svg';
         }
 

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -204,12 +204,12 @@ class Rule
     /**
      * Get an image file rule builder instance.
      *
-     * @param  bool  $allowSvgMimeType
+     * @param  bool  $allowSvg
      * @return \Illuminate\Validation\Rules\ImageFile
      */
-    public static function imageFile($allowSvgMimeType = false)
+    public static function imageFile($allowSvg = false)
     {
-        return new ImageFile($allowSvgMimeType);
+        return new ImageFile($allowSvg);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -204,11 +204,12 @@ class Rule
     /**
      * Get an image file rule builder instance.
      *
+     * @param  bool  $allowSvgMimeType
      * @return \Illuminate\Validation\Rules\ImageFile
      */
-    public static function imageFile()
+    public static function imageFile($allowSvgMimeType = false)
     {
-        return new ImageFile;
+        return new ImageFile($allowSvgMimeType);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -118,11 +118,12 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Limit the uploaded file to only image types.
      *
+     * @param  bool  $allowSvgMimeType
      * @return ImageFile
      */
-    public static function image()
+    public static function image($allowSvgMimeType = false)
     {
-        return new ImageFile();
+        return new ImageFile($allowSvgMimeType);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -118,12 +118,12 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Limit the uploaded file to only image types.
      *
-     * @param  bool  $allowSvgMimeType
+     * @param  bool  $allowSvg
      * @return ImageFile
      */
-    public static function image($allowSvgMimeType = false)
+    public static function image($allowSvg = false)
     {
-        return new ImageFile($allowSvgMimeType);
+        return new ImageFile($allowSvg);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -7,17 +7,23 @@ class ImageFile extends File
     /**
      * Create a new image file rule instance.
      *
+     * @param  bool  $allowSvgMimeType
      * @return void
      */
-    public function __construct()
+    public function __construct($allowSvgMimeType = false)
     {
-        $this->rules('image');
+        if ($allowSvgMimeType) {
+            $this->rules('image');
+        } else {
+            $this->rules('image:without_svg');
+        }
     }
 
     /**
      * The dimension constraints for the uploaded file.
      *
      * @param  \Illuminate\Validation\Rules\Dimensions  $dimensions
+     * @return $this
      */
     public function dimensions($dimensions)
     {

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -7,12 +7,12 @@ class ImageFile extends File
     /**
      * Create a new image file rule instance.
      *
-     * @param  bool  $allowSvgMimeType
+     * @param  bool  $allowSvg
      * @return void
      */
-    public function __construct($allowSvgMimeType = false)
+    public function __construct($allowSvg = false)
     {
-        if ($allowSvgMimeType) {
+        if ($allowSvg) {
             $this->rules('image:allow_svg');
         } else {
             $this->rules('image');

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -13,9 +13,9 @@ class ImageFile extends File
     public function __construct($allowSvgMimeType = false)
     {
         if ($allowSvgMimeType) {
-            $this->rules('image');
+            $this->rules('image:allow_svg');
         } else {
-            $this->rules('image:without_svg');
+            $this->rules('image');
         }
     }
 

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
@@ -191,6 +192,39 @@ class ValidationFileRuleTest extends TestCase
         $this->passes(
             File::image(),
             UploadedFile::fake()->image('foo.png'),
+        );
+    }
+
+    public function testImageFailsOnSvgByDefault()
+    {
+        $maliciousSvgFileWithXSS = UploadedFile::fake()->createWithContent(
+            name: 'foo.svg',
+            content: <<<'XML'
+                    <svg xmlns="http://www.w3.org/2000/svg" width="383" height="97" viewBox="0 0 383 97">
+                        <text x="10" y="50" font-size="30" fill="black">XSS Logo</text>
+                        <script>alert('XSS');</script>
+                    </svg>
+                    XML
+        );
+
+        $this->fails(
+            File::image(),
+            $maliciousSvgFileWithXSS,
+            ['validation.image']
+        );
+        $this->fails(
+            Rule::imageFile(),
+            $maliciousSvgFileWithXSS,
+            ['validation.image']
+        );
+
+        $this->passes(
+            File::image(allowSvgMimeType: true),
+            $maliciousSvgFileWithXSS
+        );
+        $this->passes(
+            Rule::imageFile(allowSvgMimeType: true),
+            $maliciousSvgFileWithXSS
         );
     }
 

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -219,11 +219,11 @@ class ValidationFileRuleTest extends TestCase
         );
 
         $this->passes(
-            File::image(allowSvgMimeType: true),
+            File::image(allowSvg: true),
             $maliciousSvgFileWithXSS
         );
         $this->passes(
-            Rule::imageFile(allowSvgMimeType: true),
+            Rule::imageFile(allowSvg: true),
             $maliciousSvgFileWithXSS
         );
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4891,6 +4891,12 @@ class ValidationValidatorTest extends TestCase
         $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
         $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
         $v = new Validator($trans, ['x' => $file6], ['x' => 'image']);
+        $this->assertFalse($v->passes());
+
+        $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
+        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
+        $v = new Validator($trans, ['x' => $file6], ['x' => 'image:allow_svg']);
         $this->assertTrue($v->passes());
 
         $file7 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();


### PR DESCRIPTION
Currently, the default `image` validation rule in Laravel is susceptible to **Cross-Site Scripting (XSS)** attacks, as it includes SVG files without explicit sanitization. An attacker could upload a malicious SVG file, such as:

```html
<svg xmlns="http://www.w3.org/2000/svg" width="383" height="97" viewBox="0 0 383 97">
    <text x="10" y="50" font-size="30" fill="black">XSS Logo</text>
    <script>alert('XSS');</script>
</svg>
```

When rendered directly, this file could execute arbitrary JavaScript, leading to potential data theft, session hijacking, or other malicious behavior.


#### Examples of Applications Manually Excluding SVGs
To mitigate this vulnerability, some developers already manually exclude SVGs from the allowed file types:
- [pinkary-project/pinkary.com](https://github.com/pinkary-project/pinkary.com/blob/34fa49b4718be876da6c064810fc3aad3bcb35ed/app/Livewire/Questions/Create.php#L113)

#### Many applications NOT excluding SVGs
However, many Laravel projects remain vulnerable due to relying on the default behavior of the `image` rule. A quick [GitHub search](https://github.com/search?q=%22File%3A%3Aimage%28%29%22+language%3APHP&type=code&l=PHP) shows over 500 public repos, of which nearly all of them do not exclude SVGs through additional rules.

Examples include:
- [inikoo/aiku](https://github.com/inikoo/aiku/blob/e5204fb26a5f7681ca0cd5707a5ad7ad8126f3ca/app/Actions/UI/Profile/UpdateProfile.php#L49) (profile avatar uploads)
- [yandinovriandi/WMH](https://github.com/yandinovriandi/WMH/blob/0517d700e11d3d92c22b4af5a6af165905c9022e/app/Http/Requests/ProfilePictureUpdateRequest.php#L30) (profile picture uploads)
- [vstruhar/lara-collab](https://github.com/vstruhar/lara-collab/blob/02cb6c66a657166818b0cc37f985dfe162216315/app/Http/Requests/User/StoreUserRequest.php#L34) (user profile creation)

These examples demonstrate how this vulnerability can affect widely used features like avatars, which are often displayed across an application.

---

### Why this justifies a Breaking Change
To address this vulnerability effectively, the default behavior of the `image` rule must be changed to **exclude SVGs by default**. This approach ensures:
1. **Secure Defaults**: Laravel prioritizes security by default, reducing the risk for developers who are unaware of SVG-specific vulnerabilities.
2. **Widespread Impact**: Many applications rely on the `image` validation rule for user-uploaded files. A secure default will protect applications from XSS without requiring developers to manually exclude SVGs.
3. **Alignment with Laravel's Philosophy**: Breaking changes for security improvements are justified in major releases, as they ensure the framework remains robust and trustworthy.

---

### Proposed Solution
1. **Reject SVGs by Default**:
   - The `image` rule will no longer accept SVG files unless explicitly allowed using the new `allow_svg` parameter.

2. **Opt-In SVG Support**:
   - Developers can explicitly enable SVG validation where needed:

 ```php
$rules = [
    'file' => File::image(allowSvgMimeType: true),
];
 ```
or

 ```php
$rules = [
    'file' => 'image:allow_svg',
];
 ```