### PR TITLE
[11.x] Allow secret key Updates Without Bringing the Site Up

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -42,7 +42,7 @@ class DownCommand extends Command
     public function handle()
     {
         try {
-            if ($this->laravel->maintenanceMode()->active()) {
+            if ($this->laravel->maintenanceMode()->active() && ! $this->getSecret()) {
                 $this->components->info('Application is already down.');
 
                 return 0;


### PR DESCRIPTION
Hi everyone,

This PR introduces a minor but impactful change that is fully backward compatible. The update ensures the command exits early only if neither the **--secret** nor **--with-secret** arguments are provided.

Why this change?

Currently, if you have a high-traffic site that isn’t officially launched and you need to update the secret, you'd have to run:

```shell
php artisan up && php artisan down --secret="laravel"  
```

This briefly brings the site live for a few milliseconds or seconds, which may not be ideal. With this change, you can update the secret while the site remains in maintenance mode, avoiding any public access during the update.

It’s a small tweak that makes it easier to update the secret without needing to bring the site up and down again.

Let me know what you think!