### PR TITLE
[11.x] Add a new `Number::scientific()` method to format numbers in E-notation

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -294,6 +294,24 @@ class Number
     }
 
     /**
+     * Format the given number in scientific notation.
+     *
+     * @param  int|float  $number
+     * @param  int  $precision
+     * @param  string|null  $locale
+     * @return string|false
+     */
+    public static function scientific(int|float $number, int $precision = 2, ?string $locale = null)
+    {
+        static::ensureIntlExtensionIsInstalled();
+
+        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SCIENTIFIC);
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $precision);
+
+        return $formatter->format($number);
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -327,7 +327,7 @@ class Number
             }
         }
 
-        return sprintf('%sE%d', $mantissa, $exponent);
+        return $mantissa . $formatter->getSymbol(NumberFormatter::EXPONENTIAL_SYMBOL) . $formatter->format($exponent);
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -330,6 +330,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1E0', Number::scientific(1, precision: 0));
         $this->assertSame('1E0', Number::scientific(1, precision: 2));
         $this->assertSame('1.23E1', Number::scientific(12.34));
+        $this->assertSame('1.23E1', Number::scientific(12.34, exponent: 1));
+        $this->assertSame('0.12E2', Number::scientific(12.34, exponent: 2));
+        $this->assertSame('0E4', Number::scientific(12.34, exponent: 4));
+        $this->assertSame('123400E-4', Number::scientific(12.34, exponent: -4));
+        $this->assertSame('0.001E4', Number::scientific(12.34, exponent: 4, precision: 3));
+        $this->assertSame('0.0012E4', Number::scientific(12.34, exponent: 4, precision: 4));
         $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'en'));
         $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'de'));
         $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr'));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -328,157 +328,62 @@ class SupportNumberTest extends TestCase
     {
         $this->assertSame('1E0', Number::scientific(1));
         $this->assertSame('1E0', Number::scientific(1, precision: 0));
-        $this->assertSame('1E0', Number::scientific(1, precision: 2));
         $this->assertSame('1.23E1', Number::scientific(12.34));
-        $this->assertSame('1.23E1', Number::scientific(12.34, exponent: 1));
         $this->assertSame('0.12E2', Number::scientific(12.34, exponent: 2));
-        $this->assertSame('0E4', Number::scientific(12.34, exponent: 4));
         $this->assertSame('123400E-4', Number::scientific(12.34, exponent: -4));
-        $this->assertSame('0.001E4', Number::scientific(12.34, exponent: 4, precision: 3));
         $this->assertSame('0.0012E4', Number::scientific(12.34, exponent: 4, precision: 4));
-        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'en-US'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'de-DE'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr-FR'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'ru-RU'));
-        $this->assertSame('1,23×10^1', Number::scientific(12.34, locale: 'sv-SE'));
-        $this->assertSame('١٫٢٣أس١', Number::scientific(12.34, locale: 'ar-IQ'));
-        $this->assertSame('1.23E1', Number::scientific(12.34, precision: 2));
-        $this->assertSame('1.2346E1', Number::scientific(12.3456, precision: 4));
+        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'en'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr'));
+        $this->assertContains(Number::scientific(12.34, locale: 'ar'), ['١٫٢٣أس١', '١٫٢٣اس١', '1.23E1']);
 
         // Large numbers
         $this->assertSame('1E6', Number::scientific(1000000));
-        $this->assertSame('1E6', Number::scientific(1000000, precision: 0));
-        $this->assertSame('1E6', Number::scientific(1000000, precision: 1));
-        $this->assertSame('1E6', Number::scientific(1000000, exponent: 6));
         $this->assertSame('10E5', Number::scientific(1000000, exponent: 5));
         $this->assertSame('100E4', Number::scientific(1000000, exponent: 4, precision: 1));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'en-US'));
-        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'en-US'));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'fr-FR'));
-        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'fr-FR'));
-
         $this->assertSame('1.23E6', Number::scientific(1234567));
-        $this->assertSame('1E6', Number::scientific(1234567, precision: 0));
         $this->assertSame('1.2E6', Number::scientific(1234567, precision: 1));
-        $this->assertSame('12.35E5', Number::scientific(1234567, exponent: 5));
         $this->assertSame('123.46E4', Number::scientific(1234567, exponent: 4));
-        $this->assertSame('1234.57E3', Number::scientific(1234567, exponent: 3));
-        $this->assertSame('12345.67E2', Number::scientific(1234567, exponent: 2));
         $this->assertSame('123456.7E1', Number::scientific(1234567, exponent: 1));
-        $this->assertSame('1234567E0', Number::scientific(1234567, exponent: 0));
         $this->assertSame('12.3E5', Number::scientific(1234567, exponent:5, precision: 1));
         $this->assertSame('123.5E4', Number::scientific(1234567, exponent: 4, precision: 1));
-        $this->assertSame('12.35E5', Number::scientific(1234567, exponent:5, locale: 'en-US'));
-        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'de-DE'));
-        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'fr-FR'));
-        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'ru-RU'));
-        $this->assertSame('1,23×10^6', Number::scientific(1234567, locale: 'sv-SE'));
-        $this->assertSame('١٫٢٣أس٦', Number::scientific(1234567, locale: 'ar-IQ'));
-
+        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'fr'));
+        $this->assertContains(Number::scientific(1234567, locale: 'ar'), ['١٫٢٣أس٦', '١٫٢٣اس٦', '1.23E6']);
         $this->assertSame('1.23E8', Number::scientific(123456789));
         $this->assertSame('0.12E9', Number::scientific(123456789, exponent: 9));
