### PR TITLE
Feature: php artisan key:rotate command

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -141,7 +141,7 @@ class KeyGenerateCommand extends Command
      *
      * @return string
      */
-    protected function keyReplacementPattern(): string
+    protected function keyReplacementPattern()
     {
         $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -117,7 +117,7 @@ class KeyGenerateCommand extends Command
      * @param  string  $key
      * @return bool
      */
-    protected function writeNewEnvironmentFileWith(string $key): bool
+    protected function writeNewEnvironmentFileWith($key)
     {
         $replaced = preg_replace(
             $this->keyReplacementPattern(),

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -33,7 +33,7 @@ class KeyGenerateCommand extends Command
      *
      * @return void
      */
-    public function handle(): void
+    public function handle()
     {
         if ($this->shouldSaveExistingKey()) {
             return;

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -96,7 +96,7 @@ class KeyGenerateCommand extends Command
      * @param  string  $key
      * @return bool
      */
-    protected function setKeyInEnvironmentFile(string $key): bool
+    protected function setKeyInEnvironmentFile($key)
     {
         $currentKey = $this->laravel['config']['app.key'];
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -43,6 +43,7 @@ class KeyGenerateCommand extends Command
 
         if ($this->option('show')) {
             $this->line('<comment>'.$key.'</comment>');
+
             return;
         }
 
@@ -58,7 +59,6 @@ class KeyGenerateCommand extends Command
         $this->components->info('Application key set successfully.');
     }
 
-
     /**
      * Ask the user if they want to save the existing key.
      */
@@ -67,9 +67,9 @@ class KeyGenerateCommand extends Command
         $currentKey = $this->laravel['config']['app.key'];
 
         if (! empty($currentKey) && $this->confirm(
-                'There is already an app key. Do you want to store the old key before generating a new one?',
-                true
-            )) {
+            'There is already an app key. Do you want to store the old key before generating a new one?',
+            true
+        )) {
             $this->call('key:rotate');
 
             return true;
@@ -93,7 +93,7 @@ class KeyGenerateCommand extends Command
     /**
      * Set the application key in the environment file.
      *
-     * @param string $key
+     * @param  string  $key
      * @return bool
      */
     protected function setKeyInEnvironmentFile(string $key): bool
@@ -114,7 +114,7 @@ class KeyGenerateCommand extends Command
     /**
      * Write a new environment file with the given key.
      *
-     * @param string $key
+     * @param  string  $key
      * @return bool
      */
     protected function writeNewEnvironmentFileWith(string $key): bool

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -83,7 +83,7 @@ class KeyGenerateCommand extends Command
      *
      * @return string
      */
-    protected function generateRandomKey(): string
+    protected function generateRandomKey()
     {
         return 'base64:'.base64_encode(
             Encrypter::generateKey($this->laravel['config']['app.cipher'])

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -70,7 +70,6 @@ class KeyGenerateCommand extends Command
                 'There is already an app key. Do you want to store the old key before generating a new one?',
                 true
             )) {
-
             $this->call('key:rotate');
 
             return true;

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -36,6 +36,8 @@ class KeyGenerateCommand extends Command
     public function handle(): void
     {
         if ($this->shouldSaveExistingKey()) {
+            $this->call('key:rotate');
+
             return;
         }
 
@@ -70,8 +72,6 @@ class KeyGenerateCommand extends Command
             'There is already an app key. Do you want to store the old key before generating a new one?',
             true
         )) {
-            $this->call('key:rotate');
-
             return true;
         }
 

--- a/src/Illuminate/Foundation/Console/RotateKeyCommand.php
+++ b/src/Illuminate/Foundation/Console/RotateKeyCommand.php
@@ -43,8 +43,8 @@ class RotateKeyCommand extends Command
         }
 
         // 4. Notify the user and generate a new key
-        $this->components->info('Current application key has been saved successfully. Running php artisan key:generate to generate a new key.');
-        $this->call('key:generate');
+        $this->components->info('Current application key has been saved successfully. Running php artisan key:generate --force to generate a new key.');
+        $this->call('key:generate', ['--force' => true]);
         $this->components->info('Application key has been rotated successfully.');
     }
 

--- a/src/Illuminate/Foundation/Console/RotateKeyCommand.php
+++ b/src/Illuminate/Foundation/Console/RotateKeyCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'key:rotate')]
+class RotateKeyCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'key:rotate 
+                    {--force : Force the operation to run when in production}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rotate application encryption key and store previous keys';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        // 1. Get current APP_KEY
+        $currentKey = $this->laravel['config']['app.key'];
+
+        // 2. Get current APP_PREVIOUS_KEYS as array and prepend the current key
+        $previousKeys = Arr::prepend($this->laravel['config']['app.previous_keys'] ?? [], $currentKey);
+
+        // 3. Update .env file with the new APP_PREVIOUS_KEYS and clear APP_KEY
+        if (! $this->updateEnvFile($currentKey, $previousKeys)) {
+            $this->components->error('Failed to update the environment file.');
+
+            return;
+        }
+
+        // 4. Notify the user and generate a new key
+        $this->components->info('Current application key has been saved successfully. Running php artisan key:generate to generate a new key.');
+        $this->call('key:generate');
+        $this->components->info('Application key has been rotated successfully.');
+    }
+
+    /**
+     * Update the .env file with the new APP_PREVIOUS_KEYS and clear APP_KEY.
+     */
+    protected function updateEnvFile(string $currentKey, array $previousKeys): bool
+    {
+        $envPath = $this->laravel->environmentFilePath();
+        $contents = file_get_contents($envPath);
+
+        // Convert array to comma-separated string and wrap in quotes
+        $quotedPreviousKeys = '"' . implode(',', $previousKeys) . '"';
+
+        // Update APP_PREVIOUS_KEYS
+        if (str_contains($contents, 'APP_PREVIOUS_KEYS=')) {
+            // If APP_PREVIOUS_KEYS already exists, update its value
+            $contents = preg_replace($this->previousKeysPattern(), 'APP_PREVIOUS_KEYS=' . $quotedPreviousKeys, $contents);
+        } else {
+            // If APP_PREVIOUS_KEYS does not exist, insert it after APP_KEY
+            $contents = preg_replace($this->keyPattern(), "APP_KEY=\nAPP_PREVIOUS_KEYS=" . $quotedPreviousKeys, $contents);
+        }
+
+        // Clear APP_KEY
+        $contents = preg_replace($this->keyPattern(), 'APP_KEY=', $contents);
+        $this->laravel['config']['app.key'] = null;
+
+        return file_put_contents($envPath, $contents) !== false;
+    }
+
+    /**
+     * Generate a regex pattern to match the current APP_KEY line
+     */
+    protected function keyPattern(): string
+    {
+        return '/^APP_KEY=' . preg_quote($this->laravel['config']['app.key'], '/') . '/m';
+    }
+
+    /**
+     * Generate a regex pattern to match the current APP_PREVIOUS_KEYS line
+     */
+    protected function previousKeysPattern(): string
+    {
+        return '/^APP_PREVIOUS_KEYS="' . preg_quote(implode(',', (array) $this->laravel['config']['app.previous_keys']), '/') . '"/m';
+    }
+}

