### PR TITLE
[11.x] Proper rate limiter fix with phpredis serialization/compression enabled

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -432,10 +432,6 @@ class RedisStore extends TaggableStore implements LockProvider
     protected function pack($value, $connection)
     {
         if ($connection instanceof PhpRedisConnection) {
-            if ($this->shouldBeStoredWithoutSerialization($value)) {
-                return $value;
-            }
-
             if ($connection->serialized()) {
                 return $connection->pack([$value])[0];
             }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Mockery as m;
@@ -20,6 +21,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(1);
         $cache->shouldReceive('has')->once()->with('key:timer')->andReturn(true);
         $cache->shouldReceive('add')->never();
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $this->assertTrue($rateLimiter->tooManyAttempts('key', 1));
@@ -31,6 +33,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
         $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(true);
         $cache->shouldReceive('increment')->once()->with('key', 1)->andReturn(1);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
@@ -42,6 +45,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
         $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(true);
         $cache->shouldReceive('increment')->once()->with('key', 5)->andReturn(5);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->increment('key', 1, 5);
@@ -53,6 +57,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
         $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(true);
         $cache->shouldReceive('increment')->once()->with('key', -5)->andReturn(-5);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->decrement('key', 1, 5);
@@ -65,6 +70,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(false);
         $cache->shouldReceive('increment')->once()->with('key', 1)->andReturn(1);
         $cache->shouldReceive('put')->once()->with('key', 1, 1);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
@@ -74,6 +80,7 @@ class CacheRateLimiterTest extends TestCase
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(3);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
@@ -84,6 +91,7 @@ class CacheRateLimiterTest extends TestCase
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('forget')->once()->with('key');
         $cache->shouldReceive('forget')->once()->with('key:timer');
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->clear('key');
@@ -93,6 +101,7 @@ class CacheRateLimiterTest extends TestCase
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->andReturn(now()->subSeconds(60)->getTimestamp(), null);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $this->assertTrue($rateLimiter->availableIn('key:timer') >= 0);
@@ -106,6 +115,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1);
         $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturns(1);
         $cache->shouldReceive('increment')->once()->with('key', 1)->andReturn(1);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
 
         $executed = false;
 
@@ -124,6 +134,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('add')->times(6)->with('key:timer', m::type('int'), 1);
         $cache->shouldReceive('add')->times(6)->with('key', 0, 1)->andReturns(1);
         $cache->shouldReceive('increment')->times(6)->with('key', 1)->andReturn(1);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
 
         $rateLimiter = new RateLimiter($cache);
 
@@ -157,6 +168,7 @@ class CacheRateLimiterTest extends TestCase
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(2);
         $cache->shouldReceive('has')->once()->with('key:timer')->andReturn(true);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
 
         $executed = false;
 
@@ -174,6 +186,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('get')->once()->with('john', 0)->andReturn(1);
         $cache->shouldReceive('has')->once()->with('john:timer')->andReturn(true);
         $cache->shouldReceive('add')->never();
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
         $rateLimiter = new RateLimiter($cache);
 
         $this->assertTrue($rateLimiter->tooManyAttempts('jôhn', 1));
@@ -190,6 +203,7 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('get')->once()->with($cleanedKey, 0)->andReturn(1);
         $cache->shouldReceive('has')->once()->with("$cleanedKey:timer")->andReturn(true);
         $cache->shouldReceive('add')->never();
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
 
         $this->assertTrue($rateLimiter->tooManyAttempts($key, 1));
     }

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -38,7 +38,7 @@ class RedisCacheIntegrationTest extends TestCase
         $this->assertGreaterThan(3500, $this->redis[$driver]->connection()->ttl('k'));
     }
 
-        /**
+    /**
      * @param  string  $driver
      */
     #[DataProvider('redisDriverProvider')]

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
@@ -35,6 +36,22 @@ class RedisCacheIntegrationTest extends TestCase
         $this->assertTrue($repository->add('k', 'v', 3600));
         $this->assertFalse($repository->add('k', 'v', 3600));
         $this->assertGreaterThan(3500, $this->redis[$driver]->connection()->ttl('k'));
+    }
+
+        /**
+     * @param  string  $driver
+     */
+    #[DataProvider('redisDriverProvider')]
+    public function testRedisCacheRateLimiter($driver)
+    {
+        $store = new RedisStore($this->redis[$driver]);
+        $repository = new Repository($store);
+        $rateLimiter = new RateLimiter($repository);
+
+        $this->assertFalse($rateLimiter->tooManyAttempts('key', 1));
+        $this->assertEquals(1, $rateLimiter->hit('key', 60));
+        $this->assertTrue($rateLimiter->tooManyAttempts('key', 1));
+        $this->assertFalse($rateLimiter->tooManyAttempts('key', 2));
     }
 
     /**

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -252,6 +252,8 @@ class RedisStoreTest extends TestCase
 
     public function testIncrementWithSerializationEnabled()
     {
+        $this->markTestSkipped('Test makes no sense anymore. Application must explicitly wrap such code in runClean() when used with serialization/compression enabled.');
+
         /** @var \Illuminate\Cache\RedisStore $store */
         $store = Cache::store('redis');
         /** @var \Redis $client */

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -63,6 +63,7 @@ class RateLimitedTest extends TestCase
         $cache->shouldReceive('add')->andReturn(true, true);
         $cache->shouldReceive('increment')->andReturn(1);
         $cache->shouldReceive('has')->andReturn(true);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
 
         $rateLimiter = new RateLimiter($cache);
         $this->app->instance(RateLimiter::class, $rateLimiter);


