### PR TITLE
[11.x] Optimize pluck() to avoid redundant column selection

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3384,7 +3384,7 @@ class Builder implements BuilderContract
         // given columns / key. Once we have the results, we will be able to take
         // the results and get the exact data that was requested for the query.
         $queryResult = $this->onceWithColumns(
-            is_null($key) ? [$column] : [$column, $key],
+            is_null($key) || $key === $column ? [$column] : [$column, $key],
             function () {
                 return $this->processor->processSelect(
                     $this, $this->runSelect()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3364,6 +3364,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1 => 'bar', 10 => 'baz'], $results->all());
     }
 
+    public function testPluckAvoidsDuplicateColumnSelection()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ?', [1], true)->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->pluck('foo', 'foo');
+        $this->assertEquals(['bar' => 'bar'], $results->all());
+    }
+
     public function testImplode()
     {
         // Test without glue.


### PR DESCRIPTION
Currently, using pluck(column, column) on QueryBuilder results in an unnecessary duplicate column selection in the database query.

Example:
```
User::pluck('name', 'name'); 
```

Produces:
```
SELECT name, name FROM users;
```

This fix ensures pluck() selects the column only once when the key and value are identical, optimizing queries without changing functionality, test has been added to verify the behavior.
