### PR TITLE
[11.x] Where doesnt have nullable morph

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -311,9 +311,19 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return $this
      */
-    public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
+    public function doesntHaveMorph($relation, $types = ['*'], $boolean = 'and', ?Closure $callback = null)
     {
-        return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
+        if (is_string($relation)) {
+            $relation = $this->getRelationWithoutConstraints($relation);
+        }
+
+        return $this
+            ->hasMorph($relation, $types, '<', 1, $boolean, $callback)
+            ->when($types === ['*'], fn(self $query) => $query
+                ->orWhere(fn(self $query) => $query
+                    ->whereNull([$relation->getMorphType(), $relation->getForeignKeyName()])
+                ),
+            );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -251,24 +251,23 @@ trait QueriesRelationships
             $type = Relation::getMorphedModel($type) ?? $type;
         }
 
-        return $this
-            ->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
-                foreach ($types as $type) {
-                    $query->orWhere(function ($query) use ($relation, $callback, $operator, $count, $type) {
-                        $belongsTo = $this->getBelongsToRelation($relation, $type);
+        return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
+            foreach ($types as $type) {
+                $query->orWhere(function ($query) use ($relation, $callback, $operator, $count, $type) {
+                    $belongsTo = $this->getBelongsToRelation($relation, $type);
 
-                        if ($callback) {
-                            $callback = function ($query) use ($callback, $type) {
-                                return $callback($query, $type);
-                            };
-                        }
+                    if ($callback) {
+                        $callback = function ($query) use ($callback, $type) {
+                            return $callback($query, $type);
+                        };
+                    }
 
-                        $query->where($this->qualifyColumn($relation->getMorphType()), '=', (new $type)->getMorphClass())
-                            ->whereHas($belongsTo, $callback, $operator, $count);
-                    });
-                }
-            }, null, null, $boolean)
-            ->when($checkMorphNull, fn (self $query) => $query->orWhereMorphedTo($relation, null));
+                    $query->where($this->qualifyColumn($relation->getMorphType()), '=', (new $type)->getMorphClass())
+                        ->whereHas($belongsTo, $callback, $operator, $count);
+                });
+            }
+        }, null, null, $boolean)
+        ->when($checkMorphNull, fn (self $query) => $query->orWhereMorphedTo($relation, null));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -232,9 +232,9 @@ trait QueriesRelationships
 
         // 1. does this deal with the callback?
         // 2. does this handle types properly?
-        // 3. does this handle < 2 properly?
+        // 3. does this handle other operators (>= > <= < = !=)
 
-        $checkMorphNull = ($operator === '<' && $count === 1)
+        $checkMorphNull = ($operator === '<')
             || ($operator === '=' && $count === 0);
 
         if($types === ['*'] && $checkMorphNull) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -230,6 +230,10 @@ trait QueriesRelationships
 
         $types = (array) $types;
 
+        if($types === ['*'] && $operator === '<' && $count === 1) {
+            return $this->whereMorphedTo($relation, null);
+        }
+
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())
                 ->filter()
