### PR TITLE
[11.x] Add unit-width-narrow formatting option to Number::currency()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -141,9 +141,17 @@ class Number
      * @param  int|null  $precision
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null)
+    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null, bool $unitWidthNarrow = false)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if ($unitWidthNarrow) {
+            return MessageFormatter::formatMessage(
+                $locale ?? static::$locale,
+                sprintf('{0, number, :: currency/%s unit-width-narrow}', ! empty($in) ? $in : static::$currency),
+                [$number],
+            );
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
+use MessageFormatter;
 use NumberFormatter;
 use RuntimeException;
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -155,6 +155,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$0', Number::currency(0, precision: 0));
         $this->assertSame('$5', Number::currency(5.00, precision: 0));
         $this->assertSame('$10', Number::currency(10.252, precision: 0));
+
+        $this->assertSame('123,45 CA$', Number::currency(123.45, 'CAD', 'cs_CZ'));
+        $this->assertSame('123,45 $', Number::currency(123.45, 'CAD', 'cs_CZ', unitWidthNarrow: true));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
See https://www.php.net/manual/en/messageformatter.formatmessage.php#example-2483
