### PR TITLE
[11.x] Add existence check to PotentiallyTranslatedString class

### DIFF
--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -70,6 +70,29 @@ class PotentiallyTranslatedString implements Stringable
     }
 
     /**
+     * Determine if a translation exists for a given locale.
+     *
+     * @param  string|null  $locale
+     * @return bool
+     */
+    public function hasForLocale($locale = null)
+    {
+        return $this->has($locale, false);
+    }
+
+    /**
+     * Determine if a translation exists.
+     *
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return bool
+     */
+    public function has($locale = null, $fallback = true)
+    {
+       return $this->translator->has($this->string, $locale, $fallback);
+    }
+
+    /**
      * Get the original string.
      *
      * @return string

--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -89,7 +89,7 @@ class PotentiallyTranslatedString implements Stringable
      */
     public function has($locale = null, $fallback = true)
     {
-       return $this->translator->has($this->string, $locale, $fallback);
+        return $this->translator->has($this->string, $locale, $fallback);
     }
 
     /**

--- a/tests/Translation/TranslationPotentiallyTranslatedStringTest.php
+++ b/tests/Translation/TranslationPotentiallyTranslatedStringTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\Translation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\PotentiallyTranslatedString;
+use Illuminate\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
+
+class TranslationPotentiallyTranslatedStringTest extends TestCase
+{
+    #[TestWith(['custom.hello', 'en', true])]
+    #[TestWith(['basic.hello', 'en', false])]
+    #[TestWith(['custom.world', 'en', false])]
+    #[TestWith(['custom.hello', 'de', false])]
+    public function testPotentiallyTranslatedStringExistenceCheck(string $key, string $locale, bool $exists)
+    {
+        $translator = new Translator(tap(new ArrayLoader)->addMessages('en', 'custom', [
+            'hello' => 'world',
+            'lorem' => 'ipsum',
+        ]), 'en');
+        $translation = new PotentiallyTranslatedString($key, $translator);
+        $this->assertSame($exists, $translation->hasForLocale($locale));
+    }
+}


### PR DESCRIPTION
Similar to `$translator->has($key)`, you can now do `$potentiallyTranslatedString->has()`
