### PR TITLE
[11.x] Add derived fallback locale support

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1573,15 +1573,24 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * Set the current application locale.
      *
      * @param  string  $locale
+     * @param  bool  $useDerivedFallback
      * @return void
      */
-    public function setLocale($locale)
+    public function setLocale($locale, $useDerivedFallback = false)
     {
         $this['config']->set('app.locale', $locale);
 
         $this['translator']->setLocale($locale);
 
         $this['events']->dispatch(new LocaleUpdated($locale));
+
+        if ($useDerivedFallback) {
+            $primaryLanguage = substr($locale, 0, 2);
+
+            if ($primaryLanguage !== $locale) {
+                $this->setFallbackLocale($primaryLanguage);
+            }
+        }
     }
 
     /**

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -136,4 +136,30 @@ class TranslatorTest extends TestCase
         yield [0, 'Bonjour :name', 'fr'];
         yield [3, 'Bonjour :name, vous avez :count messages non lus', 'fr'];
     }
+
+    public function test_it_can_use_derived_fallback_locale()
+    {
+        $this->app->setLocale('de_CH', true);
+
+        $this->assertSame('de', $this->app['translator']->getFallback());
+
+        $this->assertSame('Grüezi', $this->app['translator']->get('Greeting'));
+
+        $this->assertSame('Welcome', $this->app['translator']->get('Welcome'));
+
+        $this->assertSame('Goodbye', $this->app['translator']->get('Goodbye'));
+    }
+
+    public function test_has_for_locale_respects_derived_fallback()
+    {
+        $this->app['translator']->addJsonPath(__DIR__.'/lang');
+
+        $this->app->setLocale('de_CH', true);
+
+        $this->assertTrue($this->app['translator']->hasForLocale('Greeting'));
+
+        $this->assertFalse($this->app['translator']->hasForLocale('Welcome'));
+
+        $this->assertFalse($this->app['translator']->hasForLocale('Nonexistent'));
+    }
 }

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -152,8 +152,6 @@ class TranslatorTest extends TestCase
 
     public function test_has_for_locale_respects_derived_fallback()
     {
-        $this->app['translator']->addJsonPath(__DIR__.'/lang');
-
         $this->app->setLocale('de_CH', true);
 
         $this->assertTrue($this->app['translator']->hasForLocale('Greeting'));

--- a/tests/Integration/Translation/lang/de.json
+++ b/tests/Integration/Translation/lang/de.json
@@ -1,0 +1,4 @@
+{
+    "Greeting": "Hallo",
+    "Welcome": "Willkommen"
+}

--- a/tests/Integration/Translation/lang/de_CH.json
+++ b/tests/Integration/Translation/lang/de_CH.json
@@ -1,0 +1,4 @@
+{
+    "Greeting": "Grüezi",
+    "Hello": "Grüezi mitenand"
+}

--- a/tests/Integration/Translation/lang/en.json
+++ b/tests/Integration/Translation/lang/en.json
@@ -3,5 +3,7 @@
     "30 Days": "30 Days",
     "365 Days": "365 Days",
     "60 Days": "60 Days",
-    "90 Days": "90 Days"
+    "90 Days": "90 Days",
+    "Greeting": "Hello",
+    "Welcome": "Welcome"
 }


### PR DESCRIPTION
This PR adds support for derived fallback locales when setting the application locale. For example, when using 'de_CH', you can optionally have it automatically determine 'de' as a fallback locale.

Added a new `$useDerivedFallback` parameter to `setLocale()`:

```php
public function setLocale($locale, $useDerivedFallback = false)
{
    $this['config']->set('app.locale', $locale);

    $this['translator']->setLocale($locale);

    $this['events']->dispatch(new LocaleUpdated($locale));

    if ($useDerivedFallback) {
        $primaryLanguage = substr($locale, 0, 2);

        if ($primaryLanguage !== $locale) {
            $this->setFallbackLocale($primaryLanguage);
        }
    }
}