### PR TITLE
[12.X] Introduces UsePolicy attribute

### DIFF
--- a/src/Illuminate/Auth/Access/Attributes/UsePolicy.php
+++ b/src/Illuminate/Auth/Access/Attributes/UsePolicy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Auth\Access\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UsePolicy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string  $policyClass
+     * @return void
+     */
+    public function __construct(public string $policyClass) {}
+}

--- a/src/Illuminate/Auth/Access/Attributes/UsePolicy.php
+++ b/src/Illuminate/Auth/Access/Attributes/UsePolicy.php
@@ -13,5 +13,7 @@ class UsePolicy
      * @param  class-string  $policyClass
      * @return void
      */
-    public function __construct(public string $policyClass) {}
+    public function __construct(public string $policyClass)
+    {
+    }
 }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -4,8 +4,6 @@ namespace Illuminate\Auth\Access;
 
 use Closure;
 use Exception;
-use function Illuminate\Support\enum_value;
-
 use Illuminate\Auth\Access\Attributes\UsePolicy;
 use Illuminate\Auth\Access\Events\GateEvaluated;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
@@ -16,8 +14,9 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use ReflectionClass;
-
 use ReflectionFunction;
+
+use function Illuminate\Support\enum_value;
 
 class Gate implements GateContract
 {

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -731,9 +731,7 @@ class Gate implements GateContract
         if ($attributes !== []) {
             $usePolicy = $attributes[0]->newInstance();
 
-            $policy = new $usePolicy->policyClass;
-
-            return $policy;
+            return $this->resolvePolicy($usePolicy->policyClass);
         }
 
         return null;

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\Access\Attributes\UsePolicy;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Auth\Access\HandlesAuthorization;
@@ -610,6 +611,18 @@ class AuthAccessGateTest extends TestCase
         });
 
         $this->assertTrue($gate->forUser((object) ['id' => 2])->check('foo'));
+    }
+
+    public function testForUserMethodAttachesANewUserToANewGateInstanceWithTryResolvePolicyViaUsePolicyAttributeCallback()
+    {
+        $gate = $this->getBasicGate();
+
+        $policy = $gate->getPolicyFor(AccessGateTestDummyWithUsePolicyAttribute::class);
+
+        $this->assertTrue(
+            $policy instanceof AccessGateTestPolicy && 
+            get_class($policy) === AccessGateTestPolicy::class
+        );
     }
 
     public function testForUserMethodAttachesANewUserToANewGateInstanceWithGuessCallback()
@@ -1338,6 +1351,12 @@ interface AccessGateTestDummyInterface
 }
 
 class AccessGateTestDummy implements AccessGateTestDummyInterface
+{
+    //
+}
+
+#[UsePolicy(AccessGateTestPolicy::class)]
+class AccessGateTestDummyWithUsePolicyAttribute implements AccessGateTestDummyInterface
 {
     //
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -620,7 +620,7 @@ class AuthAccessGateTest extends TestCase
         $policy = $gate->getPolicyFor(AccessGateTestDummyWithUsePolicyAttribute::class);
 
         $this->assertTrue(
-            $policy instanceof AccessGateTestPolicy && 
+            $policy instanceof AccessGateTestPolicy &&
             get_class($policy) === AccessGateTestPolicy::class
         );
     }


### PR DESCRIPTION
## Description

This pull request introduces a `UsePolicy` attribute that provides **an alternative way to define a policy** for a model using PHP 8.0+ attributes. This is useful for when your policy does not follow the naming conventions to automatically look up the correct policy. Even when the policy follows the naming convention, it may help developers by making it more clear that a specific policy is used and by making it more easy to navigate.

## Usage

```php
<?php

namespace App\Models\Foo;

use App\Policies\BarPolicy;
use Illuminate\Auth\Access\Attributes\UsePolicy;

#[UsePolicy(BarPolicy::class)]
class Foo extends Model
{
    // ...
}
```

## Reasoning

This is inspired by the recent addition of the `UseFactory` attribute. It makes it easier to know which policy is used for a model, by defining it in the model class itself.

## Priority

The code is executed after looking through the defined policies and right before the guessing logic.

## Testing

The PR includes a test to verify the Policy is found.


