### PR TITLE
docs: clarify use of hasOption()

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -95,7 +95,7 @@ trait InteractsWithIO
     }
 
     /**
-     * Determine if the given option is present.
+     * Determine whether the option exists for the command.
      *
      * @param  string  $name
      * @return bool

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -95,7 +95,7 @@ trait InteractsWithIO
     }
 
     /**
-     * Determine whether the option exists for the command.
+     * Determine whether the option is defined in the command signature.
      *
      * @param  string  $name
      * @return bool


### PR DESCRIPTION
`hasOption()` does not check whether the command has been _called_ with the given option, but rather whether the command even _accepts_ the option.

i.e. it is not like `request()->has('option')`
https://laravel.com/docs/11.x/requests#input-presence 
