### PR TITLE
[12.x] feat: prevent EloquentCollection::range from returning an eloquent collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -21,6 +21,19 @@ class Collection extends BaseCollection implements QueueableCollection
     use InteractsWithDictionary;
 
     /**
+     * Create a collection with the given range.
+     *
+     * @param  int  $from
+     * @param  int  $to
+     * @param  int  $step
+     * @return \Illuminate\Support\Collection<int, int>
+     */
+    public static function range($from, $to, $step = 1)
+    {
+        return parent::range($from, $to, $step)->toBase();
+    }
+
+    /**
      * Find a model in the collection by key.
      *
      * @template TFindDefault


### PR DESCRIPTION
Hello!

This updates the `EloquentCollection::range()` method to always return a Support Collection instead of an eloquent one (given that it contains no models). This is in the same spirit as `countBy`, `collapse`, `flatten`, etc.

Thanks!