### PR TITLE
[12.x] Fix accessing `Connection` property in `Grammar` classes

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -36,6 +36,7 @@ return [
             'url' => env('DB_URL'),
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
+            'prefix_indexes' => null,
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
             'busy_timeout' => null,
             'journal_mode' => null,

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -248,9 +248,7 @@ class Connection implements ConnectionInterface
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $grammar;
+        return new QueryGrammar($this);
     }
 
     /**
@@ -1626,24 +1624,7 @@ class Connection implements ConnectionInterface
     {
         $this->tablePrefix = $prefix;
 
-        $this->getQueryGrammar()->setTablePrefix($prefix);
-
         return $this;
-    }
-
-    /**
-     * Set the table prefix and return the grammar.
-     *
-     * @template TGrammar of \Illuminate\Database\Grammar
-     *
-     * @param  TGrammar  $grammar
-     * @return TGrammar
-     */
-    public function withTablePrefix(Grammar $grammar)
-    {
-        $grammar->setTablePrefix($this->tablePrefix);
-
-        return $grammar;
     }
 
     /**

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -299,7 +299,7 @@ abstract class Grammar
     /**
      * Set the grammar's table prefix.
      *
-     * @deprecated DB::setTablePrefix()
+     * @deprecated Use DB::setTablePrefix()
      *
      * @param  string  $prefix
      * @return $this

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -19,11 +19,15 @@ abstract class Grammar
     protected $connection;
 
     /**
-     * The grammar table prefix.
+     * Create a new grammar instance.
      *
-     * @var string
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
      */
-    protected $tablePrefix = '';
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Wrap an array of values.
@@ -49,14 +53,14 @@ abstract class Grammar
             return $this->getValue($table);
         }
 
+        $prefix ??= $this->connection->getTablePrefix();
+
         // If the table being wrapped has an alias we'll need to separate the pieces
         // so we can prefix the table and then wrap each of the segments on their
         // own and then join these both back together using the "as" connector.
         if (stripos($table, ' as ') !== false) {
-            return $this->wrapAliasedTable($table);
+            return $this->wrapAliasedTable($table, $prefix);
         }
-
-        $prefix ??= $this->tablePrefix;
 
         // If the table being wrapped has a custom schema name specified, we need to
         // prefix the last segment as the table name then wrap each segment alone
@@ -118,13 +122,16 @@ abstract class Grammar
      * Wrap a table that has an alias.
      *
      * @param  string  $value
+     * @param  string|null  $prefix
      * @return string
      */
-    protected function wrapAliasedTable($value)
+    protected function wrapAliasedTable($value, $prefix = null)
     {
         $segments = preg_split('/\s+as\s+/i', $value);
 
-        return $this->wrapTable($segments[0]).' as '.$this->wrapValue($this->tablePrefix.$segments[1]);
+        $prefix ??= $this->connection->getTablePrefix();
+
+        return $this->wrapTable($segments[0], $prefix).' as '.$this->wrapValue($prefix.$segments[1]);
     }
 
     /**
@@ -238,10 +245,6 @@ abstract class Grammar
      */
     public function escape($value, $binary = false)
     {
-        if (is_null($this->connection)) {
-            throw new RuntimeException("The database driver's grammar implementation does not support escaping values.");
-        }
-
         return $this->connection->escape($value, $binary);
     }
 
@@ -284,35 +287,26 @@ abstract class Grammar
     /**
      * Get the grammar's table prefix.
      *
+     * @deprected Use DB::getTablePrefix()
+     *
      * @return string
      */
     public function getTablePrefix()
     {
-        return $this->tablePrefix;
+        return $this->connection->getTablePrefix();
     }
 
     /**
      * Set the grammar's table prefix.
+     *
+     * @deprected DB::setTablePrefix()
      *
      * @param  string  $prefix
      * @return $this
      */
     public function setTablePrefix($prefix)
     {
-        $this->tablePrefix = $prefix;
-
-        return $this;
-    }
-
-    /**
-     * Set the grammar's database connection.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return $this
-     */
-    public function setConnection($connection)
-    {
-        $this->connection = $connection;
+        $this->connection->setTablePrefix($prefix);
 
         return $this;
     }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -287,7 +287,7 @@ abstract class Grammar
     /**
      * Get the grammar's table prefix.
      *
-     * @deprected Use DB::getTablePrefix()
+     * @deprecated Use DB::getTablePrefix()
      *
      * @return string
      */
