### PR TITLE
[11.x] Fix casts + `withAttributes`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsInverseRelations;
@@ -119,7 +119,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $relation
      * @return array<int, TDeclaringModel>
      */
-    public function matchOne(array $models, Collection $results, $relation)
+    public function matchOne(array $models, EloquentCollection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'one');
     }
@@ -132,7 +132,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $relation
      * @return array<int, TDeclaringModel>
      */
-    public function matchMany(array $models, Collection $results, $relation)
+    public function matchMany(array $models, EloquentCollection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'many');
     }
@@ -146,7 +146,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $type
      * @return array<int, TDeclaringModel>
      */
-    protected function matchOneOrMany(array $models, Collection $results, $relation, $type)
+    protected function matchOneOrMany(array $models, EloquentCollection $results, $relation, $type)
     {
         $dictionary = $this->buildDictionary($results);
 
@@ -189,7 +189,7 @@ abstract class HasOneOrMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
      * @return array<array<int, TRelatedModel>>
      */
-    protected function buildDictionary(Collection $results)
+    protected function buildDictionary(EloquentCollection $results)
     {
         $foreign = $this->getForeignKeyName();
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsInverseRelations;
@@ -119,7 +119,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $relation
      * @return array<int, TDeclaringModel>
      */
-    public function matchOne(array $models, EloquentCollection $results, $relation)
+    public function matchOne(array $models, Collection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'one');
     }
@@ -132,7 +132,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $relation
      * @return array<int, TDeclaringModel>
      */
-    public function matchMany(array $models, EloquentCollection $results, $relation)
+    public function matchMany(array $models, Collection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'many');
     }
@@ -146,7 +146,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $type
      * @return array<int, TDeclaringModel>
      */
-    protected function matchOneOrMany(array $models, EloquentCollection $results, $relation, $type)
+    protected function matchOneOrMany(array $models, Collection $results, $relation, $type)
     {
         $dictionary = $this->buildDictionary($results);
 
@@ -189,7 +189,7 @@ abstract class HasOneOrMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
      * @return array<array<int, TRelatedModel>>
      */
-    protected function buildDictionary(EloquentCollection $results)
+    protected function buildDictionary(Collection $results)
     {
         $foreign = $this->getForeignKeyName();
 
@@ -448,7 +448,9 @@ abstract class HasOneOrMany extends Relation
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
 
         foreach ($this->getQuery()->pendingAttributes as $key => $value) {
-            if (! $model->hasAttribute($key)) {
+            $attributes ??= $model->getAttributes();
+
+            if (! array_key_exists($key, $attributes)) {
                 $model->setAttribute($key, $value);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -97,7 +97,9 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getMorphType()} = $this->morphClass;
 
         foreach ($this->getQuery()->pendingAttributes as $key => $value) {
-            if (! $model->hasAttribute($key)) {
+            $attributes ??= $model->getAttributes();
+
+            if (! array_key_exists($key, $attributes)) {
                 $model->setAttribute($key, $value);
             }
         }

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesTest.php
@@ -267,9 +267,30 @@ class DatabaseEloquentHasOneOrManyWithAttributesTest extends TestCase
         $this->assertSame($parent::class, $relatedModel->relatable_type);
         $this->assertSame($value, $relatedModel->$key);
     }
+
+    public function testHasManyAddsCastedAttributes(): void
+    {
+        $parentId = 123;
+
+        $parent = new RelatedWithAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedWithAttributesModel::class, 'parent_id')
+            ->withAttributes(['is_admin' => 1]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame(true, $relatedModel->is_admin);
+    }
 }
 
 class RelatedWithAttributesModel extends Model
 {
     protected $guarded = [];
+
+    protected $casts = [
+        'is_admin' => 'boolean',
+    ];
 }

--- a/tests/Database/DatabaseEloquentWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Builder;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentWithAttributesTest extends TestCase
@@ -18,6 +20,11 @@ class DatabaseEloquentWithAttributesTest extends TestCase
         ]);
         $db->bootEloquent();
         $db->setAsGlobal();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema()->dropIfExists((new WithAttributesModel)->getTable());
     }
 
     public function testAddsAttributes(): void
@@ -51,9 +58,101 @@ class DatabaseEloquentWithAttributesTest extends TestCase
             'boolean' => 'and',
         ], $wheres);
     }
+
+    public function testAddsWithCasts(): void
+    {
+        $query = WithAttributesModel::query()
+            ->withAttributes([
+                'is_admin' => 1,
+                'first_name' => 'FIRST',
+                'last_name' => 'LAST',
+                'type' => WithAttributesEnum::internal,
+            ]);
+
+        $model = $query->make();
+
+        $this->assertSame(true, $model->is_admin);
+        $this->assertSame('First', $model->first_name);
+        $this->assertSame('Last', $model->last_name);
+        $this->assertSame(WithAttributesEnum::internal, $model->type);
+
+        $this->assertEqualsCanonicalizing([
+            'id_admin' => 1,
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'type' => 'int',
+        ], $model->getAttributes());
+    }
+
+    public function testAddsWithCastsViaDb(): void
+    {
+        $this->bootTable();
+
+        $query = WithAttributesModel::query()
+            ->withAttributes([
+                'is_admin' => 1,
+                'first_name' => 'FIRST',
+                'last_name' => 'LAST',
+                'type' => WithAttributesEnum::internal,
+            ]);
+
+        $query->create();
+
+        $model = WithAttributesModel::first();
+
+        $this->assertSame(true, $model->is_admin);
+        $this->assertSame('First', $model->first_name);
+        $this->assertSame('Last', $model->last_name);
+        $this->assertSame(WithAttributesEnum::internal, $model->type);
+    }
+
+    protected function bootTable(): void
+    {
+        $this->schema()->create((new WithAttributesModel)->getTable(), function ($table) {
+            $table->id();
+            $table->boolean('is_admin');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    protected function schema(): Builder
+    {
+        return WithAttributesModel::getConnectionResolver()->connection()->getSchemaBuilder();
+    }
 }
 
 class WithAttributesModel extends Model
 {
     protected $guarded = [];
+
+    protected $casts = [
+        'is_admin' => 'boolean',
+        'type' => WithAttributesEnum::class,
+    ];
+
+    public function setFirstNameAttribute(string $value): void
+    {
+        $this->attributes['first_name'] = strtolower($value);
+    }
+
+    public function getFirstNameAttribute(?string $value): string
+    {
+        return ucfirst($value);
+    }
+
+    protected function lastName(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value) => ucfirst($value),
+            set: fn (string $value) => strtolower($value),
+        );
+    }
+}
+
+enum WithAttributesEnum: string
+{
+    case internal = 'int';
 }

--- a/tests/Database/DatabaseEloquentWithAttributesTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesTest.php
@@ -77,7 +77,7 @@ class DatabaseEloquentWithAttributesTest extends TestCase
         $this->assertSame(WithAttributesEnum::internal, $model->type);
 
         $this->assertEqualsCanonicalizing([
-            'id_admin' => 1,
+            'is_admin' => 1,
             'first_name' => 'first',
             'last_name' => 'last',
             'type' => 'int',


### PR DESCRIPTION
An issue was reported in [a comment](https://github.com/laravel/framework/pull/53720#issuecomment-2618963306) so I decided to test the pending attributes with multiple methods of casting attributes.

The error was becacuse of an inappropriate use of `hasAttribute`, this fixes it and adds a test for that case and some more cast tests.