### PR TITLE
[11.x] Add overwrite confirmation to environment encryption commands

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -94,7 +94,7 @@ class EnvironmentDecryptCommand extends Command
         if ($this->files->exists($outputFile) &&
             ! $this->option('force') &&
             ! confirm('Environment file already exists. Do you want to overwrite it?', default: false)) {
-            $this->fail('Environment file already exists.');
+            $this->fail('Command cancelled.');
         }
 
         try {

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
 
 #[AsCommand(name: 'env:decrypt')]
@@ -90,7 +91,9 @@ class EnvironmentDecryptCommand extends Command
             $this->fail('Encrypted environment file not found.');
         }
 
-        if ($this->files->exists($outputFile) && ! $this->option('force')) {
+        if ($this->files->exists($outputFile) &&
+            ! $this->option('force') &&
+            ! confirm('Environment file already exists. Do you want to overwrite it?', default: false)) {
             $this->fail('Environment file already exists.');
         }
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
 
@@ -96,8 +97,10 @@ class EnvironmentEncryptCommand extends Command
             $this->fail('Environment file not found.');
         }
 
-        if ($this->files->exists($encryptedFile) && ! $this->option('force')) {
-            $this->fail('Encrypted environment file already exists.');
+        if ($this->files->exists($encryptedFile) &&
+            ! $this->option('force') &&
+            ! confirm('Encrypted environment file already exists. Do you want to overwrite it?', default: false)) {
+            $this->fail('Command cancelled.');
         }
 
         try {

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -65,6 +65,7 @@ class EnvironmentDecryptCommandTest extends TestCase
 
         $this->artisan('env:decrypt', ['--key' => 'secret-key'])
             ->expectsConfirmation('Environment file already exists. Do you want to overwrite it?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
             ->assertExitCode(1);
     }
 

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -106,8 +106,28 @@ class EnvironmentEncryptCommandTest extends TestCase
 
         $this->artisan('env:encrypt')
             ->expectsQuestion('What encryption key would you like to use?', 'generate')
-            ->expectsOutputToContain('Encrypted environment file already exists.')
+            ->expectsConfirmation('Encrypted environment file already exists. Do you want to overwrite it?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
             ->assertExitCode(1);
+    }
+
+    public function testItPromptsForOverwriteWhenEncryptedFileExistsWhenNotForcing()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true);
+
+        $this->artisan('env:encrypt')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsConfirmation('Encrypted environment file already exists. Do you want to overwrite it?', 'yes')
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env.encrypted'), m::any());
     }
 
     public function testItGeneratesTheEncryptionFileWhenForcing()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adding minor improvements to both the `env:encrypt` and `env:decrypt` commands that prompt the user if they would like to overwrite the existing decrypted/encrypted environment file in the absence of the `--force` option.

This pull request also resolves a minor misalignment in `EnvironmentDecryptCommandTest`, where the assertions being made in `testItFailsWhenEncryptionFileCannotBeFound()` and `testItFailsWhenEnvironmentFileExists()` were incorrectly interchanged.