### PR TITLE
[11.x] Add `Macroable` and `fill()` to `Support\Fluent`

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -18,7 +18,9 @@ use JsonSerializable;
  */
 class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
-    use InteractsWithData, Macroable;
+    use InteractsWithData, Macroable {
+        __call as macroCall;
+    }
 
     /**
      * All of the attributes set on the fluent instance.
@@ -35,9 +37,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function __construct($attributes = [])
     {
-        foreach ($attributes as $key => $value) {
-            $this->attributes[$key] = $value;
-        }
+        $this->fill($attributes);
     }
 
     /**
@@ -64,6 +64,21 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     public function set($key, $value)
     {
         data_set($this->attributes, $key, $value);
+
+        return $this;
+    }
+
+    /**
+     * Fill the fluent instance with an array of attributes.
+     *
+     * @param  iterable<TKey, TValue>  $attributes
+     * @return $this
+     */
+    public function fill($attributes)
+    {
+        foreach ($attributes as $key => $value) {
+            $this->attributes[$key] = $value;
+        }
 
         return $this;
     }
@@ -228,6 +243,10 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         $this->attributes[$method] = count($parameters) > 0 ? reset($parameters) : true;
 
         return $this;

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -5,7 +5,11 @@ namespace Illuminate\Support;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\InteractsWithData;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Concerns\ValidatesAttributes;
+use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use JsonSerializable;
 
 /**
@@ -17,7 +21,7 @@ use JsonSerializable;
  */
 class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
-    use InteractsWithData;
+    use InteractsWithData, Macroable;
 
     /**
      * All of the attributes set on the fluent instance.

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -5,11 +5,8 @@ namespace Illuminate\Support;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Validation\Concerns\ValidatesAttributes;
-use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use JsonSerializable;
 
 /**

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -416,6 +416,42 @@ class SupportFluentTest extends TestCase
         $this->assertEquals([TestBackedEnum::B], $fluent->enums('int.b', TestBackedEnum::class));
         $this->assertEmpty($fluent->enums('int.doesnt_exist', TestBackedEnum::class));
     }
+
+    public function testFill()
+    {
+        $fluent = new Fluent(['name' => 'John Doe',]);
+
+        $fluent->fill([
+            'email' => 'john.doe@example.com',
+            'age' => 30,
+        ]);
+
+        $this->assertEquals([
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+            'age' => 30,
+        ], $fluent->getAttributes());
+    }
+
+    public function testMacroable()
+    {
+        Fluent::macro('foo', function () {
+            return $this->fill([
+                'foo' => 'bar',
+                'baz' => 'zal',
+            ]);
+        });
+
+        $fluent = new Fluent([
+            'bee' => 'ser',
+        ]);
+
+        $this->assertSame([
+            'bee' => 'ser',
+            'foo' => 'bar',
+            'baz' => 'zal',
+        ], $fluent->foo()->all());
+    }
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -419,7 +419,7 @@ class SupportFluentTest extends TestCase
 
     public function testFill()
     {
-        $fluent = new Fluent(['name' => 'John Doe',]);
+        $fluent = new Fluent(['name' => 'John Doe']);
 
         $fluent->fill([
             'email' => 'john.doe@example.com',


### PR DESCRIPTION
### Description

This PR adds the ability to add macros to the `Fluent` class, as well as a `fill` method for easily filling a `Fluent` instance with an array of attributes, as you're used to with Eloquent Models.

### Macro Usage

A really cool usage of `Fluent` that I've found would be very useful to have is a macro'ed `validate` method:

```php
Fluent::macro('validate', function (array $rules, ...$params) {
    return validator($this->all(), $rules, ...$params)->validate();
});
```

You could use this in Action classes, instead of having to pull in the validator yourself.

For example, consider this existing [Laravel Fortify action](https://github.com/laravel/fortify/blob/1.x/stubs/CreateNewUser.php):

```php
namespace App\Actions\Fortify;

// ...

class CreateNewUser implements CreatesNewUsers
{
    // ...

    public function create(array $input): User
    {
        Validator::make($input, [
            // ...
        ])->validate();

        return DB::transaction(...);
    }
}
```

This could be refactored to:

```php
(new CreateNewUser)->create($request->fluent());
```

```php
// ...

class CreateNewUser implements CreatesNewUsers
{
    // ...
    
    public function create(Fluent $input): User
    {
        $fluent->validate([
            // ...
        ]);

        return DB::transaction(...);
    }
}
```

### Fill Usage

The fill acts as you'd expect it to, as it just performs the same logic that was previously in its constructor:

```php
$fluent = new Fluent(['name' => 'John Doe']);

$fluent->fill([
    'email' => 'johndoe@email.com',
    'age' => 30,
]);

//[
//    'name' => 'John Doe'
//    'email' => 'johndoe@email.com',
//    'age' => 30,
//]
$fluent->all();
```