### PR TITLE
Fix/mysql schema state ssl options string

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,6 +59,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'),
             ]) : [],
         ],
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -111,7 +111,7 @@ class MySqlSchemaState extends SchemaState
                         ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
                         : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
 
-        $value .= $this->getAdditionalConnectionOptions($config['options']);
+        $value .= $this->getAdditionalConnectionOptions($config['options'] ?? []);
 
         return $value;
     }
@@ -133,7 +133,7 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
-        ], $this->getAdditionalOptionValues($config['options']));
+        ], $this->getAdditionalOptionValues($config['options'] ?? []));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -220,7 +220,7 @@ class MySqlSchemaState extends SchemaState
 
         foreach ($this->getOptionMap() as $optionKey => $optionValue) {
             if (isset($options[$optionKey])) {
-                $valueKey = 'LARAVEL_LOAD_' . Str::upper(Str::replace(['--', '-'], [null, '_'], $optionValue));
+                $valueKey = 'LARAVEL_LOAD_'.Str::upper(Str::replace(['--', '-'], [null, '_'], $optionValue));
                 $values[$valueKey] = $options[$optionKey];
             }
         }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -173,7 +173,7 @@ class MySqlSchemaState extends SchemaState
     }
 
     /**
-     * Get allowed options with mapped mysql params
+     * Get allowed options with mapped mysql params.
      *
      * @return string[]
      */
@@ -186,9 +186,9 @@ class MySqlSchemaState extends SchemaState
     }
 
     /**
-     * Get mysql options connection string
+     * Get mysql options connection string.
      *
-     * @param array $options
+     * @param  array  $options
      * @return string
      */
     private function getAdditionalConnectionOptions(array $options): string

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -126,14 +126,14 @@ class MySqlSchemaState extends SchemaState
     {
         $config['host'] ??= '';
 
-        return [
+        return array_merge([
             'LARAVEL_LOAD_SOCKET' => $config['unix_socket'] ?? '',
             'LARAVEL_LOAD_HOST' => is_array($config['host']) ? $config['host'][0] : $config['host'],
             'LARAVEL_LOAD_PORT' => $config['port'] ?? '',
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
-        ];
+        ], $this->getAdditionalOptionValues($config['options']));
     }
 
     /**
@@ -197,10 +197,34 @@ class MySqlSchemaState extends SchemaState
 
         foreach ($this->getOptionMap() as $optionKey => $optionValue) {
             if (isset($options[$optionKey])) {
-                $connectionString .= sprintf(' %s=%s', $optionValue, $options[$optionKey]);
+                $connectionString .= sprintf(
+                    ' %s="${:LARAVEL_LOAD_%s}"',
+                    $optionValue,
+                    Str::upper(Str::replace(['--', '-'], [null, '_'], $optionValue))
+                );
             }
         }
 
         return $connectionString;
+    }
+
+    /**
+     * Get mysql options connection values for binding.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    private function getAdditionalOptionValues(array $options): array
+    {
+        $values = [];
+
+        foreach ($this->getOptionMap() as $optionKey => $optionValue) {
+            if (isset($options[$optionKey])) {
+                $valueKey = 'LARAVEL_LOAD_' . Str::upper(Str::replace(['--', '-'], [null, '_'], $optionValue));
+                $values[$valueKey] = $options[$optionKey];
+            }
+        }
+
+        return $values;
     }
 }

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -42,7 +42,6 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -42,7 +42,6 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',
@@ -76,7 +75,6 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -75,7 +75,6 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -44,7 +44,6 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',
@@ -96,7 +95,6 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -70,6 +70,24 @@ class DatabaseMySqlSchemaStateTest extends TestCase
             ],
         ];
 
+        yield 'ssl' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl="${:LARAVEL_LOAD_SSL}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL' => 'OFF',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT=> 'OFF',
+                ],
+            ],
+        ];
+
         yield 'unix socket' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
                 'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -44,7 +44,6 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',
@@ -70,6 +69,24 @@ class DatabaseMySqlSchemaStateTest extends TestCase
             ],
         ];
 
+        yield 'ssl' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl="${:LARAVEL_LOAD_SSL}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL' => 'OFF',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => 'OFF',
+                ],
+            ],
+        ];
+
         yield 'unix socket' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
                 'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',
@@ -78,7 +95,6 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_USER' => 'root',
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
-                'LARAVEL_LOAD_SSL_CA' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -83,7 +83,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT=> 'OFF',
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => 'OFF',
                 ],
             ],
         ];


### PR DESCRIPTION
[11.x] Added the ability to disable secure SSL connection for DB 8.0 versions and refactoring options
Look this issue (https://github.com/laravel/framework/issues/54269)

--ssl
--ssl-ca

If you use the RefreshDatabase trait in a test case, then when you try to migrate with the trait, you will see the error
`ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it`
Tested on `mysql` version `8.0-8.0.35`

Since SSL is required by default for an outdated client

This fix allows you to skip SSL server verification, and successfully run mysql commands (including during migration in tests)

The skip parameter will be added only if env `MYSQL_ATTR_SSL_VERIFY_SERVER_CERT=OFF` is specified in the database configuration.
Otherwise, the mysql connection string will remain unchanged.