### PR TITLE
[11.x] Add precision to `Number::currency()`

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -138,13 +138,18 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
+     * @param  int|null  $precision
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null)
+    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
+
+        if (! is_null($precision)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+        }
 
         return $formatter->formatCurrency($number, ! empty($in) ? $in : static::$currency);
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -151,6 +151,10 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-$5.00', Number::currency(-5));
         $this->assertSame('$5.00', Number::currency(5.00));
         $this->assertSame('$5.32', Number::currency(5.325));
+
+        $this->assertSame('$0', Number::currency(0, precision: 0));
+        $this->assertSame('$5', Number::currency(5.00, precision: 0));
+        $this->assertSame('$10', Number::currency(10.252, precision: 0));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
This pull request adds support for specifying precision when formatting currency with the `Number` helper.

The most common use-case for this is showing larger prices (e.g. $299 or $1000) where the numbers after the decimal place aren't desired in certain contexts. Because different locales use different symbols for decimal places this can't be done properly after the fact.