### PR TITLE
[11.x] Fix docblocks for code that calls `enum_value()`

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -194,7 +194,7 @@ class Gate implements GateContract
     /**
      * Define a new ability.
      *
-     * @param  \BackedEnum|string  $ability
+     * @param  \UnitEnum|string  $ability
      * @param  callable|array|string  $callback
      * @return $this
      *
@@ -325,7 +325,7 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|\BackedEnum|string  $ability
+     * @param  iterable|\UnitEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -337,7 +337,7 @@ class Gate implements GateContract
     /**
      * Determine if any of the given abilities should be denied for the current user.
      *
-     * @param  iterable|\BackedEnum|string  $ability
+     * @param  iterable|\UnitEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -349,7 +349,7 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -363,7 +363,7 @@ class Gate implements GateContract
     /**
      * Determine if any one of the given abilities should be granted for the current user.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -375,7 +375,7 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be denied for the current user.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
@@ -387,7 +387,7 @@ class Gate implements GateContract
     /**
      * Determine if the given ability should be granted for the current user.
      *
-     * @param  \BackedEnum|string  $ability
+     * @param  \UnitEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      *
@@ -401,7 +401,7 @@ class Gate implements GateContract
     /**
      * Inspect the user for the given ability.
      *
-     * @param  \BackedEnum|string  $ability
+     * @param  \UnitEnum|string  $ability
      * @param  array|mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      */

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -32,7 +32,7 @@ class Authorize
     /**
      * Specify the ability and models for the middleware.
      *
-     * @param  \BackedEnum|string  $ability
+     * @param  \UnitEnum|string  $ability
      * @param  string  ...$models
      * @return string
      */

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -263,7 +263,7 @@ class PendingBatch
     /**
      * Specify the queue that the batched jobs should run on.
      *
-     * @param  \BackedEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -79,7 +79,7 @@ trait Queueable
     /**
      * Set the desired connection for the job.
      *
-     * @param  \BackedEnum|string|null  $connection
+     * @param  \UnitEnum|string|null  $connection
      * @return $this
      */
     public function onConnection($connection)
@@ -92,7 +92,7 @@ trait Queueable
     /**
      * Set the desired queue for the job.
      *
-     * @param  \BackedEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)
@@ -105,7 +105,7 @@ trait Queueable
     /**
      * Set the desired connection for the chain.
      *
-     * @param  \BackedEnum|string|null  $connection
+     * @param  \UnitEnum|string|null  $connection
      * @return $this
      */
     public function allOnConnection($connection)
@@ -121,7 +121,7 @@ trait Queueable
     /**
      * Set the desired queue for the chain.
      *
-     * @param  \BackedEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return $this
      */
     public function allOnQueue($queue)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -14,7 +14,7 @@ class AsEnumArrayObject implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @template TEnum
+     * @template TEnum of \UnitEnum
      *
      * @param  array{class-string<TEnum>}  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Database\Eloquent\Casts\ArrayObject<array-key, TEnum>, iterable<TEnum>>

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -14,7 +14,7 @@ class AsEnumCollection implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @template TEnum of \UnitEnum|\BackedEnum
+     * @template TEnum of \UnitEnum
      *
      * @param  array{class-string<TEnum>}  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, TEnum>, iterable<TEnum>>

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -59,12 +59,12 @@ class QueuedClosure
     /**
      * Set the desired connection for the job.
      *
-     * @param  string|null  $connection
+     * @param  \UnitEnum|string|null  $connection
      * @return $this
      */
     public function onConnection($connection)
     {
-        $this->connection = $connection;
+        $this->connection = enum_value($connection);
 
         return $this;
     }
@@ -72,7 +72,7 @@ class QueuedClosure
     /**
      * Set the desired queue for the job.
      *
-     * @param  \BackedEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -72,12 +72,12 @@ class PendingChain
     /**
      * Set the desired connection for the job.
      *
-     * @param  string|null  $connection
+     * @param  \UnitEnum|string|null  $connection
      * @return $this
      */
     public function onConnection($connection)
     {
-        $this->connection = $connection;
+        $this->connection = enum_value($connection);
 
         return $this;
     }
@@ -85,7 +85,7 @@ class PendingChain
     /**
      * Set the desired queue for the job.
      *
-     * @param  \BackedEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1085,7 +1085,7 @@ class Route
     /**
      * Specify that the "Authorize" / "can" middleware should be applied to the route with the given options.
      *
-     * @param  \BackedEnum|string  $ability
+     * @param  \UnitEnum|string  $ability
      * @param  array|string  $models
      * @return $this
      */

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -84,7 +84,7 @@ trait DatabaseRule
      * Set a "where" constraint on the query.
      *
      * @param  \Closure|string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\Closure|array|string|int|bool|null  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|\Closure|array|string|int|bool|null  $value
      * @return $this
      */
     public function where($column, $value = null)
@@ -112,7 +112,7 @@ trait DatabaseRule
      * Set a "where not" constraint on the query.
      *
      * @param  string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|array|string  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $value
      * @return $this
      */
     public function whereNot($column, $value)


### PR DESCRIPTION
Any place where we call `enum_value()`, we can actually accept a backed or unit enum. Because `\BackedEnum` extends `\UnitEnum`, it's not necessary to union the two types. For instance: `@template TEnum of \UnitEnum|\BackedEnum` is redundant and can be reduced to `TEnum of \UnitEnum`.

Also allows QueuedClosure and PendingChain to accept an enum for the connection. I can back this change out, as it is not strictly a docblock change.