### PR TITLE
[11.x] Allow `TestComponent` to be macroable

### DIFF
--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -2,12 +2,17 @@
 
 namespace Illuminate\Testing;
 
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Stringable;
 
 class TestComponent implements Stringable
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * The original component.
      *
@@ -162,6 +167,10 @@ class TestComponent implements Stringable
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         return $this->component->{$method}(...$parameters);
     }
 }

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\Testing\TestComponent;
 use Illuminate\View\Component;
 use Orchestra\Testbench\TestCase;
 
@@ -39,5 +40,22 @@ class InteractsWithViewsTest extends TestCase
         $this->assertSame('bar', $component->foo);
         $this->assertSame('hello', $component->speak());
         $component->assertSee('content');
+    }
+
+    public function testComponentMacroable()
+    {
+        TestComponent::macro('foo', fn (): string => 'bar');
+
+        $exampleComponent = new class extends Component
+        {
+            public function render()
+            {
+                return 'rendered content';
+            }
+        };
+
+        $component = $this->component(get_class($exampleComponent));
+
+        $this->assertSame('bar', $component->foo());
     }
 }


### PR DESCRIPTION
This PR allows the `TestComponent` class to be macroable like `TestView`. 

In my case, I'd like to be able to chain on my own custom HTML assertion methods:

```
TestComponent::macro('assertElement', fn (): => //...);
```

```
public function test_my_component(): void
{
    $this->component(MyComponent::class, [...])->assertElement(...);
}
```