### PR TITLE
[11.x] fix: Fluent::fill definition

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -71,10 +71,10 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Fill the fluent instance with an array of attributes.
      *
-     * @param  iterable<TKey, TValue>  $attributes
+     * @param  array<TKey, TValue>  $attributes
      * @return $this
      */
-    public function fill($attributes)
+    public function fill(array $attributes)
     {
         foreach ($attributes as $key => $value) {
             $this->attributes[$key] = $value;


### PR DESCRIPTION
Hello!

This fixes the following error introduced by #54404:

```
  In Fluent.php line 19:                                                                                                               
    Declaration of Laravel\Nova\Support\Fluent::fill(array $attributes) must   
  be                                                                           
     compatible with Illuminate\Support\Fluent::fill($attributes)   
```

Thanks!

