### PR TITLE
Added support for inline ->or->

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2053,6 +2053,10 @@ class Builder implements BuilderContract
             return new HigherOrderBuilderProxy($this, $key);
         }
 
+        if ($key === 'or') {
+            return new HigherOrderBuilderProxy($this, 'orWhere');
+        }
+
         if (in_array($key, $this->propertyPassthru)) {
             return $this->toBase()->{$key};
         }


### PR DESCRIPTION
Add support for Eloquent Query Builder to be able to use inline "or".

Consider the following Model:

```
use Illuminate\Database\Eloquent\Model;

class Media extends Model
{
    public function scopeActive(Builder $query): void
    {
        $query->where('status', 'active');
    }

    public function scopeIn(Builder $query, array|string $collection): void
    {
        $where = is_array($collection) ? 'whereIn' : 'where';

        $query->$where('collection_name', $collection);
    }
}
```

With this pull request, you'll be able to write:

```
$media = $post->media()
    ->where(fn($q) => $q->approved()->or->in('video-preview'))
    ->getQuery()
    ->get();
```

instead of this:

```
$media = $post->media()
    ->where(fn($q) => $q->approved()->orWhere(fn($q) => $q->in('video-preview')))
    ->getQuery()
    ->get();
```