### PR TITLE
[11.x] Ensure batched jobs are actually batchable

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -418,6 +418,7 @@ class PendingBatch
         foreach (Arr::wrap($job) as $job) {
             if ($job instanceof PendingBatch) {
                 $this->checkJobIsBatchable($job->jobs->all());
+
                 return;
             }
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -415,7 +415,6 @@ class PendingBatch
 
     private function checkJobIsBatchable(object|array $job): void
     {
-
         foreach (Arr::wrap($job) as $job) {
             if ($job instanceof PendingBatch) {
                 $this->checkJobIsBatchable($job->jobs->all());

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -49,8 +49,8 @@ class PendingBatch
     /**
      * Create a new pending batch instance.
      *
-     * @param \Illuminate\Contracts\Container\Container $container
-     * @param \Illuminate\Support\Collection $jobs
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Illuminate\Support\Collection  $jobs
      * @return void
      */
     public function __construct(Container $container, Collection $jobs)
@@ -230,7 +230,7 @@ class PendingBatch
     /**
      * Set the name for the batch.
      *
-     * @param string $name
+     * @param  string  $name
      * @return $this
      */
     public function name(string $name)
@@ -243,7 +243,7 @@ class PendingBatch
     /**
      * Specify the queue connection that the batched jobs should run on.
      *
-     * @param string $connection
+     * @param  string  $connection
      * @return $this
      */
     public function onConnection(string $connection)
@@ -289,7 +289,7 @@ class PendingBatch
     /**
      * Add additional data into the batch's options array.
      *
-     * @param string $key
+     * @param  string  $key
      * @param  mixed  $value
      * @return $this
      */

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
+use RuntimeException;
 use Throwable;
 
 use function Illuminate\Support\enum_value;
@@ -56,8 +57,9 @@ class PendingBatch
     public function __construct(Container $container, Collection $jobs)
     {
         $this->container = $container;
+
         $this->jobs = $jobs->each(function (object|array $job) {
-            $this->checkJobIsBatchable($job);
+            $this->ensureJobIsBatchable($job);
         });
     }
 
@@ -72,11 +74,33 @@ class PendingBatch
         $jobs = is_iterable($jobs) ? $jobs : Arr::wrap($jobs);
 
         foreach ($jobs as $job) {
-            $this->checkJobIsBatchable($job);
+            $this->ensureJobIsBatchable($job);
+
             $this->jobs->push($job);
         }
 
         return $this;
+    }
+
+    /**
+     * Ensure the given job is batchable.
+     *
+     * @param  object|array  $job
+     * @return void
+     */
+    protected function ensureJobIsBatchable(object|array $job): void
+    {
+        foreach (Arr::wrap($job) as $job) {
+            if ($job instanceof PendingBatch) {
+                $this->ensureJobIsBatchable($job->jobs->all());
+
+                return;
+            }
+
+            if (! in_array(Batchable::class, class_uses_recursive($job))) {
+                throw new RuntimeException(sprintf('Attempted to batch job [%s], but it does not use the Batchable trait.', $job::class));
+            }
+        }
     }
 
     /**
@@ -416,20 +440,5 @@ class PendingBatch
         });
 
         return $batch;
-    }
-
-    private function checkJobIsBatchable(object|array $job): void
-    {
-        foreach (Arr::wrap($job) as $job) {
-            if ($job instanceof PendingBatch) {
-                $this->checkJobIsBatchable($job->jobs->all());
-
-                return;
-            }
-
-            if (! in_array(Batchable::class, class_uses_recursive($job))) {
-                throw new \RuntimeException(sprintf('Job %s must use Batchable trait', $job::class));
-            }
-        }
     }
 }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -49,6 +49,8 @@ class PendingBatch
     /**
      * Create a new pending batch instance.
      *
+     * @param \Illuminate\Contracts\Container\Container $container
+     * @param \Illuminate\Support\Collection $jobs
      * @return void
      */
     public function __construct(Container $container, Collection $jobs)
@@ -228,6 +230,7 @@ class PendingBatch
     /**
      * Set the name for the batch.
      *
+     * @param string $name
      * @return $this
      */
     public function name(string $name)
@@ -240,6 +243,7 @@ class PendingBatch
     /**
      * Specify the queue connection that the batched jobs should run on.
      *
+     * @param string $connection
      * @return $this
      */
     public function onConnection(string $connection)
@@ -285,6 +289,7 @@ class PendingBatch
     /**
      * Add additional data into the batch's options array.
      *
+     * @param string $key
      * @param  mixed  $value
      * @return $this
      */

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -222,4 +222,13 @@ class BusPendingBatchTest extends TestCase
 
         $this->assertTrue($beforeCalled);
     }
+
+    public function test_it_throws_exception_if_batched_job_is_not_batchable(): void
+    {
+        $nonBatchableJob = new class {};
+
+        $this->expectException(RuntimeException::class);
+
+        new PendingBatch(new Container, new Collection([$nonBatchableJob]));
+    }
 }


### PR DESCRIPTION
Although the documentation for batch jobs clearly states that batched jobs should use the `Batchable` trait, there's not much that alerts or prevents the dev from wrongly trying to batch jobs that don't implement it, resulting in runtime problems. Even if we use the `assertBatched` test, tests pass even with invalid jobs supplied. I was a victim of this. (I know, it might also be a skill issue from my side, for forgetting to use the trait...)

This PR adds a check to batched jobs to ensure that the jobs use the required `Batchable` trait, throwing a `RuntimeException` if a job is found in a given list when calling `Bus::batch` or if supplied to the `add` method of a `PendingBatch` instance.