### PR TITLE
[11.x] Backport of Prevent XSS vulnerabilities by excluding SVGs by default in image validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1387,11 +1387,18 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<int, string>  $parameters
      * @return bool
      */
-    public function validateImage($attribute, $value)
+    public function validateImage($attribute, $value, $parameters = [])
     {
-        return $this->validateMimes($attribute, $value, ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp']);
+        $mimes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
+
+        if (is_array($parameters) && in_array('allow_svg', $parameters)) {
+            $mimes[] = 'svg';
+        }
+
+        return $this->validateMimes($attribute, $value, $mimes);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
 use InvalidArgumentException;
@@ -1394,7 +1395,7 @@ trait ValidatesAttributes
     {
         $mimes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
 
-        if (is_array($parameters) && in_array('allow_svg', $parameters)) {
+        if (ImageFile::$allowSvgByDefault || (is_array($parameters) && in_array('allow_svg', $parameters))) {
             $mimes[] = 'svg';
         }
 

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -215,10 +215,10 @@ class Rule
     /**
      * Get an image file rule builder instance.
      *
-     * @param  bool  $allowSvg
+     * @param  bool | null  $allowSvg
      * @return \Illuminate\Validation\Rules\ImageFile
      */
-    public static function imageFile($allowSvg = false)
+    public static function imageFile($allowSvg = null)
     {
         return new ImageFile($allowSvg);
     }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -215,11 +215,12 @@ class Rule
     /**
      * Get an image file rule builder instance.
      *
+     * @param  bool  $allowSvg
      * @return \Illuminate\Validation\Rules\ImageFile
      */
-    public static function imageFile()
+    public static function imageFile($allowSvg = false)
     {
-        return new ImageFile;
+        return new ImageFile($allowSvg);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -118,11 +118,12 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Limit the uploaded file to only image types.
      *
+     * @param  bool  $allowSvg
      * @return ImageFile
      */
-    public static function image()
+    public static function image($allowSvg = false)
     {
-        return new ImageFile();
+        return new ImageFile($allowSvg);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -118,10 +118,10 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Limit the uploaded file to only image types.
      *
-     * @param  bool  $allowSvg
+     * @param  bool|null  $allowSvg
      * @return ImageFile
      */
-    public static function image($allowSvg = false)
+    public static function image($allowSvg = null)
     {
         return new ImageFile($allowSvg);
     }

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -7,17 +7,23 @@ class ImageFile extends File
     /**
      * Create a new image file rule instance.
      *
+     * @param  bool  $allowSvg
      * @return void
      */
-    public function __construct()
+    public function __construct($allowSvg = false)
     {
-        $this->rules('image');
+        if ($allowSvg) {
+            $this->rules('image:allow_svg');
+        } else {
+            $this->rules('image');
+        }
     }
 
     /**
      * The dimension constraints for the uploaded file.
      *
      * @param  \Illuminate\Validation\Rules\Dimensions  $dimensions
+     * @return $this
      */
     public function dimensions($dimensions)
     {

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -4,14 +4,23 @@ namespace Illuminate\Validation\Rules;
 
 class ImageFile extends File
 {
+    public static $allowSvgByDefault = true;
+
+    public static function allowSvg($allowByDefault = true)
+    {
+        static::$allowSvgByDefault = $allowByDefault;
+    }
+
     /**
      * Create a new image file rule instance.
      *
-     * @param  bool  $allowSvg
+     * @param  bool|null  $allowSvg
      * @return void
      */
-    public function __construct($allowSvg = false)
+    public function __construct($allowSvg = null)
     {
+        $allowSvg ??= static::$allowSvgByDefault;
+
         if ($allowSvg) {
             $this->rules('image:allow_svg');
         } else {

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -4,8 +4,19 @@ namespace Illuminate\Validation\Rules;
 
 class ImageFile extends File
 {
+    /**
+     * Indicates if SVG files are allowed by default.
+     *
+     * @var bool
+     */
     public static $allowSvgByDefault = true;
 
+    /**
+     * Indicate whether SVG files are allowed by default.
+     *
+     * @param  bool  $allowByDefault
+     * @return void
+     */
     public static function allowSvg($allowByDefault = true)
     {
         static::$allowSvgByDefault = $allowByDefault;

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -10,6 +10,7 @@ use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\File;
+use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
@@ -206,6 +207,17 @@ class ValidationFileRuleTest extends TestCase
                     </svg>
                     XML
         );
+
+        $this->passes(
+            File::image(),
+            $maliciousSvgFileWithXSS,
+        );
+        $this->passes(
+            Rule::imageFile(),
+            $maliciousSvgFileWithXSS,
+        );
+
+        ImageFile::allowSvg(allowByDefault: false);
 
         $this->fails(
             File::image(),

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4888,6 +4888,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => $file5], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
+        $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
+        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
+        $v = new Validator($trans, ['x' => $file6], ['x' => 'image']);
+        $this->assertTrue($v->passes());
+
         ImageFile::allowSvg(allowByDefault: false);
 
         $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -25,6 +25,7 @@ use Illuminate\Translation\Translator;
 use Illuminate\Validation\DatabasePresenceVerifierInterface;
 use Illuminate\Validation\Rule as ValidationRule;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
@@ -4886,6 +4887,8 @@ class ValidationValidatorTest extends TestCase
         $file5->expects($this->any())->method('getClientOriginalExtension')->willReturn('png');
         $v = new Validator($trans, ['x' => $file5], ['x' => 'image']);
         $this->assertTrue($v->passes());
+
+        ImageFile::allowSvg(allowByDefault: false);
 
         $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file6->expects($this->any())->method('guessExtension')->willReturn('svg');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4891,6 +4891,12 @@ class ValidationValidatorTest extends TestCase
         $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
         $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
         $v = new Validator($trans, ['x' => $file6], ['x' => 'image']);
+        $this->assertFalse($v->passes());
+
+        $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
+        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
+        $v = new Validator($trans, ['x' => $file6], ['x' => 'image:allow_svg']);
         $this->assertTrue($v->passes());
 
         $file7 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -50,6 +50,7 @@ class ValidationValidatorTest extends TestCase
 
         Carbon::setTestNow(null);
         m::close();
+        ImageFile::allowSvg(allowByDefault: true);
     }
 
     public function testNestedErrorMessagesAreRetrievedFromLocalArray()


### PR DESCRIPTION
### Backport of #54331 to 11.x

This patch introduces the security enhancement from #54331, preventing XSS vulnerabilities by excluding SVG files from `ImageFile` validation by default.

To maintain backward compatibility, SVG files are **still allowed by default** in Laravel 11.x. However, a new static method, `ImageFile::allowSvg(allowByDefault: false)`, is introduced. This method can be used to disable SVG validation globally, aligning the behavior with Laravel 12.x. 

---

### Usage

To enforce the new behavior globally, add the following to your `AppServiceProvider`:

```php
use Illuminate\Validation\Rules\ImageFile;

public function boot()
{
    ImageFile::allowSvg(allowByDefault: false);
}
```

### Benefits
- **Enhanced Security:** Mitigates potential XSS vulnerabilities by providing an option to exclude SVG files from image validation.
- **Backward Compatibility:** The change preserves the default behavior in Laravel 11.x, allowing SVGs unless explicitly disabled.
- **Upgrade Readiness:** Introduces an optional configuration to align with Laravel 12.x behavior, simplifying future upgrades.
- **Global Configuration:** Provides a straightforward method to enforce stricter validation across your application with a single setting.

