### PR TITLE
feat: added decrementOrCreate to Database Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -649,6 +649,25 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Create a record matching the attributes, or decrement the existing record.
+     *
+     * @param  array  $attributes
+     * @param  string  $column
+     * @param  int|float  $default
+     * @param  int|float  $step
+     * @param  array  $extra
+     * @return TModel
+     */
+    public function decrementOrCreate(array $attributes, string $column = 'count', $default = 1, $step = 1, array $extra = [])
+    {
+        return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column, $step, $extra) {
+            if (! $instance->wasRecentlyCreated) {
+                $instance->decrement($column, $step, $extra);
+            }
+        });
+    }
+
+    /**
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array|string  $columns

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -469,6 +469,175 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
+    public function testDecrementOrCreateMethodDecrementsExistingRecord(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'count' => 5,
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('raw')
+            ->with('"count" - 1')
+            ->andReturn('4');
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "count" = ?, "updated_at" = ? where "id" = ?',
+                ['4', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $result = $model->newQuery()->decrementOrCreate(['attr' => 'foo'], 'count');
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 4,
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testDecrementOrCreateMethodCreatesNewRecord(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite', [123]);
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([]);
+
+        $model->getConnection()->expects('insert')->with(
+            'insert into "table" ("attr", "count", "updated_at", "created_at") values (?, ?, ?, ?)',
+            ['foo', '1', '2023-01-01 00:00:00', '2023-01-01 00:00:00'],
+        )->andReturnTrue();
+
+        $result = $model->newQuery()->decrementOrCreate(['attr' => 'foo']);
+        $this->assertTrue($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 1,
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testDecrementOrCreateMethodDecrementParametersArePassed(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'val' => 'bar',
+                'count' => 5,
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('raw')
+            ->with('"count" - 3')
+            ->andReturn('2');
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "count" = ?, "val" = ?, "updated_at" = ? where "id" = ?',
+                ['2', 'baz', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $result = $model->newQuery()->decrementOrCreate(['attr' => 'foo'], step: 3, extra: ['val' => 'baz']);
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 2,
+            'val' => 'baz',
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testDecrementOrCreateMethodRetrievesRecordCreatedJustNow(): void
+    {
+        $model = new EloquentBuilderCreateOrFirstTestModel();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $model->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $model->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
+            ->andReturn([]);
+
+        $sql = 'insert into "table" ("attr", "count", "updated_at", "created_at") values (?, ?, ?, ?)';
+        $bindings = ['foo', '1', '2023-01-01 00:00:00', '2023-01-01 00:00:00'];
+
+        $model->getConnection()
+            ->expects('insert')
+            ->with($sql, $bindings)
+            ->andThrow(new UniqueConstraintViolationException('sqlite', $sql, $bindings, new Exception()));
+
+        $model->getConnection()
+            ->expects('select')
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], false)
+            ->andReturn([[
+                'id' => 123,
+                'attr' => 'foo',
+                'count' => 1,
+                'created_at' => '2023-01-01 00:00:00',
+                'updated_at' => '2023-01-01 00:00:00',
+            ]]);
+
+        $model->getConnection()
+            ->expects('raw')
+            ->with('"count" - 1')
+            ->andReturn('0');
+
+        $model->getConnection()
+            ->expects('update')
+            ->with(
+                'update "table" set "count" = ?, "updated_at" = ? where "id" = ?',
+                ['0', '2023-01-01 00:00:00', 123],
+            )
+            ->andReturn(1);
+
+        $result = $model->newQuery()->decrementOrCreate(['attr' => 'foo']);
+        $this->assertFalse($result->wasRecentlyCreated);
+        $this->assertEquals([
+            'id' => 123,
+            'attr' => 'foo',
+            'count' => 0,
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
     protected function mockConnectionForModel(Model $model, string $database, array $lastInsertIds = []): void
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';


### PR DESCRIPTION
## Add `decrementOrCreate` Method to Laravel Eloquent Models

This pull request introduces a new method `decrementOrCreate` to Laravel's Eloquent Builder. This addition follows the recently merged pull request (#54300) that added the `incrementOrCreate` method. The `decrementOrCreate` method provide a straightforward approach to either decrement an existing model's column or create a new model if no existing model matches the provided attributes.

### Purpose
The `decrementOrCreate` method is particularly useful for applications that require decrement operations within their logic, such as inventory management systems where stock levels need to be adjusted down automatically.

### Usage Example
The following example demonstrates how to use the `decrementOrCreate` method in a product inventory scenario:

```php
$product = Product::decrementOrCreate(
    ['name' => 'Laptop'],
    column: 'quantity',
    step: 2,
    extra: [],
);