-        $this->assertSame('1.23E8', Number::scientific(123456789, exponent: 8));
-        $this->assertSame('1234.57E5', Number::scientific(123456789, exponent: 5));
-        $this->assertSame('1.2346E8', Number::scientific(123456789, exponent: 8, precision: 4));
-        $this->assertSame('1.23456789E8', Number::scientific(123456789, exponent: 8, precision: 15));
         $this->assertSame('123456.789E3', Number::scientific(123456789, exponent: 3, precision: 15));
-        $this->assertSame('1E8', Number::scientific(123456789, precision: 0));
         $this->assertSame('1.2E8', Number::scientific(123456789, precision: 1));
-        $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'en-US'));
-        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'de-DE'));
-        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'fr-FR'));
-        $this->assertSame('123456,789E3', Number::scientific(123456789, exponent: 3, precision: 15, locale: 'fr-FR'));
-        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'ru-RU'));
-        $this->assertSame('١٫٢٣أس٨', Number::scientific(123456789, locale: 'ar-IQ'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'fr'));
 
         // Small numbers
         $this->assertSame('1E-3', Number::scientific(0.001));
-        $this->assertSame('1E-3', Number::scientific(0.001, exponent: -3));
         $this->assertSame('10E-4', Number::scientific(0.001, exponent: -4));
-        $this->assertSame('10E-4', Number::scientific(0.001, exponent: -4, precision: 0));
-        $this->assertSame('10E-4', Number::scientific(0.001, exponent: -4, precision: 1));
         $this->assertSame('20E-4', Number::scientific(0.002, exponent: -4));
         $this->assertSame('8.23E-3', Number::scientific(0.00823, exponent: -3));
-        $this->assertSame('1E-3', Number::scientific(0.001, precision: 0));
-        $this->assertSame('1E-3', Number::scientific(0.001, precision: 1));
-        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'en-US'));
-        $this->assertSame('1.1E-3', Number::scientific(0.0011, exponent: -3, locale: 'en-US'));
-        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'fr-FR'));
-        $this->assertSame('1,1E-3', Number::scientific(0.0011, exponent: -3, locale: 'fr-FR'));
-
-        $this->assertSame('1.23E-3', Number::scientific(0.00123));
+        $this->assertSame('1,1E-3', Number::scientific(0.0011, exponent: -3, locale: 'fr'));
         $this->assertSame('1.23E-6', Number::scientific(0.000001234));
-        $this->assertSame('1.23E-6', Number::scientific(0.000001234, exponent: -6));
         $this->assertSame('123.4E-8', Number::scientific(0.000001234, exponent: -8));
-        $this->assertSame('1234E-9', Number::scientific(0.000001234, exponent: -9));
         $this->assertSame('12340E-10', Number::scientific(0.000001234, exponent: -10));
-        $this->assertSame('1E-6', Number::scientific(0.000001234, precision: 0));
-        $this->assertSame('1.2E-6', Number::scientific(0.000001234, precision: 1));
-        $this->assertSame('1.234E-6', Number::scientific(0.000001234, exponent: -6, precision: 3));
-        $this->assertSame('1.234E-6', Number::scientific(0.000001234, exponent: -6, precision: 4));
-        $this->assertSame('1.23E-6', Number::scientific(0.000001234, locale: 'en-US'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'de-DE'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'fr-FR'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'ru-RU'));
-        $this->assertSame('1,23×10^−6', Number::scientific(0.000001234, locale: 'sv-SE'));
-        $this->assertSame("١٫٢٣أس؜-٦", Number::scientific(0.000001234, locale: 'ar-IQ'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'fr'));
 
         // Zero and special values
         $this->assertSame('0E0', Number::scientific(0));
-        $this->assertSame('0E0', Number::scientific(0, exponent: 0));
-        $this->assertSame('0E0', Number::scientific(0, precision: 0));
-        $this->assertSame('0E0', Number::scientific(0, precision: 1));
-        $this->assertSame('0E0', Number::scientific(0, locale: 'en-US'));
+        $this->assertSame('0E12', Number::scientific(0.00, exponent: 12));
 
+        // Infinity and NaN
         $this->assertSame('∞', Number::scientific(INF));
-        $this->assertSame('∞', Number::scientific(INF, precision: 0));
-        $this->assertSame('∞', Number::scientific(INF, precision: 1));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'en-US'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'de-DE'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'fr-FR'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'ru-RU'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'sv-SE'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'ar-IQ'));
-
         $this->assertSame('NaN', Number::scientific(NAN));
-        $this->assertSame('NaN', Number::scientific(NAN, precision: 0));
-        $this->assertSame('NaN', Number::scientific(NAN, precision: 1));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'en-US'));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'de-DE'));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'fr-FR'));
-        $this->assertSame("не\u{A0}число", Number::scientific(NAN, locale: 'ru-RU'));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'sv-SE'));
-        $this->assertSame("ليس\u{A0}رقمًا", Number::scientific(NAN, locale: 'ar-IQ'));
+        $this->assertStringContainsString("число", Number::scientific(NAN, locale: 'ru'));
+        $this->assertStringContainsString("ليس", Number::scientific(NAN, locale: 'ar'));
 
         // Negative numbers
         $this->assertSame('-1E0', Number::scientific(-1));
-        $this->assertSame('-1E0', Number::scientific(-1, exponent: 0));
-        $this->assertSame('-0.1E1', Number::scientific(-1, exponent: 1));
         $this->assertSame('-0.01E2', Number::scientific(-1, exponent: 2));
