### PR TITLE
[11.x] Add precision support to Number::currency()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -138,13 +138,18 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
+     * @param  int|null  $precision
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null)
+    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
+
+        if (! is_null($precision)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+        }
 
         return $formatter->formatCurrency($number, ! empty($in) ? $in : static::$currency);
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -165,6 +165,28 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testToCurrencyWithDifferentPrecision()
+    {
+        $this->assertSame('$0', Number::currency(0, precision: 0));
+        $this->assertSame('$1.0', Number::currency(1, precision: 1));
+        $this->assertSame('$10.00', Number::currency(10, precision: 2));
+        $this->assertSame('$10.001', Number::currency(10.0014, precision: 3));
+        $this->assertSame('$10.002', Number::currency(10.0015, precision: 3));
+
+        $this->assertSame('€0', Number::currency(0, 'EUR', precision: 0));
+        $this->assertSame('€1.0', Number::currency(1, 'EUR', precision: 1));
+        $this->assertSame('€10.00', Number::currency(10, 'EUR', precision: 2));
+        $this->assertSame('€10.001', Number::currency(10.0014, 'EUR', precision: 3));
+        $this->assertSame('€10.002', Number::currency(10.0015, 'EUR', precision: 3));
+
+        $this->assertSame('-$5', Number::currency(-5, precision: 0));
+        $this->assertSame('$5.0', Number::currency(5.00, precision: 1));
+        $this->assertSame('$5.32', Number::currency(5.325, precision: 2));
+        $this->assertSame('$5.321', Number::currency(5.3214, precision: 3));
+        $this->assertSame('$5.322', Number::currency(5.3215, precision: 3));
+    }
+
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::fileSize(0));


### PR DESCRIPTION
`Number::format()` has this functionality.
`Number::percentage()` also has this functionality.
`fileSize`, `abbreviate`, `forHumans`, `summarize` also has this functionality.

It makes no sense not to add this option for the `currency` method.

There are times when you don't want to force your application to spit out currencies with 2 decimals - sometimes you want to work with either more or less. This PR does just that.

We've had this issue in our project, where we needed to format a bunch of numbers, percentages and currencies - however, only the first two could be done with precision, so we had to reinvent the wheel, and make our own `currency` helper.

Consistency is key, if every method can use precision, the `currency` method should also be able to have this feature. Let us do it the Laravel way, don't force us to make dumb workarounds.