### PR TITLE
Add `Builder` On Clone callback support

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -158,6 +158,13 @@ class Builder implements BuilderContract
     protected $afterQueryCallbacks = [];
 
     /**
+     * The callbacks that should be invoked on clone.
+     *
+     * @var array
+     */
+    protected $onCloneCallbacks = [];
+
+    /**
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -2169,6 +2176,33 @@ class Builder implements BuilderContract
     {
         return clone $this;
     }
+	
+	/**
+	 * Register a closure to be invoked on a clone.
+	 *
+	 * @param  \Closure  $callback
+	 * @return $this
+	 */
+	public function onClone(Closure $callback)
+	{
+		$this->onCloneCallbacks[] = $callback;
+		
+		return $this;
+	}
+	
+	/**
+	 * Invoke the "on clone" modification callbacks.
+	 *
+	 * @return static
+	 */
+	public function applyOnCloneCallbacks()
+	{
+		foreach ($this->onCloneCallbacks as $onCloneCallback) {
+			$onCloneCallback($this);
+		}
+		
+		return $this;
+	}
 
     /**
      * Force a clone of the underlying query builder when cloning.
@@ -2178,5 +2212,7 @@ class Builder implements BuilderContract
     public function __clone()
     {
         $this->query = clone $this->query;
+		
+		$this->applyOnCloneCallbacks();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2176,33 +2176,33 @@ class Builder implements BuilderContract
     {
         return clone $this;
     }
-	
-	/**
-	 * Register a closure to be invoked on a clone.
-	 *
-	 * @param  \Closure  $callback
-	 * @return $this
-	 */
-	public function onClone(Closure $callback)
-	{
-		$this->onCloneCallbacks[] = $callback;
-		
-		return $this;
-	}
-	
-	/**
-	 * Invoke the "on clone" modification callbacks.
-	 *
-	 * @return static
-	 */
-	public function applyOnCloneCallbacks()
-	{
-		foreach ($this->onCloneCallbacks as $onCloneCallback) {
-			$onCloneCallback($this);
-		}
-		
-		return $this;
-	}
+
+    /**
+     * Register a closure to be invoked on a clone.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function onClone(Closure $callback)
+    {
+        $this->onCloneCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Invoke the "on clone" modification callbacks.
+     *
+     * @return static
+     */
+    public function applyOnCloneCallbacks()
+    {
+        foreach ($this->onCloneCallbacks as $onCloneCallback) {
+            $onCloneCallback($this);
+        }
+
+        return $this;
+    }
 
     /**
      * Force a clone of the underlying query builder when cloning.
@@ -2212,7 +2212,7 @@ class Builder implements BuilderContract
     public function __clone()
     {
         $this->query = clone $this->query;
-		
-		$this->applyOnCloneCallbacks();
+
+        $this->applyOnCloneCallbacks();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2191,20 +2191,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Invoke the "on clone" modification callbacks.
-     *
-     * @return static
-     */
-    public function applyOnCloneCallbacks()
-    {
-        foreach ($this->onCloneCallbacks as $onCloneCallback) {
-            $onCloneCallback($this);
-        }
-
-        return $this;
-    }
-
-    /**
      * Force a clone of the underlying query builder when cloning.
      *
      * @return void
@@ -2212,7 +2198,9 @@ class Builder implements BuilderContract
     public function __clone()
     {
         $this->query = clone $this->query;
-
-        $this->applyOnCloneCallbacks();
+		
+	    foreach ($this->onCloneCallbacks as $onCloneCallback) {
+		    $onCloneCallback($this);
+	    }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2198,9 +2198,9 @@ class Builder implements BuilderContract
     public function __clone()
     {
         $this->query = clone $this->query;
-		
-	    foreach ($this->onCloneCallbacks as $onCloneCallback) {
-		    $onCloneCallback($this);
-	    }
+
+        foreach ($this->onCloneCallbacks as $onCloneCallback) {
+            $onCloneCallback($this);
+        }
     }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2493,8 +2493,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 		
 		$onCloneCallbackCalledCount = 0;
 		
-		$builder->onClone(function () use (&$onCloneCallbackCalledCount) {
+		$onCloneQuery = null;
+		
+		$builder->onClone(function (Builder $query) use (&$onCloneCallbackCalledCount, &$onCloneQuery) {
 			$onCloneCallbackCalledCount++;
+			
+			$onCloneQuery = $query;
 		});
 		
 		$clone = $builder->clone()->where('email', 'foo');
@@ -2504,6 +2508,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 		$this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
 		
 		$this->assertSame(1, $onCloneCallbackCalledCount);
+		$this->assertSame($onCloneQuery, $clone);
 	}
 
     public function testToRawSql()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2484,6 +2484,27 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users"', $builder->toSql());
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
+	
+	public function testCloneModelMakesAFreshCopyOfTheModel()
+	{
+		$query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+		$builder = (new Builder($query))->setModel(new EloquentBuilderTestStub);
+		$builder->select('*')->from('users');
+		
+		$onCloneCallbackCalledCount = 0;
+		
+		$builder->onClone(function () use (&$onCloneCallbackCalledCount) {
+			$onCloneCallbackCalledCount++;
+		});
+		
+		$clone = $builder->clone()->where('email', 'foo');
+		
+		$this->assertNotSame($builder, $clone);
+		$this->assertSame('select * from "users"', $builder->toSql());
+		$this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+		
+		$this->assertSame(1, $onCloneCallbackCalledCount);
+	}
 
     public function testToRawSql()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2484,32 +2484,32 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users"', $builder->toSql());
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
-	
-	public function testCloneModelMakesAFreshCopyOfTheModel()
-	{
-		$query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
-		$builder = (new Builder($query))->setModel(new EloquentBuilderTestStub);
-		$builder->select('*')->from('users');
-		
-		$onCloneCallbackCalledCount = 0;
-		
-		$onCloneQuery = null;
-		
-		$builder->onClone(function (Builder $query) use (&$onCloneCallbackCalledCount, &$onCloneQuery) {
-			$onCloneCallbackCalledCount++;
-			
-			$onCloneQuery = $query;
-		});
-		
-		$clone = $builder->clone()->where('email', 'foo');
-		
-		$this->assertNotSame($builder, $clone);
-		$this->assertSame('select * from "users"', $builder->toSql());
-		$this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
-		
-		$this->assertSame(1, $onCloneCallbackCalledCount);
-		$this->assertSame($onCloneQuery, $clone);
-	}
+
+    public function testCloneModelMakesAFreshCopyOfTheModel()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = (new Builder($query))->setModel(new EloquentBuilderTestStub);
+        $builder->select('*')->from('users');
+
+        $onCloneCallbackCalledCount = 0;
+
+        $onCloneQuery = null;
+
+        $builder->onClone(function (Builder $query) use (&$onCloneCallbackCalledCount, &$onCloneQuery) {
+            $onCloneCallbackCalledCount++;
+
+            $onCloneQuery = $query;
+        });
+
+        $clone = $builder->clone()->where('email', 'foo');
+
+        $this->assertNotSame($builder, $clone);
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+
+        $this->assertSame(1, $onCloneCallbackCalledCount);
+        $this->assertSame($onCloneQuery, $clone);
+    }
 
     public function testToRawSql()
     {


### PR DESCRIPTION
I noticed that when the Eloquent `Builder` is cloned, it will not clone the internal `Eloquent` model. This can be problematic for a package like [kirschbaum-development/eloquent-power-joins](https://github.com/kirschbaum-development/eloquent-power-joins), which depends with a cache on the `spl_object_id()` of the Eloquent model in the query.

This PRs adds a simple `onClone()` callback that will be called anytime a `Builder` is cloned, leaving open more advanced options for these more advanced Eloquent packages.

Thanks!