### PR TITLE
Adding the withQueryString method to the paginator interface.

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -35,6 +35,13 @@ interface Paginator
     public function fragment($fragment = null);
 
     /**
+     * Add all current query string values to the paginator.
+     *
+     * @return $this
+     */
+    public function withQueryString();
+
+    /**
      * The URL for the next page, or null.
      *
      * @return string|null


### PR DESCRIPTION
- According to the documentation, `paginate` has a `withQueryString` method.
  - See, https://laravel.com/docs/pagination#appending-query-string-values
- Not only `cursorPaginate`, but also `paginate` and `simplePaginate` should implement `withQueryString` and work with it.

ref: https://github.com/laravel/framework/pull/54460