### PR TITLE
[12.x] Convert interfaces from docblock to method

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -2,9 +2,6 @@
 
 namespace Illuminate\Contracts\Routing;
 
-/**
- * @method string query(string $path, array $query = [], mixed $extra = [], bool|null $secure = null)
- */
 interface UrlGenerator
 {
     /**
@@ -85,6 +82,17 @@ interface UrlGenerator
      * @return string
      */
     public function temporarySignedRoute($name, $expiration, $parameters = [], $absolute = true);
+
+    /**
+     * Generate an absolute URL with the given query parameters.
+     *
+     * @param  string  $path
+     * @param  array  $query
+     * @param  mixed  $extra
+     * @param  bool|null  $secure
+     * @return string
+     */
+    public function query($path, $query = [], $extra = [], $secure = null);
 
     /**
      * Get the URL to a controller action.

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -2,9 +2,6 @@
 
 namespace Illuminate\Queue\Failed;
 
-/**
- * @method array ids(string $queue = null)
- */
 interface FailedJobProviderInterface
 {
     /**
@@ -17,6 +14,14 @@ interface FailedJobProviderInterface
      * @return string|int|null
      */
     public function log($connection, $queue, $payload, $exception);
+
+    /**
+     * Get the IDs of all of the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function ids($queue = null);
 
     /**
      * Get a list of all of the failed jobs.


### PR DESCRIPTION
For backward compatibility, we typically add new method to Interface using docblock on minor/patch releases. This should be a good time to declare them as actual method.

* #51515 
* #49186
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
