### PR TITLE
[11.x] Minor Feature a Prohibited If Declined and Prohibited If Accepted validation rules

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -131,6 +131,8 @@ return [
     'present_with_all' => 'The :attribute field must be present when :values are present.',
     'prohibited' => 'The :attribute field is prohibited.',
     'prohibited_if' => 'The :attribute field is prohibited when :other is :value.',
+    'prohibited_if_declined' => 'The :attribute field is prohibited when :other is accepted.',
+    'prohibited_if_accepted' => 'The :attribute field is prohibited when :other is declined.',
     'prohibited_unless' => 'The :attribute field is prohibited unless :other is in :values.',
     'prohibits' => 'The :attribute field prohibits :other from being present.',
     'regex' => 'The :attribute field format is invalid.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -666,6 +666,38 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the prohibited_if_accepted rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceProhibitedIfAccepted($message, $attribute, $rule, $parameters)
+    {
+        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
+
+        return str_replace([':other'], $parameters, $message);
+    }
+
+    /**
+     * Replace all place-holders for the prohibited_if_declined rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    public function replaceProhibitedIfDeclined($message, $attribute, $rule, $parameters)
+    {
+        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
+
+        return str_replace([':other'], $parameters, $message);
+    }
+
+    /**
      * Replace all place-holders for the prohibited_unless rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2083,6 +2083,44 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute does not exist when another attribute was "accepted".
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibitedIfAccepted($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'prohibited_if_accepted');
+
+        if ($this->validateAccepted($parameters[0], $this->getValue($parameters[0]))) {
+            return $this->validateProhibited($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute does not exist when another attribute was "declined".
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibitedIfDeclined($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'prohibited_if_declined');
+
+        if ($this->validateDeclined($parameters[0], $this->getValue($parameters[0]))) {
+            return $this->validateProhibited($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute does not exist unless another attribute has a given value.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -266,6 +266,8 @@ class Validator implements ValidatorContract
         'PresentWithAll',
         'Prohibited',
         'ProhibitedIf',
+        'ProhibitedIfAccepted',
+        'ProhibitedIfDeclined',
         'ProhibitedUnless',
         'Prohibits',
         'MissingIf',


### PR DESCRIPTION
Adding a new simple validation rules that are useful for prohibiting attributes if other attribute's value is declined or accepted, in many cases I was setting the exact value to prohibit another attribute and in most cases it has a workaround to achieve the needed validation, please see the below example to understand this change:

## Before: for prohibited_if_declined
```php
"free_delivery_fees" => "bail|required",

// this rule only covers the "false" exact value
"delivery_fees" => "prohibited_if:free_delivery_fees,false|numeric|min:1|max:9999",

// this rule only covers the "0" exact value
"delivery_fees" => "prohibited_if:free_delivery_fees,0|numeric|min:1|max:9999",

// And more for all falsy values
```

## After: for prohibited_if_declined
```php
"free_delivery_fees" => "bail|required",
"delivery_fees" => "prohibited_if_declined:free_delivery_fees|numeric|min:1|max:9999",
```

## Before: for prohibited_if_accepted
```php
"discount_disabled" => "bail|required",

// this rule only covers the "true" exact value
"discount" => "prohibited_if:discount_disabled,true|numeric|min:1|max:9999",

// this rule only covers the "1" exact value
"discount" => "prohibited_if:discount_disabled,1|numeric|min:1|max:9999",

// And more for all truthy values
```

## After: for prohibited_if_accepted
```php
"discount_disabled" => "bail|required",
"discount" => "prohibited_if_accepted:discount_disabled|numeric|min:1|max:9999",
```