### PR TITLE
Auto-discover nested policies following conventional, parallel hierarchy

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -705,7 +705,7 @@ class Gate implements GateContract
             return $classDirname.'\\Policies\\'.class_basename($class).'Policy';
         })->reverse()->values()->first(function ($class) {
             return class_exists($class);
-        }) ?: [$classDirname.'\\Policies\\'.class_basename($class).'Policy']);
+        }));
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -703,6 +703,9 @@ class Gate implements GateContract
             $classDirname = implode('\\', array_slice($classDirnameSegments, 0, $index));
 
             return $classDirname.'\\Policies\\'.class_basename($class).'Policy';
+        })->when(str_contains($classDirname, '\\Models\\'), function ($collection) use ($class, $classDirname) {
+            return $collection->concat([str_replace('\\Models\\', '\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy'])
+                ->concat([str_replace('\\Models\\', '\\Models\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy']);
         })->reverse()->values()->first(function ($class) {
             return class_exists($class);
         }));

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -708,7 +708,7 @@ class Gate implements GateContract
                 ->concat([str_replace('\\Models\\', '\\Models\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy']);
         })->reverse()->values()->first(function ($class) {
             return class_exists($class);
-        }));
+        }) ?: [$classDirname.'\\Policies\\'.class_basename($class).'Policy']);
     }
 
     /**

--- a/tests/Integration/Auth/Fixtures/Models/Nested/SubTestUser.php
+++ b/tests/Integration/Auth/Fixtures/Models/Nested/SubTestUser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Models\Nested;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class SubTestUser extends Authenticatable
+{
+    public $table = 'users';
+    public $timestamps = false;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var string[]
+     */
+    protected $hidden = [
+        'password', 'remember_token',
+    ];
+}

--- a/tests/Integration/Auth/Fixtures/Models/Nested/TopTestUser.php
+++ b/tests/Integration/Auth/Fixtures/Models/Nested/TopTestUser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Models\Nested;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class TopTestUser extends Authenticatable
+{
+    public $table = 'users';
+    public $timestamps = false;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var string[]
+     */
+    protected $hidden = [
+        'password', 'remember_token',
+    ];
+}

--- a/tests/Integration/Auth/Fixtures/Models/Policies/Nested/SubTestUserPolicy.php
+++ b/tests/Integration/Auth/Fixtures/Models/Policies/Nested/SubTestUserPolicy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Models\Policies\Nested;
+
+class SubTestUserPolicy
+{
+    //
+}

--- a/tests/Integration/Auth/Fixtures/Policies/Nested/TopTestUserPolicy.php
+++ b/tests/Integration/Auth/Fixtures/Policies/Nested/TopTestUserPolicy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Policies\Nested;
+
+class TopTestUserPolicy
+{
+    //
+}

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -6,7 +6,9 @@ use Illuminate\Auth\Access\Events\GateEvaluated;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
+use Illuminate\Tests\Integration\Auth\Fixtures\Models\Policies\Nested\SubTestUserPolicy;
 use Illuminate\Tests\Integration\Auth\Fixtures\Policies\AuthenticationTestUserPolicy;
+use Illuminate\Tests\Integration\Auth\Fixtures\Policies\Nested\TopTestUserPolicy;
 use Orchestra\Testbench\TestCase;
 
 class GatePolicyResolutionTest extends TestCase
@@ -34,6 +36,19 @@ class GatePolicyResolutionTest extends TestCase
 
         $this->assertNull(
             Gate::getPolicyFor(static::class)
+        );
+    }
+
+    public function testPolicyCanBeGuessedForParallelClassHierarchies()
+    {
+        $this->assertInstanceOf(
+            TopTestUserPolicy::class,
+            Gate::getPolicyFor(Fixtures\Models\Nested\TopTestUser::class)
+        );
+
+        $this->assertInstanceOf(
+            SubTestUserPolicy::class,
+            Gate::getPolicyFor(Fixtures\Models\Nested\SubTestUser::class)
         );
     }
 


### PR DESCRIPTION
A few times now I have read the docs and interpreted that if my models are under `app/Models` and my policies under `app/Policies`, my policies will be auto-discovered. This is true, except for my nested models and policies.

Currently, Laravel **will not auto-discover** the policy `app/Policies/Nested/PostPolicy` for the model `app/Models/Nested/Post`. This has to be registered explicitly 

This PR resolves smooths out this exception of policy auto-discovery and removes the need for explicit registration for this conventional app structure.

While I don't see this to be a breaking change, I am targeting Laravel 12 as this discovers new paths and allows developers to remove explicit registration for models/policies using this conventional, parallel class hierarchy (optional).

---
**Implementation Details**
When the model class contains a `Models` sub-namespace two additional paths are added to auto-discovery: a sibling path of `Policies` and a subpath of `Models/Policies`.

This aligns with the algorithm outlined in the documentation, but anchors it to the _model path_. Since this is simply a string replacement, this should support both conventional structures as well as "modular" structures.

**Examples:**
- `App\Models\Auth\User` auto-discovers `App\Policies\Auth\UserPolicy` or `App\Models\Policies\Auth\UserPolicy`
- `Some\Domain\Models\Auth\User` auto-discovers `Some\Domain\Policies\Auth\UserPolicy` or `Some\Domain\Models\Policies\Auth\UserPolicy`