### PR TITLE
Add relative date shorthands to Query Builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsDateWhereClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsDateWhereClauses.php
@@ -77,15 +77,7 @@ trait BuildsDateWhereClauses
      */
     public function whereToday($columns, $boolean = 'and', $not = false)
     {
-        $operator = $not ? '!=' : '=';
-
-        $value = Carbon::today()->format('Y-m-d');
-
-        foreach (Arr::wrap($columns) as $column) {
-            $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
-        }
-
-        return $this;
+        return $this->whereTodayBeforeOrAfter($columns, $not ? '!=' : '=', $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsDateWhereClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsDateWhereClauses.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+
+trait BuildsDateWhereClauses
+{
+    /**
+     * Add a where clause to determine if a "date" column is in the past to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function wherePast($columns, $value = null, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '>=' : '<';
+        $value = $value ?? Carbon::now();
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the past to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function orWherePast($columns, $value = null)
+    {
+        return $this->wherePast($columns, $value, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if a "date" column is not in the past to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function whereNotPast($columns, $value = null)
+    {
+        return $this->wherePast($columns, $value, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the past to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function orWhereNotPast($columns, $value = null)
+    {
+        return $this->wherePast($columns, $value, 'or', true);
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is today to the query.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereToday($columns, $boolean = 'and', $not = false)
+    {
+        $operator = $not ? '!=' : '=';
+
+        $value = Carbon::today()->format('Y-m-d');
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is before today.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBeforeToday($columns, $boolean = 'and')
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '<', $boolean);
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is today or before to the query.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereTodayOrBefore($columns, $boolean = 'and')
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '<=', $boolean);
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is after today.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereAfterToday($columns, $boolean = 'and')
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '>', $boolean);
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is today or after to the query.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereTodayOrAfter($columns, $boolean = 'and')
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '>=', $boolean);
+    }
+
+    /**
+     * Add an "or where date" clause to determine if a "date" column is today to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function orWhereToday($columns)
+    {
+        return $this->whereToday($columns, 'or');
+    }
+
+    /**
+     * Add an "or where date" clause to determine if a "date" column is before today.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function orWhereBeforeToday($columns)
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '<', 'or');
+    }
+
+    /**
+     * Add an "or where date" clause to determine if a "date" column is today or before to the query.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function orWhereTodayOrBefore($columns)
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '<=', 'or');
+    }
+
+    /**
+     * Add an "or where date" clause to determine if a "date" column is after today.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function orWhereAfterToday($columns)
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '>', 'or');
+    }
+
+    /**
+     * Add an "or where date" clause to determine if a "date" column is today or after to the query.
+     *
+     * @param  array|string  $columns
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function orWhereTodayOrAfter($columns)
+    {
+        return $this->whereTodayBeforeOrAfter($columns, '>=', 'or');
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is today or after to the query.
+     *
+     * @param  array|string  $columns
+     * @param  string  $operator
+     * @param  string  $boolean
+     * @return $this
+     */
+    protected function whereTodayBeforeOrAfter($columns, $operator, $boolean)
+    {
+        $value = Carbon::today()->format('Y-m-d');
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a "where date" clause to determine if a "date" column is not today to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function whereNotToday($columns)
+    {
+        return $this->whereToday($columns, 'and', true);
+    }
+
+    /**
+     * Add an "or where date" clause to determine if a "date" column is not today to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function orWhereNotToday($columns)
+    {
+        return $this->whereToday($columns, 'or', true);
+    }
+
+    /**
+     * Add a where clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereFuture($columns, $value = null, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '<=' : '>';
+        $value = $value ?? Carbon::now();
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function orWhereFuture($columns, $value = null)
+    {
+        return $this->whereFuture($columns, $value, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if a "date" column is not in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function whereNotFuture($columns, $value = null)
+    {
+        return $this->whereFuture($columns, $value, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function orWhereNotFuture($columns, $value = null)
+    {
+        return $this->whereFuture($columns, $value, 'or', true);
+    }
+}

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -11,76 +11,102 @@ trait BuildsWhereDateClauses
      * Add a where clause to determine if a "date" column is in the past to the query.
      *
      * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $now
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function wherePast($columns, $value = null, $boolean = 'and', $not = false)
+    public function wherePast($columns)
     {
-        $type = 'Basic';
-        $operator = $not ? '>=' : '<';
-        $value = $value ?? Carbon::now();
+        return $this->wherePastOrFuture($columns, '<', 'and');
+    }
 
-        foreach (Arr::wrap($columns) as $column) {
-            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
-
-            $this->addBinding($value);
-        }
-
-        return $this;
+    /**
+     * Add a where clause to determine if a "date" column is in the past or now to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function whereNowOrPast($columns)
+    {
+        return $this->wherePastOrFuture($columns, '<=', 'and');
     }
 
     /**
      * Add an "or where" clause to determine if a "date" column is in the past to the query.
      *
      * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function orWherePast($columns, $value = null)
+    public function orWherePast($columns)
     {
-        return $this->wherePast($columns, $value, 'or');
+        return $this->wherePastOrFuture($columns, '<', 'or');
     }
 
     /**
-     * Add a where clause to determine if a "date" column is not in the past to the query.
+     * Add a where clause to determine if a "date" column is in the past or now to the query.
      *
      * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function whereNotPast($columns, $value = null)
+    public function orWhereNowOrPast($columns)
     {
-        return $this->wherePast($columns, $value, 'and', true);
-    }
-
-    /**
-     * Add an "or where" clause to determine if a "date" column is in the past to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function orWhereNotPast($columns, $value = null)
-    {
-        return $this->wherePast($columns, $value, 'or', true);
+        return $this->wherePastOrFuture($columns, '<=', 'or');
     }
 
     /**
      * Add a where clause to determine if a "date" column is in the future to the query.
      *
      * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @param  string  $boolean
-     * @param  bool  $not
      * @return $this
      */
-    public function whereFuture($columns, $value = null, $boolean = 'and', $not = false)
+    public function whereFuture($columns)
+    {
+        return $this->wherePastOrFuture($columns, '>', 'and');
+    }
+
+    /**
+     * Add a where clause to determine if a "date" column is in the future or now to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function whereNowOrFuture($columns)
+    {
+        return $this->wherePastOrFuture($columns, '>=', 'and');
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function orWhereFuture($columns)
+    {
+        return $this->wherePastOrFuture($columns, '>', 'or');
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the future or now to the query.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function orWhereNowOrFuture($columns)
+    {
+        return $this->wherePastOrFuture($columns, '>=', 'or');
+    }
+
+    /**
+     * Add an "where" clause to determine if a "date" column is in the past or future.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    protected function wherePastOrFuture($columns, $operator, $boolean)
     {
         $type = 'Basic';
-        $operator = $not ? '<=' : '>';
-        $value = $value ?? Carbon::now();
+        $value = Carbon::now();
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
@@ -89,42 +115,6 @@ trait BuildsWhereDateClauses
         }
 
         return $this;
-    }
-
-    /**
-     * Add an "or where" clause to determine if a "date" column is in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function orWhereFuture($columns, $value = null)
-    {
-        return $this->whereFuture($columns, $value, 'or');
-    }
-
-    /**
-     * Add a where clause to determine if a "date" column is not in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function whereNotFuture($columns, $value = null)
-    {
-        return $this->whereFuture($columns, $value, 'and', true);
-    }
-
-    /**
-     * Add an "or where" clause to determine if a "date" column is in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function orWhereNotFuture($columns, $value = null)
-    {
-        return $this->whereFuture($columns, $value, 'or', true);
     }
 
     /**
@@ -132,10 +122,9 @@ trait BuildsWhereDateClauses
      *
      * @param  array|string  $columns
      * @param  string  $boolean
-     * @param  bool  $not
      * @return $this
      */
-    public function whereToday($columns, $boolean = 'and', $not = false)
+    public function whereToday($columns, $boolean = 'and')
     {
         return $this->whereTodayBeforeOrAfter($columns, $not ? '!=' : '=', $boolean);
     }
@@ -144,48 +133,44 @@ trait BuildsWhereDateClauses
      * Add a "where date" clause to determine if a "date" column is before today.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
-    public function whereBeforeToday($columns, $boolean = 'and')
+    public function whereBeforeToday($columns)
     {
-        return $this->whereTodayBeforeOrAfter($columns, '<', $boolean);
+        return $this->whereTodayBeforeOrAfter($columns, '<', 'and');
     }
 
     /**
      * Add a "where date" clause to determine if a "date" column is today or before to the query.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
-    public function whereTodayOrBefore($columns, $boolean = 'and')
+    public function whereTodayOrBefore($columns)
     {
-        return $this->whereTodayBeforeOrAfter($columns, '<=', $boolean);
+        return $this->whereTodayBeforeOrAfter($columns, '<=', 'and');
     }
 
     /**
      * Add a "where date" clause to determine if a "date" column is after today.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
-    public function whereAfterToday($columns, $boolean = 'and')
+    public function whereAfterToday($columns)
     {
-        return $this->whereTodayBeforeOrAfter($columns, '>', $boolean);
+        return $this->whereTodayBeforeOrAfter($columns, '>', 'and');
     }
 
     /**
      * Add a "where date" clause to determine if a "date" column is today or after to the query.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
-    public function whereTodayOrAfter($columns, $boolean = 'and')
+    public function whereTodayOrAfter($columns)
     {
-        return $this->whereTodayBeforeOrAfter($columns, '>=', $boolean);
+        return $this->whereTodayBeforeOrAfter($columns, '>=', 'and');
     }
 
     /**
@@ -263,27 +248,5 @@ trait BuildsWhereDateClauses
         }
 
         return $this;
-    }
-
-    /**
-     * Add a "where date" clause to determine if a "date" column is not today to the query.
-     *
-     * @param  array|string  $columns
-     * @return $this
-     */
-    public function whereNotToday($columns)
-    {
-        return $this->whereToday($columns, 'and', true);
-    }
-
-    /**
-     * Add an "or where date" clause to determine if a "date" column is not today to the query.
-     *
-     * @param  array|string  $columns
-     * @return $this
-     */
-    public function orWhereNotToday($columns)
-    {
-        return $this->whereToday($columns, 'or', true);
     }
 }

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -11,8 +11,6 @@ trait BuildsWhereDateClauses
      * Add a where clause to determine if a "date" column is in the past to the query.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
-     * @param  bool  $not
      * @return $this
      */
     public function wherePast($columns)

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Concerns;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
 
-trait BuildsDateWhereClauses
+trait BuildsWhereDateClauses
 {
     /**
      * Add a where clause to determine if a "date" column is in the past to the query.

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -124,7 +124,7 @@ trait BuildsWhereDateClauses
      */
     public function whereToday($columns, $boolean = 'and')
     {
-        return $this->whereTodayBeforeOrAfter($columns, $not ? '!=' : '=', $boolean);
+        return $this->whereTodayBeforeOrAfter($columns, '=', $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -68,6 +68,66 @@ trait BuildsWhereDateClauses
     }
 
     /**
+     * Add a where clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereFuture($columns, $value = null, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '<=' : '>';
+        $value = $value ?? Carbon::now();
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function orWhereFuture($columns, $value = null)
+    {
+        return $this->whereFuture($columns, $value, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if a "date" column is not in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function whereNotFuture($columns, $value = null)
+    {
+        return $this->whereFuture($columns, $value, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
+     *
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
+     * @return $this
+     */
+    public function orWhereNotFuture($columns, $value = null)
+    {
+        return $this->whereFuture($columns, $value, 'or', true);
+    }
+
+    /**
      * Add a "where date" clause to determine if a "date" column is today to the query.
      *
      * @param  array|string  $columns
@@ -225,65 +285,5 @@ trait BuildsWhereDateClauses
     public function orWhereNotToday($columns)
     {
         return $this->whereToday($columns, 'or', true);
-    }
-
-    /**
-     * Add a where clause to determine if a "date" column is in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @param  string  $boolean
-     * @param  bool  $not
-     * @return $this
-     */
-    public function whereFuture($columns, $value = null, $boolean = 'and', $not = false)
-    {
-        $type = 'Basic';
-        $operator = $not ? '<=' : '>';
-        $value = $value ?? Carbon::now();
-
-        foreach (Arr::wrap($columns) as $column) {
-            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
-
-            $this->addBinding($value);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Add an "or where" clause to determine if a "date" column is in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function orWhereFuture($columns, $value = null)
-    {
-        return $this->whereFuture($columns, $value, 'or');
-    }
-
-    /**
-     * Add a where clause to determine if a "date" column is not in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function whereNotFuture($columns, $value = null)
-    {
-        return $this->whereFuture($columns, $value, 'and', true);
-    }
-
-    /**
-     * Add an "or where" clause to determine if a "date" column is in the future to the query.
-     *
-     * @param  array|string  $columns
-     * @param  \DateTimeInterface|string|null  $value
-     * @return $this
-     */
-    public function orWhereNotFuture($columns, $value = null)
-    {
-        return $this->whereFuture($columns, $value, 'or', true);
     }
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -10,8 +10,8 @@ use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Database\Query\ConditionExpression;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Concerns\BuildsDateWhereClauses;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Concerns\BuildsWhereDateClauses;
 use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -29,13 +29,12 @@ use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 use UnitEnum;
-
 use function Illuminate\Support\enum_value;
 
 class Builder implements BuilderContract
 {
     /** @use \Illuminate\Database\Concerns\BuildsQueries<object> */
-    use BuildsDateWhereClauses, BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
+    use BuildsWhereDateClauses, BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1507,26 +1507,23 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where clause to determine if "date" column is in the past to the query.
+     * Add a where clause to determine if a "date" column is in the past to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @param  \DateTimeInterface|string|null  $now
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function wherePast($columns, $now = null, $boolean = 'and', $not = false)
+    public function wherePast($columns, $value = null, $boolean = 'and', $not = false)
     {
         $type = 'Basic';
         $operator = $not ? '>=' : '<';
-        $value = $now ?? Carbon::now();
-
-        if ($value instanceof DateTimeInterface) {
-            $value = $value->format('Y-m-d H:i:s.u');
-        }
+        $value = $value ?? Carbon::now();
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+
             $this->addBinding($value);
         }
 
@@ -1534,45 +1531,45 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where" clause to determine if "date" column is in the past to the query.
+     * Add an "or where" clause to determine if a "date" column is in the past to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function orWherePast($columns, $now = null)
+    public function orWherePast($columns, $value = null)
     {
-        return $this->wherePast($columns, $now, 'or');
+        return $this->wherePast($columns, $value, 'or');
     }
 
     /**
-     * Add a where clause to determine if "date" column is not in the past to the query.
+     * Add a where clause to determine if a "date" column is not in the past to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function whereNotPast($columns, $now = null)
+    public function whereNotPast($columns, $value = null)
     {
-        return $this->wherePast($columns, $now, 'and', true);
+        return $this->wherePast($columns, $value, 'and', true);
     }
 
     /**
-     * Add an "or where" clause to determine if "date" column is in the past to the query.
+     * Add an "or where" clause to determine if a "date" column is in the past to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function orWhereNotPast($columns, $now = null)
+    public function orWhereNotPast($columns, $value = null)
     {
-        return $this->wherePast($columns, $now, 'or', true);
+        return $this->wherePast($columns, $value, 'or', true);
     }
 
     /**
-     * Add a "where date" clause to determine if "date" column is today to the query.
+     * Add a "where date" clause to determine if a "date" column is today to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -1580,6 +1577,7 @@ class Builder implements BuilderContract
     public function whereToday($columns, $boolean = 'and', $not = false)
     {
         $operator = $not ? '!=' : '=';
+
         $value = Carbon::now()->format('Y-m-d');
 
         foreach (Arr::wrap($columns) as $column) {
@@ -1590,9 +1588,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where date" clause to determine if "date" column is today to the query.
+     * Add an "or where date" clause to determine if a "date" column is today to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @return $this
      */
     public function orWhereToday($columns)
@@ -1601,9 +1599,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "where date" clause to determine if "date" column is not today to the query.
+     * Add a "where date" clause to determine if a "date" column is not today to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @return $this
      */
     public function whereNotToday($columns)
@@ -1612,9 +1610,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where date" clause to determine if "date" column is not today to the query.
+     * Add an "or where date" clause to determine if a "date" column is not today to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @return $this
      */
     public function orWhereNotToday($columns)
@@ -1623,26 +1621,23 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where clause to determine if "date" column is in the future to the query.
+     * Add a where clause to determine if a "date" column is in the future to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function whereFuture($columns, $now = null, $boolean = 'and', $not = false)
+    public function whereFuture($columns, $value = null, $boolean = 'and', $not = false)
     {
         $type = 'Basic';
         $operator = $not ? '<=' : '>';
-        $value = $now ?? Carbon::now();
-
-        if ($value instanceof DateTimeInterface) {
-            $value = $value->format('Y-m-d H:i:s.u');
-        }
+        $value = $value ?? Carbon::now();
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+
             $this->addBinding($value);
         }
 
@@ -1650,39 +1645,39 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where" clause to determine if "date" column is in the future to the query.
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function orWhereFuture($columns, $now = null)
+    public function orWhereFuture($columns, $value = null)
     {
-        return $this->whereFuture($columns, $now, 'or');
+        return $this->whereFuture($columns, $value, 'or');
     }
 
     /**
-     * Add a where clause to determine if "date" column is not in the future to the query.
+     * Add a where clause to determine if a "date" column is not in the future to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function whereNotFuture($columns, $now = null)
+    public function whereNotFuture($columns, $value = null)
     {
-        return $this->whereFuture($columns, $now, 'and', true);
+        return $this->whereFuture($columns, $value, 'and', true);
     }
 
     /**
-     * Add an "or where" clause to determine if "date" column is in the future to the query.
+     * Add an "or where" clause to determine if a "date" column is in the future to the query.
      *
-     * @param  string|array  $columns
-     * @param  \DateTimeInterface|string|null  $now
+     * @param  array|string  $columns
+     * @param  \DateTimeInterface|string|null  $value
      * @return $this
      */
-    public function orWhereNotFuture($columns, $now = null)
+    public function orWhereNotFuture($columns, $value = null)
     {
-        return $this->whereFuture($columns, $now, 'or', true);
+        return $this->whereFuture($columns, $value, 'or', true);
     }
 
     /**
@@ -2701,7 +2696,7 @@ class Builder implements BuilderContract
     /**
      * Add a "having null" clause to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -2731,7 +2726,7 @@ class Builder implements BuilderContract
     /**
      * Add a "having not null" clause to the query.
      *
-     * @param  string|array  $columns
+     * @param  array|string  $columns
      * @param  string  $boolean
      * @return $this
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query;
 
 use BackedEnum;
+use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Closure;
 use DateTimeInterface;
@@ -1503,6 +1504,185 @@ class Builder implements BuilderContract
     public function orWhereNotNull($column)
     {
         return $this->whereNotNull($column, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function wherePast($columns, $now = null, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '>=' : '<';
+        $value = $now ?? Carbon::now();
+
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('Y-m-d H:i:s.u');
+        }
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @return $this
+     */
+    public function orWherePast($columns, $now = null)
+    {
+        return $this->wherePast($columns, $now, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is not in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @return $this
+     */
+    public function whereNotPast($columns, $now = null)
+    {
+        return $this->wherePast($columns, $now, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @return $this
+     */
+    public function orWhereNotPast($columns, $now = null)
+    {
+        return $this->wherePast($columns, $now, 'or', true);
+    }
+
+    /**
+     * Add a "where date" clause to determine if "date" column is today to the query.
+     *
+     * @param  string|array  $columns
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereToday($columns, $boolean = 'and', $not = false)
+    {
+        $operator = $not ? '!=' : '=';
+        $value = Carbon::now()->format('Y-m-d');
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where date" clause to determine if "date" column is today to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereToday($columns)
+    {
+        return $this->whereToday($columns, 'or');
+    }
+
+    /**
+     * Add a "where date" clause to determine if "date" column is not today to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function whereNotToday($columns)
+    {
+        return $this->whereToday($columns, 'and', true);
+    }
+
+    /**
+     * Add an "or where date" clause to determine if "date" column is not today to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereNotToday($columns)
+    {
+        return $this->whereToday($columns, 'or', true);
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereFuture($columns, $now = null, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '<=' : '>';
+        $value = $now ?? Carbon::now();
+
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('Y-m-d H:i:s.u');
+        }
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @return $this
+     */
+    public function orWhereFuture($columns, $now = null)
+    {
+        return $this->whereFuture($columns, $now, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is not in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @return $this
+     */
+    public function whereNotFuture($columns, $now = null)
+    {
+        return $this->whereFuture($columns, $now, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
+     * @return $this
+     */
+    public function orWhereNotFuture($columns, $now = null)
+    {
+        return $this->whereFuture($columns, $now, 'or', true);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -645,18 +645,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
-
-        $now = Carbon::create(2021, 1, 2, 3, 4, 56);
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->wherePast('published_at', $now);
-        $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at', $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
     }
 
     public function testWherePastUsesArray()
@@ -674,89 +662,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
-
-        $now = Carbon::create(2021, 12, 31, 5, 6, 7);
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->wherePast(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "published_at" < ? and "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => Carbon::create('2021-12-31 05:06:07.000000'), 1 => Carbon::create('2021-12-31 05:06:07.000000')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-12-31 05:06:07.000000'), 2 => Carbon::create('2021-12-31 05:06:07.000000')], $builder->getBindings());
-    }
-
-    public function testWhereNotPast()
-    {
-        Carbon::setTestNow('2022-04-20 12:34:56.123456');
-
-        $testDate = Carbon::create('2022-04-20 12:34:56.123456');
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotPast('published_at');
-        $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => $testDate], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at');
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
-
-        $now = Carbon::create(2021, 1, 2, 3, 4, 56);
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotPast('published_at', $now);
-        $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at', $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
-    }
-
-    public function testWhereNotPastWithArray()
-    {
-        Carbon::setTestNow('2022-04-20 12:34:56.123456');
-
-        $testDate = Carbon::create('2022-04-20 12:34:56.123456');
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at']);
-        $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => $testDate, 1 => $testDate], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at']);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
-
-        $now = Carbon::create(2021, 11, 22, 3, 45, 6);
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => Carbon::create('2021-11-22 03:45:06.000000'), 1 => Carbon::create('2021-11-22 03:45:06.000000')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-11-22 03:45:06.000000'), 2 => Carbon::create('2021-11-22 03:45:06.000000')], $builder->getBindings());
-    }
-
-    public function testWherePastPassingNowAsString()
-    {
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->wherePast('published_at', '2022-04-22');
-        $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals(['2022-04-22'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at', 'some-point-in-time');
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([1, 'some-point-in-time'], $builder->getBindings());
     }
 
     public function testWhereTodayMySQL()
@@ -786,36 +691,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereToday(['published_at', 'held_at']);
         $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) = ? or date(`held_at`) = ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
-    }
-
-    public function testWhereNotTodayMySQL()
-    {
-        Carbon::setTestNow('2022-04-20 12:34:56.123456');
-
-        $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('posts')->whereNotToday('published_at');
-        $this->assertSame('select * from `posts` where date(`published_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20'], $builder->getBindings());
-
-        $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday('published_at');
-        $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
-    }
-
-    public function testPassingArrayToWhereNotTodayMySQL()
-    {
-        Carbon::setTestNow('2022-04-20 12:34:56.123456');
-
-        $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('posts')->whereNotToday(['published_at', 'held_at']);
-        $this->assertSame('select * from `posts` where date(`published_at`) != ? and date(`held_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20', 1 => '2022-04-20'], $builder->getBindings());
-
-        $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday(['published_at', 'held_at']);
-        $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) != ? or date(`held_at`) != ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
@@ -849,36 +724,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testWhereNotTodaySqlServer()
-    {
-        Carbon::setTestNow('2022-04-20 12:34:56.123456');
-
-        $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('posts')->whereNotToday('published_at');
-        $this->assertSame('select * from [posts] where cast([published_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20'], $builder->getBindings());
-
-        $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday('published_at');
-        $this->assertSame('select * from [posts] where [id] = ? or cast([published_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
-    }
-
-    public function testPassingArrayToWhereNotTodaySqlServer()
-    {
-        Carbon::setTestNow('2022-04-20 12:34:56.123456');
-
-        $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('posts')->whereNotToday(['published_at', 'held_at']);
-        $this->assertSame('select * from [posts] where cast([published_at] as date) != ? and cast([held_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20', 1 => '2022-04-20'], $builder->getBindings());
-
-        $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday(['published_at', 'held_at']);
-        $this->assertSame('select * from [posts] where [id] = ? or cast([published_at] as date) != ? or cast([held_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
-    }
-
     public function testWhereFuture()
     {
         Carbon::setTestNow('2022-04-22 21:01:23.123456');
@@ -894,18 +739,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
-
-        $now = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2022-04-22 23:11:09.987654');
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereFuture('published_at', $now);
-        $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals([Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at', $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([1, Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereFuture()
@@ -923,89 +756,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
-
-        $now = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2022-04-22 23:11:09.987654');
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereFuture(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "published_at" > ? and "held_at" > ?', $builder->toSql());
-        $this->assertEquals([Carbon::create('2022-04-22 23:11:09.987654'), Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
-        $this->assertEquals([1, Carbon::create('2022-04-22 23:11:09.987654'), Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
-    }
-
-    public function testWhereNotFuture()
-    {
-        Carbon::setTestNow('2022-04-22 01:23:45.123456');
-
-        $testDate = Carbon::create('2022-04-22 01:23:45.123456');
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotFuture('published_at');
-        $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => $testDate], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at');
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
-
-        $now = Carbon::create(2021, 2, 3, 4, 5, 6);
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotFuture('published_at', $now);
-        $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at', $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
-    }
-
-    public function testPassingArrayToWhereNotFuture()
-    {
-        Carbon::setTestNow('2022-04-22 01:23:45.123456');
-
-        $testDate = Carbon::create('2022-04-22 01:23:45.123456');
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at']);
-        $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => $testDate, 1 => $testDate], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at']);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
-
-        $now = Carbon::create(2021, 2, 3, 4, 5, 6);
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([Carbon::create('2021-02-03 04:05:06.000000'), Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at'], $now);
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([1, Carbon::create('2021-02-03 04:05:06.000000'), Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
-    }
-
-    public function testPassingStringToWhereFuture()
-    {
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->whereFuture('published_at', '2022-04-22 23:11:09');
-        $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals(['2022-04-22 23:11:09'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at', 'date-string');
-        $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([1, 'date-string'], $builder->getBindings());
     }
 
     public function testWhereLikePostgres()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -634,108 +634,116 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         Carbon::setTestNow('2022-04-20 23:45:06.123456');
 
+        $testDate = Carbon::create('2022-04-20 23:45:06.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast('published_at');
         $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 23:45:06.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 23:45:06.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
 
         $now = Carbon::create(2021, 1, 2, 3, 4, 56);
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast('published_at', $now);
         $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
+        $this->assertEquals([0 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at', $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
     }
 
     public function testWherePastUsesArray()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
+        $testDate = Carbon::create('2022-04-20 12:34:56.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" < ? and "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56.123456', 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate, 1 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456', 2 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
 
         $now = Carbon::create(2021, 12, 31, 5, 6, 7);
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "published_at" < ? and "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2021-12-31 05:06:07.000000', 1 => '2021-12-31 05:06:07.000000'], $builder->getBindings());
+        $this->assertEquals([0 => Carbon::create('2021-12-31 05:06:07.000000'), 1 => Carbon::create('2021-12-31 05:06:07.000000')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2021-12-31 05:06:07.000000', 2 => '2021-12-31 05:06:07.000000'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-12-31 05:06:07.000000'), 2 => Carbon::create('2021-12-31 05:06:07.000000')], $builder->getBindings());
     }
 
     public function testWhereNotPast()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
+        $testDate = Carbon::create('2022-04-20 12:34:56.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast('published_at');
         $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
 
         $now = Carbon::create(2021, 1, 2, 3, 4, 56);
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast('published_at', $now);
         $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
+        $this->assertEquals([0 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at', $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-01-02 03:04:56.000000')], $builder->getBindings());
     }
 
     public function testWhereNotPastWithArray()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
+        $testDate = Carbon::create('2022-04-20 12:34:56.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56.123456', 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate, 1 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456', 2 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
 
         $now = Carbon::create(2021, 11, 22, 3, 45, 6);
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => '2021-11-22 03:45:06.000000', 1 => '2021-11-22 03:45:06.000000'], $builder->getBindings());
+        $this->assertEquals([0 => Carbon::create('2021-11-22 03:45:06.000000'), 1 => Carbon::create('2021-11-22 03:45:06.000000')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2021-11-22 03:45:06.000000', 2 => '2021-11-22 03:45:06.000000'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-11-22 03:45:06.000000'), 2 => Carbon::create('2021-11-22 03:45:06.000000')], $builder->getBindings());
     }
 
     public function testWherePastPassingNowAsString()
@@ -875,108 +883,116 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         Carbon::setTestNow('2022-04-22 21:01:23.123456');
 
+        $testDate = Carbon::create('2022-04-22 21:01:23.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 21:01:23.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 21:01:23.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
 
         $now = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2022-04-22 23:11:09.987654');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture('published_at', $now);
         $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals(['2022-04-22 23:11:09.987654'], $builder->getBindings());
+        $this->assertEquals([Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at', $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([1, '2022-04-22 23:11:09.987654'], $builder->getBindings());
+        $this->assertEquals([1, Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereFuture()
     {
         Carbon::setTestNow('2022-04-22 01:23:45.123456');
 
+        $testDate = Carbon::create('2022-04-22 01:23:45.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" > ? and "held_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45.123456', 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate, 1 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456', 2 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
 
         $now = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2022-04-22 23:11:09.987654');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "published_at" > ? and "held_at" > ?', $builder->toSql());
-        $this->assertEquals(['2022-04-22 23:11:09.987654', '2022-04-22 23:11:09.987654'], $builder->getBindings());
+        $this->assertEquals([Carbon::create('2022-04-22 23:11:09.987654'), Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
-        $this->assertEquals([1, '2022-04-22 23:11:09.987654', '2022-04-22 23:11:09.987654'], $builder->getBindings());
+        $this->assertEquals([1, Carbon::create('2022-04-22 23:11:09.987654'), Carbon::create('2022-04-22 23:11:09.987654')], $builder->getBindings());
     }
 
     public function testWhereNotFuture()
     {
         Carbon::setTestNow('2022-04-22 01:23:45.123456');
 
+        $testDate = Carbon::create('2022-04-22 01:23:45.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate], $builder->getBindings());
 
         $now = Carbon::create(2021, 2, 3, 4, 5, 6);
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture('published_at', $now);
         $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => '2021-02-03 04:05:06.000000'], $builder->getBindings());
+        $this->assertEquals([0 => Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at', $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2021-02-03 04:05:06.000000'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotFuture()
     {
         Carbon::setTestNow('2022-04-22 01:23:45.123456');
 
+        $testDate = Carbon::create('2022-04-22 01:23:45.123456');
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45.123456', 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+        $this->assertEquals([0 => $testDate, 1 => $testDate], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456', 2 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => $testDate, 2 => $testDate], $builder->getBindings());
 
         $now = Carbon::create(2021, 2, 3, 4, 5, 6);
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
-        $this->assertEquals(['2021-02-03 04:05:06.000000', '2021-02-03 04:05:06.000000'], $builder->getBindings());
+        $this->assertEquals([Carbon::create('2021-02-03 04:05:06.000000'), Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at'], $now);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([1, '2021-02-03 04:05:06.000000', '2021-02-03 04:05:06.000000'], $builder->getBindings());
+        $this->assertEquals([1, Carbon::create('2021-02-03 04:05:06.000000'), Carbon::create('2021-02-03 04:05:06.000000')], $builder->getBindings());
     }
 
     public function testPassingStringToWhereFuture()


### PR DESCRIPTION
I PR'd a version of this almost 3 years ago and still reach for it. So I figured I'd give it another shot.

This adds a few relative, human readable shorthands for working with dates (cause dates are hard).

```php
$archivedPost = Post::wherePast('archived_at')->get();
$currentReleases = Release::whereToday('released_at')->get();
$activeTokens = Token::whereFuture('expire_at')->get();
```

While I appreciate this adds weight to this ever growing class, there are dozens of other shorthands. Queries are something devs write everyday. As such, I believe any shorthand continues to improve the DX of Laravel.

All of these methods have their `where`, `or`, and `orWhereNot` counterparts. All methods also accept an array of column names as the first argument. The `wherePast` and `whereFuture` have an optional second argument to set `$now`.