### PR TITLE
[11.x] Prevents Bcrypt hashing from spilling over and creating insecure hashes.

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -5,7 +5,7 @@ namespace Illuminate\Hashing;
 use Error;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use RuntimeException;
-use Illuminate\Hashing\BcryptValueTooLongException;
+
 class BcryptHasher extends AbstractHasher implements HasherContract
 {
     /**

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -5,9 +5,14 @@ namespace Illuminate\Hashing;
 use Error;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use RuntimeException;
-
+use Illuminate\Hashing\BcryptValueTooLongException;
 class BcryptHasher extends AbstractHasher implements HasherContract
 {
+    /**
+     * The maximum length of the string that can be hashed by bcrypt.
+     */
+    const BCRYPT_STR_LIMIT = 72;
+
     /**
      * The default cost factor.
      *
@@ -46,6 +51,10 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     public function make(#[\SensitiveParameter] $value, array $options = [])
     {
         try {
+            if (strlen($value) > self::BCRYPT_STR_LIMIT) {
+                throw new BcryptValueTooLongException;
+            }
+
             $hash = password_hash($value, PASSWORD_BCRYPT, [
                 'cost' => $this->cost($options),
             ]);

--- a/src/Illuminate/Hashing/BcryptValueTooLongException.php
+++ b/src/Illuminate/Hashing/BcryptValueTooLongException.php
@@ -8,6 +8,6 @@ class BcryptValueTooLongException extends RuntimeException
 {
     public function __construct(int $maxLength = BcryptHasher::BCRYPT_STR_LIMIT)
     {
-        parent::__construct("Value is too long. Maximum length is {$maxLength} characters.");
+        parent::__construct("Value to hash is too long. Bcrypt only allows for a maximum length of {$maxLength} characters. Shorten your value or use a different hashing algorithm.");
     }
 }

--- a/src/Illuminate/Hashing/BcryptValueTooLongException.php
+++ b/src/Illuminate/Hashing/BcryptValueTooLongException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Hashing;
+
+use RuntimeException;
+
+class BcryptValueTooLongException extends RuntimeException
+{
+    public function __construct(int $maxLength = BcryptHasher::BCRYPT_STR_LIMIT)
+    {
+        parent::__construct("Value is too long. Maximum length is {$maxLength} characters.");
+    }
+}

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -11,7 +11,7 @@ use Illuminate\Hashing\HashManager;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-
+use Illuminate\Hashing\BcryptValueTooLongException;
 class HasherTest extends TestCase
 {
     public $hashManager;
@@ -57,6 +57,13 @@ class HasherTest extends TestCase
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
         $this->assertGreaterThanOrEqual(12, password_get_info($value)['options']['cost']);
         $this->assertTrue($this->hashManager->isHashed($value));
+    }
+
+    public function testBcryptTooLongValue()
+    {
+        $this->expectException(BcryptValueTooLongException::class);
+
+        (new BcryptHasher())->make(str_repeat('a', 73));
     }
 
     public function testBasicArgon2iHashing()

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -7,11 +7,12 @@ use Illuminate\Container\Container;
 use Illuminate\Hashing\Argon2IdHasher;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
+use Illuminate\Hashing\BcryptValueTooLongException;
 use Illuminate\Hashing\HashManager;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Illuminate\Hashing\BcryptValueTooLongException;
+
 class HasherTest extends TestCase
 {
     public $hashManager;


### PR DESCRIPTION
Recently Okta had a security incident created by them using bcrypt hashes that were over 72 chars in length, bcrypt implementations generally allow strings longer than 72 charachters, but simply omit the characters over that length. This can lead to predictable hashes if you can "stuff" the string with 72 known characters.

Take this simple example from Laravel Framework 11.41.3. 

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Support\Facades\Hash;
class TestBcryptSpillOver extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'bcrypt:test';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'Test bcrypt spill over';

    /**
     * Execute the console command.
     */
    public function handle()
    {
        // Make our prefixes 72 characters long
        $my_hash_prefix = "some.very.long.prefix-"; // 22 characters
        $my_hash_key = "lnHQkcD7fZdMzJt640xbeOhzDGCI3aki7mePMxQgEQBkuUuwwm"; // 50 characters
        $super_secret_password = "thisIsMySuperSecretPassword";
        $random_password = "thisIsARandomPassword";

        $hash_one = $my_hash_prefix . $my_hash_key . $super_secret_password;
        $hash_two = $my_hash_prefix . $my_hash_key . $random_password;

        $computed_hash_one = Hash::make($hash_one);
        $computed_hash_two = Hash::make($hash_two);

        $this->info("Hash one: " . $computed_hash_one);
        $this->info("Hash two: " . $computed_hash_two);

        $this->info("Checking hashes for match");

        $check_one = Hash::check($hash_one, $computed_hash_one);
        $check_two = Hash::check($hash_two, $computed_hash_one);

        if($check_one && $check_two) {
            $this->info("Hashes match, bcrypt is vulnerable to spill over");
        } else {
            $this->info("Hashes do not match, bcrypt is not vulnerable to spill over");
        }
    }
}

```

Running this, should return us `Hashes do not match, bcrypt is not vulnerable to spill over` because `$hash_two` should not be the same as `$computed_hash_one` but it doesn't, it returns `Hashes match, bcrypt is vulnerable to spill over` because of the spill over. 

This change, very simply rejects strings longer than 72 chars, when passed to `Hash::make()` when using Bcrypt. 

Running the same code above after my change, throws an exception instead of silently failing.

### Resources
1. https://trust.okta.com/security-advisories/okta-ad-ldap-delegated-authentication-username/
2. https://n0rdy.foo/posts/20250121/okta-bcrypt-lessons-for-better-apis/
