### PR TITLE
[11.x] Introduce queue config env vars for `after_commit`

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -40,7 +40,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
-            'after_commit' => false,
+            'after_commit' => (bool) env('DB_QUEUE_AFTER_COMMIT', false),
         ],
 
         'beanstalkd' => [
@@ -49,7 +49,7 @@ return [
             'queue' => env('BEANSTALKD_QUEUE', 'default'),
             'retry_after' => (int) env('BEANSTALKD_QUEUE_RETRY_AFTER', 90),
             'block_for' => 0,
-            'after_commit' => false,
+            'after_commit' => (bool) env('BEANSTALKD_QUEUE_AFTER_COMMIT', false),
         ],
 
         'sqs' => [
@@ -60,7 +60,7 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
-            'after_commit' => false,
+            'after_commit' => (bool) env('SQS_QUEUE_AFTER_COMMIT', false),
         ],
 
         'redis' => [
@@ -69,7 +69,7 @@ return [
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
             'block_for' => null,
-            'after_commit' => false,
+            'after_commit' => (bool) env('REDIS_QUEUE_AFTER_COMMIT', false),
         ],
 
     ],


### PR DESCRIPTION
@nunomaduro thinks it's a great idea to enable `after_commit` for queue jobs globally:
https://x.com/enunomaduro/status/1884187385816039502
https://youtu.be/N0jlh912xcM 🤌

And that should ~~probably~~ **literally** be the recommended default for most projects that heavily use DB transaction in combination with job dispatching. Until now, I had no reason to publish `config/queue.php`, so let's just introduce more env vars here for config luxury.