-        $this->assertSame('-10E-1', Number::scientific(-1, exponent: -1));
         $this->assertSame('-100E-2', Number::scientific(-1, exponent: -2));
-        $this->assertSame('-0.01E2', Number::scientific(-1, exponent: 2, precision: 4));
-        $this->assertSame('-1E0', Number::scientific(-1, precision: 0));
-        $this->assertSame('-1E0', Number::scientific(-1, precision: 1));
-        $this->assertSame('-1E0', Number::scientific(-1, locale: 'en-US'));
-        $this->assertSame('-1E0', Number::scientific(-1, locale: 'fr-FR'));
-
         $this->assertSame('-1.23E1', Number::scientific(-12.34));
-        $this->assertSame('-1.23E1', Number::scientific(-12.34, exponent: 1));
         $this->assertSame('-0.12E2', Number::scientific(-12.34, exponent: 2));
-        $this->assertSame('-123.4E-1', Number::scientific(-12.34, exponent: -1));
         $this->assertSame('-1234E-2', Number::scientific(-12.34, exponent: -2));
-        $this->assertSame('-1.234E1', Number::scientific(-12.34, precision: 3));
-        $this->assertSame('-1.2E1', Number::scientific(-12.34, precision: 1));
-        $this->assertSame('-1.23E1', Number::scientific(-12.34, locale: 'en-US'));
-        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'fr-FR'));
-
+        $this->assertSame('-123,4E-1', Number::scientific(-12.34, exponent: -1, locale: 'fr'));
         $this->assertSame('-1.23E-3', Number::scientific(-0.00123));
-        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, exponent: -3));
         $this->assertSame('-12.3E-4', Number::scientific(-0.00123, exponent: -4));
-        $this->assertSame('-1E-3', Number::scientific(-0.00123, precision: 0));
-        $this->assertSame('-1.2E-3', Number::scientific(-0.00123, precision: 1));
-        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, locale: 'en-US'));
-        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'fr-FR'));
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -334,7 +334,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'de'));
         $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr'));
         $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'ru'));
-        $this->assertSame('1,23×10^1', Number::scientific(12.34, locale: 'sv'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'sv'));
         $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'ar'));
         $this->assertSame('1.23E1', Number::scientific(12.34, precision: 2));
         $this->assertSame('1.2346E1', Number::scientific(12.3456, precision: 4));
@@ -342,66 +342,87 @@ class SupportNumberTest extends TestCase
         // Large numbers
         $this->assertSame('1E6', Number::scientific(1000000));
         $this->assertSame('1E6', Number::scientific(1000000, precision: 0));
+        $this->assertSame('1E6', Number::scientific(1000000, precision: 1));
+        $this->assertSame('1E6', Number::scientific(1000000, exponent: 6));
+        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5));
+        $this->assertSame('100E4', Number::scientific(1000000, exponent: 4, precision: 1));
         $this->assertSame('1E6', Number::scientific(1000000, locale: 'en'));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'de'));
+        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'en'));
         $this->assertSame('1E6', Number::scientific(1000000, locale: 'fr'));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'ru'));
-        $this->assertSame('1×10^6', Number::scientific(1000000, locale: 'sv'));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'ar'));
+        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'fr'));
 
         $this->assertSame('1.23E6', Number::scientific(1234567));
-        $this->assertSame('1.234567E6', Number::scientific(1234567, precision: 0));
+        $this->assertSame('1E6', Number::scientific(1234567, precision: 0));
         $this->assertSame('1.2E6', Number::scientific(1234567, precision: 1));
-        $this->assertSame('1.23E6', Number::scientific(1234567, locale: 'en'));
-        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'de'));
-        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'fr'));
+        $this->assertSame('12.35E5', Number::scientific(1234567, exponent: 5));
+        $this->assertSame('123.46E4', Number::scientific(1234567, exponent: 4));
+        $this->assertSame('1234.57E3', Number::scientific(1234567, exponent: 3));
+        $this->assertSame('12345.67E2', Number::scientific(1234567, exponent: 2));
+        $this->assertSame('123456.7E1', Number::scientific(1234567, exponent: 1));
+        $this->assertSame('1234567E0', Number::scientific(1234567, exponent: 0));
+        $this->assertSame('12.3E5', Number::scientific(1234567, exponent:5, precision: 1));
+        $this->assertSame('123.5E4', Number::scientific(1234567, exponent: 4, precision: 1));
+        $this->assertSame('12.35E5', Number::scientific(1234567, exponent:5, locale: 'en'));
+        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'de'));
+        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'fr'));
         $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'ru'));
-        $this->assertSame('1,23×10^6', Number::scientific(1234567, locale: 'sv'));
+        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'sv'));
         $this->assertSame('1.23E6', Number::scientific(1234567, locale: 'ar'));
 
         $this->assertSame('1.23E8', Number::scientific(123456789));
-        $this->assertSame('1.23456789E8', Number::scientific(123456789, precision: 0));
+        $this->assertSame('0.12E9', Number::scientific(123456789, exponent: 9));
+        $this->assertSame('1.23E8', Number::scientific(123456789, exponent: 8));
+        $this->assertSame('1234.57E5', Number::scientific(123456789, exponent: 5));
+        $this->assertSame('1.2346E8', Number::scientific(123456789, exponent: 8, precision: 4));
+        $this->assertSame('1.23456789E8', Number::scientific(123456789, exponent: 8, precision: 15));
+        $this->assertSame('123456.789E3', Number::scientific(123456789, exponent: 3, precision: 15));
+        $this->assertSame('1E8', Number::scientific(123456789, precision: 0));
         $this->assertSame('1.2E8', Number::scientific(123456789, precision: 1));
         $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'en'));
         $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'de'));
         $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'fr'));
