### PR TITLE
[12.x] Add missing `previousPath` to `UrlGenerator` interface

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -20,6 +20,14 @@ interface UrlGenerator
     public function previous($fallback = false);
 
     /**
+     * Get the previous path info for the request.
+     *
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousPath($fallback = false);
+
+    /**
      * Generate an absolute URL to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -20,7 +20,7 @@ interface UrlGenerator
     public function previous($fallback = false);
 
     /**
-     * Get the previous path info for the request.
+     * Get the URL for the previous request without query parameters.
      *
      * @param  mixed  $fallback
      * @return string

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -176,7 +176,7 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Get the previous path info for the request.
+     * Get the URL for the previous request without query parameters.
      *
      * @param  mixed  $fallback
      * @return string


### PR DESCRIPTION
This adds the missing `previousPath` method to the `UrlGenerator` interface.

The `previousPath` method was introduced in #41661 but was not added to the `Illuminate\Contracts\Routing\UrlGenerator` interface at the time to avoid a breaking change.

This should now be possible as part of the new major version release.
