### PR TITLE
Update Stringable Rule testcases

### DIFF
--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
 include_once 'Enums.php';
@@ -34,5 +37,22 @@ class ValidationArrayRuleTest extends TestCase
         $rule = Rule::array([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2, ArrayKeysBacked::key_3]);
 
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+    }
+
+    public function testArrayValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['foo' => 'not an array'], ['foo' => Rule::array()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => ['bar']], ['foo' => (string) Rule::array()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar', 'key_2' => '']], ['foo' => Rule::array(['key_1', 'key_2'])]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => 'bar', 'key_2' => '']], ['foo' => ['required', Rule::array(['key_1', 'key_2'])]]);
+        $this->assertTrue($v->passes());
     }
 }

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -134,5 +134,15 @@ class ValidationDateRuleTest extends TestCase
         );
 
         $this->assertEmpty($validator->errors()->first('date'));
+
+        $rule = Rule::date()->between('2024/01/01', '2024/02/01')->format('Y/m/d');
+
+        $validator = new Validator(
+            $trans,
+            ['date' => '2024/01/15'],
+            ['date' => [$rule]]
+        );
+
+        $this->assertEmpty($validator->errors()->first('date'));
     }
 }

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -73,5 +73,16 @@ class ValidationDimensionsRuleTest extends TestCase
             $trans->get('validation.dimensions', ['width' => 100, 'height' => 100, 'min_ratio' => 0.5, 'max_ratio' => 0.4]),
             $validator->errors()->first('image')
         );
+
+        $validator = new Validator(
+            $trans,
+            ['image' => $image],
+            ['image' => [$rule]]
+        );
+
+        $this->assertSame(
+            $trans->get('validation.dimensions', ['width' => 100, 'height' => 100, 'min_ratio' => 0.5, 'max_ratio' => 0.4]),
+            $validator->errors()->first('image')
+        );
     }
 }

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -245,6 +245,24 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertSame('exists:table,NULL,softdeleted_at,"NOT_NULL"', (string) $rule);
     }
 
+    public function testItIsAPartOfListRules()
+    {
+        $rule = new Exists('users', 'id');
+
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => ['required', $rule]]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData(['id' => 1]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertTrue($v->passes());
+    }
+
     protected function createSchema()
     {
         $this->schema('default')->create('users', function ($table) {

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -3,8 +3,11 @@
 namespace Illuminate\Tests\Validation;
 
 use Illuminate\Tests\Validation\fixtures\Values;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
 include_once 'Enums.php';
@@ -68,5 +71,22 @@ class ValidationInRuleTest extends TestCase
         $rule = Rule::in([PureEnum::one]);
 
         $this->assertSame('in:"one"', (string) $rule);
+    }
+
+    public function testInRuleValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => Rule::in('foo', 'bar')]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => (string) Rule::in('foo', 'bar')]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => [Rule::in('bar', 'baz')]]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['required', Rule::in('foo', 'bar')]]);
+        $this->assertTrue($v->passes());
     }
 }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -3,8 +3,11 @@
 namespace Illuminate\Tests\Validation;
 
 use Illuminate\Tests\Validation\fixtures\Values;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
 include_once 'Enums.php';
@@ -64,5 +67,22 @@ class ValidationNotInRuleTest extends TestCase
         $rule = Rule::notIn([PureEnum::one]);
 
         $this->assertSame('not_in:"one"', (string) $rule);
+    }
+
+    public function testNotInRuleValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => Rule::notIn('bar', 'baz')]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => (string) Rule::notIn('bar', 'baz')]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => [Rule::notIn('foo', 'bar')]]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['required', Rule::notIn('bar', 'baz')]]);
+        $this->assertTrue($v->passes());
     }
 }

--- a/tests/Validation/ValidationProhibitedIfTest.php
+++ b/tests/Validation/ValidationProhibitedIfTest.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\ProhibitedIf;
+use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -56,5 +59,29 @@ class ValidationProhibitedIfTest extends TestCase
         serialize(new ProhibitedIf(function () {
             return true;
         }));
+    }
+
+    public function testProhibitedIfRuleValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $rule = new ProhibitedIf(true);
+
+        $v = new Validator($trans, ['y' => 'foo'], ['x' => $rule]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['y' => 'foo'], ['x' => (string) $rule]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['y' => 'foo'], ['x' => [$rule]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['string', $rule]]);
+        $this->assertTrue($v->fails());
+
+        $rule = new ProhibitedIf(false);
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['string', $rule]]);
+        $this->assertTrue($v->passes());
     }
 }

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -50,5 +53,29 @@ class ValidationRequiredIfTest extends TestCase
         $rule = serialize(new RequiredIf(function () {
             return true;
         }));
+    }
+
+    public function testRequiredIfRuleValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $rule = new RequiredIf(true);
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => $rule]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ''], ['x' => (string) $rule]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => [$rule]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['string', $rule]]);
+        $this->assertTrue($v->passes());
+
+        $rule = new RequiredIf(false);
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['string', $rule]]);
+        $this->assertTrue($v->passes());
     }
 }


### PR DESCRIPTION
This PR adds more test cases for the ```Stringable``` rule validation. These test cases are follow-up to PR [#54353](https://github.com/laravel/framework/pull/54353#ref-pullrequest-2647637201) to ensure comprehensive coverage and reliability.