### PR TITLE
[11.x] Add a new `forget_nullable` rule validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2561,6 +2561,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is nullable and remove it from data if it is empty.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateForgetNullable($attribute, $value)
+    {
+        return ($this->shouldForget($value) && $this->forgetAttribute($attribute)) || true;
+    }
+
+    /**
      * Get the size of an attribute.
      *
      * @param  string  $attribute
@@ -2722,5 +2734,30 @@ trait ValidatesAttributes
         }
 
         return $value;
+    }
+
+    /**
+     * Determine if the value should be forgotten.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function shouldForget($value)
+    {
+        return is_null($value) ||
+            (is_string($value) && trim($value) === '') ||
+            (is_countable($value) && count($value) === 0) ||
+            ($this->isValidFileInstance($value) && ($value->getPath() === '' || $value->getSize() === 0));
+    }
+
+    /**
+     * Forget the attribute.
+     *
+     * @param  string  $attribute
+     * @return void
+     */
+    protected function forgetAttribute($attribute)
+    {
+        unset($this->data[$attribute]);
     }
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -209,6 +209,7 @@ class Validator implements ValidatorContract
         'Declined',
         'DeclinedIf',
         'Filled',
+        'ForgetNullable',
         'Missing',
         'MissingIf',
         'MissingUnless',

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -229,6 +229,41 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
     }
 
+    public function testForgetNullableValidationWithNull()
+    {
+        $request = $this->createRequest(['name' => null], FoundationTestFormRequestForgetNullableStub::class);
+        $request->validateResolved();
+        $this->assertEquals([], $request->validated());
+    }
+
+    public function testForgetNullableValidationWithEmptyString()
+    {
+        $request = $this->createRequest(['name' => ''], FoundationTestFormRequestForgetNullableStub::class);
+        $request->validateResolved();
+        $this->assertEquals([], $request->validated());
+    }
+
+    public function testForgetNullableValidationWithEmptyArray()
+    {
+        $request = $this->createRequest(['name' => []], FoundationTestFormRequestForgetNullableStub::class);
+        $request->validateResolved();
+        $this->assertEquals([], $request->validated());
+    }
+
+    public function testForgetNullableValidationWithNotEmptyString()
+    {
+        $request = $this->createRequest(['name' => 'Taylor'], FoundationTestFormRequestForgetNullableStub::class);
+        $request->validateResolved();
+        $this->assertEquals(['name' => 'Taylor'], $request->validated());
+    }
+
+    public function testForgetNullableValidationWithNotEmptyArray()
+    {
+        $request = $this->createRequest(['name' => ['Taylor']], FoundationTestFormRequestForgetNullableStub::class);
+        $request->validateResolved();
+        $this->assertEquals(['name' => ['Taylor']], $request->validated());
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -514,5 +549,13 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
                 'a' => ['required', 'int', 'min:2'],
             ];
         }
+    }
+}
+
+class FoundationTestFormRequestForgetNullableStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'forget_nullable'];
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5170,6 +5170,15 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateForgetNullableWithEmptyFile()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $uploadedFile = new UploadedFile(__DIR__.'/fixtures/empty.png', '', null, null, true);
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'forget_nullable|file']);
+        $this->assertTrue($v->passes());
+        $this->assertEquals([], $v->validated());
+    }
+
     public function testEmptyRulesSkipped()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION

## Problem
When updating records, we often face issues with nullable fields in request data. The traditional validation approach keeps null values in the validated data, which can unintentionally override existing database values during updates.

For example, when updating a user profile with an optional password field, the current behavior would set the password to `null` if it is not provided instead of preserving the existing password.

## Solution
Introducing the `forget_nullable` validation rule that automatically removes null fields from the validated data array.

A field is "empty" if it meets one of the following criteria:
- The value is `null`.
- The value is an `empty string`.
- The value is an empty array or empty `Countable` object.
- The value is an uploaded file with an `empty path` or `zero size`.

### Usage Example
```php

// Input data
$input = [
    'name' => 'Taylor',
    'password' => null,
];

// Traditional approach that keeps null values ❌
$rules = [
    'name' => 'nullable|string|max:50',
    'password' => 'nullable|string|max:255',
];

$data = $request->validated();

// Traditional validation result
[
    'name' => 'Taylor',
    'password' => null, // This will override existing password!
]

unset($data['password']);

// New approach that removes empty values ✅
$rules = [
    'name' => 'nullable|string|max:50',
    'password' => 'forget_nullable|string|max:255',
];

// New validation result with forget_nullable
[
    'name' => 'Taylor',
    // password field is removed since it was null
]
```

Addatinal example for multiple data type
```php
$rules = [
    'name' => 'forget_nullable|string|max:50',
    'file' => 'forget_nullable|file',
    'tags' => 'forget_nullable|array',
];

$inputs = [
    'name' => '',
    'file' => null,
    'tags' => [],
];
// will return after validated() => []

$inputs = [
    'name' => 'Taylor',
    'file' => null,
    'tags' => [],
];
// will return after validated() => ['name' => 'Taylor']
```

> ⚠️ Note: Please review the name of the rule `forget_nullable` in the correct form in English because I was confused about the correct name. I had suggestions for the name, including `nullify`, `clear_nullify`, `prune_nullable`, `ignore_nullable`, `ignore_empty`, `omit_empty`, `skip_blank` and `unset_if_empty`
 > Please tell me what is correct.





