### PR TITLE
[12.x] Fix aggregate alias when using  expression

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -775,7 +775,11 @@ trait QueriesRelationships
             // the query builder. Then, we will return the builder instance back to the developer
             // for further constraint chaining that needs to take place on the query as needed.
             $alias ??= Str::snake(
-                preg_replace('/[^[:alnum:][:space:]_]/u', '', "$name $function {$this->getQuery()->getGrammar()->getValue($column)}")
+                preg_replace(
+                    '/[^[:alnum:][:space:]_]/u',
+                    '',
+                    sprintf('%s %s %s', $name, $function, strtolower($this->getQuery()->getGrammar()->getValue($column)))
+                )
             );
 
             if ($function === 'exists') {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1441,6 +1441,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithAggregateAlias()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withAggregate('foo', new Expression('TIMESTAMPDIFF(SECOND, `created_at`, `updated_at`)'), 'sum');
+
+        $this->assertSame(
+            'select "eloquent_builder_test_model_parent_stubs".*, (select sum(TIMESTAMPDIFF(SECOND, `created_at`, `updated_at`)) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_sum_timestampdiffsecond_created_at_updated_at" from "eloquent_builder_test_model_parent_stubs"',
+            $builder->toSql()
+        );
+    }
+
     public function testWithAggregateAndSelfRelationConstrain()
     {
         EloquentBuilderTestStub::resolveRelationUsing('children', function ($model) {


### PR DESCRIPTION
Recently I discovered, when using `withAggregate` with a custom `Expression` insead of passing a column, the alias is not properly formatted.

For example:

```php
$model->withAggregate('foo', new Expression('TIMESTAMPDIFF(SECOND, `created_at`, `updated_at`)'), 'sum')

// The generated alias:

// Before: foo_sum_t_i_m_e_s_t_a_m_p_d_i_f_f_s_e_c_o_n_d_created_at_updated_at

// After: foo_sum_timestampdiffsecond_created_at_updated_at
```

We could add an alias explicitly to handle this, but often it's easier to use the generated column aliases.

I targeted the master branch, because I think this could be a breaking change.