+        $this->assertSame('123456,789E3', Number::scientific(123456789, exponent: 3, precision: 15, locale: 'fr'));
         $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'ru'));
-        $this->assertSame('1,23×10^8', Number::scientific(123456789, locale: 'sv'));
         $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'ar'));
 
         // Small numbers
         $this->assertSame('1E-3', Number::scientific(0.001));
+        $this->assertSame('1E-3', Number::scientific(0.001, exponent: -3));
+        $this->assertSame('10E-4', Number::scientific(0.001, exponent: -4));
+        $this->assertSame('10E-4', Number::scientific(0.001, exponent: -4, precision: 0));
+        $this->assertSame('10E-4', Number::scientific(0.001, exponent: -4, precision: 1));
+        $this->assertSame('20E-4', Number::scientific(0.002, exponent: -4));
+        $this->assertSame('8.23E-3', Number::scientific(0.00823, exponent: -3));
         $this->assertSame('1E-3', Number::scientific(0.001, precision: 0));
         $this->assertSame('1E-3', Number::scientific(0.001, precision: 1));
         $this->assertSame('1E-3', Number::scientific(0.001, locale: 'en'));
-        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'de'));
+        $this->assertSame('1.1E-3', Number::scientific(0.0011, exponent: -3, locale: 'en'));
         $this->assertSame('1E-3', Number::scientific(0.001, locale: 'fr'));
-        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'ru'));
-        $this->assertSame('1×10^−3', Number::scientific(0.001, locale: 'sv'));
-        $this->assertSame("1E\u{200E}-3", Number::scientific(0.001, locale: 'ar'));
+        $this->assertSame('1,1E-3', Number::scientific(0.0011, exponent: -3, locale: 'fr'));
 
         $this->assertSame('1.23E-3', Number::scientific(0.00123));
         $this->assertSame('1.23E-6', Number::scientific(0.000001234));
-        $this->assertSame('1.234E-6', Number::scientific(0.000001234, precision: 0));
+        $this->assertSame('1.23E-6', Number::scientific(0.000001234, exponent: -6));
+        $this->assertSame('123.4E-8', Number::scientific(0.000001234, exponent: -8));
+        $this->assertSame('1234E-9', Number::scientific(0.000001234, exponent: -9));
+        $this->assertSame('12340E-10', Number::scientific(0.000001234, exponent: -10));
+        $this->assertSame('1E-6', Number::scientific(0.000001234, precision: 0));
         $this->assertSame('1.2E-6', Number::scientific(0.000001234, precision: 1));
+        $this->assertSame('1.234E-6', Number::scientific(0.000001234, exponent: -6, precision: 3));
+        $this->assertSame('1.234E-6', Number::scientific(0.000001234, exponent: -6, precision: 4));
         $this->assertSame('1.23E-6', Number::scientific(0.000001234, locale: 'en'));
         $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'de'));
         $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'fr'));
         $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'ru'));
-        $this->assertSame('1,23×10^−6', Number::scientific(0.000001234, locale: 'sv'));
-        $this->assertSame("1.23E\u{200E}-6", Number::scientific(0.000001234, locale: 'ar'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'sv'));
+        $this->assertSame("1.23E-6", Number::scientific(0.000001234, locale: 'ar'));
 
         // Zero and special values
         $this->assertSame('0E0', Number::scientific(0));
+        $this->assertSame('0E0', Number::scientific(0, exponent: 0));
         $this->assertSame('0E0', Number::scientific(0, precision: 0));
         $this->assertSame('0E0', Number::scientific(0, precision: 1));
-        $this->assertSame('0E0', Number::scientific(0, precision: 3));
-        $this->assertSame('0E0', Number::scientific(0, locale: 'en'));
-        $this->assertSame('0E0', Number::scientific(0, locale: 'de'));
         $this->assertSame('0E0', Number::scientific(0, locale: 'fr'));
-        $this->assertSame('0E0', Number::scientific(0, locale: 'ru'));
-        $this->assertSame('0×10^0', Number::scientific(0, locale: 'sv'));
-        $this->assertSame('0E0', Number::scientific(0, locale: 'ar'));
 
         $this->assertSame('∞', Number::scientific(INF));
         $this->assertSame('∞', Number::scientific(INF, precision: 0));
@@ -425,31 +446,33 @@ class SupportNumberTest extends TestCase
 
         // Negative numbers
         $this->assertSame('-1E0', Number::scientific(-1));
+        $this->assertSame('-1E0', Number::scientific(-1, exponent: 0));
+        $this->assertSame('-0.1E1', Number::scientific(-1, exponent: 1));
+        $this->assertSame('-0.01E2', Number::scientific(-1, exponent: 2));
+        $this->assertSame('-10E-1', Number::scientific(-1, exponent: -1));
+        $this->assertSame('-100E-2', Number::scientific(-1, exponent: -2));
+        $this->assertSame('-0.01E2', Number::scientific(-1, exponent: 2, precision: 4));
         $this->assertSame('-1E0', Number::scientific(-1, precision: 0));
         $this->assertSame('-1E0', Number::scientific(-1, precision: 1));
         $this->assertSame('-1E0', Number::scientific(-1, locale: 'en'));
-        $this->assertSame('-1E0', Number::scientific(-1, locale: 'de'));
         $this->assertSame('-1E0', Number::scientific(-1, locale: 'fr'));
