### PR TITLE
[11.x] Optimize `loadTranslationsFrom` function for simplicity and clarity

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -244,7 +244,7 @@ abstract class ServiceProvider
      */
     protected function loadTranslationsFrom($path, $namespace = null)
     {
-        $this->callAfterResolving('translator', fn($translator) => is_null($namespace)
+        $this->callAfterResolving('translator', fn ($translator) => is_null($namespace)
             ? $translator->addPath($path)
             : $translator->addNamespace($namespace, $path));
     }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -236,17 +236,17 @@ abstract class ServiceProvider
     }
 
     /**
-     * Register a translation file namespace.
+     * Register a translation file namespace or path.
      *
      * @param  string  $path
-     * @param  string  $namespace
+     * @param  string|null  $namespace
      * @return void
      */
-    protected function loadTranslationsFrom($path, $namespace)
+    protected function loadTranslationsFrom($path, $namespace = null)
     {
-        $this->callAfterResolving('translator', function ($translator) use ($path, $namespace) {
-            $translator->addNamespace($namespace, $path);
-        });
+        $this->callAfterResolving('translator', fn($translator) => is_null($namespace)
+            ? $translator->addPath($path)
+            : $translator->addNamespace($namespace, $path));
     }
 
     /**

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -205,6 +205,16 @@ class FileLoader implements Loader
     }
 
     /**
+     * Get an array of all the registered paths to translation files.
+     *
+     * @return array
+     */
+    public function paths()
+    {
+        return $this->paths;
+    }
+
+    /**
      * Get an array of all the registered paths to JSON translation files.
      *
      * @return array

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -165,7 +165,7 @@ class SupportServiceProviderTest extends TestCase
     public function testLoadTranslationsFromWithoutNamespace()
     {
         $translator = m::mock(Translator::class);
-        $translator->shouldReceive('addPath')->once()->with(__DIR__ . '/translations');
+        $translator->shouldReceive('addPath')->once()->with(__DIR__.'/translations');
 
         $this->app->shouldReceive('afterResolving')->once()->with('translator', m::on(function ($callback) use ($translator) {
             $callback($translator);
@@ -173,13 +173,13 @@ class SupportServiceProviderTest extends TestCase
         }));
 
         $provider = new ServiceProviderForTestingOne($this->app);
-        $provider->loadTranslationsFrom(__DIR__ . '/translations');
+        $provider->loadTranslationsFrom(__DIR__.'/translations');
     }
 
     public function testLoadTranslationsFromWithNamespace()
     {
         $translator = m::mock(Translator::class);
-        $translator->shouldReceive('addNamespace')->once()->with('namespace', __DIR__ . '/translations');
+        $translator->shouldReceive('addNamespace')->once()->with('namespace', __DIR__.'/translations');
 
         $this->app->shouldReceive('afterResolving')->once()->with('translator', m::on(function ($callback) use ($translator) {
             $callback($translator);
@@ -187,7 +187,7 @@ class SupportServiceProviderTest extends TestCase
         }));
 
         $provider = new ServiceProviderForTestingOne($this->app);
-        $provider->loadTranslationsFrom(__DIR__ . '/translations', 'namespace');
+        $provider->loadTranslationsFrom(__DIR__.'/translations', 'namespace');
     }
 }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -169,6 +169,7 @@ class SupportServiceProviderTest extends TestCase
 
         $this->app->shouldReceive('afterResolving')->once()->with('translator', m::on(function ($callback) use ($translator) {
             $callback($translator);
+
             return true;
         }));
 
@@ -183,6 +184,7 @@ class SupportServiceProviderTest extends TestCase
 
         $this->app->shouldReceive('afterResolving')->once()->with('translator', m::on(function ($callback) use ($translator) {
             $callback($translator);
+
             return true;
         }));
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -209,7 +209,7 @@ class ServiceProviderForTestingOne extends ServiceProvider
         $this->publishesMigrations(['source/tagged/multiple_two' => 'destination/tagged/multiple_two'], ['tag_four', 'tag_five']);
     }
 
-    protected function loadTranslationsFrom($path, $namespace = null)
+    public function loadTranslationsFrom($path, $namespace = null)
     {
         $this->callAfterResolving('translator', fn ($translator) => is_null($namespace)
             ? $translator->addPath($path)

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Translation\Translator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -160,6 +161,34 @@ class SupportServiceProviderTest extends TestCase
 
         $this->assertNotContains('source/tagged/five', ServiceProvider::publishableMigrationPaths());
     }
+
+    public function testLoadTranslationsFromWithoutNamespace()
+    {
+        $translator = m::mock(Translator::class);
+        $translator->shouldReceive('addPath')->once()->with(__DIR__ . '/translations');
+
+        $this->app->shouldReceive('afterResolving')->once()->with('translator', m::on(function ($callback) use ($translator) {
+            $callback($translator);
+            return true;
+        }));
+
+        $provider = new ServiceProviderForTestingOne($this->app);
+        $provider->loadTranslationsFrom(__DIR__ . '/translations');
+    }
+
+    public function testLoadTranslationsFromWithNamespace()
+    {
+        $translator = m::mock(Translator::class);
+        $translator->shouldReceive('addNamespace')->once()->with('namespace', __DIR__ . '/translations');
+
+        $this->app->shouldReceive('afterResolving')->once()->with('translator', m::on(function ($callback) use ($translator) {
+            $callback($translator);
+            return true;
+        }));
+
+        $provider = new ServiceProviderForTestingOne($this->app);
+        $provider->loadTranslationsFrom(__DIR__ . '/translations', 'namespace');
+    }
 }
 
 class ServiceProviderForTestingOne extends ServiceProvider
@@ -178,6 +207,13 @@ class ServiceProviderForTestingOne extends ServiceProvider
         $this->publishesMigrations(['source/unmarked/two' => 'destination/unmarked/two']);
         $this->publishesMigrations(['source/tagged/three' => 'destination/tagged/three'], 'tag_three');
         $this->publishesMigrations(['source/tagged/multiple_two' => 'destination/tagged/multiple_two'], ['tag_four', 'tag_five']);
+    }
+
+    protected function loadTranslationsFrom($path, $namespace = null)
+    {
+        $this->callAfterResolving('translator', fn ($translator) => is_null($namespace)
+            ? $translator->addPath($path)
+            : $translator->addNamespace($namespace, $path));
     }
 }
 

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -18,13 +18,13 @@ class TranslationFileLoaderTest extends TestCase
     {
         $files = m::mock(Filesystem::class);
         $loader = new FileLoader($files, __DIR__);
-        $loader->addPath(__DIR__ . '/another');
+        $loader->addPath(__DIR__.'/another');
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/messages.php')->andReturn(['foo' => 'bar']);
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(['baz' => 'backagesplash']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/another/en/messages.php')->andReturn(['baz' => 'backagesplash']);
 
         $this->assertEquals(['foo' => 'bar', 'baz' => 'backagesplash'], $loader->load('en', 'messages'));
     }
@@ -33,12 +33,12 @@ class TranslationFileLoaderTest extends TestCase
     {
         $files = m::mock(Filesystem::class);
         $loader = new FileLoader($files, __DIR__);
-        $loader->addPath(__DIR__ . '/missing');
+        $loader->addPath(__DIR__.'/missing');
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/messages.php')->andReturn(['foo' => 'bar']);
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/missing/en/messages.php')->andReturn(false);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/missing/en/messages.php')->andReturn(false);
 
         $this->assertEquals(['foo' => 'bar'], $loader->load('en', 'messages'));
     }
@@ -47,13 +47,13 @@ class TranslationFileLoaderTest extends TestCase
     {
         $files = m::mock(Filesystem::class);
         $loader = new FileLoader($files, __DIR__);
-        $loader->addPath(__DIR__ . '/another');
+        $loader->addPath(__DIR__.'/another');
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/messages.php')->andReturn(['foo' => 'bar']);
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(['foo' => 'baz']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/another/en/messages.php')->andReturn(['foo' => 'baz']);
 
         $this->assertEquals(['foo' => 'baz'], $loader->load('en', 'messages'));
     }
@@ -62,17 +62,17 @@ class TranslationFileLoaderTest extends TestCase
     {
         $files = m::mock(Filesystem::class);
         $loader = new FileLoader($files, __DIR__);
-        $loader->addPath(__DIR__ . '/another');
-        $loader->addPath(__DIR__ . '/yet-another');
+        $loader->addPath(__DIR__.'/another');
+        $loader->addPath(__DIR__.'/yet-another');
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/messages.php')->andReturn(['foo' => 'bar']);
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(['baz' => 'backagesplash']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/another/en/messages.php')->andReturn(['baz' => 'backagesplash']);
 
-        $files->shouldReceive('exists')->once()->with(__DIR__ . '/yet-another/en/messages.php')->andReturn(true);
-        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/yet-another/en/messages.php')->andReturn(['qux' => 'quux']);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/yet-another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/yet-another/en/messages.php')->andReturn(['qux' => 'quux']);
 
         $this->assertEquals(['foo' => 'bar', 'baz' => 'backagesplash', 'qux' => 'quux'], $loader->load('en', 'messages'));
     }

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -223,6 +223,6 @@ class TranslationFileLoaderTest extends TestCase
         $path2 = __DIR__.'/another2';
         $loader->addPath($path1);
         $loader->addPath($path2);
-        $this->assertEquals([$path1, $path2], $loader->paths());
+        $this->assertEquals([$path1, $path2], array_slice($loader->paths(), 1));
     }
 }

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -14,6 +14,69 @@ class TranslationFileLoaderTest extends TestCase
         m::close();
     }
 
+    public function testLoadMethodLoadsTranslationsFromAddedPath()
+    {
+        $files = m::mock(Filesystem::class);
+        $loader = new FileLoader($files, __DIR__);
+        $loader->addPath(__DIR__ . '/another');
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(['baz' => 'backagesplash']);
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'backagesplash'], $loader->load('en', 'messages'));
+    }
+
+    public function testLoadMethodHandlesMissingAddedPath()
+    {
+        $files = m::mock(Filesystem::class);
+        $loader = new FileLoader($files, __DIR__);
+        $loader->addPath(__DIR__ . '/missing');
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/missing/en/messages.php')->andReturn(false);
+
+        $this->assertEquals(['foo' => 'bar'], $loader->load('en', 'messages'));
+    }
+
+    public function testLoadMethodOverwritesExistingKeysFromAddedPath()
+    {
+        $files = m::mock(Filesystem::class);
+        $loader = new FileLoader($files, __DIR__);
+        $loader->addPath(__DIR__ . '/another');
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(['foo' => 'baz']);
+
+        $this->assertEquals(['foo' => 'baz'], $loader->load('en', 'messages'));
+    }
+
+    public function testLoadMethodLoadsTranslationsFromMultipleAddedPaths()
+    {
+        $files = m::mock(Filesystem::class);
+        $loader = new FileLoader($files, __DIR__);
+        $loader->addPath(__DIR__ . '/another');
+        $loader->addPath(__DIR__ . '/yet-another');
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/en/messages.php')->andReturn(['foo' => 'bar']);
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/another/en/messages.php')->andReturn(['baz' => 'backagesplash']);
+
+        $files->shouldReceive('exists')->once()->with(__DIR__ . '/yet-another/en/messages.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__ . '/yet-another/en/messages.php')->andReturn(['qux' => 'quux']);
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'backagesplash', 'qux' => 'quux'], $loader->load('en', 'messages'));
+    }
+
     public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
     {
         $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -152,4 +152,14 @@ class TranslationFileLoaderTest extends TestCase
         $loader->addJsonPath($path2);
         $this->assertEquals([$path1, $path2], $loader->jsonPaths());
     }
+
+    public function testAllAddedPathsReturnProperly()
+    {
+        $loader = new FileLoader(m::mock(Filesystem::class), __DIR__);
+        $path1 = __DIR__.'/another';
+        $path2 = __DIR__.'/another2';
+        $loader->addPath($path1);
+        $loader->addPath($path2);
+        $this->assertEquals([$path1, $path2], $loader->paths());
+    }
 }


### PR DESCRIPTION
## Current Behavior

When developing packages or performing specific translation loading operations, there are two methods available for loading translations: `loadJsonTranslationsFrom` and `loadTranslationsFrom`. Currently, it is not possible to register translations without a namespace using the `loadTranslationsFrom` method.

```php
class FooServiceProvider extends ServiceProvider
{
     public function register()
     {
          $this->loadTranslationsFrom(__DIR__.'/../path/to', 'namespace');
          // OR
          $this->loadJsonTranslationsFrom(__DIR__.'/../path/to');
     }
}
 ```

 ## Issue

When using the `loadTranslationsFrom` method to register a translation, the only way to use it with the `__()`, `trans()`, or `trans_choice()` methods is by specifying the namespace, like namespace::file.foo.bar. This often results in repetitive and long names when developing packages, making the code cumbersome and less readable.

Example :
```php
// To call a translation registered this way, you would need to use:
$this->loadTranslationsFrom(__DIR__.'/../path/to', 'namespace');

// While this is not a major issue in general, it becomes problematic when the file name and namespace are the same or when the line lengths increase due to specific requirements, leading to repetitive and cluttered code.
trans('namespace::file.foo.bar')
// OR
trans('namespace::namespace.foo.bar')
```

Although this issue can be resolved using `loadJsonTranslationsFrom()`, it may cause specific problems when multiple packages are used, and JSON translations do not offer the same functionality as the `loadTranslationsFrom()` method.

## Proposed Change
We propose adding an `addPath` method to the `Translator` and `FileLoader` classes and making the `$namespace` parameter in the `ServiceProvider` class's `loadTranslationsFrom` method default to null. When a `null` value is provided, the directory should be included in the translation loader without needing a namespace.

This change will not break backward compatibility and will allow developers to load external translation directories without a namespace, preserving the original behavior.

```php
class FooServiceProvider extends ServiceProvider
{
    public function register()
    {
        // New (Usage: trans('file.foo.bar'))
        $this->loadTranslationsFrom(__DIR__.'/../path/to');
        // OR (Usage: trans('namespace::file.foo.bar'))
        $this->loadTranslationsFrom(__DIR__.'/../path/to', 'namespace');
        // OR (Usage: trans('Foo bar'))
        $this->loadJsonTranslationsFrom(__DIR__.'/../path/to');
    }
}
 ```

 ## Backward Compatibility
This pull request does not create any backwards incompatibility. Added some specific tests to ensure it won't work.
