### PR TITLE
[11.x] Introduced new PipeMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/PipeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PipeMakeCommand.php
@@ -85,7 +85,7 @@ class PipeMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the event already exists'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the pipe already exists'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/PipeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PipeMakeCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Illuminate/Foundation/Console/PipeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PipeMakeCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:pipe')]
+class PipeMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:pipe';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new pipe class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Pipe';
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($rawName) ||
+               $this->files->exists($this->getPath($this->qualifyClass($rawName)));
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/pipe.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Pipes';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the event already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/pipe.stub
+++ b/src/Illuminate/Foundation/Console/stubs/pipe.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+
+class {{ class }}
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(object $data, Closure $next): void
+    {
+        $next($data);
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/pipe.stub
+++ b/src/Illuminate/Foundation/Console/stubs/pipe.stub
@@ -6,9 +6,6 @@ use Closure;
 
 class {{ class }}
 {
-    /**
-     * Handle the event.
-     */
     public function handle(object $data, Closure $next): void
     {
         $next($data);

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -67,6 +67,7 @@ use Illuminate\Foundation\Console\ObserverMakeCommand;
 use Illuminate\Foundation\Console\OptimizeClearCommand;
 use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
+use Illuminate\Foundation\Console\PipeMakeCommand;
 use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\RequestMakeCommand;
@@ -211,6 +212,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ObserverMake' => ObserverMakeCommand::class,
         'PolicyMake' => PolicyMakeCommand::class,
         'ProviderMake' => ProviderMakeCommand::class,
+        'PipeMake' => PipeMakeCommand::class,
         'QueueFailedTable' => FailedTableCommand::class,
         'QueueTable' => TableCommand::class,
         'QueueBatchesTable' => BatchesTableCommand::class,
@@ -625,6 +627,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(ProviderMakeCommand::class, function ($app) {
             return new ProviderMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerPipeMakeCommand()
+    {
+        $this->app->singleton(PipeMakeCommand::class, function ($app) {
+            return new PipeMakeCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Generators/PipeMakeCommandTest.php
+++ b/tests/Integration/Generators/PipeMakeCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class PipeMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Pipes/FooPipe.php',
+        'tests/Feature/Pipes/FooPipeTest.php',
+    ];
+
+    public function testItCanGeneratePipeFile()
+    {
+        $this->artisan('make:pipe', ['name' => 'FooPipe'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Pipes;',
+            'class FooPipe',
+        ], 'app/Pipes/FooPipe.php');
+    }
+}


### PR DESCRIPTION
Within the commands defined in the structure there is currently no option to create a pipe class to be used with pipelines. 

I believe since Laravel offers Pipelines for developers to use, it would be very useful to have a command to easily create a pipe classes to be used in pipelines.

The command is structured just as all Laravel's make commands, and creates the pipe classes in a separate folder in the app directory named Pipes

`php artisan make:pipe`
