### PR TITLE
add publish method on phpDoc annotation on Redis Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -29,6 +29,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
+ * @method static void publish(string $channel, string $message)
  *
  * @see \Illuminate\Redis\RedisManager
  */


### PR DESCRIPTION
Added the missing PHPDoc annotation for the `publish` method in `Illuminate\Support\Facades\Redis`.  

#### **Changes:**  
- Added `@method static void publish(string $channel, string $message)` to `Redis` Facade.  

#### **Benefits:**  
- Provides better IDE autocompletion and static analysis support.  
- Enhances developer experience by documenting the `publish` method explicitly.  
- Does not introduce any breaking changes or modify existing functionality.  

This update improves Laravel's developer experience by ensuring better code assistance when using Redis publish/subscribe functionality.