### PR TITLE
[11.x] Make model factory `for()` calls take precedence over factory states

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -449,9 +449,9 @@ abstract class Factory
     protected function getRawAttributes(?Model $parent)
     {
         return $this->states->pipe(function ($states) {
-            return $this->for->isEmpty() ? $states : new Collection(array_merge([function () {
+            return $this->for->isEmpty() ? $states : new Collection(array_merge($states->all(), [function () {
                 return $this->parentResolvers();
-            }], $states->all()));
+            }]));
         })->reduce(function ($carry, $state) use ($parent) {
             if ($state instanceof Closure) {
                 $state = $state->bindTo($this);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -331,6 +331,21 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestPost::all());
     }
 
+    public function test_belongs_to_relationship_overrides_state()
+    {
+        $posts = FactoryTestPostFactory::times(3)
+            ->draft()
+            ->for(FactoryTestUserFactory::new(['name' => 'Taylor Otwell']), 'user')
+            ->create();
+
+        $this->assertCount(3, $posts->filter(function ($post) {
+            return $post->user->name === 'Taylor Otwell';
+        }));
+
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
+    }
+
     public function test_morph_to_relationship()
     {
         $posts = FactoryTestCommentFactory::times(3)
@@ -895,6 +910,14 @@ class FactoryTestPostFactory extends Factory
             'user_id' => FactoryTestUserFactory::new(),
             'title' => $this->faker->name(),
         ];
+    }
+
+    public function draft()
+    {
+        return $this->state(fn ($attributes) => [
+            'user_id' => -1,
+            'title' => '(draft) '.$attributes['title']
+        ]);
     }
 }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -916,7 +916,7 @@ class FactoryTestPostFactory extends Factory
     {
         return $this->state(fn ($attributes) => [
             'user_id' => -1,
-            'title' => '(draft) '.$attributes['title']
+            'title' => '(draft) '.$attributes['title'],
         ]);
     }
 }


### PR DESCRIPTION
### Background

When using an Eloquent model factory, the `for()` method can be used to assign a `belongsTo` foreign key to a new or existing model. If the factory definition includes an assigned value for that foreign key, the `for()` method will take precedence and override it.

### Issue

Though foreign keys specified in the definition will be overridden, foreign keys specified in a factory state are not. If the factory call uses both a state that assigns a foreign key and a `for()` method call, then the `for()` method is essentially ignored. I believe that a call to `for()` that is intended to set a specific relationship is much more intentional than a call to a state that can be more general and set many fields, and therefore the call to `for()` should have a higher precedence.

### Resolution

This PR switches the order in which "states" and "fors" are applied to the factory. This will make it so that calls to `for()` will override any foreign keys set via factory states.

### Example

Below is the failing test added to the test suite. In this example, there has been a `draft()` state added to the factory that sets multiple fields, including the `user_id` foreign key. However, our test uses the `for()` method to clarify the intent is that the posts should be related to the user we are specifying.

Before the PR, the `user_id` from the `draft()` state is used, the `for()` call is ignored, and this test fails. After the PR, the `user_id` field is set by the `for()` call, overriding the definition and state, and the test succeeds.

    public function test_belongs_to_relationship_overrides_state()
    {
        $posts = FactoryTestPostFactory::times(3)
            ->draft()
            ->for(FactoryTestUserFactory::new(['name' => 'Taylor Otwell']), 'user')
            ->create();

        $this->assertCount(3, $posts->filter(function ($post) {
            return $post->user->name === 'Taylor Otwell';
        }));

        $this->assertCount(1, FactoryTestUser::all());
        $this->assertCount(3, FactoryTestPost::all());
    }

### Caveats

Fields directly set in calls to the `make()` or `create()` methods are treated as states. With this PR, the relationship set by the `for()` call will take precedence over any foreign key manually assigned in the call to `make()` or `create()`.

For example, given the following code:

    $posts = FactoryTestPostFactory::times(3)
        ->draft()
        ->for(FactoryTestUserFactory::new(['name' => 'Taylor Otwell']), 'user')
        ->create(['user_id' => 2]);

With this PR, the `user_id` field will be assigned using the call to the `for()` method, and will override the `user_id` defined in the `draft()` state and the `user_id` specified in the `create()` call.

### Target

I targeted this at 11.x to be treated as a bugfix. However, people may have existing tests that rely on the current order of "states" and "fors" (even though their "fors" would be ignored).

If desired, I can treat this as a breaking change and submit a new PR that targets master.

Thanks,
Patrick
