### PR TITLE
Allow precognition dispatchers to be bound by name for overriding

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -60,8 +60,8 @@ class HandlePrecognitiveRequests
     {
         $request->attributes->set('precognitive', true);
 
-        $this->container->bind(CallableDispatcherContract::class, fn ($app) => new PrecognitionCallableDispatcher($app));
-        $this->container->bind(ControllerDispatcherContract::class, fn ($app) => new PrecognitionControllerDispatcher($app));
+        $this->container->bind(CallableDispatcherContract::class, PrecognitionCallableDispatcher::class);
+        $this->container->bind(ControllerDispatcherContract::class, PrecognitionControllerDispatcher::class);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi, I'm working on a PR for Laravel Actions with the goal of enabling Precognition for Actions, as I'd like to start using Precognition within Actions. While I've made this work with an extension of the `HandlePrecognitiveRequests` middleware for backwards compatibility that people would have to remember to use over the built in one, this is a cleaner way of doing and enables `It Just Works™` compatibility.

This change is what allows Spice-King/laravel-actions@4c4720ac2123466f7dc444733e71ea22c9f889bb to make it seamless. I only really need `ControllerDispatcher` done for what I've done, *but* there was no compelling reason to not make them match and `CallableDispatcher` might be needed solve how `WithAttributes` functions without `FormRequest`s.