### PR TITLE
[11.x] Fluent Array validation

### DIFF
--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -37,17 +37,17 @@ class ArrayRule implements Stringable
         }
 
         $keys = array_map(
-            static fn($key) => enum_value($key),
+            static fn ($key) => enum_value($key),
             $keys,
         );
 
-        return $this->addRule('array:' . implode(',', $keys));
+        return $this->addRule('array:'.implode(',', $keys));
     }
 
     /**
      * The field under validation must have a distinct values.
      *
-     * @param  bool $strict
+     * @param  bool  $strict
      * @return $this
      */
     public function distinct(bool $strict = false)
@@ -56,9 +56,9 @@ class ArrayRule implements Stringable
     }
 
     /**
-     * The field under validation must have size less than or equal to a maximum value
+     * The field under validation must have size less than or equal to a maximum value.
      *
-     * @param  int $max
+     * @param  int  $max
      * @return $this
      */
     public function max(int $max)
@@ -67,9 +67,9 @@ class ArrayRule implements Stringable
     }
 
     /**
-     * The field under validation must have size greater than or equal to a minimum value
+     * The field under validation must have size greater than or equal to a minimum value.
      *
-     * @param  int $min
+     * @param  int  $min
      * @return $this
      */
     public function min(int $min)
@@ -78,9 +78,9 @@ class ArrayRule implements Stringable
     }
 
     /**
-     * The field under validation must have a size matching the given value
+     * The field under validation must have a size matching the given value.
      *
-     * @param  int $size
+     * @param  int  $size
      * @return $this
      */
     public function size(int $size)
@@ -89,10 +89,10 @@ class ArrayRule implements Stringable
     }
 
     /**
-     * The field under validation must have a size between the given min and max
+     * The field under validation must have a size between the given min and max.
      *
-     * @param  int $min
-     * @param  int $max
+     * @param  int  $min
+     * @param  int  $max
      * @return $this
      */
     public function between(int $min, int $max)
@@ -114,7 +114,7 @@ class ArrayRule implements Stringable
     /**
      * The field under validation must be an array that contains all of the given parameter values.
      *
-     * @param  array|string $keys
+     * @param  array|string  $keys
      * @return $this
      */
     public function contains($keys)
@@ -126,17 +126,18 @@ class ArrayRule implements Stringable
         $keys = is_array($keys) ? $keys : func_get_args();
 
         $keys = array_map(
-            static fn($key) => enum_value($key),
+            static fn ($key) => enum_value($key),
             $keys,
         );
 
