### PR TITLE
[11.x] Add Higher Order Messaging support for last

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -37,6 +37,7 @@ use function Illuminate\Support\enum_value;
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $flatMap
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $groupBy
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $keyBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $last
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $map
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $max
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $min
@@ -84,6 +85,7 @@ trait EnumeratesValues
         'flatMap',
         'groupBy',
         'keyBy',
+        'last',
         'map',
         'max',
         'min',

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1133,6 +1133,7 @@ assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->flatMap);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->groupBy);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->keyBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->last);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->map);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->max);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, Animal>', $coll->min);

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -385,6 +385,21 @@ assertType('string|User', $collection->first(null, function () {
     return 'string';
 }));
 
+assertType('User|null', $collection->last());
+assertType('User|null', $collection->last(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', $collection->last(function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', $collection->last(null, function () {
+    return 'string';
+}));
+
 assertType('Illuminate\Support\LazyCollection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\LazyCollection<int, mixed>', $collection::make(['string' => 'string'])->flatten(4));
 
@@ -919,6 +934,7 @@ assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $co
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->flatMap);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->groupBy);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->keyBy);
+assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->last);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->map);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->max);
 assertType('Illuminate\Support\HigherOrderCollectionProxy<int, LazyAnimal>', $coll->min);


### PR DESCRIPTION
This PR adds support for Higher Order Messages to the last() method in Laravel collections, similar to how first() already supports Higher Order Messages.

