### PR TITLE
[11.x] Refactor validation rule parsing for improved readability

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -96,7 +96,7 @@ class ValidationRuleParser
         }
 
         return array_map(
-            [$this, 'prepareRule'],
+            $this->prepareRule(...),
             $rule,
             array_fill((int) array_key_first($rule), count($rule), $attribute)
         );
@@ -132,11 +132,13 @@ class ValidationRuleParser
             )->rules[$attribute];
         }
 
-        if (str_contains((string) $rule, '|')) {
-            return explode('|', (string) $rule);
+        $rule = (string) $rule;
+
+        if (str_contains($rule, '|')) {
+            return explode('|', $rule);
         }
 
-        return (string) $rule;
+        return $rule;
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 
@@ -96,17 +95,11 @@ class ValidationRuleParser
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
 
-        $rules = [];
-
-        foreach ($rule as $value) {
-            if ($value instanceof Date) {
-                $rules = array_merge($rules, explode('|', (string) $value));
-            } else {
-                $rules[] = $this->prepareRule($value, $attribute);
-            }
-        }
-
-        return $rules;
+        return array_map(
+            [$this, 'prepareRule'],
+            $rule,
+            array_fill((int) array_key_first($rule), count($rule), $attribute)
+        );
     }
 
     /**
@@ -137,6 +130,10 @@ class ValidationRuleParser
             return $rule->compile(
                 $attribute, $this->data[$attribute] ?? null, Arr::dot($this->data), $this->data
             )->rules[$attribute];
+        }
+
+        if (str_contains((string) $rule, '|')) {
+            return explode('|', (string) $rule);
         }
 
         return (string) $rule;


### PR DESCRIPTION
This PR enhances the `explodeExplicitRule` to support rules as both strings and arrays. In the future, rules can be used as strings with `|` for validation, eliminating the need for `instanceof` checks for specific classes like the `Date` rule.