### PR TITLE
Add `RoutedBy` Eloquent model attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/RoutedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/RoutedBy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class RoutedBy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function __construct(public string $key)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Attributes\RoutedBy;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
@@ -24,6 +25,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonException;
 use JsonSerializable;
 use LogicException;
+use ReflectionClass;
 use Stringable;
 
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, UrlRoutable
@@ -2065,7 +2067,25 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getRouteKeyName()
     {
-        return $this->getKeyName();
+        return $this->resolveRouteKeyNameFromAttribute() ?? $this->getKeyName();
+    }
+
+    /**
+     * Resolve the route key name from the RoutedBy attribute.
+     *
+     * @return string|void
+     */
+    protected function resolveRouteKeyNameFromAttribute()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+
+        $attributes = $reflectionClass->getAttributes(RoutedBy::class);
+
+        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
+            return;
+        }
+
+        return $attributes[0]->getArguments()[0];
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -17,6 +17,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\RoutedBy;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
@@ -1942,6 +1943,12 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $this->assertSame('id', $model->getRouteKeyName());
+    }
+
+    public function testRouteNameCanBeSetWithRoutedByAttribute()
+    {
+        $model = new EloquentModelWithRoutedByAttribute;
+        $this->assertSame('slug', $model->getRouteKeyName());
     }
 
     public function testCloneModelMakesAFreshCopyOfTheModel()
@@ -4018,4 +4025,9 @@ class EloquentModelWithUseFactoryAttributeFactory extends Factory
 class EloquentModelWithUseFactoryAttribute extends Model
 {
     use HasFactory;
+}
+
+#[RoutedBy('slug')]
+class EloquentModelWithRoutedByAttribute extends Model
+{
 }


### PR DESCRIPTION
Adds a `RoutedBy` attribute to set a custom route key name on a model:

```php
#[RoutedBy('slug')]
class Post extends Model
{
    //
}
```

Same idea as #49843, #53122, and #54065. This attribute provides a more compact way to set a custom routing key, instead of overriding the `getRouteKeyName` method.

Fully backwards-compatible and optional, `getRouteKeyName` continues to work exactly as before and takes precedence over this attribute.