### PR TITLE
[11.x] Add Context "missing" method

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -74,7 +74,7 @@ class Repository
      */
     public function missing($key)
     {
-        return ! $this->get($key);
+        return ! $this->has($key);
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -89,6 +89,17 @@ class Repository
     }
 
     /**
+     * Determine if the given key is missing within the hidden context data.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missingHidden($key)
+    {
+        return ! $this->hasHidden($key);
+    }
+
+    /**
      * Retrieve all the context data.
      *
      * @return array<string, mixed>

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -67,6 +67,17 @@ class Repository
     }
 
     /**
+     * Determine if the given key is missing.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return ! $this->get($key);
+    }
+
+    /**
      * Determine if the given key exists within the hidden context data.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static bool has(string $key)
+ * @method static bool missing(string $key)
  * @method static bool hasHidden(string $key)
  * @method static array all()
  * @method static array allHidden()

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -6,6 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool has(string $key)
  * @method static bool missing(string $key)
  * @method static bool hasHidden(string $key)
+ * @method static bool missingHidden(string $key)
  * @method static array all()
  * @method static array allHidden()
  * @method static mixed get(string $key, mixed $default = null)

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -263,6 +263,14 @@ class ContextTest extends TestCase
         $this->assertFalse(Context::has('unset'));
     }
 
+    public function test_it_can_check_if_context_is_missing()
+    {
+        Context::add('foo', 'bar');
+
+        $this->assertTrue(Context::missing('bar'));
+        $this->assertFalse(Context::missing('foo'));
+    }
+
     public function test_it_can_check_if_value_is_in_context_stack()
     {
         Context::push('foo', 'bar', 'lorem');

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -267,7 +267,7 @@ class ContextTest extends TestCase
     {
         Context::add('foo', 'bar');
 
-        $this->assertTrue(Context::missing('bar'));
+        $this->assertTrue(Context::missing('lorem'));
         $this->assertFalse(Context::missing('foo'));
     }
 


### PR DESCRIPTION
I tried using the `missing` method on the Context facade and was surprised to find it didn’t exist. Other facades like Cache and Session have it, so it felt natural to expect it here too.

This PR adds the missing method to keep things consistent and make life a little easier for developers.

If this gets merged I'll create a PR to the docs too!