@@ -313,17 +317,7 @@ trait QueriesRelationships
      */
     public function doesntHaveMorph($relation, $types = ['*'], $boolean = 'and', ?Closure $callback = null)
     {
-        if (is_string($relation)) {
-            $relation = $this->getRelationWithoutConstraints($relation);
-        }
-
-        return $this
-            ->hasMorph($relation, $types, '<', 1, $boolean, $callback)
-            ->when($types === ['*'], fn(self $query) => $query
-                ->orWhere(fn(self $query) => $query
-                    ->whereNull([$relation->getMorphType(), $relation->getForeignKeyName()])
-                ),
-            );
+        return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -146,7 +146,7 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|null $callback
+     * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -310,7 +310,7 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @return $this
      */
-    public function doesntHaveMorph($relation, $types = ['*'], $boolean = 'and', ?Closure $callback = null)
+    public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -230,12 +230,36 @@ trait QueriesRelationships
 
         $types = (array) $types;
 
-        // 1. does this deal with the callback?
-        // 2. does this handle types properly?
-        // 3. does this handle other operators (>= > <= < = !=)
+        // operators;
+        // 1. >=
+        //   a) positive: doesnt need nulls as is inclusionary
+        //   b) zero:     will always be true...
+        //   c) negative: will always be true...
+        // 2. >
+        //   a) positive: doesnt need nulls as is inclusionary
+        //   b) zero:     doesnt need nulls as is inclusionary
+        //   c) negative: will always be true...
+        // 3. <=
+        //   a) positive: needs nulls as is exclusionary
+        //   b) zero:     needs nulls as is exclusionary
+        //   c) negative: can never be true...
+        // 4. <
+        //   a) positive: needs nulls as is exclusionary
+        //   b) zero:     can never be true...
+        //   c) negative: can never be true...
+        // 5. =
+        //   a) positive: doesnt need nulls as is inclusionary
+        //   b) zero:     needs nulls as is exclusionary
+        //   c) negative: can never be true...
+        // 6. !=
+        //   a) positive: needs nulls as is exclusionary
+        //   b) zero:     doesnt need nulls as is inclusionary
+        //   c) negative: will always be true...
 
-        $checkMorphNull = ($operator === '<')
-            || ($operator === '=' && $count === 0);
+        $checkMorphNull = ($operator === '<' && $count >= 1)
+            || ($operator === '<=' && $count >= 0)
+            || ($operator === '=' && $count === 0)
+            || ($operator === '!=' && $count >= 1);
 
         if($types === ['*'] && $checkMorphNull) {
             return $this->whereMorphedTo($relation, null);

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -230,7 +230,14 @@ trait QueriesRelationships
 
         $types = (array) $types;
 
-        if($types === ['*'] && $operator === '<' && $count === 1) {
+        // 1. does this deal with the callback?
+        // 2. does this handle types properly?
+        // 3. does this handle < 2 properly?
+
+        $checkMorphNull = ($operator === '<' && $count === 1)
+            || ($operator === '=' && $count === 0);
+
+        if($types === ['*'] && $checkMorphNull) {
             return $this->whereMorphedTo($relation, null);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -28,6 +28,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return $this
      *
      * @throws \RuntimeException
@@ -122,6 +123,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
      * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
@@ -144,6 +146,7 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|null $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -159,6 +162,7 @@ trait QueriesRelationships
      * Also load the relationship with same condition.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -173,6 +177,7 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -186,6 +191,7 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function whereDoesntHave($relation, ?Closure $callback = null)
@@ -197,6 +203,7 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function orWhereDoesntHave($relation, ?Closure $callback = null)
@@ -212,6 +219,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
@@ -308,6 +316,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array  $types
      * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
@@ -332,6 +341,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array  $types
+     * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -346,6 +356,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array  $types
+     * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -360,6 +371,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array  $types
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function whereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
@@ -372,6 +384,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array  $types
+     * @param  \Closure|null  $callback
      * @return $this
      */
     public function orWhereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
@@ -925,6 +938,11 @@ trait QueriesRelationships
 
     /**
      * Updates the table name for any columns with a new qualified name.
+     *
+     * @param  array  $wheres
+     * @param  string  $from
+     * @param  string  $to
+     * @return array
      */
     protected function requalifyWhereTables(array $wheres, string $from, string $to): array
     {
@@ -940,6 +958,7 @@ trait QueriesRelationships
     /**
      * Add a sub-query count clause to this query.
      *
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -255,6 +255,13 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
         $this->assertEquals([1, 4], $comments->pluck('id')->all());
     }
+
+    public function testWhereDoesntHaveMorphWithNullableMorph()
+    {
+        $comments = Comment::whereDoesntHaveMorph('commentable', '*')->orderBy('id')->get();
+
+        $this->assertEquals([3, 7, 8], $comments->pluck('id')->all());
+    }
 }
 
 class Comment extends Model


### PR DESCRIPTION
Hey, this PR aims to resolve [this issue](https://github.com/laravel/framework/issues/54315).

The problem currently (as described in the issue) is that `QueriesRelationships::` excludes Models with a `null` `morph_type` value.

This is due to the logic in `QueriesRelationships::hasMorph` revolving around `types` (which exludes `null`):

```php
// src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php (231)
if ($types === ['*']) {
    $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())
        ->filter()
        ->map(fn ($item) => enum_value($item))
        ->all();
}
```

My proposed solution adds a conditional clause to the query, to also include models with a `null` morph relation. I made the decision to widen the scope to include other operators - as this felt more complete of a solution than just solving for default `whereDoesntHave`. I understand this comes with it's own drawbacks, and am happy to partly undo if desired.

This only applies if the chosen `type` is wildcard, as I understand choosing types currently means any results must have that type of morph relation (and naturally, `null` cannot acheieve this). Truthfully I'm not particularily confident on this bit - would appreciate any checking over!

I've only added the test case from the issue, as it feels like the majority use case. 

Please see my logic for deciding which operators to include below.

```
operators;
1. >=
  a) positive: doesnt need nulls as is inclusionary
  b) zero:     will always be true...
  c) negative: will always be true...
2. >
  a) positive: doesnt need nulls as is inclusionary
  b) zero:     doesnt need nulls as is inclusionary
  c) negative: will always be true...
3. <=
  a) positive: needs nulls as is exclusionary
  b) zero:     needs nulls as is exclusionary
  c) negative: can never be true...
4. <
  a) positive: needs nulls as is exclusionary
  b) zero:      can never be true...
  c) negative: can never be true...
5. =
  a) positive: doesnt need nulls as is inclusionary
  b) zero:     needs nulls as is exclusionary
  c) negative: can never be true...
6. !=
  a) positive: needs nulls as is exclusionary
  b) zero:     doesnt need nulls as is inclusionary
  c) negative: will always be true...
```