### PR TITLE
[11.x] Fix `hasAttribute()` returning true for missing casted attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -449,7 +449,6 @@ trait HasAttributes
         }
 
         return array_key_exists($key, $this->attributes) ||
-            array_key_exists($key, $this->casts) ||
             $this->hasGetMutator($key) ||
             $this->hasAttributeMutator($key) ||
             $this->isClassCastable($key);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3151,23 +3151,29 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testHasAttributeWithCastedValues()
     {
-        Model::preventAccessingMissingAttributes();
+        $originalMode = Model::preventsAccessingMissingAttributes();
 
-        $user = new EloquentModelStub;
-        $user->setDateFormat('d-m-Y H:i:s');
-        $user->exists = true;
+        try {
+            Model::preventAccessingMissingAttributes();
 
-        $user->castedDateTime = '2025-01-27 15:00:00';
+            $user = new EloquentModelStub;
+            $user->setDateFormat('d-m-Y H:i:s');
+            $user->exists = true;
 
-        $this->assertTrue($user->hasAttribute('castedDateTime'));
+            $user->castedDateTime = '2025-01-27 15:00:00';
 
-        $this->assertInstanceOf(Carbon::class, $user->castedDateTime);
+            $this->assertTrue($user->hasAttribute('castedDateTime'));
 
-        $this->assertFalse($user->hasAttribute('castedFloat'));
+            $this->assertInstanceOf(Carbon::class, $user->castedDateTime);
 
-        $this->expectException(MissingAttributeException::class);
+            $this->assertFalse($user->hasAttribute('castedFloat'));
 
-        $user->castedFloat;
+            $this->expectException(MissingAttributeException::class);
+
+            $user->castedFloat;
+        } finally {
+            Model::preventAccessingMissingAttributes($originalMode);
+        }
     }
 
     public function testModelToJsonSucceedsWithPriorErrors(): void

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3145,9 +3145,29 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertTrue($user->hasAttribute('name'));
         $this->assertTrue($user->hasAttribute('password'));
-        $this->assertTrue($user->hasAttribute('castedFloat'));
         $this->assertFalse($user->hasAttribute('nonexistent'));
         $this->assertFalse($user->hasAttribute('belongsToStub'));
+    }
+
+    public function testHasAttributeWithCastedValues()
+    {
+        Model::preventAccessingMissingAttributes();
+
+        $user = new EloquentModelStub;
+        $user->setDateFormat('d-m-Y H:i:s');
+        $user->exists = true;
+
+        $user->castedDateTime = '2025-01-27 15:00:00';
+
+        $this->assertTrue($user->hasAttribute('castedDateTime'));
+
+        $this->assertInstanceOf(Carbon::class, $user->castedDateTime);
+
+        $this->assertFalse($user->hasAttribute('castedFloat'));
+
+        $this->expectException(MissingAttributeException::class);
+
+        $user->castedFloat;
     }
 
     public function testModelToJsonSucceedsWithPriorErrors(): void
@@ -3253,7 +3273,10 @@ class EloquentModelStub extends Model
     public $scopesCalled = [];
     protected $table = 'stub';
     protected $guarded = [];
-    protected $casts = ['castedFloat' => 'float'];
+    protected $casts = [
+        'castedFloat' => 'float',
+        'castedDateTime' => 'datetime',
+    ];
 
     public function getListItemsAttribute($value)
     {


### PR DESCRIPTION
I'm in the process of enabling `Model::preventAccessingMissingAttributes()` for a big existing project. I ran into a bug where `hasAttribute()` always returns `true` if an attribute has a cast, even if that attribute is missing. For example:

```php
class User extends Model 
{
    public $casts = [
        'paid_at' => 'datetime',
    ];
}

Model::preventAccessingMissingAttributes();

$user->hasAttribute('paid_at'); // always returns true, even if it is missing

$user->paid_at; // throws a MissingAttributeException if it is missing
```

What I'm trying to do is this:

```php
return [
    'paid_at' => $user->hasAttribute('paid_at') ? $user->paid_at->toDateTimeString() : null,
];
```

But `->hasAttribute('paid_at')` always returns true, so the code above doesn't prevent an exception from being thrown if `paid_at` is missing.

This PR targets 11.x because I assume this is a bug fix, let me know if I should target 12.x instead.

For reference, `hasAttribute()` was added in https://github.com/laravel/framework/pull/50909. The `hasAttribute()` method was intended to be a safe way to check if `Model::preventAccessingMissingAttributes()` would throw an exception.