### PR TITLE
[11.x] Prevent unintended serialization and compression

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -432,7 +432,7 @@ class RedisStore extends TaggableStore implements LockProvider
     protected function pack($value, $connection)
     {
         if ($connection instanceof PhpRedisConnection) {
-            if ($this->storePlainValue($value)) {
+            if ($this->shouldBeStoredWithoutSerialization($value)) {
                 return $value;
             }
 
@@ -449,17 +449,6 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Determine if the given value should be stored as plain value or be serialized/compressed instead.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function storePlainValue($value): bool
-    {
-        return is_numeric($value) && ! in_array($value, [INF, -INF]) && ! is_nan($value);
-    }
-
-    /**
      * Serialize the value.
      *
      * @param  mixed  $value
@@ -467,7 +456,18 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return $this->storePlainValue($value) ? $value : serialize($value);
+        return $this->shouldBeStoredWithoutSerialization($value) ? $value : serialize($value);
+    }
+
+    /**
+     * Determine if the given value should be stored as plain value.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function shouldBeStoredWithoutSerialization($value): bool
+    {
+        return is_numeric($value) && ! in_array($value, [INF, -INF]) && ! is_nan($value);
     }
 
     /**

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -249,4 +249,20 @@ class RedisStoreTest extends TestCase
             'fizz' => 'buz',
         ], 10);
     }
+
+    public function testIncrementWithSerializationEnabled()
+    {
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->connection()->client();
+        $client->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_PHP);
+
+        $store->flush();
+        $store->add('foo', 1, 10);
+        $this->assertEquals(1, $store->get('foo'));
+
+        $store->increment('foo');
+        $this->assertEquals(2, $store->get('foo'));
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue when using serialization and compression combined with the increment function, introduced in https://github.com/laravel/framework/pull/54221. 

This is something used by the RateLimiter and causes it to fail since the v11.39.0.

This PR is intended to fix https://github.com/laravel/framework/issues/54307.

