### PR TITLE
[11.x] feat: add better closure typing in QueriesRelationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -24,11 +24,13 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @return $this
      *
      * @throws \RuntimeException
@@ -79,7 +81,7 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<*>): mixed)|null  $callback
      * @return $this
      */
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
@@ -121,9 +123,11 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @return $this
      */
     public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
@@ -145,8 +149,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -161,8 +167,8 @@ trait QueriesRelationships
      *
      * Also load the relationship with same condition.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|null  $callback
+     * @param  string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -176,8 +182,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -190,8 +198,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @return $this
      */
     public function whereDoesntHave($relation, ?Closure $callback = null)
@@ -202,8 +212,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @return $this
      */
     public function orWhereDoesntHave($relation, ?Closure $callback = null)
@@ -214,12 +226,14 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @return $this
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
@@ -292,7 +306,7 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
+     * @param  string|array<int, string>  $types
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -305,10 +319,12 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @return $this
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
@@ -320,7 +336,7 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
+     * @param  string|array<int, string>  $types
      * @return $this
      */
     public function orDoesntHaveMorph($relation, $types)
@@ -331,9 +347,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -346,9 +364,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, array>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -361,9 +381,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @return $this
      */
     public function whereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
@@ -374,9 +396,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @return $this
      */
     public function orWhereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
@@ -387,8 +411,10 @@ trait QueriesRelationships
     /**
      * Add a basic where clause to a relationship query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -407,8 +433,10 @@ trait QueriesRelationships
     /**
      * Add an "or where" clause to a relationship query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -427,8 +455,10 @@ trait QueriesRelationships
     /**
      * Add a basic count / exists condition to a relationship query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -447,8 +477,10 @@ trait QueriesRelationships
     /**
      * Add an "or where" clause to a relationship query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -467,9 +499,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -484,9 +518,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -501,9 +537,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with a doesn't have clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -518,9 +556,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with an "or doesn't have" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
+     * @param  string|array<int, string>  $types
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -5,119 +5,176 @@ namespace Illuminate\Types\Builder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\HasBuilder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use User;
 
 use function PHPStan\Testing\assertType;
 
-/** @param \Illuminate\Database\Eloquent\Builder<\User> $query */
+/** @param \Illuminate\Database\Eloquent\Builder<User> $query */
 function test(
     Builder $query,
+    User $user,
     Post $post,
     ChildPost $childPost,
     Comment $comment,
     QueryBuilder $queryBuilder
 ): void {
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->where('id', 1));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhere('name', 'John'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereNot('status', 'active'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->with('relation'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->with(['relation' => ['foo' => fn ($q) => $q]]));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->with(['relation' => function ($query) {
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->where('id', 1));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhere('name', 'John'));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereNot('status', 'active'));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->with('relation'));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->with(['relation' => ['foo' => fn ($q) => $q]]));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->with(['relation' => function ($query) {
         // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
     }]));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->without('relation'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->withOnly(['relation']));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->withOnly(['relation' => ['foo' => fn ($q) => $q]]));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->withOnly(['relation' => function ($query) {
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->without('relation'));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->withOnly(['relation']));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->withOnly(['relation' => ['foo' => fn ($q) => $q]]));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->withOnly(['relation' => function ($query) {
         // assertType('Illuminate\Database\Eloquent\Relations\Relation<*,*,*>', $query);
     }]));