-        $this->assertSame('-1E0', Number::scientific(-1, locale: 'ru'));
 
         $this->assertSame('-1.23E1', Number::scientific(-12.34));
-        $this->assertSame('-1.234E1', Number::scientific(-12.34, precision: 0));
+        $this->assertSame('-1.23E1', Number::scientific(-12.34, exponent: 1));
+        $this->assertSame('-0.12E2', Number::scientific(-12.34, exponent: 2));
+        $this->assertSame('-123.4E-1', Number::scientific(-12.34, exponent: -1));
+        $this->assertSame('-1234E-2', Number::scientific(-12.34, exponent: -2));
+        $this->assertSame('-1.234E1', Number::scientific(-12.34, precision: 3));
         $this->assertSame('-1.2E1', Number::scientific(-12.34, precision: 1));
         $this->assertSame('-1.23E1', Number::scientific(-12.34, locale: 'en'));
-        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'de'));
         $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'fr'));
-        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'ru'));
-        $this->assertSame('−1,23×10^1', Number::scientific(-12.34, locale: 'sv'));
-        $this->assertSame("\u{200E}-1.23E1", Number::scientific(-12.34, locale: 'ar'));
 
         $this->assertSame('-1.23E-3', Number::scientific(-0.00123));
-        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, precision: 0));
+        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, exponent: -3));
+        $this->assertSame('-12.3E-4', Number::scientific(-0.00123, exponent: -4));
+        $this->assertSame('-1E-3', Number::scientific(-0.00123, precision: 0));
         $this->assertSame('-1.2E-3', Number::scientific(-0.00123, precision: 1));
         $this->assertSame('-1.23E-3', Number::scientific(-0.00123, locale: 'en'));
-        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'de'));
         $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'fr'));
-        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'ru'));
-        $this->assertSame('−1,23×10^−3', Number::scientific(-0.00123, locale: 'sv'));
-        $this->assertSame("\u{200E}-1.23E\u{200E}-3", Number::scientific(-0.00123, locale: 'ar'));
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -336,12 +336,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('123400E-4', Number::scientific(12.34, exponent: -4));
         $this->assertSame('0.001E4', Number::scientific(12.34, exponent: 4, precision: 3));
         $this->assertSame('0.0012E4', Number::scientific(12.34, exponent: 4, precision: 4));
-        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'en'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'de'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'ru'));
-        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'sv'));
-        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'ar'));
+        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'en-US'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'de-DE'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr-FR'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'ru-RU'));
+        $this->assertSame('1,23×10^1', Number::scientific(12.34, locale: 'sv-SE'));
+        $this->assertSame('١٫٢٣أس١', Number::scientific(12.34, locale: 'ar-IQ'));
         $this->assertSame('1.23E1', Number::scientific(12.34, precision: 2));
         $this->assertSame('1.2346E1', Number::scientific(12.3456, precision: 4));
 
@@ -352,10 +352,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1E6', Number::scientific(1000000, exponent: 6));
         $this->assertSame('10E5', Number::scientific(1000000, exponent: 5));
         $this->assertSame('100E4', Number::scientific(1000000, exponent: 4, precision: 1));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'en'));
-        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'en'));
-        $this->assertSame('1E6', Number::scientific(1000000, locale: 'fr'));
-        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'fr'));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'en-US'));
+        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'en-US'));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'fr-FR'));
+        $this->assertSame('10E5', Number::scientific(1000000, exponent: 5, locale: 'fr-FR'));
 
         $this->assertSame('1.23E6', Number::scientific(1234567));
         $this->assertSame('1E6', Number::scientific(1234567, precision: 0));
@@ -368,12 +368,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1234567E0', Number::scientific(1234567, exponent: 0));
         $this->assertSame('12.3E5', Number::scientific(1234567, exponent:5, precision: 1));
         $this->assertSame('123.5E4', Number::scientific(1234567, exponent: 4, precision: 1));
-        $this->assertSame('12.35E5', Number::scientific(1234567, exponent:5, locale: 'en'));
-        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'de'));
-        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'fr'));
-        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'ru'));
-        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'sv'));
-        $this->assertSame('1.23E6', Number::scientific(1234567, locale: 'ar'));
+        $this->assertSame('12.35E5', Number::scientific(1234567, exponent:5, locale: 'en-US'));
+        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'de-DE'));
+        $this->assertSame('123,46E4', Number::scientific(1234567, exponent: 4, locale: 'fr-FR'));
+        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'ru-RU'));
+        $this->assertSame('1,23×10^6', Number::scientific(1234567, locale: 'sv-SE'));
+        $this->assertSame('١٫٢٣أس٦', Number::scientific(1234567, locale: 'ar-IQ'));
 
         $this->assertSame('1.23E8', Number::scientific(123456789));
         $this->assertSame('0.12E9', Number::scientific(123456789, exponent: 9));
@@ -384,12 +384,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('123456.789E3', Number::scientific(123456789, exponent: 3, precision: 15));
         $this->assertSame('1E8', Number::scientific(123456789, precision: 0));
         $this->assertSame('1.2E8', Number::scientific(123456789, precision: 1));
-        $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'en'));
-        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'de'));
-        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'fr'));
-        $this->assertSame('123456,789E3', Number::scientific(123456789, exponent: 3, precision: 15, locale: 'fr'));
-        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'ru'));
-        $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'ar'));
+        $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'en-US'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'de-DE'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'fr-FR'));
+        $this->assertSame('123456,789E3', Number::scientific(123456789, exponent: 3, precision: 15, locale: 'fr-FR'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'ru-RU'));
+        $this->assertSame('١٫٢٣أس٨', Number::scientific(123456789, locale: 'ar-IQ'));
 
         // Small numbers
         $this->assertSame('1E-3', Number::scientific(0.001));
