### PR TITLE
Test Improvements

### DIFF
--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 
 class CloudTest extends TestCase
 {
-    #[WithConfig('database.connections.pgsql', ['host' => 'test-pooler.pg.laravel.cloud', 'username' => 'test-username', 'password' => 'test-password'])
+    #[WithConfig('database.connections.pgsql', ['host' => 'test-pooler.pg.laravel.cloud', 'username' => 'test-username', 'password' => 'test-password'])]
     public function test_it_can_resolve_core_container_aliases()
     {
         Cloud::configureUnpooledPostgresConnection($this->app);

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -3,18 +3,14 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Illuminate\Foundation\Cloud;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
 class CloudTest extends TestCase
 {
+    #[WithConfig('database.connections.pgsql', ['host' => 'test-pooler.pg.laravel.cloud', 'username' => 'test-username', 'password' => 'test-password'])
     public function test_it_can_resolve_core_container_aliases()
     {
-        $this->app['config']->set('database.connections.pgsql', [
-            'host' => 'test-pooler.pg.laravel.cloud',
-            'username' => 'test-username',
-            'password' => 'test-password',
-        ]);
-
         Cloud::configureUnpooledPostgresConnection($this->app);
 
         $this->assertEquals([


### PR DESCRIPTION
Using the `WithConfig` attribute to load configuration during the Laravel bootstrapping step for a specific test (between `RegisterProviders` and `BootProviders`) instead of loading the configuration when the application is booted.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
