### PR TITLE
[11.x] Fix assertContent on laravel test that respond with Symfony Response Object

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -527,7 +527,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertContent($value)
     {
-        PHPUnit::withResponse($this)->assertSame($value, $this->content());
+        PHPUnit::withResponse($this)->assertSame($value, $this->getContent());
 
         return $this;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request fixes an issue when a controller is returning a Symfony\Component\HttpFoundation\Response object instead of the usual Laravel Response object. This is down to Symfony response object not having content function defined.

I noticed that the rest of the TestResponse class uses ->getContent(), which works with the Symfony object. So I've applied that to this function as well.

Test:
```
$test = \Illuminate\Testing\TestResponse::fromBaseResponse(
    new \Symfony\Component\HttpFoundation\Response('testing', 200)
 );

$test->assertContent('testing');
```