-        return $this->addRule('contains:' . implode(',', $keys));
+        return $this->addRule('contains:'.implode(',', $keys));
     }
 
     /**
      * The field under validation must exist in anotherfield's values.
      *
      * string $anotherField
+     *
      * @return $this
      */
     public function inArray(string $anotherField)

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -3,18 +3,20 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 use Stringable;
 
 use function Illuminate\Support\enum_value;
 
 class ArrayRule implements Stringable
 {
+    use Conditionable;
+
     /**
-     * The accepted keys.
-     *
-     * @var array
+     * The constraints for the number rule.
      */
-    protected $keys;
+    protected array $constraints = [];
 
     /**
      * Create a new array rule instance.
@@ -28,25 +30,135 @@ class ArrayRule implements Stringable
             $keys = $keys->toArray();
         }
 
-        $this->keys = is_array($keys) ? $keys : func_get_args();
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        if (empty($keys)) {
+            return $this->addRule('array');
+        }
+
+        $keys = array_map(
+            static fn($key) => enum_value($key),
+            $keys,
+        );
+
+        return $this->addRule('array:' . implode(',', $keys));
+    }
+
+    /**
+     * The field under validation must have a distinct values.
+     *
+     * @param  bool $strict
+     * @return $this
+     */
+    public function distinct(bool $strict = false)
+    {
+        return $this->addRule($strict ? 'distinct:strict' : 'distinct');
+    }
+
+    /**
+     * The field under validation must have size less than or equal to a maximum value
+     *
+     * @param  int $max
+     * @return $this
+     */
+    public function max(int $max)
+    {
+        return $this->addRule("max:$max");
+    }
+
+    /**
+     * The field under validation must have size greater than or equal to a minimum value
+     *
+     * @param  int $min
+     * @return $this
+     */
+    public function min(int $min)
+    {
+        return $this->addRule("min:$min");
+    }
+
+    /**
+     * The field under validation must have a size matching the given value
+     *
+     * @param  int $size
+     * @return $this
+     */
+    public function size(int $size)
+    {
+        return $this->addRule("size:$size");
+    }
+
+    /**
+     * The field under validation must have a size between the given min and max
+     *
+     * @param  int $min
+     * @param  int $max
+     * @return $this
+     */
+    public function between(int $min, int $max)
+    {
+        return $this->addRule("between:$min,$max");
+    }
+
+    /**
+     * The field under validation must be an array that is a list.
+     * An array is considered a list if its keys consist of consecutive numbers from 0 to count($array) - 1.
+     *
+     * @return $this
+     */
+    public function list()
+    {
+        return $this->addRule('list');
+    }
+
+    /**
+     * The field under validation must be an array that contains all of the given parameter values.
+     *
+     * @param  array|string $keys
+     * @return $this
+     */
+    public function contains($keys)
+    {
+        if ($keys instanceof Arrayable) {
+            $keys = $keys->toArray();
+        }
+
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $keys = array_map(
+            static fn($key) => enum_value($key),
+            $keys,
+        );
+
+        return $this->addRule('contains:' . implode(',', $keys));
+    }
+
+    /**
+     * The field under validation must exist in anotherfield's values.
+     *
+     * string $anotherField
+     * @return $this
+     */
+    public function inArray(string $anotherField)
+    {
+        return $this->addRule("in_array:$anotherField");
     }
 
     /**
      * Convert the rule to a validation string.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
-        if (empty($this->keys)) {
-            return 'array';
-        }
+        return implode('|', array_unique($this->constraints));
+    }
 
-        $keys = array_map(
-            static fn ($key) => enum_value($key),
-            $this->keys,
-        );
+    /**
+     * Add custom rules to the validation rules array.
+     */
+    protected function addRule(array|string $rules): ArrayRule
+    {
+        $this->constraints = array_merge($this->constraints, Arr::wrap($rules));
 
-        return 'array:'.implode(',', $keys);
+        return $this;
     }
 }

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -32,7 +32,7 @@ class ArrayRule implements Stringable
 
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        if (empty($keys)) {
+        if ($keys === []) {
             return $this->addRule('array');
         }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Numeric;
@@ -100,7 +101,7 @@ class ValidationRuleParser
         $rules = [];
 
         foreach ($rule as $value) {
-            if ($value instanceof Date || $value instanceof Numeric) {
+            if ($value instanceof Date || $value instanceof Numeric || $value instanceof ArrayRule) {
                 $rules = array_merge($rules, explode('|', (string) $value));
             } else {
                 $rules[] = $this->prepareRule($value, $attribute);

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -205,5 +205,54 @@ class ValidationArrayRuleTest extends TestCase
             ['foo' => (string) Rule::array()->contains(1)]
         );
         $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->list()]]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->max(3)]]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->min(3)]]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->between(3, 5)]]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->size(3)]]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->distinct()]]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => ['required', Rule::array()->contains(1)]]
+        );
+        $this->assertTrue($v->passes());
     }
 }

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Validation;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
@@ -39,6 +40,107 @@ class ValidationArrayRuleTest extends TestCase
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
     }
 
