### PR TITLE
[11.x] Database testing traits has impact to artisan calls

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -354,6 +354,8 @@ class PendingCommand
         $this->verifyExpectations();
         $this->flushExpectations();
 
+        $this->app->offsetUnset(OutputStyle::class);
+
         return $exitCode;
     }
 


### PR DESCRIPTION
The PendingCommand creats a mock for OutputStyle and bind that mock to the app. This binding is only cleared if the app is cleared. The PendingCommand should cleare that Mock. This left over binding has inpact to tests and code. 
This is especially unexpected when the test use one of the the traits DatabaseMigrations, DatabaseTrunctation or RefreshDatabase. That traits give the impression that they have inpact to console/artisan behavior.

```php
<?php

namespace Tests;

use Illuminate\Contracts\Console\Kernel;
use Illuminate\Foundation\Application;
use Illuminate\Foundation\Testing\DatabaseTruncation;
use Illuminate\Foundation\Testing\TestCase;
use Illuminate\Support\Facades\Artisan;
use Symfony\Component\Console\Output\BufferedOutput;

class DemoTest extends TestCase
{
    use DatabaseTruncation;

    public function createApplication(): Application
    {
        $app = require __DIR__.'/../bootstrap/app.php';

        $app->make(Kernel::class)->bootstrap();

        return $app;
    }

    public function testNumberOne() : void {
        $buffer     = new BufferedOutput();
        Artisan::call('inspire', [], $buffer);
        self::assertNotEmpty($buffer->fetch());
    }

    public function testNumberTwo() : void {
        $buffer     = new BufferedOutput();
        Artisan::call('inspire', [], $buffer);
        self::assertNotEmpty($buffer->fetch());
    }
}
```
