### PR TITLE
[11.x] Added support for passing custom JSON flags in the http client response factory.

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -151,12 +151,13 @@ class Factory
      * @param  array|string|null  $body
      * @param  int  $status
      * @param  array  $headers
+     * @param  int  $flags
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public static function response($body = null, $status = 200, $headers = [])
+    public static function response($body = null, $status = 200, $headers = [], int $flags = 0)
     {
         if (is_array($body)) {
-            $body = json_encode($body);
+            $body = json_encode($body, $flags);
 
             $headers['Content-Type'] = 'application/json';
         }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -151,7 +151,7 @@ class Factory
      * @param  array|string|null  $body
      * @param  int  $status
      * @param  array  $headers
-     * @param  int  $flags
+     * @param  int-mask-of<JSON_*>  $flags
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
     public static function response($body = null, $status = 200, $headers = [], int $flags = 0)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -33,6 +33,7 @@ use JsonSerializable;
 use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -3471,6 +3472,22 @@ class HttpClientTest extends TestCase
         $factory = new Factory();
 
         $this->assertInstanceOf(PendingRequest::class, $factory->createPendingRequest());
+    }
+
+    public function testJsonResponseFactoryWithFlags()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['value' => 10.0], flags: JSON_PRESERVE_ZERO_FRACTION),
+        ]);
+
+        $value = $this->factory
+            ->get('https://laravel.com')
+            ->json('value');
+
+        $this->assertThat(
+            $value,
+            new IsIdentical(10.0)
+        );
     }
 }
 


### PR DESCRIPTION
Adds support for passing custom JSON flags in the HTTP client response factory. When the body is an array, it is now encoded using the provided JSON flags, which allows developers to preserve specific numeric formatting (e.g. trailing zeros with JSON_PRESERVE_ZERO_FRACTION) when needed.

### Before

```php
Http::fake(
    '*' => Http::response(['value' => 10.0])
);

// When making a request:
$response = Http::get('https://example.com');
// The response JSON returns:
// ["value" => 10]
```

### After

```php
Http::fake(
    '*' => Http::response(['value' => 10.0], flags: JSON_PRESERVE_ZERO_FRACTION)
);

// When making a request:
$response = Http::get('https://example.com');
// The response JSON returns:
// ["value" => 10.0]
```

