### PR TITLE
Ignore docker-compose.override.yml in .gitignore for flexible local setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 /.fleet
 /.vscode
 .phpunit.result.cache
+docker-compose.override.yml


### PR DESCRIPTION
This PR updates .gitignore to exclude docker-compose.override.yml, allowing contributors to use custom Docker configurations without affecting the repository.

#### Why this change?
Laravel’s core repository includes a docker-compose.yml, but contributors might need additional configurations (e.g., adding a PHP service for running tests in Docker).

docker-compose.override.yml is a built-in mechanism in Docker Compose that lets users extend the default setup without modifying the main file.

By ignoring this file, contributors can define their own overrides without accidentally committing personal configurations.
This makes local development more flexible while keeping the repository clean. 🚀