### PR TITLE
Support relative paths to SQLite databases

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -29,7 +29,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         $path = realpath($config['database']);
-        if (!file_exists($path)) {
+        if (! file_exists($path)) {
             $path = realpath(base_path($config['database']));
         }
 

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -29,6 +29,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         $path = realpath($config['database']);
+
         if (! file_exists($path)) {
             $path = realpath(base_path($config['database']));
         }

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -29,6 +29,9 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         $path = realpath($config['database']);
+        if (!file_exists($path)) {
+            $path = realpath(base_path($config['database']));
+        }
 
         // Here we'll verify that the SQLite database exists before going any further
         // as the developer probably wants to know if the database exists and this


### PR DESCRIPTION
Related: https://github.com/laravel/framework/pull/45626, https://github.com/wintercms/storm/pull/191.

This makes it so that `.env` files can define the path to the sqlite database file as relative to the project root rather than only supporting absolute paths.
