### PR TITLE
[11.x] Add generics to lazy queries

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -224,7 +224,7 @@ trait BuildsQueries
      * Query lazily, by chunks of the given size.
      *
      * @param  int  $chunkSize
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TValue>
      *
      * @throws \InvalidArgumentException
      */
@@ -259,7 +259,7 @@ trait BuildsQueries
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TValue>
      *
      * @throws \InvalidArgumentException
      */
@@ -274,7 +274,7 @@ trait BuildsQueries
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TValue>
      *
      * @throws \InvalidArgumentException
      */

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -64,6 +64,9 @@ function test(
     assertType('User', $query->firstOrFail());
     assertType('User', $query->sole());
     assertType('Illuminate\Support\LazyCollection<int, User>', $query->cursor());
+    assertType('Illuminate\Support\LazyCollection<int, User>', $query->lazy());
+    assertType('Illuminate\Support\LazyCollection<int, User>', $query->lazyById());
+    assertType('Illuminate\Support\LazyCollection<int, User>', $query->lazyByIdDesc());
     assertType('Illuminate\Support\Collection<(int|string), mixed>', $query->pluck('foo'));
     assertType('Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model, User, *>', $query->getRelation('foo'));
     assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\Post>', $query->setModel(new Post()));

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -33,6 +33,9 @@ function test(Builder $query, EloquentBuilder $userQuery): void
     assertType('Illuminate\Database\Query\Builder', $query->unionAll($userQuery));
     assertType('int', $query->insertUsing([], $userQuery));
     assertType('int', $query->insertOrIgnoreUsing([], $userQuery));
+    assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazy());
+    assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyById());
+    assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyByIdDesc());
 
     $query->chunk(1, function ($users, $page) {
         assertType('Illuminate\Support\Collection<int, object>', $users);


### PR DESCRIPTION
This PR adds generics to the builder methods that return lazy collections, allowing editors and static analysis tools to understand the value type within the collection.