### PR TITLE
[11.x] Fix validator return fails if using different date formats

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -299,6 +299,8 @@ trait ValidatesAttributes
     {
         $firstDate = $this->getDateTimeWithOptionalFormat($format, $first);
 
+        $format = $this->getDateFormat($second) ?: $format;
+
         if (! $secondDate = $this->getDateTimeWithOptionalFormat($format, $second)) {
             if (is_null($second = $this->getValue($second))) {
                 return true;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6316,6 +6316,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '1970-01-02', '2018-05-12' => '1970-01-01'], ['x' => 'date_format:Y-m-d|after:2018-05-12']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '2020-08-05', 'y' => '2020-06-08'], ['x' => 'date_format:Y-m-d|before:y', 'y' => 'date_format:Y-d-m']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2020-05-08', 'y' => '2020-08-06'], ['x' => 'date_format:Y-m-d', 'y' => 'date_format:Y-d-m|after:x']);
+        $this->assertTrue($v->passes());
     }
 
     public function testWeakBeforeAndAfter()
@@ -6417,6 +6423,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '2012-01-15 11:00', 'bar' => null], ['foo' => 'before_or_equal:bar', 'bar' => 'nullable']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '2020-08-05', 'y' => '2020-05-08'], ['x' => 'date_format:Y-m-d|before_or_equal:y', 'y' => 'date_format:Y-d-m']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2020-05-08', 'y' => '2020-08-05'], ['x' => 'date_format:Y-m-d', 'y' => 'date_format:Y-d-m|after_or_equal:x']);
+        $this->assertTrue($v->passes());
     }
 
     public function testSometimesAddingRules()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6317,10 +6317,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '1970-01-02', '2018-05-12' => '1970-01-01'], ['x' => 'date_format:Y-m-d|after:2018-05-12']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['x' => '2020-08-05', 'y' => '2020-06-08'], ['x' => 'date_format:Y-m-d|before:y', 'y' => 'date_format:Y-d-m']);
+        $v = new Validator($trans, ['from' => '2020-08-05', 'to' => '2020-06-08'], ['from' => 'date_format:Y-m-d|before:to', 'to' => 'date_format:Y-d-m']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => '2020-05-08', 'y' => '2020-08-06'], ['x' => 'date_format:Y-m-d', 'y' => 'date_format:Y-d-m|after:x']);
+        $v = new Validator($trans, ['from' => '2020-05-08', 'to' => '2020-08-06'], ['from' => 'date_format:Y-m-d', 'to' => 'date_format:Y-d-m|after:from']);
         $this->assertTrue($v->passes());
     }
 
@@ -6424,10 +6424,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '2012-01-15 11:00', 'bar' => null], ['foo' => 'before_or_equal:bar', 'bar' => 'nullable']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['x' => '2020-08-05', 'y' => '2020-05-08'], ['x' => 'date_format:Y-m-d|before_or_equal:y', 'y' => 'date_format:Y-d-m']);
+        $v = new Validator($trans, ['from' => '2020-08-05', 'to' => '2020-05-08'], ['from' => 'date_format:Y-m-d|before_or_equal:to', 'to' => 'date_format:Y-d-m']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => '2020-05-08', 'y' => '2020-08-05'], ['x' => 'date_format:Y-m-d', 'y' => 'date_format:Y-d-m|after_or_equal:x']);
+        $v = new Validator($trans, ['from' => '2020-05-08', 'to' => '2020-08-05'], ['from' => 'date_format:Y-m-d', 'to' => 'date_format:Y-d-m|after_or_equal:from']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
This PR fix the date validator if the validator has diff date formats like this: 

```
[
    'from' => 'date|before:to|date_format:Y-m-d',
    'to' => 'date|date_format:Y-d-m|after:from',
]
```

```checkDateTimeOrder()``` only use the first format.