### PR TITLE
[11.x] Use `Date` facade for storing the password confirmation timestamp

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -785,7 +786,7 @@ class Store implements Session
      */
     public function passwordConfirmed()
     {
-        $this->put('auth.password_confirmed_at', time());
+        $this->put('auth.password_confirmed_at', Date::now()->unix());
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,7 +23,7 @@
         "illuminate/conditionable": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
-        "nesbot/carbon": "^2.72.2|^3.4",
+        "nesbot/carbon": "^2.72.6|^3.8.4",
         "voku/portable-ascii": "^2.0.2"
     },
     "conflict": {


### PR DESCRIPTION
This matches the changes via laravel/fortify#520

--------------

## Problem

Currently, the password confirmation endpoint uses PHP's inbuilt `time()` function. This does not consider `freezeSecond()` or `Date::setTestNow()`. Leading to inconsistent results during tests.

## Solution

This update maintains compatibility with existing features as both `time()` and `->unix()` return a UNIX timestamp.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
