### PR TITLE
[11.x] fix  the method ```explodeExplicitRule``` to support Customizable Date Validation

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -101,8 +101,7 @@ class ValidationRuleParser
         foreach ($rule as $value) {
             if ($value instanceof Date) {
                 $rules = array_merge($rules, explode('|', (string) $value));
-            }
-            else {
+            } else {
                 $rules[] = $this->prepareRule($value, $attribute);
             }
         }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 
@@ -95,11 +96,11 @@ class ValidationRuleParser
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
 
-        return array_map(
+        return Arr::flatten(array_map(
             [$this, 'prepareRule'],
             $rule,
             array_fill((int) array_key_first($rule), count($rule), $attribute)
-        );
+        ));
     }
 
     /**
@@ -124,6 +125,10 @@ class ValidationRuleParser
             ($rule instanceof Exists && $rule->queryCallbacks()) ||
             ($rule instanceof Unique && $rule->queryCallbacks())) {
             return $rule;
+        }
+
+        if ($rule instanceof Date) {
+            return explode('|', (string) $rule);
         }
 
         if ($rule instanceof NestedRules) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -96,11 +96,18 @@ class ValidationRuleParser
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
 
-        return Arr::flatten(array_map(
-            [$this, 'prepareRule'],
-            $rule,
-            array_fill((int) array_key_first($rule), count($rule), $attribute)
-        ));
+        $rules = [];
+
+        foreach ($rule as $value) {
+            if ($value instanceof Date) {
+                $rules = array_merge($rules, explode('|', (string) $value));
+            }
+            else {
+                $rules[] = $this->prepareRule($value, $attribute);
+            }
+        }
+
+        return $rules;
     }
 
     /**
@@ -125,10 +132,6 @@ class ValidationRuleParser
             ($rule instanceof Exists && $rule->queryCallbacks()) ||
             ($rule instanceof Unique && $rule->queryCallbacks())) {
             return $rule;
-        }
-
-        if ($rule instanceof Date) {
-            return explode('|', (string) $rule);
         }
 
         if ($rule instanceof NestedRules) {


### PR DESCRIPTION
The Date Validation returns a string ```date|date_format:Y-m-d``` so that when a Form Request using it such as: 
```
return [
    'from' => ['required', Rule::date()->after('today')]
]
```
we'll get the error: Method Illuminate\\Validation\\Validator::validateDate|dateFormat does not exist