### PR DESCRIPTION
As a follow up from https://github.com/laravel/framework/issues/54307:

As it turns out it is not safe to globally skip phpredis's serialization/compression for numeric values in EVAL script parameters. The result of my investigation (with the help of the phpredis team, see: https://github.com/phpredis/phpredis/pull/2616) concludes the following: when those options are enabled, the framework must not interfere at all. The application code must disable serialization/compression on per key basis where we know that this key is used for increment/decrement or similar operations.

I have found several cases where skipping the serialization/compression for numeric values, causes the RateLimiter to still fail.

One example is when used with MSGPACK. Its a binary format and for example the rate limit counter 1 is stored as 1, but when this counter value is read, it is interpreted as 49.

### Proof

For the following test I expect a fresh counter with a rate limit of 1

```php
/**
 * @param  string  $driver
 */
#[DataProvider('redisDriverProvider')]
public function testRedisCacheRateLimiter($driver)
{
    $store = new RedisStore($this->redis[$driver]);
    $repository = new Repository($store);
    $rateLimiter = new RateLimiter($repository);

    $this->assertFalse($rateLimiter->tooManyAttempts('key', 1));
    $this->assertEquals(1, $rateLimiter->hit('key', 60));
    $this->assertTrue($rateLimiter->tooManyAttempts('key', 1));

    // Fails here, because the stored value is 49 when read back instead of 1.
    $this->assertFalse($rateLimiter->tooManyAttempts('key', 2));
}
```

Redis output looks fine here

```
1737982882.439262 [5 172.18.0.1:46038] "GET" "test_key"
1737982882.453418 [5 172.18.0.1:46038] "EVAL" "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])" "1" "test_key:timer" "1737982942" "60"
1737982882.453455 [5 lua] "exists" "test_key:timer"
1737982882.453461 [5 lua] "setex" "test_key:timer" "60" "1737982942"
1737982882.453601 [5 172.18.0.1:46038] "EVAL" "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])" "1" "test_key" "0" "60"
1737982882.453612 [5 lua] "exists" "test_key"
1737982882.453615 [5 lua] "setex" "test_key" "60" "0"
1737982882.453670 [5 172.18.0.1:46038] "INCRBY" "test_key" "1"
1737982882.453841 [5 172.18.0.1:46038] "GET" "test_key"
1737982882.453992 [5 172.18.0.1:46038] "GET" "test_key:timer"
1737982882.454303 [5 172.18.0.1:46038] "GET" "test_key"
1737982882.454383 [5 172.18.0.1:46038] "GET" "test_key:timer"
1737982882.457179 [5 172.18.0.1:46038] "FLUSHDB"
```

Phpunit output reveals the error when we read back the value and phpredis tries to deserialize

```bash
vendor/bin/phpunit tests/Cache/RedisCacheIntegrationTest.php --filter=testRedisCacheRateLimiter
PHPUnit 11.5.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.16
Configuration: /home/xxx/Documents/workspace/framework/phpunit.xml

F                                                                   1 / 1 (100%)

Time: 00:00.029, Memory: 14.00 MB

There was 1 failure:

1) Illuminate\Tests\Cache\RedisCacheIntegrationTest::testRedisCacheRateLimiter with data set #0 ('phpredis')
Failed asserting that true is false.

/home/xxx/Documents/workspace/framework/tests/Cache/RedisCacheIntegrationTest.php:54

--

1 test triggered 1 PHP warning:

1) /home/xxx/Documents/workspace/framework/src/Illuminate/Redis/Connections/Connection.php:116
[msgpack] (php_msgpack_unserialize) Extra bytes

Triggered by:

* Illuminate\Tests\Cache\RedisCacheIntegrationTest::testRedisCacheRateLimiter#0 (2 times)
  /home/xxx/Documents/workspace/framework/tests/Cache/RedisCacheIntegrationTest.php:45

FAILURES!
Tests: 1, Assertions: 4, Failures: 1, Warnings: 1.
```

### Solution

1. Do not interfere or decide what needs to be serialized/deserialized or compressed/uncompressed on application side while those settings are enabled. Let phpredis deal with packing/unpacking exclusively.
2. For concrete features like RateLimiter, disable serialization/compression for the duration of the operation. Reading/writing those options is just a flag flip, so basically 0 extra overhead (as confirmed by phpredis maintainer).

Because the `RateLimiter` is built on top of the `Cache` component, I have added this logic in all 3 places where it sets and reads the counter value. As a result the test pass with all combinations of compression/serialization settings locally.

In addition a new helper method is provided in the `PacksPhpRedisValues` trait that users can use to skip phpredis serialization/compression on per key basis. This allows full control over this behavior. (fyi, we should mention in the docs that connections with those settings should ideally by only used for caching).