@@ -401,10 +401,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('8.23E-3', Number::scientific(0.00823, exponent: -3));
         $this->assertSame('1E-3', Number::scientific(0.001, precision: 0));
         $this->assertSame('1E-3', Number::scientific(0.001, precision: 1));
-        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'en'));
-        $this->assertSame('1.1E-3', Number::scientific(0.0011, exponent: -3, locale: 'en'));
-        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'fr'));
-        $this->assertSame('1,1E-3', Number::scientific(0.0011, exponent: -3, locale: 'fr'));
+        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'en-US'));
+        $this->assertSame('1.1E-3', Number::scientific(0.0011, exponent: -3, locale: 'en-US'));
+        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'fr-FR'));
+        $this->assertSame('1,1E-3', Number::scientific(0.0011, exponent: -3, locale: 'fr-FR'));
 
         $this->assertSame('1.23E-3', Number::scientific(0.00123));
         $this->assertSame('1.23E-6', Number::scientific(0.000001234));
@@ -416,39 +416,39 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1.2E-6', Number::scientific(0.000001234, precision: 1));
         $this->assertSame('1.234E-6', Number::scientific(0.000001234, exponent: -6, precision: 3));
         $this->assertSame('1.234E-6', Number::scientific(0.000001234, exponent: -6, precision: 4));
-        $this->assertSame('1.23E-6', Number::scientific(0.000001234, locale: 'en'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'de'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'fr'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'ru'));
-        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'sv'));
-        $this->assertSame("1.23E-6", Number::scientific(0.000001234, locale: 'ar'));
+        $this->assertSame('1.23E-6', Number::scientific(0.000001234, locale: 'en-US'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'de-DE'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'fr-FR'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'ru-RU'));
+        $this->assertSame('1,23×10^−6', Number::scientific(0.000001234, locale: 'sv-SE'));
+        $this->assertSame("١٫٢٣أس؜-٦", Number::scientific(0.000001234, locale: 'ar-IQ'));
 
         // Zero and special values
         $this->assertSame('0E0', Number::scientific(0));
         $this->assertSame('0E0', Number::scientific(0, exponent: 0));
         $this->assertSame('0E0', Number::scientific(0, precision: 0));
         $this->assertSame('0E0', Number::scientific(0, precision: 1));
-        $this->assertSame('0E0', Number::scientific(0, locale: 'fr'));
+        $this->assertSame('0E0', Number::scientific(0, locale: 'en-US'));
 
         $this->assertSame('∞', Number::scientific(INF));
         $this->assertSame('∞', Number::scientific(INF, precision: 0));
         $this->assertSame('∞', Number::scientific(INF, precision: 1));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'en'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'de'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'fr'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'ru'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'sv'));
-        $this->assertSame('∞', Number::scientific(INF, locale: 'ar'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'en-US'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'de-DE'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'fr-FR'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'ru-RU'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'sv-SE'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'ar-IQ'));
 
         $this->assertSame('NaN', Number::scientific(NAN));
         $this->assertSame('NaN', Number::scientific(NAN, precision: 0));
         $this->assertSame('NaN', Number::scientific(NAN, precision: 1));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'en'));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'de'));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'fr'));
-        $this->assertSame("не\u{A0}число", Number::scientific(NAN, locale: 'ru'));
-        $this->assertSame('NaN', Number::scientific(NAN, locale: 'sv'));
-        $this->assertSame("ليس\u{A0}رقمًا", Number::scientific(NAN, locale: 'ar'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'en-US'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'de-DE'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'fr-FR'));
+        $this->assertSame("не\u{A0}число", Number::scientific(NAN, locale: 'ru-RU'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'sv-SE'));
+        $this->assertSame("ليس\u{A0}رقمًا", Number::scientific(NAN, locale: 'ar-IQ'));
 
         // Negative numbers
         $this->assertSame('-1E0', Number::scientific(-1));
@@ -460,8 +460,8 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-0.01E2', Number::scientific(-1, exponent: 2, precision: 4));
         $this->assertSame('-1E0', Number::scientific(-1, precision: 0));
         $this->assertSame('-1E0', Number::scientific(-1, precision: 1));
-        $this->assertSame('-1E0', Number::scientific(-1, locale: 'en'));
-        $this->assertSame('-1E0', Number::scientific(-1, locale: 'fr'));
+        $this->assertSame('-1E0', Number::scientific(-1, locale: 'en-US'));
+        $this->assertSame('-1E0', Number::scientific(-1, locale: 'fr-FR'));
 
         $this->assertSame('-1.23E1', Number::scientific(-12.34));
         $this->assertSame('-1.23E1', Number::scientific(-12.34, exponent: 1));
@@ -470,15 +470,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1234E-2', Number::scientific(-12.34, exponent: -2));
         $this->assertSame('-1.234E1', Number::scientific(-12.34, precision: 3));
         $this->assertSame('-1.2E1', Number::scientific(-12.34, precision: 1));
-        $this->assertSame('-1.23E1', Number::scientific(-12.34, locale: 'en'));
-        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'fr'));
+        $this->assertSame('-1.23E1', Number::scientific(-12.34, locale: 'en-US'));
+        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'fr-FR'));
 
         $this->assertSame('-1.23E-3', Number::scientific(-0.00123));
         $this->assertSame('-1.23E-3', Number::scientific(-0.00123, exponent: -3));
         $this->assertSame('-12.3E-4', Number::scientific(-0.00123, exponent: -4));
         $this->assertSame('-1E-3', Number::scientific(-0.00123, precision: 0));
         $this->assertSame('-1.2E-3', Number::scientific(-0.00123, precision: 1));
