### PR TITLE
[11.x] Merge in eager loads from nested where queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -317,6 +317,8 @@ class Builder implements BuilderContract
         if ($column instanceof Closure && is_null($operator)) {
             $column($query = $this->model->newQueryWithoutRelationships());
 
+            $this->eagerLoad = array_merge($this->eagerLoad, $query->getEagerLoads());
+
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
             $this->query->where(...func_get_args());

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1031,6 +1031,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedQuery = m::mock(Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
+        $nestedQuery->shouldReceive('getEagerLoads')->once()->andReturn([]);
         $model = $this->getMockModel()->makePartial();
         $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();
@@ -1092,6 +1093,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedQuery = m::mock(Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
+        $nestedQuery->shouldReceive('getEagerLoads')->once()->andReturn([]);
         $model = $this->getMockModel()->makePartial();
         $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();
@@ -1120,6 +1122,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedQuery = m::mock(Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
+        $nestedQuery->shouldReceive('getEagerLoads')->once()->andReturn([]);
         $model = $this->getMockModel()->makePartial();
         $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -720,7 +720,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithWhereHasWorksInNestedQuery()
     {
         $model = new EloquentModelWithWhereHasStub;
-        $instance = $model->newInstance()->newQuery()->with(fn ($q) => $q->withWhereHas('foo:diaa,fares'));
+        $instance = $model->newInstance()->newQuery()->where(fn (Builder $q) => $q->withWhereHas('foo:diaa,fares'));
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('select')->once()->with(['diaa', 'fares']);
         $this->assertNotNull($instance->getEagerLoads()['foo']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -720,7 +720,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithWhereHasWorksInNestedQuery()
     {
         $model = new EloquentModelWithWhereHasStub;
-        $instance = $model->newInstance()->newQuery()->with(fn($q) => $q->withWhereHas('foo:diaa,fares'));
+        $instance = $model->newInstance()->newQuery()->with(fn ($q) => $q->withWhereHas('foo:diaa,fares'));
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('select')->once()->with(['diaa', 'fares']);
         $this->assertNotNull($instance->getEagerLoads()['foo']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -717,6 +717,17 @@ class DatabaseEloquentModelTest extends TestCase
         $closure($builder);
     }
 
+    public function testWithWhereHasWorksInNestedQuery()
+    {
+        $model = new EloquentModelWithWhereHasStub;
+        $instance = $model->newInstance()->newQuery()->with(fn($q) => $q->withWhereHas('foo:diaa,fares'));
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('select')->once()->with(['diaa', 'fares']);
+        $this->assertNotNull($instance->getEagerLoads()['foo']);
+        $closure = $instance->getEagerLoads()['foo'];
+        $closure($builder);
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);


### PR DESCRIPTION
This PR merges in any eager loads from nested where clauses, so that `withWhereHas` can be used within a nested `where`.