### PR TITLE
[11.x] Add whenHasFile() method to Request class

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -225,6 +225,27 @@ trait InteractsWithInput
     }
 
     /**
+     * Apply the callback if the instance contains the given file key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenHasFile($key, callable $callback, ?callable $default = null)
+    {
+        if ($this->hasFile($key)) {
+            return $callback($this->file($key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
      * Check that the given file is a valid file instance.
      *
      * @param  mixed  $file

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1036,6 +1036,36 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->hasFile('bar'));
     }
 
+    public function testWhenHasFileMethod()
+    {
+        $request = Request::create('/', 'GET', [], [], []);
+
+        $hasFile = $noFile = false;
+
+        $files = [
+            'foo' => [
+                'size' => 500,
+                'name' => 'foo.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'blah',
+                'error' => null,
+            ],
+        ];
+
+        $request = Request::create('/', 'GET', [], [], $files);
+
+        $request->whenHasFile('foo', function ($file) use (&$hasFile) {
+            $hasFile = true;
+        });
+
+        $request->whenHasFile('bar', function () use (&$noFile) {
+            $noFile = true;
+        });
+
+        $this->assertTrue($hasFile);
+        $this->assertFalse($noFile);
+    }
+
     public function testServerMethod()
     {
         $request = Request::create('/', 'GET', [], [], [], ['foo' => 'bar']);


### PR DESCRIPTION
This PR introduces the whenHasFile() method to the Request class, allowing a more fluent and expressive way to handle file uploads. 
Inspired by whenHas/whenFilled(), this method executes a callback only when a file is present in the request and it passes the file instance to the callback.

```php
$request->whenHasFile('file', function ($file) {
    $file->store('uploads', 'public');
});
```