### PR TITLE
[11.x] Add onBreach hook method to the Limit class

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -26,6 +26,13 @@ class Limit
     public $decaySeconds;
 
     /**
+     * The callback that should be executed when the limit is breached.
+     *
+     * @var callable
+     */
+    public $breachCallback;
+
+    /**
      * The response generator callback.
      *
      * @var callable
@@ -126,6 +133,19 @@ class Limit
     public function by($key)
     {
         $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the callback that should be executed when the limit is breached.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onBreach(callable $callback)
+    {
+        $this->breachCallback = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -58,6 +58,10 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     {
         foreach ($limits as $limit) {
             if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
+                if (is_callable($limit->breachCallback)) {
+                    call_user_func($limit->breachCallback);
+                }
+
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
         }


### PR DESCRIPTION
This PR introduces a new `onBreach` method to the `Illuminate\Cache\RateLimiting\Limit` class.

The method allows developers to define a custom closure that will be executed right before an exception is thrown when the rate limit is exceeded.

This provides an opportunity to perform additional actions (e.g., logging, notification, or custom handling) before the exception is triggered.

e.g.

```php
RateLimiter::for('login', function (Request $request) {
    return Limit::perMinute(3)->by($request->user()->id)->onBreach(function () use ($request) {
        LockUserAccount::dispatch($request->user());
    });
});
```