### PR TITLE
Switch a few of the Illuminate Support classes to use constructor property promotion

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -11,31 +11,18 @@ use Symfony\Component\Process\Process;
 class Composer
 {
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
-     * The working path to regenerate from.
-     *
-     * @var string|null
-     */
-    protected $workingPath;
-
-    /**
      * Create a new Composer manager instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string|null  $workingPath
      * @return void
      */
-    public function __construct(Filesystem $files, $workingPath = null)
-    {
-        $this->files = $files;
-        $this->workingPath = $workingPath;
-    }
+    public function __construct(
+        protected Filesystem $files,
+        protected string|null $workingPath = null
+    )
+    {}
+
 
     /**
      * Determine if the given Composer package is installed.

--- a/src/Illuminate/Support/HigherOrderTapProxy.php
+++ b/src/Illuminate/Support/HigherOrderTapProxy.php
@@ -5,22 +5,15 @@ namespace Illuminate\Support;
 class HigherOrderTapProxy
 {
     /**
-     * The target being tapped.
-     *
-     * @var mixed
-     */
-    public $target;
-
-    /**
      * Create a new tap proxy instance.
      *
      * @param  mixed  $target
      * @return void
      */
-    public function __construct($target)
-    {
-        $this->target = $target;
-    }
+    public function __construct(
+        public mixed $target
+    )
+    {}
 
     /**
      * Dynamically pass method calls to the target.

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -8,22 +8,15 @@ use Stringable;
 class HtmlString implements Htmlable, Stringable
 {
     /**
-     * The HTML string.
-     *
-     * @var string
-     */
-    protected $html;
-
-    /**
      * Create a new HTML string instance.
      *
      * @param  string  $html
      * @return void
      */
-    public function __construct($html = '')
-    {
-        $this->html = $html;
-    }
+    public function __construct(
+        protected string $html = ''
+    )
+    {}
 
     /**
      * Get the HTML string.

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -9,13 +9,6 @@ use InvalidArgumentException;
 abstract class Manager
 {
     /**
-     * The container instance.
-     *
-     * @var \Illuminate\Contracts\Container\Container
-     */
-    protected $container;
-
-    /**
      * The configuration repository instance.
      *
      * @var \Illuminate\Contracts\Config\Repository
@@ -42,9 +35,10 @@ abstract class Manager
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
      */
-    public function __construct(Container $container)
+    public function __construct(
+        protected Container $container
+    )
     {
-        $this->container = $container;
         $this->config = $container->make('config');
     }
 

--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -13,21 +13,13 @@ class Optional implements ArrayAccess
     }
 
     /**
-     * The underlying object.
-     *
-     * @var mixed
-     */
-    protected $value;
-
-    /**
      * Create a new optional instance.
      *
      * @param  mixed  $value
      * @return void
      */
-    public function __construct($value)
+    public function __construct(protected mixed $value)
     {
-        $this->value = $value;
     }
 
     /**


### PR DESCRIPTION
Switch a few of the Illuminate Support classes to use constructor property promotion where the previously didn't to aid readability. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
