### PR TITLE
Introduce a `Str::taylor()` helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -225,6 +225,31 @@ class Str
     }
 
     /**
+     * Convert a string into Laravel style code comment lines.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function taylor($value)
+    {
+    	$totalLength = strlen($value);
+    	$targetLengths = [ceil($totalLength / 3) + 4, ceil($totalLength / 3), ceil($totalLength / 3) - 4];
+
+    	[$_, $lines] = static::of($value)->trim()->split('/\s+/')
+    		->reduceSpread(function ($lineNumber, $lines, $word) use ($targetLengths) {
+    			if ($lineNumber < 2 && strlen(trim("{$lines[$lineNumber]} {$word}")) >= $targetLengths[$lineNumber]) {
+    				$lineNumber++;
+    			}
+
+                $lines[$lineNumber] = trim("{$lines[$lineNumber]} {$word}");
+
+                return [$lineNumber, $lines];
+            }, 0, ['', '', '']);
+
+        return implode("\n", $lines);
+    }
+
+    /**
      * Get the character at the specified index.
      *
      * @param  string  $subject

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1056,6 +1056,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('1FooBar', Str::camel('1 foo bar'));
     }
 
+    public function testTaylor()
+    {
+        $input = 'Split the input into exactly three lines, each as close to three chars fewer than the last.';
+        $expected = "Split the input into exactly three\nlines, each as close to three\nchars fewer than the last.";
+
+        $this->assertSame($expected, Str::taylor($input));
+    }
+
     public function testCharAt()
     {
         $this->assertEquals('р', Str::charAt('Привет, мир!', 1));


### PR DESCRIPTION
Laravel is known for its incredible attention to detail, down to the code comments. For example, Taylor Otwell has famously taken the time to ensure that all config comments are exactly three lines, with each line three characters shorter than the previous one:

```php
/*
 |
 | This value is the name of your application, which will be used when the
 | framework needs to place the application's name in a notification or
 | other UI elements where an application name needs to be displayed.
 |
 */
```

This PR introduces a new `Str::taylor()` function to make it easy to format a string to match this "three lines in decreasing length" style.