### PR TITLE
[11.x] Fix the method explodeExplicitRule to support Numeric Validation

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\Unique;
 
 class ValidationRuleParser
@@ -99,7 +100,7 @@ class ValidationRuleParser
         $rules = [];
 
         foreach ($rule as $value) {
-            if ($value instanceof Date) {
+            if ($value instanceof Date || $value instanceof Numeric) {
                 $rules = array_merge($rules, explode('|', (string) $value));
             } else {
                 $rules[] = $this->prepareRule($value, $attribute);

--- a/tests/Validation/ValidationNumericRuleTest.php
+++ b/tests/Validation/ValidationNumericRuleTest.php
@@ -338,6 +338,16 @@ class ValidationNumericRuleTest extends TestCase
         );
 
         $this->assertEmpty($validator->errors()->first('numeric'));
+
+        $rule = Rule::numeric()->exactly(10);
+
+        $validator = new Validator(
+            $trans,
+            ['numeric' => 10],
+            ['numeric' => [$rule]]
+        );
+
+        $this->assertEmpty($validator->errors()->first('numeric'));
     }
 
     public function testUniquenessValidation()


### PR DESCRIPTION
Similar as [#54353](https://github.com/laravel/framework/pull/54353). New validation in [#54425](https://github.com/laravel/framework/pull/54425) returns a string with ```'|'```.

This PR also includes testcase for that.