### PR TITLE
Fix race condition checking if event mutex exists

### DIFF
--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -61,9 +61,8 @@ class CacheEventMutex implements EventMutex, CacheAware
     public function exists(Event $event)
     {
         if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
-            return ! $this->cache->store($this->store)->getStore()
-                ->lock($event->mutexName(), $event->expiresAt * 60)
-                ->get(fn () => true);
+            return $this->cache->store($this->store)->getStore()
+                    ->get($event->mutexName()) !== null;
         }
 
         return $this->cache->store($this->store)->has($event->mutexName());


### PR DESCRIPTION
Fix issue #50330  a race condition checking if lock already exists.

It's possible for a race condition to occur if we acquire the lock just to check if it's free. 

The exists check interferes with the actual lock acquisition at event startup. As a result it's possible to miss an event run.

Imagine following scenario:

1) thread A goes inside the exists method and lock the mutex.

2) All other threads conclude that the event will be run by thread A and skip the event run to avoid overlapping

3) thread A releases the lock by returning from the exists methog

4) thread A proceeds to acquire the lock "for real" but the lock has already been locked by another thread running the exists method.

5) Thread A bails out thinking the event is being run by another thread but in fact it's not.