-        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, locale: 'en'));
-        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'fr'));
+        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, locale: 'en-US'));
+        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'fr-FR'));
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -322,4 +322,37 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    #[RequiresPhpExtension('intl')]
+    public function testScientific()
+    {
+        $this->assertSame('1E0', Number::scientific(1));
+        $this->assertSame('1E0', Number::scientific(1, precision: 0));
+        $this->assertSame('1E0', Number::scientific(1, precision: 2));
+        $this->assertSame('1.23E1', Number::scientific(12.34));
+        $this->assertSame('1.23E1', Number::scientific(12.34, precision: 2));
+        $this->assertSame('1.2346E1', Number::scientific(12.3456, precision: 4));
+
+        // Large numbers
+        $this->assertSame('1E6', Number::scientific(1000000));
+        $this->assertSame('1.23E6', Number::scientific(1234567));
+        $this->assertSame('1.23E8', Number::scientific(123456789));
+
+        // Small numbers
+        $this->assertSame('1E-3', Number::scientific(0.001));
+        $this->assertSame('1.23E-3', Number::scientific(0.00123));
+        $this->assertSame('1.23E-6', Number::scientific(0.000001234));
+
+        // Zero and special values
+        $this->assertSame('0E0', Number::scientific(0));
+        $this->assertSame('0E0', Number::scientific(0, precision: 1));
+        $this->assertSame('0E0', Number::scientific(0, precision: 3));
+        $this->assertSame('∞', Number::scientific(INF));
+        $this->assertSame('NaN', Number::scientific(NAN));
+
+        // Negative numbers
+        $this->assertSame('-1E0', Number::scientific(-1));
+        $this->assertSame('-1.23E1', Number::scientific(-12.34));
+        $this->assertSame('-1.23E-3', Number::scientific(-0.00123));
+    }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -330,29 +330,126 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1E0', Number::scientific(1, precision: 0));
         $this->assertSame('1E0', Number::scientific(1, precision: 2));
         $this->assertSame('1.23E1', Number::scientific(12.34));
+        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'en'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'de'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'fr'));
+        $this->assertSame('1,23E1', Number::scientific(12.34, locale: 'ru'));
+        $this->assertSame('1,23×10^1', Number::scientific(12.34, locale: 'sv'));
+        $this->assertSame('1.23E1', Number::scientific(12.34, locale: 'ar'));
         $this->assertSame('1.23E1', Number::scientific(12.34, precision: 2));
         $this->assertSame('1.2346E1', Number::scientific(12.3456, precision: 4));
 
         // Large numbers
         $this->assertSame('1E6', Number::scientific(1000000));
+        $this->assertSame('1E6', Number::scientific(1000000, precision: 0));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'en'));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'de'));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'fr'));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'ru'));
+        $this->assertSame('1×10^6', Number::scientific(1000000, locale: 'sv'));
+        $this->assertSame('1E6', Number::scientific(1000000, locale: 'ar'));
+
         $this->assertSame('1.23E6', Number::scientific(1234567));
+        $this->assertSame('1.234567E6', Number::scientific(1234567, precision: 0));
+        $this->assertSame('1.2E6', Number::scientific(1234567, precision: 1));
+        $this->assertSame('1.23E6', Number::scientific(1234567, locale: 'en'));
+        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'de'));
+        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'fr'));
+        $this->assertSame('1,23E6', Number::scientific(1234567, locale: 'ru'));
+        $this->assertSame('1,23×10^6', Number::scientific(1234567, locale: 'sv'));
+        $this->assertSame('1.23E6', Number::scientific(1234567, locale: 'ar'));
+
         $this->assertSame('1.23E8', Number::scientific(123456789));
+        $this->assertSame('1.23456789E8', Number::scientific(123456789, precision: 0));
+        $this->assertSame('1.2E8', Number::scientific(123456789, precision: 1));
+        $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'en'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'de'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'fr'));
+        $this->assertSame('1,23E8', Number::scientific(123456789, locale: 'ru'));
+        $this->assertSame('1,23×10^8', Number::scientific(123456789, locale: 'sv'));
+        $this->assertSame('1.23E8', Number::scientific(123456789, locale: 'ar'));
 
         // Small numbers
         $this->assertSame('1E-3', Number::scientific(0.001));
+        $this->assertSame('1E-3', Number::scientific(0.001, precision: 0));
+        $this->assertSame('1E-3', Number::scientific(0.001, precision: 1));
+        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'en'));
+        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'de'));
+        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'fr'));
+        $this->assertSame('1E-3', Number::scientific(0.001, locale: 'ru'));
+        $this->assertSame('1×10^−3', Number::scientific(0.001, locale: 'sv'));
+        $this->assertSame("1E\u{200E}-3", Number::scientific(0.001, locale: 'ar'));
+
         $this->assertSame('1.23E-3', Number::scientific(0.00123));
         $this->assertSame('1.23E-6', Number::scientific(0.000001234));
+        $this->assertSame('1.234E-6', Number::scientific(0.000001234, precision: 0));
+        $this->assertSame('1.2E-6', Number::scientific(0.000001234, precision: 1));
+        $this->assertSame('1.23E-6', Number::scientific(0.000001234, locale: 'en'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'de'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'fr'));
+        $this->assertSame('1,23E-6', Number::scientific(0.000001234, locale: 'ru'));
+        $this->assertSame('1,23×10^−6', Number::scientific(0.000001234, locale: 'sv'));
+        $this->assertSame("1.23E\u{200E}-6", Number::scientific(0.000001234, locale: 'ar'));
 
         // Zero and special values
         $this->assertSame('0E0', Number::scientific(0));
