### PR TITLE
Patch CVE-2025-22145 in nesbot/carbon package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "league/flysystem-local": "^3.25.1",
         "league/uri": "^7.5.1",
         "monolog/monolog": "^3.0",
-        "nesbot/carbon": "^2.72.2|^3.4",
+        "nesbot/carbon": "^2.72.6|^3.8.4",
         "nunomaduro/termwind": "^2.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
Updates minimum versions for nesbot/carbon to `^2.72.6|^3.8.4`.

This patches [CVE-2025-22145](https://github.com/advisories/GHSA-j3f9-p6hm-5w6q)