### PR TITLE
[11.x] Improve check for relative sqlite databases

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -28,11 +28,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             return $this->createConnection('sqlite:'.$config['database'], $config, $options);
         }
 
-        $path = realpath($config['database']);
-
-        if (! file_exists($path)) {
-            $path = realpath(base_path($config['database']));
-        }
+        $path = realpath($config['database']) ?: realpath(base_path($config['database']));
 
         // Here we'll verify that the SQLite database exists before going any further
         // as the developer probably wants to know if the database exists and this


### PR DESCRIPTION
Applies the suggestion from @Sekaiichi in laravel/framework#54480.

realpath() returns false if the file doesn't exist, so the previous code would have been file_exists(false), which technically doesn't match the file_exists signature.

See https://stackoverflow.com/a/8374026