### PR TITLE
[12.x] Allow limiting bcrypt hashing to 72 bytes to prevent insecure hashes.

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -31,6 +31,7 @@ return [
     'bcrypt' => [
         'rounds' => env('BCRYPT_ROUNDS', 12),
         'verify' => env('HASH_VERIFY', true),
+        'limit_length' => env('BCRYPT_LIMIT_LENGTH', true),
     ],
 
     /*

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -9,6 +9,13 @@ use RuntimeException;
 class BcryptHasher extends AbstractHasher implements HasherContract
 {
     /**
+     * The maximum byte length of the value to hash.
+     *
+     * @var int
+     */
+    const MAX_BYTE_LENGTH = 72;
+
+    /**
      * The default cost factor.
      *
      * @var int
@@ -23,6 +30,13 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     protected $verifyAlgorithm = false;
 
     /**
+     * Impose bcrypt byte limit.
+     *
+     * @var bool
+     */
+    protected $limitLength = false;
+
+    /**
      * Create a new hasher instance.
      *
      * @param  array  $options
@@ -32,6 +46,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     {
         $this->rounds = $options['rounds'] ?? $this->rounds;
         $this->verifyAlgorithm = $options['verify'] ?? $this->verifyAlgorithm;
+        $this->limitLength = $options['limit_length'] ?? $this->limitLength;
     }
 
     /**
@@ -46,6 +61,10 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     public function make(#[\SensitiveParameter] $value, array $options = [])
     {
         try {
+            if ($this->limitLength && strlen($value) > self::MAX_BYTE_LENGTH) {
+                throw new BcryptValueTooLongException;
+            }
+
             $hash = password_hash($value, PASSWORD_BCRYPT, [
                 'cost' => $this->cost($options),
             ]);

--- a/src/Illuminate/Hashing/BcryptValueTooLongException.php
+++ b/src/Illuminate/Hashing/BcryptValueTooLongException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Hashing;
+
+use RuntimeException;
+
+class BcryptValueTooLongException extends RuntimeException
+{
+    public function __construct(int $maxLength = BcryptHasher::MAX_BYTE_LENGTH)
+    {
+        parent::__construct("Value to hash is too long. Bcrypt only allows for a maximum length of {$maxLength} bytes. Shorten your value or use a different hashing algorithm.");
+    }
+}

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Hashing\Argon2IdHasher;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
+use Illuminate\Hashing\BcryptValueTooLongException;
 use Illuminate\Hashing\HashManager;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
@@ -57,6 +58,13 @@ class HasherTest extends TestCase
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
         $this->assertGreaterThanOrEqual(12, password_get_info($value)['options']['cost']);
         $this->assertTrue($this->hashManager->isHashed($value));
+    }
+
+    public function testBcryptValueTooLong()
+    {
+        $this->expectException(BcryptValueTooLongException::class);
+        $hasher = new BcryptHasher(['limit_length' => true]);
+        $hasher->make(str_repeat('a', 73));
     }
 
     public function testBasicArgon2iHashing()


### PR DESCRIPTION
> This is an updated version of [this PR](https://github.com/laravel/framework/pull/54494) designed to target Laravel 12.

## Why This PR?
Recently Okta had a security incident created by them using bcrypt hashes that were over 72 chars in length, bcrypt implementations generally allow strings longer than 72 charachters, but simply omit the characters over that length. This can lead to predictable hashes if you can "stuff" the string with 72 known characters.

Take this simple example from Laravel Framework 11.41.3. 

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Support\Facades\Hash;
class TestBcryptSpillOver extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'bcrypt:test';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'Test bcrypt spill over';

    /**
     * Execute the console command.
     */
    public function handle()
    {
        // Make our prefixes 72 characters long
        $my_hash_prefix = "some.very.long.prefix-"; // 22 characters
        $my_hash_key = "lnHQkcD7fZdMzJt640xbeOhzDGCI3aki7mePMxQgEQBkuUuwwm"; // 50 characters
        $super_secret_password = "thisIsMySuperSecretPassword";
        $random_password = "thisIsARandomPassword";

        $hash_one = $my_hash_prefix . $my_hash_key . $super_secret_password;
        $hash_two = $my_hash_prefix . $my_hash_key . $random_password;

        $computed_hash_one = Hash::make($hash_one);
        $computed_hash_two = Hash::make($hash_two);

        $this->info("Hash one: " . $computed_hash_one);
        $this->info("Hash two: " . $computed_hash_two);

        $this->info("Checking hashes for match");

        $check_one = Hash::check($hash_one, $computed_hash_one);
        $check_two = Hash::check($hash_two, $computed_hash_one);

        if($check_one && $check_two) {
            $this->info("Hashes match, bcrypt is vulnerable to spill over");
        } else {
            $this->info("Hashes do not match, bcrypt is not vulnerable to spill over");
        }
    }
}

```

Running this, should return us `Hashes do not match, bcrypt is not vulnerable to spill over` because `$hash_two` should not be the same as `$computed_hash_one` but it doesn't, it returns `Hashes match, bcrypt is vulnerable to spill over` because of the spill over. 

## Whats Changed?
This change intoduces a new config value `hashing.bcrypt.limit_length` in `hashing.php` to allow you to enable limiting the length of values passed to `Hash::make()` when using bcrypt.

Running the same code above after my change, throws an exception instead of silently failing.

### Resources
1. https://trust.okta.com/security-advisories/okta-ad-ldap-delegated-authentication-username/
2. https://n0rdy.foo/posts/20250121/okta-bcrypt-lessons-for-better-apis/


