### PR TITLE
Improve: add fire failed event at once

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -261,6 +261,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return true;
         }
 
+        $this->fireFailedEvent($this->lastAttempted, $credentials);
+
         return false;
     }
 


### PR DESCRIPTION
This pull request adds support for firing the `failed` event when using the `Auth::once` method. Previously, this method did not trigger the `failed` event when authentication failed, making it inconsistent with other authentication methods like `attempt'