### PR TITLE
[11.x] Fix error handling for uniqueVia() when wrong type is returned

### DIFF
--- a/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
+++ b/src/Illuminate/Foundation/Queue/InteractsWithUniqueJobs.php
@@ -52,7 +52,7 @@ trait InteractsWithUniqueJobs
      */
     protected function getUniqueJobCacheStore($job): ?string
     {
-        if(! method_exists($job, 'uniqueVia')) {
+        if (! method_exists($job, 'uniqueVia')) {
             return config('cache.default');
         }
 


### PR DESCRIPTION
# Description
This PR gives better error handling when calling the `uniqueVia()` method in case the wrong value is returned from the function.

example:
```php
    public function uniqueVia()
    {
        return 'a string value';
    }

```

This will throw an exception in `InteractsWithUniqueJobs` (#54000)

```diff
    /**
     * Determine the cache store used by the unique job to acquire locks.
     *
     * @param  mixed  $job
     * @return string|null
     */
    protected function getUniqueJobCacheStore($job): ?string
    {
        return method_exists($job, 'uniqueVia')
-            ? $job->uniqueVia()->getName()
+            ? $job->uniqueVia()->getName() //throws here
            : config('cache.default');
    }

```

 The following ambiguous error is thrown

![current-error](https://github.com/user-attachments/assets/1b2cc0b8-c673-447b-9ab2-8086fe35fc51)

This PR provides better error handling

![new-error](https://github.com/user-attachments/assets/3210c5fa-3e2f-4c4d-b710-12e96087b648)

Let me know if this requires a test.

