### PR TITLE
Fixed incomplete return type signature on insertGetId method. Updated Model class and added test.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1356,9 +1356,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function insertAndSetId(Builder $query, $attributes)
     {
+        /** @var int|false $id */
         $id = $query->insertGetId($attributes, $keyName = $this->getKeyName());
 
-        $this->setAttribute($keyName, $id);
+        if ($id !== false) {
+            $this->setAttribute($keyName, $id);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3786,7 +3786,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return false|int
      */
     public function insertGetId(array $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -28,7 +28,7 @@ class MySqlProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return false|int
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -25,7 +25,7 @@ class Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return false|int
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -15,7 +15,7 @@ class SqlServerProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return false|int
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {


### PR DESCRIPTION
### Explanation

There can be unexpected consequences when calling methods like `$model->insertAndSetId()` or `$table->insertGetId()` are called and the returned value is `false`, which is not accounted for in the signatures of those methods. This can happen because both functions return the result of  `Illuminate\Database\Query\Processors\Processor\processInsertGetId()` (also needing a PHPDoc update), which in turn returns the result of `PDO\lastInsertId()`, which correctly indicates it could return a value of `false`. 

### Changes

1. I have updated the PHPDoc signatures in places where it seemed appropriate. 
2. I have updated the `Model\insertAndSetId()` method to **not set the attribute** if the return value is false. There must be a better way to handle this, but I wanted to be consistent with other database functions and not throw an error.
3. I have added a test for the `Model` class to handle the case in which the attribute is not set. I'm not sure if I put my test in the right place. Improvements are probably needed anyway.

> [!NOTE]
>  There are many other places where a `false` return value from `lastInsertId()` could be problematic. Further review and tests are encouraged.

### Beware

1. This is my first ever attempt at contributing  so please accept my apologies if I'm not doing it correctly. 🙏 
2. The change to the `Model` class seems like a be a breaking change to me, so based on the guidelines, I'm hoping I selected the right branch. Again, sorry if I'm getting this wrong.

