### PR TITLE
cache remember-unless

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -404,6 +404,28 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * * If unless is true, execute the given Closure, store the result and return it (even if the value already exists), otherwise run remember.
+     *
+     * @template TCacheValue
+     *
+     * @param  bool  $unless
+     * @param  string  $key
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public function rememberUnless($unless, $key, $ttl, Closure $callback)
+    {
+        if ($unless) {
+            $this->put($key, $value = $callback(), $ttl);
+
+            return $value;
+        }
+
+        return $this->remember($key, $ttl, $callback);
+    }
+
+    /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @template TCacheValue
@@ -424,9 +446,7 @@ class Repository implements ArrayAccess, CacheContract
             return $value;
         }
 
-        $value = $callback();
-
-        $this->put($key, $value, value($ttl, $value));
+        $this->put($key, $value = $callback(), value($ttl, $value));
 
         return $value;
     }
@@ -442,6 +462,27 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function sear($key, Closure $callback)
     {
+        return $this->rememberForever($key, $callback);
+    }
+
+    /**
+    * If unless is true, execute the given Closure, store the result forever and return it (even if the value already exists), otherwise run rememberForever.
+     *
+     * @template TCacheValue
+     *
+     * @param  bool  $unless
+     * @param  string  $key
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public function rememberForeverUnless($unless, $key, Closure $callback)
+    {
+        if ($unless) {
+            $this->put($key, $value = $callback());
+
+            return $value;
+        }
+
         return $this->rememberForever($key, $callback);
     }
 


### PR DESCRIPTION
## Context
I have a cached data that takes 5 minutes to execute the closure, this process of recalculating the cache is executed on demand only in certain circumstances, validating the administrator's permissions and with a special parameter in the URL request. In addition this cache has a TTL of 24 hours

The first approach (which was incorrect), when I needed to recalculate the cache, first I would do a `forget` and then I would do a `remember`. However, if at the time the value was being calculated (after the `forget` but during the 5 minutes it takes to process) a request arrives, the `get` (or `remember`) that the user does would give null because the value had already been deleted from the cache and had not yet been saved again.

Obviously the admin should execute the `put` method to overwrite the value from the cache, if while the recalculation process is running, a request arrives, the value that is still in the cache and was not overwritten is used.

I've looked at the documentation for `flexible` but it's not exactly what I need, because the cache might still be valid when it needs to be recalculated.

I am aware that this can be solved by putting the closure in a separate method and differentiating the user calls vs. the administrator calls.
```php
class MyData {

    protected $keyCacheStore = 'my_key';
    
    protected function getTtlCacheStore(): int
    {
        return \Carbon\CarbonInterval::createFromDateString('1 day')->total('seconds');
    }

    public function getData() {
        return Cache::remember($this->keyCacheStore, $this->getCacheTtl(), function () {
            return $this->calculateData();
        });
    }

    public function refreshData() {
        $value = $this->calculateData();
        Cache::put($this->keyCacheStore, $value, $this->getCacheTtl());

        return $value;
    }

    public function calculateData() {
        // a long process
        return [];
    }
}
```

*But the proposal is to use a new method to make it clearer and save a few lines of code.*

```php
class MyData {

    public function getData($refresh = false) {
        $ttlCacheStore = \Carbon\CarbonInterval::createFromDateString('1 day')->total('seconds');
        return Cache::rememberUnless($refresh, 'my_key', $ttlCacheStore, function () {
            return $this->calculateData();
        });
    }

    public function calculateData() {
        // a long process
        return [];
    }
}
```

 --- 
Another alternative would be to add the parameter `$when` to the `remember` function, but I thought a new method would be better.