### PR TITLE
[12.x] Using constructor property promotion in Client Events

### DIFF
--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -8,29 +8,15 @@ use Illuminate\Http\Client\Request;
 class ConnectionFailed
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Client\Request
-     */
-    public $request;
-
-    /**
-     * The exception instance.
-     *
-     * @var \Illuminate\Http\Client\ConnectionException
-     */
-    public $exception;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Http\Client\Request  $request
-     * @param  \Illuminate\Http\Client\ConnectionException  $exception
+     * @param  \Illuminate\Http\Client\Request  $request  The request instance.
+     * @param  \Illuminate\Http\Client\ConnectionException  $exception  The exception instance.
      * @return void
      */
-    public function __construct(Request $request, ConnectionException $exception)
-    {
-        $this->request = $request;
-        $this->exception = $exception;
+    public function __construct(
+        public Request $request,
+        public ConnectionException $exception,
+    ) {
     }
 }

--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -7,20 +7,13 @@ use Illuminate\Http\Client\Request;
 class RequestSending
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Client\Request
-     */
-    public $request;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Http\Client\Request  $request
+     * @param  \Illuminate\Http\Client\Request  $request  The request instance.
      * @return void
      */
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
+    public function __construct(
+        public Request $request,
+    ) {
     }
 }

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -8,29 +8,15 @@ use Illuminate\Http\Client\Response;
 class ResponseReceived
 {
     /**
-     * The request instance.
-     *
-     * @var \Illuminate\Http\Client\Request
-     */
-    public $request;
-
-    /**
-     * The response instance.
-     *
-     * @var \Illuminate\Http\Client\Response
-     */
-    public $response;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Http\Client\Request  $request
-     * @param  \Illuminate\Http\Client\Response  $response
+     * @param  \Illuminate\Http\Client\Request  $request  The request instance.
+     * @param  \Illuminate\Http\Client\Response  $response  The response instance.
      * @return void
      */
-    public function __construct(Request $request, Response $response)
-    {
-        $this->request = $request;
-        $this->response = $response;
+    public function __construct(
+        public Request $request,
+        public Response $response,
+    ) {
     }
 }


### PR DESCRIPTION
Using constructor property promotion in Client Events to reduce boilerplate code