@@ -299,7 +299,7 @@ abstract class Grammar
     /**
      * Set the grammar's table prefix.
      *
-     * @deprected DB::setTablePrefix()
+     * @deprecated DB::setTablePrefix()
      *
      * @param  string  $prefix
      * @return $this

--- a/src/Illuminate/Database/MariaDbConnection.php
+++ b/src/Illuminate/Database/MariaDbConnection.php
@@ -47,9 +47,7 @@ class MariaDbConnection extends MySqlConnection
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new QueryGrammar($this);
     }
 
     /**
@@ -73,9 +71,7 @@ class MariaDbConnection extends MySqlConnection
      */
     protected function getDefaultSchemaGrammar()
     {
-        ($grammar = new SchemaGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new SchemaGrammar($this);
     }
 
     /**

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -121,9 +121,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new QueryGrammar($this);
     }
 
     /**
@@ -147,9 +145,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        ($grammar = new SchemaGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new SchemaGrammar($this);
     }
 
     /**

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -62,9 +62,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new QueryGrammar($this);
     }
 
     /**
@@ -88,9 +86,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        ($grammar = new SchemaGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new SchemaGrammar($this);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -439,12 +439,12 @@ class SQLiteGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($query->from);
+        [$schema, $table] = $query->getConnection()->getSchemaBuilder()->parseSchemaAndTable($query->from);
 
         $schema = $schema ? $this->wrapValue($schema).'.' : '';
 
         return [
-            'delete from '.$schema.'sqlite_sequence where name = ?' => [$this->getTablePrefix().$table],
+            'delete from '.$schema.'sqlite_sequence where name = ?' => [$query->getConnection()->getTablePrefix().$table],
             'delete from '.$this->wrapTable($query->from) => [],
         ];
     }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -162,9 +162,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new QueryGrammar($this);
     }
 
     /**
@@ -188,9 +186,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        ($grammar = new SchemaGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new SchemaGrammar($this);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1819,7 +1819,7 @@ class Blueprint
     /**
      * Get the table prefix.
      *
-     * @deprected Use DB::getTablePrefix()
+     * @deprecated Use DB::getTablePrefix()
      *
      * @return string
      */

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -35,13 +35,6 @@ class Blueprint
     protected $table;
 
     /**
-     * The prefix of the table.
-     *
-     * @var string
-     */
-    protected $prefix;
-
-    /**
      * The columns that should be added to the table.
      *
      * @var \Illuminate\Database\Schema\ColumnDefinition[]
@@ -103,15 +96,13 @@ class Blueprint
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $table
      * @param  \Closure|null  $callback
-     * @param  string  $prefix
      * @return void
      */
-    public function __construct(Connection $connection, $table, ?Closure $callback = null, $prefix = '')
+    public function __construct(Connection $connection, $table, ?Closure $callback = null)
     {
         $this->connection = $connection;
         $this->grammar = $connection->getSchemaGrammar();
         $this->table = $table;
-        $this->prefix = $prefix;
 
         if (! is_null($callback)) {
             $callback($this);
@@ -158,7 +149,7 @@ class Blueprint
                     $this->state->update($command);
                 }
 
-                if (! is_null($sql = $this->grammar->$method($this, $command, $this->connection))) {
+                if (! is_null($sql = $this->grammar->$method($this, $command))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }
@@ -290,7 +281,7 @@ class Blueprint
             return;
         }
 
-        $alterCommands = $this->grammar->getAlterCommands($this->connection);
+        $alterCommands = $this->grammar->getAlterCommands();
 
         [$commands, $lastCommandWasAlter, $hasAlterCommand] = [
             [], false, false,
@@ -313,7 +304,7 @@ class Blueprint
         }
 
         if ($hasAlterCommand) {
-            $this->state = new BlueprintState($this, $this->connection, $this->grammar);
+            $this->state = new BlueprintState($this, $this->connection);
         }
 
         $this->commands = $commands;
@@ -1703,9 +1694,13 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $table = str_contains($this->table, '.')
-            ? substr_replace($this->table, '.'.$this->prefix, strrpos($this->table, '.'), 1)
-            : $this->prefix.$this->table;
+        $table = $this->table;
+
+        if ($this->connection->getConfig('prefix_indexes')) {
+            $table = str_contains($this->table, '.')
+                ? substr_replace($this->table, '.'.$this->connection->getTablePrefix(), strrpos($this->table, '.'), 1)
+                : $this->connection->getTablePrefix().$this->table;
+        }
 
         $index = strtolower($table.'_'.implode('_', $columns).'_'.$type);
 
@@ -1824,11 +1819,13 @@ class Blueprint
     /**
      * Get the table prefix.
      *
+     * @deprected Use DB::getTablePrefix()
+     *
      * @return string
      */
     public function getPrefix()
     {
-        return $this->prefix;
+        return $this->connection->getTablePrefix();
     }
 
     /**
@@ -1854,7 +1851,6 @@ class Blueprint
     /**
      * Determine if the blueprint has state.
      *
-     * @param  mixed  $name
      * @return bool
      */
     private function hasState(): bool

--- a/src/Illuminate/Database/Schema/BlueprintState.php
+++ b/src/Illuminate/Database/Schema/BlueprintState.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
@@ -24,13 +23,6 @@ class BlueprintState
      * @var \Illuminate\Database\Connection
      */
     protected $connection;
-
-    /**
-     * The grammar instance.
-     *
-     * @var \Illuminate\Database\Schema\Grammars\Grammar
-     */
-    protected $grammar;
 
     /**
      * The columns.
@@ -65,14 +57,12 @@ class BlueprintState
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    public function __construct(Blueprint $blueprint, Connection $connection, Grammar $grammar)
+    public function __construct(Blueprint $blueprint, Connection $connection)
     {
         $this->blueprint = $blueprint;
         $this->connection = $connection;
-        $this->grammar = $grammar;
 
         $schema = $connection->getSchemaBuilder();
         $table = $blueprint->getTable();

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -126,12 +126,12 @@ class Builder
      *
      * @param  string  $name
      * @return bool
-     *
-     * @throws \LogicException
      */
     public function createDatabase($name)
     {
-        throw new LogicException('This database driver does not support creating databases.');
+        return $this->connection->statement(
+            $this->grammar->compileCreateDatabase($name)
+        );
     }
 
     /**
@@ -139,12 +139,12 @@ class Builder
      *
      * @param  string  $name
      * @return bool
-     *
-     * @throws \LogicException
      */
     public function dropDatabaseIfExists($name)
     {
-        throw new LogicException('This database driver does not support dropping databases.');
+        return $this->connection->statement(
+            $this->grammar->compileDropDatabaseIfExists($name)
+        );
     }
 
     /**
@@ -630,13 +630,11 @@ class Builder
     {
         $connection = $this->connection;
 
-        $prefix = $connection->getConfig('prefix_indexes') ? $connection->getConfig('prefix') : '';
-
         if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $connection, $table, $callback, $prefix);
+            return call_user_func($this->resolver, $connection, $table, $callback);
         }
 
-        return Container::getInstance()->make(Blueprint::class, compact('connection', 'table', 'callback', 'prefix'));
+        return Container::getInstance()->make(Blueprint::class, compact('connection', 'table', 'callback'));
     }
 
     /**
@@ -696,19 +694,6 @@ class Builder
     public function getConnection()
     {
         return $this->connection;
-    }
-
-    /**
-     * Set the database connection instance.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return $this
-     */
-    public function setConnection(Connection $connection)
-    {
-        $this->connection = $connection;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -5,11 +5,9 @@ namespace Illuminate\Database\Schema\Grammars;
 use BackedEnum;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Concerns\CompilesJsonPaths;
-use Illuminate\Database\Connection;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
-use LogicException;
 use RuntimeException;
 
 abstract class Grammar extends BaseGrammar
@@ -41,27 +39,26 @@ abstract class Grammar extends BaseGrammar
      * Compile a create database command.
      *
      * @param  string  $name
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return void
-     *
-     * @throws \LogicException
+     * @return string
      */
-    public function compileCreateDatabase($name, $connection)
+    public function compileCreateDatabase($name)
     {
-        throw new LogicException('This database driver does not support creating databases.');
+        return sprintf('create database %s',
+            $this->wrapValue($name),
+        );
     }
 
     /**
      * Compile a drop database if exists command.
      *
      * @param  string  $name
-     * @return void
-     *
-     * @throws \LogicException
+     * @return string
      */
     public function compileDropDatabaseIfExists($name)
     {
-        throw new LogicException('This database driver does not support dropping databases.');
+        return sprintf('drop database if exists %s',
+            $this->wrapValue($name)
+        );
     }
 
     /**
@@ -172,10 +169,9 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection  $connection
      * @return array|string
      */
-    public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileRenameColumn(Blueprint $blueprint, Fluent $command)
     {
         return sprintf('alter table %s rename column %s to %s',
             $this->wrapTable($blueprint),
@@ -189,14 +185,13 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection  $connection
      * @return array|string
      *
      * @throws \RuntimeException
      */
-    public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileChange(Blueprint $blueprint, Fluent $command)
     {
-        throw new LogicException('This database driver does not support modifying columns.');
+        throw new RuntimeException('This database driver does not support modifying columns.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 
@@ -13,16 +12,15 @@ class MariaDbGrammar extends MySqlGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection  $connection
      * @return array|string
      */
-    public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileRenameColumn(Blueprint $blueprint, Fluent $command)
     {
-        if (version_compare($connection->getServerVersion(), '10.5.2', '<')) {
-            return $this->compileLegacyRenameColumn($blueprint, $command, $connection);
+        if (version_compare($this->connection->getServerVersion(), '10.5.2', '<')) {
+            return $this->compileLegacyRenameColumn($blueprint, $command);
         }
 
-        return parent::compileRenameColumn($blueprint, $command, $connection);
+        return parent::compileRenameColumn($blueprint, $command);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
@@ -36,35 +35,6 @@ class SqlServerGrammar extends Grammar
      * @var string[]
      */
     protected $fluentCommands = ['Default'];
-
-    /**
-     * Compile a create database command.
-     *
-     * @param  string  $name
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return string
-     */
-    public function compileCreateDatabase($name, $connection)
-    {
-        return sprintf(
-            'create database %s',
-            $this->wrapValue($name),
-        );
-    }
-
-    /**
-     * Compile a drop database if exists command.
-     *
-     * @param  string  $name
-     * @return string
-     */
-    public function compileDropDatabaseIfExists($name)
-    {
-        return sprintf(
-            'drop database if exists %s',
-            $this->wrapValue($name)
-        );
-    }
 
     /**
      * Compile the query to determine the schemas.
@@ -261,10 +231,9 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection  $connection
      * @return array|string
      */
-    public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileRenameColumn(Blueprint $blueprint, Fluent $command)
     {
         return sprintf("sp_rename %s, %s, N'COLUMN'",
             $this->quoteString($this->wrapTable($blueprint).'.'.$this->wrap($command->from)),
@@ -277,12 +246,9 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection  $connection
      * @return array|string
-     *
-     * @throws \RuntimeException
      */
-    public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileChange(Blueprint $blueprint, Fluent $command)
     {
         return [
             $this->compileDropDefaultConstraint($blueprint, $command),

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -5,32 +5,6 @@ namespace Illuminate\Database\Schema;
 class MySqlBuilder extends Builder
 {
     /**
-     * Create a database in the schema.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function createDatabase($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileCreateDatabase($name, $this->connection)
-        );
-    }
-
-    /**
-     * Drop a database from the schema if the database exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function dropDatabaseIfExists($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileDropDatabaseIfExists($name)
-        );
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -9,32 +9,6 @@ class PostgresBuilder extends Builder
     use ParsesSearchPath;
 
     /**
-     * Create a database in the schema.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function createDatabase($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileCreateDatabase($name, $this->connection)
-        );
-    }
-
-    /**
-     * Drop a database from the schema if the database exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function dropDatabaseIfExists($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileDropDatabaseIfExists($name)
-        );
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -27,9 +27,7 @@ class SQLiteBuilder extends Builder
      */
     public function dropDatabaseIfExists($name)
     {
-        return File::exists($name)
-            ? File::delete($name)
-            : true;
+        return ! File::exists($name) || File::delete($name);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -7,32 +7,6 @@ use Illuminate\Support\Arr;
 class SqlServerBuilder extends Builder
 {
     /**
-     * Create a database in the schema.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function createDatabase($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileCreateDatabase($name, $this->connection)
-        );
-    }
-
-    /**
-     * Drop a database from the schema if the database exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function dropDatabaseIfExists($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileDropDatabaseIfExists($name)
-        );
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -93,9 +93,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new QueryGrammar($this);
     }
 
     /**
@@ -119,9 +117,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        ($grammar = new SchemaGrammar)->setConnection($this);
-
-        return $this->withTablePrefix($grammar);
+        return new SchemaGrammar($this);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -104,7 +104,6 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static \Illuminate\Database\Connection setReadWriteType(string|null $readWriteType)
  * @method static string getTablePrefix()
  * @method static \Illuminate\Database\Connection setTablePrefix(string $prefix)
- * @method static \Illuminate\Database\Grammar withTablePrefix(\Illuminate\Database\Grammar $grammar)
  * @method static mixed withoutTablePrefix(\Closure $callback)
  * @method static string getServerVersion()
  * @method static void resolverFor(string $driver, \Closure $callback)

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -17,21 +17,17 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new class extends Grammar {};
+        $connection = m::mock(Connection::class);
+        $grammar = new class($connection) extends Grammar {};
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('This database driver does not support creating databases.');
-
-        $grammar->compileCreateDatabase('foo', m::mock(Connection::class));
+        $this->assertSame('create database "foo"', $grammar->compileCreateDatabase('foo'));
     }
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new class extends Grammar {};
+        $connection = m::mock(Connection::class);
+        $grammar = new class($connection) extends Grammar {};
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('This database driver does not support dropping databases.');
-
-        $grammar->compileDropDatabaseIfExists('foo');
+        $this->assertSame('drop database if exists "foo"', $grammar->compileDropDatabaseIfExists('foo'));
     }
 }

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Grammars\Grammar;
-use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Illuminate\Tests\Database;
 
 use Exception;
-use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -450,9 +450,11 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
         $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
-        $grammar = new $grammarClass;
         $processor = new $processorClass;
-        $connection = Mockery::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $connection = Mockery::mock(Connection::class, ['getPostProcessor' => $processor]);
+        $grammar = new $grammarClass($connection);
+        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Exception;
-use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder;
@@ -473,9 +473,11 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
         $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
-        $grammar = new $grammarClass;
         $processor = new $processorClass;
-        $connection = Mockery::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $connection = Mockery::mock(Connection::class, ['getPostProcessor' => $processor]);
+        $grammar = new $grammarClass($connection);
+        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new Builder($connection, $grammar, $processor);
         });

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Exception;
-use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -320,9 +320,11 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
         $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
-        $grammar = new $grammarClass;
         $processor = new $processorClass;
-        $connection = Mockery::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $connection = Mockery::mock(Connection::class, ['getPostProcessor' => $processor]);
+        $grammar = new $grammarClass($connection);
+        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new Builder($connection, $grammar, $processor);
         });

--- a/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Illuminate\Tests\Database;
 
 use Exception;
-use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -372,9 +372,11 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
         $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
-        $grammar = new $grammarClass;
         $processor = new $processorClass;
-        $connection = Mockery::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $connection = Mockery::mock(Connection::class, ['getPostProcessor' => $processor]);
+        $grammar = new $grammarClass($connection);
+        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new Builder($connection, $grammar, $processor);
         });

--- a/tests/Database/DatabaseMariaDbBuilderTest.php
+++ b/tests/Database/DatabaseMariaDbBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database;
+namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Grammars\MariaDbGrammar;
@@ -17,9 +17,9 @@ class DatabaseMariaDbBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new MariaDbGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new MariaDbGrammar($connection);
+
         $connection->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8mb4');
         $connection->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8mb4_unicode_ci');
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
@@ -33,9 +33,9 @@ class DatabaseMariaDbBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new MariaDbGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new MariaDbGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'drop database if exists `my_database_a`'

--- a/tests/Database/DatabaseMariaDbQueryGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbQueryGrammarTest.php
@@ -18,8 +18,7 @@ class DatabaseMariaDbQueryGrammarTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
-        $grammar = new MariaDbGrammar;
-        $grammar->setConnection($connection);
+        $grammar = new MariaDbGrammar($connection);
 
         $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = ?',

--- a/tests/Database/DatabaseMySqlBuilderTest.php
+++ b/tests/Database/DatabaseMySqlBuilderTest.php
@@ -17,9 +17,9 @@ class DatabaseMySqlBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new MySqlGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
+
         $connection->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8mb4');
         $connection->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8mb4_unicode_ci');
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
@@ -33,9 +33,9 @@ class DatabaseMySqlBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new MySqlGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'drop database if exists `my_database_a`'

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -18,8 +18,7 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
-        $grammar = new MySqlGrammar;
-        $grammar->setConnection($connection);
+        $grammar = new MySqlGrammar($connection);
 
         $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = ?',

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -165,10 +165,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testBasicCreateTableWithPrefix()
     {
-        $grammar = $this->getGrammar();
-        $grammar->setTablePrefix('prefix_');
-
-        $conn = $this->getConnection($grammar);
+        $conn = $this->getConnection(prefix: 'prefix_');
         $conn->shouldReceive('getConfig')->andReturn(null);
 
         $blueprint = new Blueprint($conn, 'users');
@@ -1340,7 +1337,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8mb4_foo');
         $connection->shouldReceive('getConfig')->once()->once()->with('collation')->andReturn('utf8mb4_unicode_ci_foo');
 
-        $statement = $this->getGrammar()->compileCreateDatabase('my_database_a', $connection);
+        $statement = $this->getGrammar($connection)->compileCreateDatabase('my_database_a');
 
         $this->assertSame(
             'create database `my_database_a` default character set `utf8mb4_foo` default collate `utf8mb4_unicode_ci_foo`',
@@ -1351,7 +1348,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8mb4_bar');
         $connection->shouldReceive('getConfig')->once()->once()->with('collation')->andReturn('utf8mb4_unicode_ci_bar');
 
-        $statement = $this->getGrammar()->compileCreateDatabase('my_database_b', $connection);
+        $statement = $this->getGrammar($connection)->compileCreateDatabase('my_database_b');
 
         $this->assertSame(
             'create database `my_database_b` default character set `utf8mb4_bar` default collate `utf8mb4_unicode_ci_bar`',
@@ -1508,19 +1505,26 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     protected function getConnection(
         ?MySqlGrammar $grammar = null,
         ?MySqlBuilder $builder = null,
+        string $prefix = ''
     ) {
-        $grammar ??= $this->getGrammar();
+        $connection = m::mock(Connection::class)
+            ->shouldReceive('getTablePrefix')->andReturn($prefix)
+            ->shouldReceive('getConfig')->with('prefix_indexes')->andReturn(null)
+            ->shouldReceive('isMaria')->andReturn(false)
+            ->getMock();
+
+        $grammar ??= $this->getGrammar($connection);
         $builder ??= $this->getBuilder();
 
-        return m::mock(Connection::class)
+        return $connection
             ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
             ->shouldReceive('getSchemaBuilder')->andReturn($builder)
             ->getMock();
     }
 
-    public function getGrammar()
+    public function getGrammar(?Connection $connection = null)
     {
-        return new MySqlGrammar;
+        return new MySqlGrammar($connection ?? $this->getConnection());
     }
 
     public function getBuilder()

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -18,9 +18,9 @@ class DatabasePostgresBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new PostgresGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new PostgresGrammar($connection);
+
         $connection->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
@@ -33,9 +33,9 @@ class DatabasePostgresBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new PostgresGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new PostgresGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'drop database if exists "my_database_a"'

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -19,8 +19,7 @@ class DatabasePostgresQueryGrammarTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
-        $grammar = new PostgresGrammar;
-        $grammar->setConnection($connection);
+        $grammar = new PostgresGrammar($connection);
 
         $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'{}\' ?? \'Hello\\\'\\\'World?\' AND "email" = ?',
@@ -36,8 +35,7 @@ class DatabasePostgresQueryGrammarTest extends TestCase
         PostgresGrammar::customOperators(['@@>', 1]);
 
         $connection = m::mock(Connection::class);
-        $grammar = new PostgresGrammar;
-        $grammar->setConnection($connection);
+        $grammar = new PostgresGrammar($connection);
 
         $operators = $grammar->getOperators();
 
@@ -51,7 +49,10 @@ class DatabasePostgresQueryGrammarTest extends TestCase
 
     public function testCompileTruncate()
     {
-        $postgres = new PostgresGrammar;
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+
+        $postgres = new PostgresGrammar($connection);
         $builder = m::mock(Builder::class);
         $builder->from = 'users';
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1115,7 +1115,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $connection = $this->getConnection();
         $connection->shouldReceive('getServerVersion')->once()->andReturn('12.0.0');
 
-        $statement =  $connection->getSchemaGrammar()->compileColumns('public', 'table');
+        $statement = $connection->getSchemaGrammar()->compileColumns('public', 'table');
 
         $this->assertStringContainsString("where c.relname = 'table' and n.nspname = 'public'", $statement);
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -57,7 +57,10 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testCreateTableWithAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $connection = $this->getConnection();
+        $connection->getSchemaBuilder()->shouldReceive('parseSchemaAndTable')->andReturn([null, 'users']);
+
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->create();
         $blueprint->increments('id')->startingValue(1000);
         $blueprint->string('email');
@@ -71,7 +74,10 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddColumnsWithMultipleAutoIncrementStartingValue()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('parseSchemaAndTable')->andReturn([null, 'users']);
+
+        $blueprint = new Blueprint($this->getConnection(builder: $builder), 'users');
         $blueprint->id()->from(100);
         $blueprint->increments('code')->from(200);
         $blueprint->string('name')->from(300);
@@ -158,7 +164,10 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $connection = $this->getConnection();
+        $connection->getSchemaBuilder()->shouldReceive('parseSchemaAndTable')->andReturn([null, 'users']);
+
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->dropPrimary();
         $statements = $blueprint->toSql();
 
@@ -1046,7 +1055,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     {
         $connection = $this->getConnection();
         $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8_foo');
-        $statement = $this->getGrammar()->compileCreateDatabase('my_database_a', $connection);
+        $statement = $this->getGrammar($connection)->compileCreateDatabase('my_database_a');
 
         $this->assertSame(
             'create database "my_database_a" encoding "utf8_foo"',
@@ -1055,7 +1064,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $connection = $this->getConnection();
         $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8_bar');
-        $statement = $this->getGrammar()->compileCreateDatabase('my_database_b', $connection);
+        $statement = $this->getGrammar($connection)->compileCreateDatabase('my_database_b');
 
         $this->assertSame(
             'create database "my_database_b" encoding "utf8_bar"',
@@ -1104,12 +1113,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testCompileColumns()
     {
         $connection = $this->getConnection();
-        $grammar = $this->getGrammar();
-
         $connection->shouldReceive('getServerVersion')->once()->andReturn('12.0.0');
-        $grammar->setConnection($connection);
 
-        $statement = $grammar->compileColumns('public', 'table');
+        $statement =  $connection->getSchemaGrammar()->compileColumns('public', 'table');
 
         $this->assertStringContainsString("where c.relname = 'table' and n.nspname = 'public'", $statement);
     }
@@ -1118,18 +1124,23 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ?PostgresGrammar $grammar = null,
         ?PostgresBuilder $builder = null
     ) {
-        $grammar ??= $this->getGrammar();
+        $connection = m::mock(Connection::class)
+            ->shouldReceive('getTablePrefix')->andReturn('')
+            ->shouldReceive('getConfig')->with('prefix_indexes')->andReturn(null)
+            ->getMock();
+
+        $grammar ??= $this->getGrammar($connection);
         $builder ??= $this->getBuilder();
 
-        return m::mock(Connection::class)
+        return $connection
             ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
             ->shouldReceive('getSchemaBuilder')->andReturn($builder)
             ->getMock();
     }
 
-    public function getGrammar()
+    public function getGrammar(?Connection $connection = null)
     {
-        return new PostgresGrammar;
+        return new PostgresGrammar($connection ?? $this->getConnection());
     }
 
     public function getBuilder()

--- a/tests/Database/DatabaseQueryGrammarTest.php
+++ b/tests/Database/DatabaseQueryGrammarTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar;
@@ -19,7 +20,7 @@ class DatabaseQueryGrammarTest extends TestCase
     public function testWhereRawReturnsStringWhenExpressionPassed()
     {
         $builder = m::mock(Builder::class);
-        $grammar = new Grammar;
+        $grammar = new Grammar(m::mock(Connection::class));
         $reflection = new ReflectionClass($grammar);
         $method = $reflection->getMethod('whereRaw');
         $expressionArray = ['sql' => new Expression('select * from "users"')];
@@ -32,7 +33,7 @@ class DatabaseQueryGrammarTest extends TestCase
     public function testWhereRawReturnsStringWhenStringPassed()
     {
         $builder = m::mock(Builder::class);
-        $grammar = new Grammar;
+        $grammar = new Grammar(m::mock(Connection::class));
         $reflection = new ReflectionClass($grammar);
         $method = $reflection->getMethod('whereRaw');
         $stringArray = ['sql' => 'select * from "users"'];

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -18,8 +18,7 @@ class DatabaseSQLiteQueryGrammarTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
-        $grammar = new SQLiteGrammar;
-        $grammar->setConnection($connection);
+        $grammar = new SQLiteGrammar($connection);
 
         $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'Hello\'\'World?\' IS NOT NULL AND "email" = ?',

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -1094,7 +1094,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function getGrammar(?Connection $connection = null)
     {
-        return (new SQLiteGrammar())->setConnection($connection ?? $this->getConnection());
+        return new SQLiteGrammar($connection ?? $this->getConnection());
     }
 
     public function getBuilder()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -6,17 +6,7 @@ use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
-use Illuminate\Database\Schema\Grammars\Grammar;
-use Illuminate\Database\Schema\Grammars\MariaDbGrammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
-use Illuminate\Database\Schema\Grammars\PostgresGrammar;
-use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
-use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
-use Illuminate\Database\Schema\MariaDbBuilder;
-use Illuminate\Database\Schema\MySqlBuilder;
-use Illuminate\Database\Schema\PostgresBuilder;
-use Illuminate\Database\Schema\SQLiteBuilder;
-use Illuminate\Database\Schema\SqlServerBuilder;
 use Illuminate\Tests\Database\Fixtures\Models\User;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -120,10 +110,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `users` add `created` datetime not null default CURRENT_TIMESTAMP'], $getSql(new MySqlGrammar));
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql(new PostgresGrammar));
-        $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql(new SQLiteGrammar));
-        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql(new SqlServerGrammar));
+        $this->assertEquals(['alter table `users` add `created` datetime not null default CURRENT_TIMESTAMP'], $getSql('MySql'));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
+        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
     }
 
     public function testDefaultCurrentTimestamp()
@@ -134,10 +124,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `users` add `created` timestamp not null default CURRENT_TIMESTAMP'], $getSql(new MySqlGrammar));
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql(new PostgresGrammar));
-        $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql(new SQLiteGrammar));
-        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql(new SqlServerGrammar));
+        $this->assertEquals(['alter table `users` add `created` timestamp not null default CURRENT_TIMESTAMP'], $getSql('MySql'));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
+        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
     }
 
     public function testRemoveColumn()
@@ -150,7 +140,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $getSql(new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $getSql('MySql'));
     }
 
     public function testRenameColumn()
@@ -165,15 +155,15 @@ class DatabaseSchemaBlueprintTest extends TestCase
             }))->toSql();
         };
 
-        $this->assertEquals(['alter table `users` rename column `foo` to `bar`'], $getSql(new MySqlGrammar));
-        $this->assertEquals(['alter table "users" rename column "foo" to "bar"'], $getSql(new PostgresGrammar));
-        $this->assertEquals(['alter table "users" rename column "foo" to "bar"'], $getSql(new SQLiteGrammar));
-        $this->assertEquals(['sp_rename N\'"users"."foo"\', "bar", N\'COLUMN\''], $getSql(new SqlServerGrammar));
+        $this->assertEquals(['alter table `users` rename column `foo` to `bar`'], $getSql('MySql'));
+        $this->assertEquals(['alter table "users" rename column "foo" to "bar"'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "users" rename column "foo" to "bar"'], $getSql('SQLite'));
+        $this->assertEquals(['sp_rename N\'"users"."foo"\', "bar", N\'COLUMN\''], $getSql('SqlServer'));
     }
 
     public function testNativeRenameColumnOnMysql57()
     {
-        $connection = $this->getConnection(new MySqlGrammar);
+        $connection = $this->getConnection('MySql');
         $connection->shouldReceive('isMaria')->andReturn(false);
         $connection->shouldReceive('getServerVersion')->andReturn('5.7');
         $connection->getSchemaBuilder()->shouldReceive('getColumns')->andReturn([
@@ -197,7 +187,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testNativeRenameColumnOnLegacyMariaDB()
     {
-        $connection = $this->getConnection(new MariaDbGrammar);
+        $connection = $this->getConnection('MariaDb');
         $connection->shouldReceive('isMaria')->andReturn(true);
         $connection->shouldReceive('getServerVersion')->andReturn('10.1.35');
         $connection->getSchemaBuilder()->shouldReceive('getColumns')->andReturn([
@@ -230,15 +220,15 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `users` drop `foo`'], $getSql(new MySqlGrammar));
-        $this->assertEquals(['alter table "users" drop column "foo"'], $getSql(new PostgresGrammar));
-        $this->assertEquals(['alter table "users" drop column "foo"'], $getSql(new SQLiteGrammar));
-        $this->assertStringContainsString('alter table "users" drop column "foo"', $getSql(new SqlServerGrammar)[0]);
+        $this->assertEquals(['alter table `users` drop `foo`'], $getSql('MySql'));
+        $this->assertEquals(['alter table "users" drop column "foo"'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "users" drop column "foo"'], $getSql('SQLite'));
+        $this->assertStringContainsString('alter table "users" drop column "foo"', $getSql('SqlServer')[0]);
     }
 
     public function testNativeColumnModifyingOnMySql()
     {
-        $blueprint = $this->getBlueprint(new MySqlGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('MySql', 'users', function ($table) {
             $table->double('amount')->nullable()->invisible()->after('name')->change();
             $table->timestamp('added_at', 4)->nullable(false)->useCurrent()->useCurrentOnUpdate()->change();
             $table->enum('difficulty', ['easy', 'hard'])->default('easy')->charset('utf8mb4')->collation('unicode')->change();
@@ -268,7 +258,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             return 'bar';
         });
 
-        $blueprint = $this->getBlueprint(new MySqlGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('MySql', 'users', function ($table) {
             $table->foo();
         });
 
@@ -287,7 +277,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `comments` add `commentable_type` varchar(255) not null',
             'alter table `comments` add `commentable_id` bigint unsigned not null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDefaultUsingNullableIdMorph()
@@ -302,7 +292,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `comments` add `commentable_type` varchar(255) null',
             'alter table `comments` add `commentable_id` bigint unsigned null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDefaultUsingUuidMorph()
@@ -319,7 +309,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `comments` add `commentable_type` varchar(255) not null',
             'alter table `comments` add `commentable_id` char(36) not null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDefaultUsingNullableUuidMorph()
@@ -336,7 +326,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `comments` add `commentable_type` varchar(255) null',
             'alter table `comments` add `commentable_id` char(36) null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDefaultUsingUlidMorph()
@@ -353,7 +343,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `comments` add `commentable_type` varchar(255) not null',
             'alter table `comments` add `commentable_id` char(26) not null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDefaultUsingNullableUlidMorph()
@@ -370,7 +360,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `comments` add `commentable_type` varchar(255) null',
             'alter table `comments` add `commentable_id` char(26) null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testGenerateRelationshipColumnWithIncrementalModel()
@@ -383,7 +373,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `user_id` bigint unsigned not null',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testGenerateRelationshipColumnWithNonIncrementalModel()
@@ -396,7 +386,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `model_using_non_incremented_int_id` bigint unsigned not null',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testGenerateRelationshipColumnWithUuidModel()
@@ -409,7 +399,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `model_using_uuid_id` char(36) not null',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testGenerateRelationshipColumnWithUlidModel()
@@ -422,11 +412,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "posts" add column "model_using_ulid_id" char(26) not null',
-        ], $getSql(new PostgresGrammar));
+        ], $getSql('Postgres'));
 
         $this->assertEquals([
             'alter table `posts` add `model_using_ulid_id` char(26) not null',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testGenerateRelationshipConstrainedColumn()
@@ -440,7 +430,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` add `user_id` bigint unsigned not null',
             'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testGenerateRelationshipForModelWithNonStandardPrimaryKeyName()
@@ -454,7 +444,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` add `user_internal_id` bigint unsigned not null',
             'alter table `posts` add constraint `posts_user_internal_id_foreign` foreign key (`user_internal_id`) references `users` (`internal_id`)',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDropRelationshipColumnWithIncrementalModel()
@@ -467,7 +457,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` drop `user_id`',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDropRelationshipColumnWithUuidModel()
@@ -480,7 +470,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` drop `model_using_uuid_id`',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDropConstrainedRelationshipColumnWithIncrementalModel()
@@ -494,7 +484,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` drop foreign key `posts_user_id_foreign`',
             'alter table `posts` drop `user_id`',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testDropConstrainedRelationshipColumnWithUuidModel()
@@ -508,7 +498,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `posts` drop foreign key `posts_model_using_uuid_id_foreign`',
             'alter table `posts` drop `model_using_uuid_id`',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
     }
 
     public function testTinyTextColumn()
@@ -519,10 +509,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `posts` add `note` tinytext not null'], $getSql(new MySqlGrammar));
-        $this->assertEquals(['alter table "posts" add column "note" text not null'], $getSql(new SQLiteGrammar));
-        $this->assertEquals(['alter table "posts" add column "note" varchar(255) not null'], $getSql(new PostgresGrammar));
-        $this->assertEquals(['alter table "posts" add "note" nvarchar(255) not null'], $getSql(new SqlServerGrammar));
+        $this->assertEquals(['alter table `posts` add `note` tinytext not null'], $getSql('MySql'));
+        $this->assertEquals(['alter table "posts" add column "note" text not null'], $getSql('SQLite'));
+        $this->assertEquals(['alter table "posts" add column "note" varchar(255) not null'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "posts" add "note" nvarchar(255) not null'], $getSql('SqlServer'));
     }
 
     public function testTinyTextNullableColumn()
@@ -533,10 +523,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `posts` add `note` tinytext null'], $getSql(new MySqlGrammar));
-        $this->assertEquals(['alter table "posts" add column "note" text'], $getSql(new SQLiteGrammar));
-        $this->assertEquals(['alter table "posts" add column "note" varchar(255) null'], $getSql(new PostgresGrammar));
-        $this->assertEquals(['alter table "posts" add "note" nvarchar(255) null'], $getSql(new SqlServerGrammar));
+        $this->assertEquals(['alter table `posts` add `note` tinytext null'], $getSql('MySql'));
+        $this->assertEquals(['alter table "posts" add column "note" text'], $getSql('SQLite'));
+        $this->assertEquals(['alter table "posts" add column "note" varchar(255) null'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "posts" add "note" nvarchar(255) null'], $getSql('SqlServer'));
     }
 
     public function testRawColumn()
@@ -549,19 +539,19 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `legacy_boolean` INT(1) null',
-        ], $getSql(new MySqlGrammar));
+        ], $getSql('MySql'));
 
         $this->assertEquals([
             'alter table "posts" add column "legacy_boolean" INT(1)',
-        ], $getSql(new SQLiteGrammar));
+        ], $getSql('SQLite'));
 
         $this->assertEquals([
             'alter table "posts" add column "legacy_boolean" INT(1) null',
-        ], $getSql(new PostgresGrammar));
+        ], $getSql('Postgres'));
 
         $this->assertEquals([
             'alter table "posts" add "legacy_boolean" INT(1) null',
-        ], $getSql(new SqlServerGrammar));
+        ], $getSql('SqlServer'));
     }
 
     public function testTableComment()
@@ -572,42 +562,43 @@ class DatabaseSchemaBlueprintTest extends TestCase
             })->toSql();
         };
 
-        $this->assertEquals(['alter table `posts` comment = \'Look at my comment, it is amazing\''], $getSql(new MySqlGrammar));
-        $this->assertEquals(['comment on table "posts" is \'Look at my comment, it is amazing\''], $getSql(new PostgresGrammar));
+        $this->assertEquals(['alter table `posts` comment = \'Look at my comment, it is amazing\''], $getSql('MySql'));
+        $this->assertEquals(['comment on table "posts" is \'Look at my comment, it is amazing\''], $getSql('Postgres'));
     }
 
-    protected function getConnection(?Grammar $grammar = null)
+    protected function getConnection(?string $grammar = null, string $prefix = '')
     {
-        $grammar ??= new MySqlGrammar;
-
-        $builder = mock(match ($grammar::class) {
-            MySqlGrammar::class => MySqlBuilder::class,
-            PostgresGrammar::class => PostgresBuilder::class,
-            SQLiteGrammar::class => SQLiteBuilder::class,
-            SqlServerGrammar::class => SqlServerBuilder::class,
-            MariaDbGrammar::class => MariaDbBuilder::class,
-            default => Builder::class,
-        });
-
         $connection = m::mock(Connection::class)
-            ->shouldReceive('getSchemaGrammar')->andReturn($grammar)
-            ->shouldReceive('getSchemaBuilder')->andReturn($builder);
+            ->shouldReceive('getTablePrefix')->andReturn($prefix)
+            ->shouldReceive('getConfig')->with('prefix_indexes')->andReturn(true)
+            ->getMock();
 
-        if ($grammar instanceof SQLiteGrammar) {
+        $grammar ??= 'MySql';
+        $grammarClass = 'Illuminate\Database\Schema\Grammars\\'.$grammar.'Grammar';
+        $builderClass = 'Illuminate\Database\Schema\\'.$grammar.'Builder';
+
+        $connection->shouldReceive('getSchemaGrammar')->andReturn(new $grammarClass($connection));
+        $connection->shouldReceive('getSchemaBuilder')->andReturn(m::mock($builderClass));
+
+        if ($grammar === 'SQLite') {
             $connection->shouldReceive('getServerVersion')->andReturn('3.35');
         }
 
-        return $connection->getMock();
+        if ($grammar === 'MySql') {
+            $connection->shouldReceive('isMaria')->andReturn(false);
+        }
+
+        return $connection;
     }
 
     protected function getBlueprint(
-        ?Grammar $grammar = null,
+        ?string $grammar = null,
         string $table = '',
         ?Closure $callback = null,
         string $prefix = ''
     ): Blueprint {
-        $connection = $this->getConnection($grammar);
+        $connection = $this->getConnection($grammar, $prefix);
 
-        return new Blueprint($connection, $table, $callback, $prefix);
+        return new Blueprint($connection, $table, $callback);
     }
 }

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -22,26 +22,24 @@ class DatabaseSchemaBuilderTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $grammar = m::mock(stdClass::class);
+        $grammar->shouldReceive('compileCreateDatabase')->andReturn('sql');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $connection->shouldReceive('statement')->with('sql')->andReturnTrue();
         $builder = new Builder($connection);
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('This database driver does not support creating databases.');
-
-        $builder->createDatabase('foo');
+        $this->assertTrue($builder->createDatabase('foo'));
     }
 
     public function testDropDatabaseIfExists()
     {
         $connection = m::mock(Connection::class);
         $grammar = m::mock(stdClass::class);
+        $grammar->shouldReceive('compileDropDatabaseIfExists')->andReturn('sql');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $connection->shouldReceive('statement')->with('sql')->andReturnTrue();
         $builder = new Builder($connection);
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('This database driver does not support dropping databases.');
-
-        $builder->dropDatabaseIfExists('foo');
+        $this->assertTrue($builder->dropDatabaseIfExists('foo'));
     }
 
     public function testHasTableCorrectlyCallsGrammar()

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\Grammars\Grammar;
-use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -18,8 +18,7 @@ class DatabaseSqlServerQueryGrammarTest extends TestCase
     {
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
-        $grammar = new SqlServerGrammar;
-        $grammar->setConnection($connection);
+        $grammar = new SqlServerGrammar($connection);
 
         $query = $grammar->substituteBindingsIntoRawSql(
             "select * from [users] where 'Hello''World?' IS NOT NULL AND [email] = ?",

--- a/tests/Database/SqlServerBuilderTest.php
+++ b/tests/Database/SqlServerBuilderTest.php
@@ -17,9 +17,9 @@ class SqlServerBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new SqlServerGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new SqlServerGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'create database "my_temporary_database_a"'
@@ -31,9 +31,9 @@ class SqlServerBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new SqlServerGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new SqlServerGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'drop database if exists "my_temporary_database_b"'

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -4,11 +4,6 @@ namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Closure;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Schema\Grammars\Grammar;
-use Illuminate\Database\Schema\Grammars\MySqlGrammar;
-use Illuminate\Database\Schema\Grammars\PostgresGrammar;
-use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
-use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\RequiresDatabase;
@@ -37,7 +32,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             $table->string('age');
         });
 
-        $blueprint = $this->getBlueprint(new SQLiteGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('SQLite', 'users', function ($table) {
             $table->renameColumn('name', 'first_name');
             $table->integer('age')->change();
         });
@@ -76,7 +71,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testNativeColumnModifyingOnPostgreSql()
     {
-        $blueprint = $this->getBlueprint(new PostgresGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('Postgres', 'users', function ($table) {
             $table->integer('code')->autoIncrement()->from(10)->comment('my comment')->change();
         });
 
@@ -88,7 +83,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'comment on column "users"."code" is \'my comment\'',
         ], $blueprint->toSql());
 
-        $blueprint = $this->getBlueprint(new PostgresGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('Postgres', 'users', function ($table) {
             $table->char('name', 40)->nullable()->default('easy')->collation('unicode')->change();
         });
 
@@ -101,7 +96,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'comment on column "users"."name" is NULL',
         ], $blueprint->toSql());
 
-        $blueprint = $this->getBlueprint(new PostgresGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('Postgres', 'users', function ($table) {
             $table->integer('foo')->generatedAs('expression')->always()->change();
         });
 
@@ -115,7 +110,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'comment on column "users"."foo" is NULL',
         ], $blueprint->toSql());
 
-        $blueprint = $this->getBlueprint(new PostgresGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('Postgres', 'users', function ($table) {
             $table->geometry('foo', 'point', 1234)->change();
         });
 
@@ -128,7 +123,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'comment on column "users"."foo" is NULL',
         ], $blueprint->toSql());
 
-        $blueprint = $this->getBlueprint(new PostgresGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('Postgres', 'users', function ($table) {
             $table->timestamp('added_at', 2)->useCurrent()->storedAs(null)->change();
         });
 
@@ -145,7 +140,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testNativeColumnModifyingOnSqlServer()
     {
-        $blueprint = $this->getBlueprint(new SqlServerGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('SqlServer', 'users', function ($table) {
             $table->timestamp('added_at', 4)->nullable(false)->useCurrent()->change();
         });
 
@@ -155,7 +150,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "users" add default CURRENT_TIMESTAMP for "added_at"',
         ], $blueprint->toSql());
 
-        $blueprint = $this->getBlueprint(new SqlServerGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('SqlServer', 'users', function ($table) {
             $table->char('name', 40)->nullable()->default('easy')->collation('unicode')->change();
         });
 
@@ -165,7 +160,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "users" add default \'easy\' for "name"',
         ], $blueprint->toSql());
 
-        $blueprint = $this->getBlueprint(new SqlServerGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('SqlServer', 'users', function ($table) {
             $table->integer('foo')->change();
         });
 
@@ -181,11 +176,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
             $table->string('age');
         });
 
-        $blueprint = $this->getBlueprint(new SQLiteGrammar, 'users', function ($table) {
+        $blueprint = $this->getBlueprint('SQLite', 'users', function ($table) {
             $table->integer('age')->collation('RTRIM')->change();
         });
 
-        $blueprint2 = $this->getBlueprint(new SQLiteGrammar, 'users', function ($table) {
+        $blueprint2 = $this->getBlueprint('SQLite', 'users', function ($table) {
             $table->integer('age')->collation('NOCASE')->change();
         });
 
@@ -231,7 +226,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "__temp__users" rename to "users"',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
     }
 
     public function testChangingPrimaryAutoincrementColumnsToNonAutoincrementColumnsWork()
@@ -253,7 +248,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "__temp__users" rename to "users"',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
     }
 
     public function testChangingDoubleColumnsWork()
@@ -275,7 +270,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "__temp__products" rename to "products"',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
     }
 
     public function testChangingColumnsWithDefaultWorks()
@@ -300,7 +295,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "__temp__products" rename to "products"',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
     }
 
     public function testRenameIndexWorks()
@@ -324,25 +319,25 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'create index "index2" on "users" ("name")',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
 
         $expected = [
             'sp_rename N\'"users"."index1"\', "index2", N\'INDEX\'',
         ];
 
-        $this->assertEquals($expected, $getSql(new SqlServerGrammar));
+        $this->assertEquals($expected, $getSql('SqlServer'));
 
         $expected = [
             'alter table `users` rename index `index1` to `index2`',
         ];
 
-        $this->assertEquals($expected, $getSql(new MySqlGrammar));
+        $this->assertEquals($expected, $getSql('MySql'));
 
         $expected = [
             'alter index "index1" rename to "index2"',
         ];
 
-        $this->assertEquals($expected, $getSql(new PostgresGrammar));
+        $this->assertEquals($expected, $getSql('Postgres'));
     }
 
     public function testAddUniqueIndexWithoutNameWorks()
@@ -362,7 +357,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `users` add unique `users_name_unique`(`name`)',
         ];
 
-        $this->assertEquals($expected, $getSql(new MySqlGrammar));
+        $this->assertEquals($expected, $getSql('MySql'));
 
         $expected = [
             'alter table "users" alter column "name" type varchar(255), alter column "name" drop not null, alter column "name" drop default, alter column "name" drop identity if exists',
@@ -370,7 +365,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'comment on column "users"."name" is NULL',
         ];
 
-        $this->assertEquals($expected, $getSql(new PostgresGrammar));
+        $this->assertEquals($expected, $getSql('Postgres'));
 
         $expected = [
             'create table "__temp__users" ("name" varchar)',
@@ -380,7 +375,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'create unique index "users_name_unique" on "users" ("name")',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
 
         $expected = [
             "DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE \"users\" DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM sys.columns WHERE [object_id] = OBJECT_ID(N'\"users\"') AND [name] in ('name') AND [default_object_id] <> 0;EXEC(@sql)",
@@ -388,7 +383,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'create unique index "users_name_unique" on "users" ("name")',
         ];
 
-        $this->assertEquals($expected, $getSql(new SqlServerGrammar));
+        $this->assertEquals($expected, $getSql('SqlServer'));
     }
 
     public function testAddUniqueIndexWithNameWorks()
@@ -408,7 +403,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `users` add unique `index1`(`name`)',
         ];
 
-        $this->assertEquals($expected, $getSql(new MySqlGrammar));
+        $this->assertEquals($expected, $getSql('MySql'));
 
         $expected = [
             'alter table "users" alter column "name" type integer, alter column "name" drop not null, alter column "name" drop default, alter column "name" drop identity if exists',
@@ -416,7 +411,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'comment on column "users"."name" is NULL',
         ];
 
-        $this->assertEquals($expected, $getSql(new PostgresGrammar));
+        $this->assertEquals($expected, $getSql('Postgres'));
 
         $expected = [
             'create table "__temp__users" ("name" integer)',
@@ -426,7 +421,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'create unique index "index1" on "users" ("name")',
         ];
 
-        $this->assertEquals($expected, $getSql(new SQLiteGrammar));
+        $this->assertEquals($expected, $getSql('SQLite'));
 
         $expected = [
             "DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE \"users\" DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM sys.columns WHERE [object_id] = OBJECT_ID(N'\"users\"') AND [name] in ('name') AND [default_object_id] <> 0;EXEC(@sql)",
@@ -434,7 +429,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'create unique index "index1" on "users" ("name")',
         ];
 
-        $this->assertEquals($expected, $getSql(new SqlServerGrammar));
+        $this->assertEquals($expected, $getSql('SqlServer'));
     }
 
     public function testAddColumnNamedCreateWorks()
@@ -464,22 +459,22 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertContains(
             'alter table `users` drop index `users_name_unique`',
-            $getSql(new MySqlGrammar),
+            $getSql('MySql'),
         );
 
         $this->assertContains(
             'alter table "users" drop constraint "users_name_unique"',
-            $getSql(new PostgresGrammar),
+            $getSql('Postgres'),
         );
 
         $this->assertContains(
             'drop index "users_name_unique"',
-            $getSql(new SQLiteGrammar),
+            $getSql('SQLite'),
         );
 
         $this->assertContains(
             'drop index "users_name_unique" on "users"',
-            $getSql(new SqlServerGrammar),
+            $getSql('SqlServer'),
         );
     }
 
@@ -515,12 +510,14 @@ class DatabaseSchemaBlueprintTest extends TestCase
     }
 
     protected function getBlueprint(
-        Grammar $grammar,
+        string $grammar,
         string $table,
         Closure $callback,
     ): Blueprint {
-        $connection = DB::connection()->setSchemaGrammar($grammar);
-        $grammar->setConnection($connection);
+        $grammarClass = 'Illuminate\Database\Schema\Grammars\\'.$grammar.'Grammar';
+
+        $connection = DB::connection();
+        $connection->setSchemaGrammar(new $grammarClass($connection));
 
         return new Blueprint($connection, $table, $callback);
     }

--- a/tests/Testing/Concerns/InteractsWithDatabaseTest.php
+++ b/tests/Testing/Concerns/InteractsWithDatabaseTest.php
@@ -2,13 +2,8 @@
 
 namespace Illuminate\Tests\Testing\Concerns;
 
-use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Database\Query\Grammars\MariaDbGrammar;
-use Illuminate\Database\Query\Grammars\MySqlGrammar;
-use Illuminate\Database\Query\Grammars\PostgresGrammar;
-use Illuminate\Database\Query\Grammars\SQLiteGrammar;
-use Illuminate\Database\Query\Grammars\SqlServerGrammar;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Facade;
@@ -30,7 +25,7 @@ class InteractsWithDatabaseTest extends TestCase
 
     public function testCastToJsonSqlite()
     {
-        $grammar = new SQLiteGrammar();
+        $grammar = 'SQLite';
 
         $this->assertEquals(<<<'TEXT'
         '["foo","bar"]'
@@ -53,7 +48,7 @@ class InteractsWithDatabaseTest extends TestCase
 
     public function testCastToJsonPostgres()
     {
-        $grammar = new PostgresGrammar();
+        $grammar = 'Postgres';
 
         $this->assertEquals(<<<'TEXT'
         '["foo","bar"]'
@@ -76,7 +71,7 @@ class InteractsWithDatabaseTest extends TestCase
 
     public function testCastToJsonSqlServer()
     {
-        $grammar = new SqlServerGrammar();
+        $grammar = 'SqlServer';
 
         $this->assertEquals(<<<'TEXT'
         json_query('["foo","bar"]')
@@ -99,7 +94,7 @@ class InteractsWithDatabaseTest extends TestCase
 
     public function testCastToJsonMySql()
     {
-        $grammar = new MySqlGrammar();
+        $grammar = 'MySql';
 
         $this->assertEquals(<<<'TEXT'
         cast('["foo","bar"]' as json)
@@ -122,7 +117,7 @@ class InteractsWithDatabaseTest extends TestCase
 
     public function testCastToJsonMariaDb()
     {
-        $grammar = new MariaDbGrammar();
+        $grammar = 'MariaDb';
 
         $this->assertEquals(<<<'TEXT'
         json_query('["foo","bar"]', '$')
@@ -145,7 +140,9 @@ class InteractsWithDatabaseTest extends TestCase
 
     protected function castAsJson($value, $grammar)
     {
-        $connection = m::mock(ConnectionInterface::class);
+        $connection = m::mock(Connection::class);
+        $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$grammar.'Grammar';
+        $grammar = new $grammarClass($connection);
 
         $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
 


### PR DESCRIPTION
The `Illuminate\Database\Grammar` class has required a `Connection $connection` property since Laravel 10.x (via #46558), but it was passed via `setConnection()` method to avoid signature changes in a patch release. Since then, many methods in the `Grammar` classes have needed access to the `Connection` property (mainly to retrieve config properties and compare driver versions). This PR does:

* Adding `Connection $connection` to the `Grammar` constructor, instead of calling `setConnection()` when instantiating.
* Fixing table prefix issues by using `Connection::getTablePrefix()` instead of having the `$prefix` property in the `Grammar` and `Blueprint` classes.

**P.S. 1**: This PR doesn’t require any upgrade guide for end-users.

**P.S. 2**: The `$connection` property was added to the `Blueprint` constructor in Laravel 12.x via #51821, so now is a good time to fix it in the `Grammar` class as well.

## Summary

* Adds missing `prefix_indexes` config property to `sqlite` connection to be consistent with other DB driver connections.
* Adds `Connection $connection` property to `Illuminate/Database/Grammar::__construct()` method.
* Removes `Illuminate\Database\Connection::withTablePrefix()` method.
* Removes `Illuminate\Database\Grammar::setConnection()` method.
* Removes `Illuminate\Database\Schema\Builder::setConnection()` method.
* Removes `$prefix` property from `Illuminate\Database\Schema\Blueprint::__construct()` method.
* Deprecates `Illuminate\Database\Grammar::getTablePrefix()` method (Use `Illuminate\Database\Connection::getTablePrefix()` instead).
* Deprecates `Illuminate\Database\Grammar::setTablePrefix()` method (Use `Illuminate\Database\Connection::setTablePrefix()` instead).
* Deprecates `Illuminate\Database\Schema\Blueprint::getPrefix()` method (Use `Illuminate\Database\Connection::getTablePrefix()` instead).
* Fix a bug on wrapping aliased tables with prefix.
* Fix a bug where table prefix was totally ignored on `Blueprint` when `prefix_indexes` is set to `false`.
* Fix a bug on defining starting value for a column of a table with non-default schema on PostgreSQL.
* Moves overridden `createDatabase()` and `dropDatabaseIfExists()` methods to `Illuminate\Database\Schema\Builder` parent class (The same method was overridden on all inherited classes.)