### PR TITLE
[11.x] add Generics to Paginator's ArrayAccess methods

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -601,7 +601,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Determine if the given item exists.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return bool
      */
     public function offsetExists($key): bool
@@ -612,8 +612,8 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Get the item at the given offset.
      *
-     * @param  mixed  $key
-     * @return mixed
+     * @param  TKey  $key
+     * @return TValue
      */
     public function offsetGet($key): mixed
     {
@@ -623,8 +623,8 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Set the item at the given offset.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  TKey|null  $key
+     * @param  TValue  $value
      * @return void
      */
     public function offsetSet($key, $value): void
@@ -635,7 +635,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Unset the item at the given key.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return void
      */
     public function offsetUnset($key): void

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -726,7 +726,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * Determine if the given item exists.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return bool
      */
     public function offsetExists($key): bool
@@ -737,8 +737,8 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * Get the item at the given offset.
      *
-     * @param  mixed  $key
-     * @return mixed
+     * @param  TKey  $key
+     * @return TValue
      */
     public function offsetGet($key): mixed
     {
@@ -748,8 +748,8 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * Set the item at the given offset.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  TKey|null  $key
+     * @param  TValue  $value
      * @return void
      */
     public function offsetSet($key, $value): void
@@ -760,7 +760,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * Unset the item at the given key.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return void
      */
     public function offsetUnset($key): void


### PR DESCRIPTION
This PR will make Paginator aligned with Collection, [which already has these generic types defined](https://github.com/laravel/framework/blob/6cdef2c687366ff056942968d155640455cf1e24/src/Illuminate/Collections/Collection.php#L1875-L1922) for ArrayAccess methods.
