### PR TITLE
[11.x] use Auth::userResolver when resolving the authenticated user

### DIFF
--- a/src/Illuminate/Container/Attributes/Authenticated.php
+++ b/src/Illuminate/Container/Attributes/Authenticated.php
@@ -25,6 +25,6 @@ class Authenticated implements ContextualAttribute
      */
     public static function resolve(self $attribute, Container $container)
     {
-        return $container->make('auth')->guard($attribute->guard)->user();
+        return call_user_func($container->make('auth')->userResolver(), $attribute->guard);
     }
 }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -111,6 +111,7 @@ class ContextualAttributeBindingTest extends TestCase
         $container = new Container;
         $container->singleton('auth', function () {
             $manager = m::mock(AuthManager::class);
+            $manager->shouldReceive('userResolver')->andReturn(fn ($guard = null) => $manager->guard($guard)->user());
             $manager->shouldReceive('guard')->with('foo')->andReturnUsing(function () {
                 $guard = m::mock(GuardContract::class);
                 $guard->shouldReceive('user')->andReturn(m:mock(AuthenticatableContract::class));


### PR DESCRIPTION
Laravel 11 introduced Contextual Attributes, which allows a developer to resolve dependencies from the container using PHP's Attributes to annotate parameters.

The `Illuminate\Container\Attributes\Authenticated` Attribute resolves the current authenticated user and injects it to the parameter annotated with it.

The Authentication component allows a developer to provide a custom user resolver closure with a custom logic on how to resolve the current authenticated user.

This resolver is then bound to the container, to the Gate component and to the Request object.

But the `Illuminate\Container\Attributes\Authenticated` Attribute did not use this resolver.

In projects which provide a custom resolver, this could result in the wrong user instance -- or no instance at all (aka `null`) -- being resolved, instead of using the custom logic as intended by the developer.

This PR:

- Fixes the `Illuminate\Container\Attributes\Authenticated` Attribute to use the Authentication component user resolver
- Changed the test case to account for the additional call on the `AuthManager` mock object


**Note**

I used the same logic as the resolver used in the request to allow the Attribute's guard parameter to be used:

https://github.com/laravel/framework/blob/2d10f2aeddc94e57529a2fb33a50bed8810e3923/src/Illuminate/Auth/AuthServiceProvider.php#L85-L92