### PR TITLE
[11.x] Adds the `addPath()` method to the `Lang` facade and the `Translator` class.

### DIFF
--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void load(string $namespace, string $group, string $locale)
  * @method static \Illuminate\Translation\Translator handleMissingKeysUsing(callable|null $callback)
  * @method static void addNamespace(string $namespace, string $hint)
+ * @method static void addPath(string $path)
  * @method static void addJsonPath(string $path)
  * @method static array parseKey(string $key)
  * @method static void determineLocalesUsing(callable $callback)

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -416,6 +416,17 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
+     * Add a new path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addPath($path)
+    {
+        $this->loader->addPath($path);
+    }
+
+    /**
      * Parse a key into namespace, group, and item.
      *
      * @param  string  $key

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -405,17 +405,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Add a new JSON path to the loader.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function addJsonPath($path)
-    {
-        $this->loader->addJsonPath($path);
-    }
-
-    /**
      * Add a new path to the loader.
      *
      * @param  string  $path
@@ -424,6 +413,17 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     public function addPath($path)
     {
         $this->loader->addPath($path);
+    }
+
+    /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJsonPath($path)
+    {
+        $this->loader->addJsonPath($path);
     }
 
     /**


### PR DESCRIPTION
When you want to add a translation path at any stage throughout the application, it makes it possible to add it directly as follows.

```php
app('translator')->addPath($path);

// OR

Lang::addPath($path);
```