### PR TITLE
[11.x] Optimize `PendingBatch@ensureJobIsBatchable`

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -99,8 +99,6 @@ class PendingBatch
     {
         foreach (Arr::wrap($job) as $job) {
             if ($job instanceof PendingBatch) {
-                $this->ensureJobIsBatchable($job->jobs->all());
-
                 return;
             }
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -48,6 +48,13 @@ class PendingBatch
     public $options = [];
 
     /**
+     * Batches that have been checked to contain the Batchable trait.
+     *
+     * @var array<class-string, bool>
+     */
+    protected static $batchableClasses = [];
+
+    /**
      * Create a new pending batch instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -97,9 +104,13 @@ class PendingBatch
                 return;
             }
 
-            if (! in_array(Batchable::class, class_uses_recursive($job))) {
+            if (! (static::$batchableClasses[$job::class] ?? false) && ! in_array(Batchable::class, class_uses_recursive($job))) {
+                static::$batchableClasses[$job::class] = false;
+
                 throw new RuntimeException(sprintf('Attempted to batch job [%s], but it does not use the Batchable trait.', $job::class));
             }
+
+            static::$batchableClasses[$job::class] = true;
         }
     }
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -48,7 +48,7 @@ class PendingBatch
     public $options = [];
 
     /**
-     * Batches that have been checked to contain the Batchable trait.
+     * Jobs that have been verified to contain the Batchable trait.
      *
      * @var array<class-string, bool>
      */

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -231,4 +231,22 @@ class BusPendingBatchTest extends TestCase
 
         new PendingBatch(new Container, new Collection([$nonBatchableJob]));
     }
+
+    public function test_it_throws_an_exception_if_batched_job_contains_batch_with_nonbatchable_job(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $container = new Container;
+        new PendingBatch(
+            $container,
+            new Collection(
+                [new PendingBatch($container, new Collection([new BatchableJob, new class {}]))]
+            )
+        );
+    }
+}
+
+class BatchableJob
+{
+    use Batchable;
 }


### PR DESCRIPTION
Building on top of https://github.com/laravel/framework/pull/54442

We can memoize the classes which use Batchable. I imagine there are more than a few cases where a developer is chaining/batching hundreds of the same job (just for different users or something), so we don't need to recursively check the traits of the same class repeatedly.

**What about a long-running process like Octane? Don't you need to clear the cache on application tear down?**  No, because if the classes change (and now do use `Batchable` where they previously hadn't) this would require a server restart, which would be clearing them anyways. As an added bonus, we've memoized the failures as well for this use case.