### PR TITLE
[11.x] Added optional arguments to fullUrlWithoutQuery() and fullUrlWithQuery() method in Request and Arr::query() to allow custom URI encoding when using these methods.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -702,11 +702,12 @@ class Arr
      * Convert the array into a query string.
      *
      * @param  array  $array
+     * @param int-mask $encoding_type (optional) PHP Query encoding type.
      * @return string
      */
-    public static function query($array)
+    public static function query($array, $encoding_type = PHP_QUERY_RFC3986)
     {
-        return http_build_query($array, '', '&', PHP_QUERY_RFC3986);
+        return http_build_query($array, '', '&', $encoding_type);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -4,9 +4,12 @@ namespace Illuminate\Support;
 
 use ArgumentCountError;
 use ArrayAccess;
+use Illuminate\Http\Request\Enums\HttpQueryEncoding;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
+
+use function Illuminate\Support\enum_value;
 
 class Arr
 {
@@ -702,12 +705,12 @@ class Arr
      * Convert the array into a query string.
      *
      * @param  array  $array
-     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
+     * @param  int-mask-of<PHP_QUERY_*>|HttpQueryEncoding $encodingType (optional) Query encoding type.
      * @return string
      */
-    public static function query($array, $encodingType = PHP_QUERY_RFC3986)
+    public static function query($array, $encodingType = HttpQueryEncoding::Rfc3986)
     {
-        return http_build_query($array, '', '&', $encodingType);
+        return http_build_query($array, '', '&', enum_value($encodingType));
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -702,7 +702,7 @@ class Arr
      * Convert the array into a query string.
      *
      * @param  array  $array
-     * @param  int-mask $encoding_type (optional) PHP Query encoding type.
+     * @param  int-mask-of<PHP_QUERY_*> $encoding_type (optional) PHP Query encoding type.
      * @return string
      */
     public static function query($array, $encoding_type = PHP_QUERY_RFC3986)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -702,12 +702,12 @@ class Arr
      * Convert the array into a query string.
      *
      * @param  array  $array
-     * @param  int-mask-of<PHP_QUERY_*> $encoding_type (optional) PHP Query encoding type.
+     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) PHP Query encoding type.
      * @return string
      */
-    public static function query($array, $encoding_type = PHP_QUERY_RFC3986)
+    public static function query($array, $encodingType = PHP_QUERY_RFC3986)
     {
-        return http_build_query($array, '', '&', $encoding_type);
+        return http_build_query($array, '', '&', $encodingType);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -702,7 +702,7 @@ class Arr
      * Convert the array into a query string.
      *
      * @param  array  $array
-     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) PHP Query encoding type.
+     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
      * @return string
      */
     public static function query($array, $encodingType = PHP_QUERY_RFC3986)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -702,7 +702,7 @@ class Arr
      * Convert the array into a query string.
      *
      * @param  array  $array
-     * @param int-mask $encoding_type (optional) PHP Query encoding type.
+     * @param  int-mask $encoding_type (optional) PHP Query encoding type.
      * @return string
      */
     public static function query($array, $encoding_type = PHP_QUERY_RFC3986)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -155,17 +155,17 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the full URL for the request without the given query string parameters.
      *
      * @param  array|string  $keys
-     * @param  int-mask  $encoding_type (optional) PHP Query encoding type.
+     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
      * @return string
      */
-    public function fullUrlWithoutQuery($keys, $encoding_type = PHP_QUERY_RFC3986)
+    public function fullUrlWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986)
     {
         $query = Arr::except($this->query(), $keys);
 
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($query) > 0
-            ? $this->url().$question.Arr::query($query, $encoding_type)
+            ? $this->url().$question.Arr::query($query, $encodingType)
             : $this->url();
     }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -140,30 +140,15 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the full URL for the request with the added query string parameters.
      *
      * @param  array  $query
-     * @param int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
      * @return string
      */
     public function fullUrlWithQuery(array $query, $encodingType = PHP_QUERY_RFC3986)
     {
-        return $this->schemeAndHttpHost().$this->UriWithQuery($query, $encodingType = PHP_QUERY_RFC3986);
-    }
-
-    /**
-     * Get the URI for the request with the added query string parameters.
-     *
-     * @param  array  $query
-     * @param int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
-     * @return string
-     */
-    public function UriWithQuery(array $query, $encodingType = PHP_QUERY_RFC3986)
-    {
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($this->query()) > 0
-            // if the request have querys use a stripped boi and add them back in
-            ? $this->uri()->pathRaw().$question.Arr::query(array_merge($this->query(), $query), $encodingType)
-            // if there's no queries just dump the new ones on the end.
-            : $this->uri()->pathRaw().$question.Arr::query($query, $encodingType);
+            ? $this->url().$question.Arr::query(array_merge($this->query(), $query), $encodingType)
+            : $this->fullUrl().$question.Arr::query($query, $encodingType);
     }
 
     /**
@@ -175,25 +160,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function fullUrlWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986)
     {
-        return $this->schemeAndHttpHost().$this->UriWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986);
-    }
-
-    /**
-     * Get the URI for the request without the given query string parameters.
-     *
-     * @param  array|string  $keys
-     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
-     * @return string
-     */
-    public function UriWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986)
-    {
         $query = Arr::except($this->query(), $keys);
 
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($query) > 0
-            ? $this->uri()->pathRaw().$question.Arr::query($query, $encodingType)
-            : $this->uri()->pathRaw();
+            ? $this->url().$question.Arr::query($query, $encodingType)
+            : $this->url();
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -140,15 +140,30 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the full URL for the request with the added query string parameters.
      *
      * @param  array  $query
+     * @param int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
      * @return string
      */
-    public function fullUrlWithQuery(array $query)
+    public function fullUrlWithQuery(array $query, $encodingType = PHP_QUERY_RFC3986)
+    {
+        return $this->schemeAndHttpHost().$this->UriWithQuery($query, $encodingType = PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * Get the URI for the request with the added query string parameters.
+     *
+     * @param  array  $query
+     * @param int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
+     * @return string
+     */
+    public function UriWithQuery(array $query, $encodingType = PHP_QUERY_RFC3986)
     {
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($this->query()) > 0
-            ? $this->url().$question.Arr::query(array_merge($this->query(), $query))
-            : $this->fullUrl().$question.Arr::query($query);
+            // if the request have querys use a stripped boi and add them back in
+            ? $this->uri()->pathRaw().$question.Arr::query(array_merge($this->query(), $query), $encodingType)
+            // if there's no queries just dump the new ones on the end.
+            : $this->uri()->pathRaw().$question.Arr::query($query, $encodingType);
     }
 
     /**
@@ -160,13 +175,25 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function fullUrlWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986)
     {
+        return $this->schemeAndHttpHost().$this->UriWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * Get the URI for the request without the given query string parameters.
+     *
+     * @param  array|string  $keys
+     * @param  int-mask-of<PHP_QUERY_*> $encodingType (optional) Query encoding type.
+     * @return string
+     */
+    public function UriWithoutQuery($keys, $encodingType = PHP_QUERY_RFC3986)
+    {
         $query = Arr::except($this->query(), $keys);
 
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($query) > 0
-            ? $this->url().$question.Arr::query($query, $encodingType)
-            : $this->url();
+            ? $this->uri()->pathRaw().$question.Arr::query($query, $encodingType)
+            : $this->uri()->pathRaw();
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -155,7 +155,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the full URL for the request without the given query string parameters.
      *
      * @param  array|string  $keys
-     * @param  int-mask $encoding_type (optional) PHP Query encoding type.
+     * @param  int-mask  $encoding_type (optional) PHP Query encoding type.
      * @return string
      */
     public function fullUrlWithoutQuery($keys, $encoding_type = PHP_QUERY_RFC3986)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -155,16 +155,17 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Get the full URL for the request without the given query string parameters.
      *
      * @param  array|string  $keys
+     * @param  int-mask $encoding_type (optional) PHP Query encoding type.
      * @return string
      */
-    public function fullUrlWithoutQuery($keys)
+    public function fullUrlWithoutQuery($keys, $encoding_type = PHP_QUERY_RFC3986)
     {
         $query = Arr::except($this->query(), $keys);
 
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
 
         return count($query) > 0
-            ? $this->url().$question.Arr::query($query)
+            ? $this->url().$question.Arr::query($query, $encoding_type)
             : $this->url();
     }
 

--- a/src/Illuminate/Http/Request/Enums/HttpQueryEncoding.php
+++ b/src/Illuminate/Http/Request/Enums/HttpQueryEncoding.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Http\Request\Enums;
+
+enum HttpQueryEncoding: int
+{
+    case Rfc1738 = PHP_QUERY_RFC1738;
+    case Rfc3986 = PHP_QUERY_RFC3986;
+}

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -153,18 +153,6 @@ class Uri implements Htmlable, Responsable, Stringable
     }
 
     /**
-     * Get the URI's path without trimming it.
-     *
-     * Empty or missing paths are returned as a single "/".
-     */
-    public function pathRaw(): ?string
-    {
-        $path = $this->uri->getPath();
-
-        return $path === '' ? '/' : $path;
-    }
-
-    /**
      * Get the URI's query string.
      */
     public function query(): UriQueryString

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -153,6 +153,18 @@ class Uri implements Htmlable, Responsable, Stringable
     }
 
     /**
+     * Get the URI's path without trimming it.
+     *
+     * Empty or missing paths are returned as a single "/".
+     */
+    public function pathRaw(): ?string
+    {
+        $path = $this->uri->getPath();
+
+        return $path === '' ? '/' : $path;
+    }
+
+    /**
      * Get the URI's query string.
      */
     public function query(): UriQueryString


### PR DESCRIPTION
Came across the issue of needing a custom encoding type while working on a redirect addon. For the moments I've reimplemented these functions but I'd like it to be optional in the core framework.

Default behaviour should be preserved with the default values in the optional args

Arr.php - Added optional argument in query() method for encoding type passed to http_build_query to allow custom encoding types (Default it set to the type that was previously hard-coded)

Request.php - Added optional argument to the fullUrlWithoutQuery() method to allow a custom encoding type for the URI from Arr::query() default is configured as the previous hardcoded default inside Arr::query() so the default behaviour without the optional arg remains the same

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