--- a/src/Illuminate/Foundation/Console/RotateKeyCommand.php
+++ b/src/Illuminate/Foundation/Console/RotateKeyCommand.php
@@ -57,15 +57,15 @@ class RotateKeyCommand extends Command
         $contents = file_get_contents($envPath);
 
         // Convert array to comma-separated string and wrap in quotes
-        $quotedPreviousKeys = '"' . implode(',', $previousKeys) . '"';
+        $quotedPreviousKeys = '"'.implode(',', $previousKeys).'"';
 
         // Update APP_PREVIOUS_KEYS
         if (str_contains($contents, 'APP_PREVIOUS_KEYS=')) {
             // If APP_PREVIOUS_KEYS already exists, update its value
-            $contents = preg_replace($this->previousKeysPattern(), 'APP_PREVIOUS_KEYS=' . $quotedPreviousKeys, $contents);
+            $contents = preg_replace($this->previousKeysPattern(), 'APP_PREVIOUS_KEYS='.$quotedPreviousKeys, $contents);
         } else {
             // If APP_PREVIOUS_KEYS does not exist, insert it after APP_KEY
-            $contents = preg_replace($this->keyPattern(), "APP_KEY=\nAPP_PREVIOUS_KEYS=" . $quotedPreviousKeys, $contents);
+            $contents = preg_replace($this->keyPattern(), "APP_KEY=\nAPP_PREVIOUS_KEYS=".$quotedPreviousKeys, $contents);
         }
 
         // Clear APP_KEY
@@ -76,18 +76,18 @@ class RotateKeyCommand extends Command
     }
 
     /**
-     * Generate a regex pattern to match the current APP_KEY line
+     * Generate a regex pattern to match the current APP_KEY line.
      */
     protected function keyPattern(): string
     {
-        return '/^APP_KEY=' . preg_quote($this->laravel['config']['app.key'], '/') . '/m';
+        return '/^APP_KEY='.preg_quote($this->laravel['config']['app.key'], '/').'/m';
     }
 
     /**
-     * Generate a regex pattern to match the current APP_PREVIOUS_KEYS line
+     * Generate a regex pattern to match the current APP_PREVIOUS_KEYS line.
      */
     protected function previousKeysPattern(): string
     {
-        return '/^APP_PREVIOUS_KEYS="' . preg_quote(implode(',', (array) $this->laravel['config']['app.previous_keys']), '/') . '"/m';
+        return '/^APP_PREVIOUS_KEYS="'.preg_quote(implode(',', (array) $this->laravel['config']['app.previous_keys']), '/').'"/m';
     }
 }


### PR DESCRIPTION
## New Feature:

This PR adds a new `php artisan key:rotate command` and adds a safety level to the `KeyGenerateCommand`.

When generating a new application key, users are now prompted to optionally save the existing key before overwriting it. 
This completes the Laravel 11 rotating `APP_KEY` feature. 

## Example:
When running `php artisan key:generate`, if an existing key is found, the user is prompted:

```bash 
There is already an app key. Do you want to store the old key before generating a new one? (yes/no) [yes]:
```

If the user confirms, the `key:rotate` command is executed to save the old key before generating a new one.

## Key Changes:

- Added a new `shouldSaveExistingKey()` method to `KeyGenerateCommand` to prompt users to save the existing key.
- Introduced a new `RotateKeyCommand` to handle the key rotation process.
- Added missing return types to improve code clarity and consistency.


## Testing - help, please:
**I need help** with this part. I tested it locally but I don't know how to write a test that alters the .env file


## Non-breaking change:
This change is fully backward-compatible and does not have any effect, unless the user opts to save the old key.


## Additional thoughts/questions:
- use `ConfirmableTrait` trait?
- skip all confirmations, when not in production?
- skip entirely, when not in production? The command can always be used by itself... 

Let me know if you’d like to refine this further!

------------------


_Yes, phpstorm AI plugin, helped me write this PR description ;)_ 
