### PR TITLE
feat: gracefully handle command not found exception - avoid creds exposure

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\ConfigurationUrlParser;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
 
@@ -44,13 +45,21 @@ class DbCommand extends Command
             return Command::FAILURE;
         }
 
-        (new Process(
-            array_merge([$this->getCommand($connection)], $this->commandArguments($connection)),
-            null,
-            $this->commandEnvironment($connection)
-        ))->setTimeout(null)->setTty(true)->mustRun(function ($type, $buffer) {
-            $this->output->write($buffer);
-        });
+        try {
+            (new Process(
+                array_merge([$command = $this->getCommand($connection)], $this->commandArguments($connection)),
+                null,
+                $this->commandEnvironment($connection)
+            ))->setTimeout(null)->setTty(true)->mustRun(function ($type, $buffer) {
+                $this->output->write($buffer);
+            });
+        } catch (ProcessFailedException $e) {
+            // see https://tldp.org/LDP/abs/html/exitcodes.html
+            throw_unless($e->getProcess()->getExitCode() === 127, $e);
+            $this->error("{$command} not found in path");
+
+            return Command::FAILURE;
+        }
 
         return 0;
     }

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -54,9 +54,9 @@ class DbCommand extends Command
                 $this->output->write($buffer);
             });
         } catch (ProcessFailedException $e) {
-            // see https://tldp.org/LDP/abs/html/exitcodes.html
             throw_unless($e->getProcess()->getExitCode() === 127, $e);
-            $this->error("{$command} not found in path");
+
+            $this->error("{$command} not found in path.");
 
             return Command::FAILURE;
         }


### PR DESCRIPTION
When you run `php artisan db` on a shell, where the `mysql` binary is not available; it throws an error which logs at `error` level.

Any 3rd party log channels like Sentry also captures this info and the password in displayed/stored in plain text.

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/8aa84359-d7c7-4271-b317-ccba57934279" />

- I came up with a way to fix that, I capture the exception and display error ONLY IF the command is not found (exit code 127 - see https://tldp.org/LDP/abs/html/exitcodes.html).

  <img width="438" alt="image" src="https://github.com/user-attachments/assets/257934cb-36ac-4b99-b819-4559ddb6bc13" />

- For any other type of exception, I let the exception to be thrown for the framework to handle.

  ![image](https://github.com/user-attachments/assets/ce0ca6ea-e397-4156-a3b6-82624a8e7bd4)



