### PR TITLE
fix(Collection::pop()): count < 1

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -986,7 +986,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function pop($count = 1)
     {
-        if ($count < 1 ) { 
+        if ($count < 1) { 
             return new static;
         }
         

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -986,6 +986,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function pop($count = 1)
     {
+        if ($count < 1 ) { 
+            return new static;
+        }
+        
         if ($count === 1) {
             return array_pop($this->items);
         }


### PR DESCRIPTION
If $count = 0 then this method is returning two items. If count<0 then things got worse than that. I think that in this case allowing $count <1 makes no sense and either we should throw an error, or we should return an empty result. In this PR I've gone with an empty result as I can see empty results being returned by the function anyway, so I would expect end user code to understand it, so I would expect that to be the least problematic solution. 

I guess there is danger merging this PR if people are accidentally passing negative numbers through and their code is right by accident, but from the evidence below I think that's a weird consideration to block this PR. 

Below is a tinker. I understand cases where $count is 3 and 2, but not what we're getting if it's 0,-1 etc. 

```php 
> collect([1,2])->pop(3);
= Illuminate\Support\Collection {#7529
    all: [
      2,
      1,
    ],
  }

> collect([1,2])->pop(-1);
= Illuminate\Support\Collection {#7526
    all: [
      2,
      1,
      null,
    ],
  }

> collect([1,2])->pop(2);
= Illuminate\Support\Collection {#7527
    all: [
      2,
      1,
    ],
  }

> collect([1,2])->pop(0);
= Illuminate\Support\Collection {#7516
    all: [
      2,
      1,
    ],
  }

> collect([1,2])->pop(1);
= 2
```

Also I would have preferred $count=1 to return a Collection, but I'm sure that boat has sailed. 
