### PR TITLE
[11.x] `slug()` with alphanumeric separator

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1461,11 +1461,11 @@ class Str
      * @param  string|null  $language
      * @param  array<string, string>  $dictionary
      * @return string
-     * 
+     *
      * @throws InvalidArgumentException
      */
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
-    {        
+    {
         if (ctype_alnum($separator)) {
             throw new InvalidArgumentException('The separator must not be alphanumeric.');
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use JsonException;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
@@ -1460,11 +1461,16 @@ class Str
      * @param  string|null  $language
      * @param  array<string, string>  $dictionary
      * @return string
+     * 
+     * @throws InvalidArgumentException
      */
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
-    {
+    {        
+        if (ctype_alnum($separator)) {
+            throw new InvalidArgumentException('The separator must not be alphanumeric.');
+        }
+
         $title = $language ? static::ascii($title, $language) : $title;
-        $separator = ctype_alnum($separator) ? '-' : $separator;
 
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1464,6 +1464,7 @@ class Str
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
     {
         $title = $language ? static::ascii($title, $language) : $title;
+        $separator = ctype_alnum($separator) ? '-' : $separator;
 
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
+use InvalidArgumentException;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
@@ -739,10 +740,18 @@ class SupportStringableTest extends TestCase
         $this->assertSame('sometext', (string) $this->stringable('some text')->slug(''));
         $this->assertSame('', (string) $this->stringable('')->slug(''));
         $this->assertSame('', (string) $this->stringable('')->slug());
-        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('eb'));
-        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('e'));
-        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('2'));
-        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('2'));
+    }
+
+    public function testSlugDoesNotSupportAlphaSeparator()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->stringable('hello world')->slug('a');
+    }
+
+    public function testSlugDoesNotSupportNumericSeparator()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->stringable('hello world')->slug('2');
     }
 
     public function testSquish()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -739,6 +739,10 @@ class SupportStringableTest extends TestCase
         $this->assertSame('sometext', (string) $this->stringable('some text')->slug(''));
         $this->assertSame('', (string) $this->stringable('')->slug(''));
         $this->assertSame('', (string) $this->stringable('')->slug());
+        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('eb'));
+        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('e'));
+        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('2'));
+        $this->assertSame('hello-world', (string) $this->stringable('hello world')->slug('2'));
     }
 
     public function testSquish()


### PR DESCRIPTION
Fixes #54444

This PR made `slug()` fallback to default separator (`-`) when an alphanumeric separator been passed.

### Examples
#### Before
```php
str('nad')->slug('az'); // nazd
```

#### After
```php
str('nad')->slug('az'); // nad

str('hello world')->slug('e'); // hello-word
str('hello world')->slug('2'); // hello-word
```