+        $this->assertSame('0E0', Number::scientific(0, precision: 0));
         $this->assertSame('0E0', Number::scientific(0, precision: 1));
         $this->assertSame('0E0', Number::scientific(0, precision: 3));
+        $this->assertSame('0E0', Number::scientific(0, locale: 'en'));
+        $this->assertSame('0E0', Number::scientific(0, locale: 'de'));
+        $this->assertSame('0E0', Number::scientific(0, locale: 'fr'));
+        $this->assertSame('0E0', Number::scientific(0, locale: 'ru'));
+        $this->assertSame('0×10^0', Number::scientific(0, locale: 'sv'));
+        $this->assertSame('0E0', Number::scientific(0, locale: 'ar'));
+
         $this->assertSame('∞', Number::scientific(INF));
+        $this->assertSame('∞', Number::scientific(INF, precision: 0));
+        $this->assertSame('∞', Number::scientific(INF, precision: 1));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'en'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'de'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'fr'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'ru'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'sv'));
+        $this->assertSame('∞', Number::scientific(INF, locale: 'ar'));
+
         $this->assertSame('NaN', Number::scientific(NAN));
+        $this->assertSame('NaN', Number::scientific(NAN, precision: 0));
+        $this->assertSame('NaN', Number::scientific(NAN, precision: 1));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'en'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'de'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'fr'));
+        $this->assertSame("не\u{A0}число", Number::scientific(NAN, locale: 'ru'));
+        $this->assertSame('NaN', Number::scientific(NAN, locale: 'sv'));
+        $this->assertSame("ليس\u{A0}رقمًا", Number::scientific(NAN, locale: 'ar'));
 
         // Negative numbers
         $this->assertSame('-1E0', Number::scientific(-1));
+        $this->assertSame('-1E0', Number::scientific(-1, precision: 0));
+        $this->assertSame('-1E0', Number::scientific(-1, precision: 1));
+        $this->assertSame('-1E0', Number::scientific(-1, locale: 'en'));
+        $this->assertSame('-1E0', Number::scientific(-1, locale: 'de'));
+        $this->assertSame('-1E0', Number::scientific(-1, locale: 'fr'));
+        $this->assertSame('-1E0', Number::scientific(-1, locale: 'ru'));
+
         $this->assertSame('-1.23E1', Number::scientific(-12.34));
+        $this->assertSame('-1.234E1', Number::scientific(-12.34, precision: 0));
+        $this->assertSame('-1.2E1', Number::scientific(-12.34, precision: 1));
+        $this->assertSame('-1.23E1', Number::scientific(-12.34, locale: 'en'));
+        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'de'));
+        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'fr'));
+        $this->assertSame('-1,23E1', Number::scientific(-12.34, locale: 'ru'));
+        $this->assertSame('−1,23×10^1', Number::scientific(-12.34, locale: 'sv'));
+        $this->assertSame("\u{200E}-1.23E1", Number::scientific(-12.34, locale: 'ar'));
+
         $this->assertSame('-1.23E-3', Number::scientific(-0.00123));
+        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, precision: 0));
+        $this->assertSame('-1.2E-3', Number::scientific(-0.00123, precision: 1));
+        $this->assertSame('-1.23E-3', Number::scientific(-0.00123, locale: 'en'));
+        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'de'));
+        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'fr'));
+        $this->assertSame('-1,23E-3', Number::scientific(-0.00123, locale: 'ru'));
+        $this->assertSame('−1,23×10^−3', Number::scientific(-0.00123, locale: 'sv'));
+        $this->assertSame("\u{200E}-1.23E\u{200E}-3", Number::scientific(-0.00123, locale: 'ar'));
     }
 }


### PR DESCRIPTION
# Add scientific notation formatting to the Number class

This PR adds a new `scientific()` method to the `Number` class that formats numbers in scientific notation using PHP's Intl extension.

The new method allows formatting numbers in E-notation with configurable precision and locale support. For example:
```php
// Syntax
scientific(int|float $number, int $exponent = null, int $precision = 2, ?string $locale = null)

Number::scientific(12.34); // "1.23E1"
Number::scientific(12.34, exponent: 2); // "0.12E2"
Number::scientific(1234567); // "1.23E6"
Number::scientific(1234567, exponent: 5); // "12.35E5"
Number::scientific(0.00123); // "1.23E-3"
Number::scientific(0.00823, exponent: -3); // "8.23E-3'"
Number::scientific(12.34, precision: 4); // "1.234E1"
Number::scientific(12.34, precision: 2, locale: 'fr'); // "1,23E1"

Number::scientific(-12.34)); // "-1.23E1"
Number::scientific(-1, exponent: -1); // "-10E-1"

Number::scientific(INF) // "∞"
Number::scientific(NAN)); // "NaN"
Number::scientific(NAN, locale: 'fr')); // "NaN"
Number::scientific(NAN, locale: 'ru')); // "не число"
Number::scientific(NAN, locale: 'ar')); // "ليس رقمًا"
```


Key features:
- Supports positive and negative numbers
- Locale-aware formatting
- Handles special values (INF, NAN)
- Requires the PHP Intl extension

This addition complements the existing number formatting capabilities in Laravel's Number class by providing scientific notation support for working with very large or small numbers in a standardized way.