### PR TITLE
[11.x] Add currency-aware isFractionUnit param to Number::currency()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -160,14 +160,14 @@ class Number
 
     private static function fractionUnitToCurrencyDecimal(int $number, string $in)
     {
-        return $number / 10 ** (match (! empty($in) ? $in : static::$currency) {
+        return $number / 10 ** match (! empty($in) ? $in : static::$currency) {
             'BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF' => throw new InvalidArgumentException(sprintf(
                 'The currency %s does not have a minor unit',
                 ! empty($in) ? $in : static::$currency,
             )),
             'BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND' => 3,
             default => 2,
-        } - 1);
+        };
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -158,8 +158,8 @@ class SupportNumberTest extends TestCase
 
         $this->assertSame('$0.00', Number::currency(0, isFractionUnit: true));
         $this->assertSame('$5.00', Number::currency(500, isFractionUnit: true));
-        $this->assertSame('$10.25', Number::currency(10.252, isFractionUnit: true));
-        $this->assertSame('$10.252', Number::currency(10.252, 'LYD', isFractionUnit: true));
+        $this->assertSame('$102.52', Number::currency(10252, isFractionUnit: true));
+        $this->assertSame('$10.252', Number::currency(10252, 'LYD', isFractionUnit: true));
     }
 
     #[RequiresPhpExtension('intl')]

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -159,7 +159,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$0.00', Number::currency(0, isFractionUnit: true));
         $this->assertSame('$5.00', Number::currency(500, isFractionUnit: true));
         $this->assertSame('$102.52', Number::currency(10252, isFractionUnit: true));
-        $this->assertSame('LYD 10.252', Number::currency(10252, 'LYD', isFractionUnit: true));
+        $this->assertSame('LYD 10.252', Number::currency(10252, 'LYD', isFractionUnit: true));
     }
 
     #[RequiresPhpExtension('intl')]

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -159,7 +159,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$0.00', Number::currency(0, isFractionUnit: true));
         $this->assertSame('$5.00', Number::currency(500, isFractionUnit: true));
         $this->assertSame('$102.52', Number::currency(10252, isFractionUnit: true));
-        $this->assertSame('$10.252', Number::currency(10252, 'LYD', isFractionUnit: true));
+        $this->assertSame('LYD 10.252', Number::currency(10252, 'LYD', isFractionUnit: true));
     }
 
     #[RequiresPhpExtension('intl')]

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -155,6 +155,11 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$0', Number::currency(0, precision: 0));
         $this->assertSame('$5', Number::currency(5.00, precision: 0));
         $this->assertSame('$10', Number::currency(10.252, precision: 0));
+
+        $this->assertSame('$0.00', Number::currency(0, isFractionUnit: true));
+        $this->assertSame('$5.00', Number::currency(500, isFractionUnit: true));
+        $this->assertSame('$10.25', Number::currency(10.252, isFractionUnit: true));
+        $this->assertSame('$10.252', Number::currency(10.252, 'LYD', isFractionUnit: true));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
See discussions in #54360, #54163, and #54456

Instead of
```php
$amount = 10252; // from database, request, etc.
echo Number::currency(10252 / 1000, 'LYD', 3); // $1.025
echo Number::currency(10252 / 100, 'USD', 2); // $10.25
```

you can now do
```php
$amount = 10252; // from database, request, etc.
echo Number::currency(10252, 'LYD', isFractionUnit: true); // $1.025
echo Number::currency(10252, 'USD', isFractionUnit: true); // $10.25
```

and don't need to know, how many Libyan dirham is one dinar (did you even know that? Me neither)