+    public function testDefaultArrayRule()
+    {
+        $rule = Rule::array();
+        $this->assertEquals('array', (string) $rule);
+
+        $rule = new ArrayRule();
+        $this->assertSame('array', (string) $rule);
+    }
+
+    public function testDefaultArrayRuleWithKeys()
+    {
+        $rule = Rule::array(['a', 'b']);
+        $this->assertEquals('array:a,b', (string) $rule);
+
+        $rule = new ArrayRule([1, 2]);
+        $this->assertSame('array:1,2', (string) $rule);
+    }
+
+    public function testDistinctValidation()
+    {
+        $rule = Rule::array()->distinct();
+        $this->assertEquals('array|distinct', (string) $rule);
+
+        $rule = Rule::array()->distinct(strict: true);
+        $this->assertEquals('array|distinct:strict', (string) $rule);
+    }
+
+    public function testMaxRule()
+    {
+        $rule = Rule::array()->max(10);
+        $this->assertEquals('array|max:10', (string) $rule);
+    }
+
+    public function testMinRule()
+    {
+        $rule = Rule::array()->min(10);
+        $this->assertEquals('array|min:10', (string) $rule);
+    }
+
+    public function testSizeRule()
+    {
+        $rule = Rule::array()->size(10);
+        $this->assertEquals('array|size:10', (string) $rule);
+    }
+
+    public function testBetweenRule()
+    {
+        $rule = Rule::array()->between(1, 5);
+        $this->assertEquals('array|between:1,5', (string) $rule);
+    }
+
+    public function testListRule()
+    {
+        $rule = Rule::array()->list();
+        $this->assertEquals('array|list', (string) $rule);
+    }
+
+    public function testContainsRule()
+    {
+        $rule = Rule::array()->contains(['a', 'b']);
+        $this->assertEquals('array|contains:a,b', (string) $rule);
+
+        $rule = Rule::array()->contains('a,b');
+        $this->assertEquals('array|contains:a,b', (string) $rule);
+
+        $rule = Rule::array()->contains(collect(['key_1', 'key_2', 'key_3']));
+        $this->assertSame('array|contains:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::array()->contains([ArrayKeys::key_1, ArrayKeys::key_2, ArrayKeys::key_3]);
+        $this->assertSame('array|contains:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::array()->contains([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2, ArrayKeysBacked::key_3]);
+        $this->assertSame('array|contains:key_1,key_2,key_3', (string) $rule);
+    }
+
+    public function testInArrayRule()
+    {
+        $rule = Rule::array()->inArray('another_filed');
+        $this->assertEquals('array|in_array:another_filed', (string) $rule);
+    }
+
+    public function testChainedRules()
+    {
+        $rule = Rule::array()
+            ->min(5)
+            ->max(10)
+            ->distinct()
+            ->list();
+        $this->assertEquals('array|min:5|max:10|distinct|list', (string) $rule);
+
+        $rule = Rule::array()
+            ->size(5)
+            ->when(true, function ($rule) {
+                $rule->distinct();
+            })
+            ->unless(false, function ($rule) {
+                $rule->list();
+            });
+        $this->assertSame('array|size:5|distinct|list', (string) $rule);
+    }
+
     public function testArrayValidation()
     {
         $trans = new Translator(new ArrayLoader, 'en');
@@ -53,6 +155,55 @@ class ValidationArrayRuleTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => ['key_1' => 'bar', 'key_2' => '']], ['foo' => ['required', Rule::array(['key_1', 'key_2'])]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->list()]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->max(3)]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->min(3)]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->between(3, 5)]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->size(3)]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->distinct()]
+        );
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            $trans,
+            ['foo' => [1, 2, 3]],
+            ['foo' => (string) Rule::array()->contains(1)]
+        );
         $this->assertTrue($v->passes());
     }
 }


### PR DESCRIPTION
This pull request introduces a new fluent array validation class, offering a more elegant and expressive way to define array validation rules.

Before this PR, arrray validation required string-based rules:

```
$rules = [
    'array' => ['required', 'array', 'min:3', 'max:5', 'list'],
    'array_with_specific_elements' => ['required', 'array:a,b,c']
];
```

To use the fluent array validation:

```
use Illuminate\Validation\Rule;

$rules = [
    'array' => [
       'required',
        Rule::array()
            ->min(3)
            ->max(5)
            ->list();
    ],
    'array_with_specific_elements' => ['required', Rule::array(['a', 'b', 'c'])],
];
```


**Available methods**

- **`distinct(bool $strict = false)`**
- **`max(int $max)`**
- **`min(int $min)`**
- **`between(int $min, int $max)`**
- **`size(int $size)`**
- **`contains($keys)`**
- **`inArray(string $anotherField)`**
-  **`list()`**