-    assertType('array<int, User>', $query->getModels());
-    assertType('array<int, User>', $query->eagerLoadRelations([]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->get());
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->hydrate([]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->fromQuery('foo', []));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->findMany([1, 2, 3]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->findOrFail([1]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->findOrNew([1]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->find([1]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, User>', $query->findOr([1], callback: fn () => 42));
-    assertType('User', $query->findOrFail(1));
-    assertType('User|null', $query->find(1));
-    assertType('42|User', $query->findOr(1, fn () => 42));
-    assertType('42|User', $query->findOr(1, callback: fn () => 42));
-    assertType('User|null', $query->first());
-    assertType('42|User', $query->firstOr(fn () => 42));
-    assertType('42|User', $query->firstOr(callback: fn () => 42));
-    assertType('User', $query->firstOrNew(['id' => 1]));
-    assertType('User', $query->findOrNew(1));
-    assertType('User', $query->firstOrCreate(['id' => 1]));
-    assertType('User', $query->create(['name' => 'John']));
-    assertType('User', $query->forceCreate(['name' => 'John']));
-    assertType('User', $query->forceCreateQuietly(['name' => 'John']));
-    assertType('User', $query->getModel());
-    assertType('User', $query->make(['name' => 'John']));
-    assertType('User', $query->forceCreate(['name' => 'John']));
-    assertType('User', $query->updateOrCreate(['id' => 1], ['name' => 'John']));
-    assertType('User', $query->firstOrFail());
-    assertType('User', $query->sole());
-    assertType('Illuminate\Support\LazyCollection<int, User>', $query->cursor());
-    assertType('Illuminate\Support\LazyCollection<int, User>', $query->lazy());
-    assertType('Illuminate\Support\LazyCollection<int, User>', $query->lazyById());
-    assertType('Illuminate\Support\LazyCollection<int, User>', $query->lazyByIdDesc());
+    assertType('array<int, Illuminate\Types\Builder\User>', $query->getModels());
+    assertType('array<int, Illuminate\Types\Builder\User>', $query->eagerLoadRelations([]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->get());
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->hydrate([]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->fromQuery('foo', []));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findMany([1, 2, 3]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOrFail([1]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOrNew([1]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->find([1]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Types\Builder\User>', $query->findOr([1], callback: fn () => 42));
+    assertType('Illuminate\Types\Builder\User', $query->findOrFail(1));
+    assertType('Illuminate\Types\Builder\User|null', $query->find(1));
+    assertType('42|Illuminate\Types\Builder\User', $query->findOr(1, fn () => 42));
+    assertType('42|Illuminate\Types\Builder\User', $query->findOr(1, callback: fn () => 42));
+    assertType('Illuminate\Types\Builder\User|null', $query->first());
+    assertType('42|Illuminate\Types\Builder\User', $query->firstOr(fn () => 42));
+    assertType('42|Illuminate\Types\Builder\User', $query->firstOr(callback: fn () => 42));
+    assertType('Illuminate\Types\Builder\User', $query->firstOrNew(['id' => 1]));
+    assertType('Illuminate\Types\Builder\User', $query->findOrNew(1));
+    assertType('Illuminate\Types\Builder\User', $query->firstOrCreate(['id' => 1]));
+    assertType('Illuminate\Types\Builder\User', $query->create(['name' => 'John']));
+    assertType('Illuminate\Types\Builder\User', $query->forceCreate(['name' => 'John']));
+    assertType('Illuminate\Types\Builder\User', $query->forceCreateQuietly(['name' => 'John']));
+    assertType('Illuminate\Types\Builder\User', $query->getModel());
+    assertType('Illuminate\Types\Builder\User', $query->make(['name' => 'John']));
+    assertType('Illuminate\Types\Builder\User', $query->forceCreate(['name' => 'John']));
+    assertType('Illuminate\Types\Builder\User', $query->updateOrCreate(['id' => 1], ['name' => 'John']));
+    assertType('Illuminate\Types\Builder\User', $query->firstOrFail());
+    assertType('Illuminate\Types\Builder\User', $query->sole());
+    assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->cursor());
+    assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->cursor());
+    assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->lazy());
+    assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->lazyById());
+    assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Builder\User>', $query->lazyByIdDesc());
     assertType('Illuminate\Support\Collection<(int|string), mixed>', $query->pluck('foo'));
-    assertType('Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model, User, *>', $query->getRelation('foo'));
+    assertType('Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model, Illuminate\Types\Builder\User, *>', $query->getRelation('foo'));
     assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query->setModel(new Post()));
 
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->has('foo'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->has($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orHas($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->doesntHave($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orDoesntHave($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereHas($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->withWhereHas($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereHas($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereDoesntHave($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereDoesntHave($post->users()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->hasMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orHasMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->doesntHaveMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orDoesntHaveMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereHasMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereDoesntHaveMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereDoesntHaveMorph($post->taggable(), 'taggable'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereRelation($post->users(), 'foo'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereRelation($post->users(), 'foo'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereMorphRelation($post->taggable(), 'taggable', 'foo'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereMorphRelation($post->taggable(), 'taggable', 'foo'));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereMorphedTo($post->taggable(), new Post()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->whereNotMorphedTo($post->taggable(), new Post()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereMorphedTo($post->taggable(), new Post()));
-    assertType('Illuminate\Database\Eloquent\Builder<User>', $query->orWhereNotMorphedTo($post->taggable(), new Post()));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->has('foo', callback: function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->has($user->posts(), callback: function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orHas($user->posts()));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->doesntHave($user->posts(), callback: function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orDoesntHave($user->posts()));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereHas($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->withWhereHas('posts', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<*>|Illuminate\Database\Eloquent\Relations\Relation<*, *, *>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereHas($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereDoesntHave($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereDoesntHave($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->hasMorph($post->taggable(), 'taggable', callback: function ($query, $type) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+        assertType('string', $type);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orHasMorph($post->taggable(), 'taggable'));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->doesntHaveMorph($post->taggable(), 'taggable', callback: function ($query, $type) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+        assertType('string', $type);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orDoesntHaveMorph($post->taggable(), 'taggable'));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereHasMorph($post->taggable(), 'taggable', function ($query, $type) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+        assertType('string', $type);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereHasMorph($post->taggable(), 'taggable', function ($query, $type) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+        assertType('string', $type);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereDoesntHaveMorph($post->taggable(), 'taggable', function ($query, $type) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+        assertType('string', $type);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereDoesntHaveMorph($post->taggable(), 'taggable', function ($query, $type) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+        assertType('string', $type);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereRelation($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereRelation($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereDoesntHaveRelation($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereDoesntHaveRelation($user->posts(), function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereMorphRelation($post->taggable(), 'taggable', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereMorphRelation($post->taggable(), 'taggable', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereMorphDoesntHaveRelation($post->taggable(), 'taggable', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereMorphDoesntHaveRelation($post->taggable(), 'taggable', function ($query) {
+        assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
+    }));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereMorphedTo($post->taggable(), new Post()));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->whereNotMorphedTo($post->taggable(), new Post()));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereMorphedTo($post->taggable(), new Post()));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->orWhereNotMorphedTo($post->taggable(), new Post()));
 
     $query->chunk(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, User>', $users);
+        assertType('Illuminate\Support\Collection<int, Illuminate\Types\Builder\User>', $users);
         assertType('int', $page);
     });
     $query->chunkById(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, User>', $users);
+        assertType('Illuminate\Support\Collection<int, Illuminate\Types\Builder\User>', $users);
         assertType('int', $page);
     });
     $query->chunkMap(function ($users) {
-        assertType('User', $users);
+        assertType('Illuminate\Types\Builder\User', $users);
     });
     $query->chunkByIdDesc(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, User>', $users);
+        assertType('Illuminate\Support\Collection<int, Illuminate\Types\Builder\User>', $users);
         assertType('int', $page);
     });
     $query->each(function ($users, $page) {
-        assertType('User', $users);
+        assertType('Illuminate\Types\Builder\User', $users);
         assertType('int', $page);
     });
     $query->eachById(function ($users, $page) {
-        assertType('User', $users);
+        assertType('Illuminate\Types\Builder\User', $users);
         assertType('int', $page);
     });
 
@@ -167,6 +224,15 @@ function test(
     assertType('Illuminate\Types\Builder\Comment', $comment->newQuery()->create(['name' => 'John']));
 }
 
+class User extends Model
+{
+    /** @return HasMany<Post, $this> */
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+}
+
 class Post extends Model
 {
     /** @use HasBuilder<CommonBuilder<static>> */
@@ -174,10 +240,10 @@ class Post extends Model
 
     protected static string $builder = CommonBuilder::class;
 
-    /** @return HasMany<User, $this> */
-    public function users(): HasMany
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
     {
-        return $this->hasMany(User::class);
+        return $this->belongsTo(User::class);
     }
 
     /** @return MorphTo<\Illuminate\Database\Eloquent\Model, $this> */


### PR DESCRIPTION
Hello!

This adds better closure types to the methods in `QueriesRelationships`:

```php
$query->whereHas($user->posts(), function ($query) {
    // Knows that it's a Post Builder!
    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query);
});
$query->whereHasMorph($post->taggable(), 'taggable', function ($query, $type) {
    // Knows the parameter types!
    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>', $query);
    assertType('string', $type);
});
```

Closes https://github.com/calebdw/larastan/issues/25

Thanks!