### PR TITLE
[11.x] Add fluent URL validation class rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -245,8 +245,11 @@ class Rule
         return new Numeric;
     }
 
+    /**
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null $protocols
+     */
     public static function url($protocols = null)
     {
-        return new Url($protocols);
+        return new Url(...func_get_args());
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -20,6 +20,7 @@ use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\Url;
 
 class Rule
 {
@@ -242,5 +243,10 @@ class Rule
     public static function numeric()
     {
         return new Numeric;
+    }
+
+    public static function url($protocols = null)
+    {
+        return new Url($protocols);
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -246,7 +246,7 @@ class Rule
     }
 
     /**
-     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null $protocols
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $protocols
      */
     public static function url($protocols = null)
     {

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
+
+use function Illuminate\Support\enum_value;
+
+class Url implements Stringable
+{
+    protected bool $active = false;
+    
+    /**
+     * @var  string[]  $protocols
+     */
+    protected array $protocols = [];
+
+    /**
+     * Create a new array rule instance.
+     *
+     * @param  array|null  $protocols
+     * @return void
+     */
+    public function __construct($protocols = null)
+    {
+        $this->protocols($protocols);
+    }
+
+    public function active(bool $active)
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    /**
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable
+     */
+    public function protocols($protocols = null)
+    {
+        $this->protocols = match (true) {
+            $keys instanceof Arrayable => $keys->toArray(),
+            !is_array($keys) => func_get_args(),
+            default => $keys,
+        };
+
+        return $this;
+    }
+
+    public function protocol(string $protocol)
+    {
+        $this->protocols = array_unique([ ...$this->protocols, $protocol ]);
+
+        return $this;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->active) {
+            return 'active_url';
+        }
+
+        if ($this->protocols === []) {
+            return 'url';
+        }
+
+        return 'url:'.implode(',', $this->protocols);
+    }
+}

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -38,9 +38,9 @@ class Url implements Stringable
     public function protocols($protocols = null)
     {
         $this->protocols = match (true) {
-            $keys instanceof Arrayable => $keys->toArray(),
-            ! is_array($keys) => func_get_args(),
-            default => $keys,
+            $protocols instanceof Arrayable => $protocols->toArray(),
+            ! is_array($protocols) => func_get_args(),
+            default => $protocols,
         };
 
         return $this;

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -33,7 +33,7 @@ class Url implements Stringable
     }
 
     /**
-     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null $protocols
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $protocols
      */
     public function protocols($protocols = null)
     {

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -22,7 +22,7 @@ class Url implements Stringable
      */
     public function __construct($protocols = null)
     {
-        $this->protocols($protocols);
+        $this->protocols(...func_get_args());
     }
 
     public function active(bool $active)

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -10,7 +10,7 @@ class Url implements Stringable
     protected bool $active = false;
 
     /**
-     * @var  string[]
+     * @var string[]
      */
     protected array $protocols = [];
 

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -15,7 +15,7 @@ class Url implements Stringable
     protected array $protocols = [];
 
     /**
-     * Create a new array rule instance.
+     * Create a new url rule instance.
      *
      * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $protocols
      * @return void

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -5,14 +5,12 @@ namespace Illuminate\Validation\Rules;
 use Illuminate\Contracts\Support\Arrayable;
 use Stringable;
 
-use function Illuminate\Support\enum_value;
-
 class Url implements Stringable
 {
     protected bool $active = false;
-    
+
     /**
-     * @var  string[]  $protocols
+     * @var  string[]
      */
     protected array $protocols = [];
 
@@ -41,7 +39,7 @@ class Url implements Stringable
     {
         $this->protocols = match (true) {
             $keys instanceof Arrayable => $keys->toArray(),
-            !is_array($keys) => func_get_args(),
+            ! is_array($keys) => func_get_args(),
             default => $keys,
         };
 
@@ -50,7 +48,7 @@ class Url implements Stringable
 
     public function protocol(string $protocol)
     {
-        $this->protocols = array_unique([ ...$this->protocols, $protocol ]);
+        $this->protocols = array_unique([...$this->protocols, $protocol]);
 
         return $this;
     }

--- a/src/Illuminate/Validation/Rules/Url.php
+++ b/src/Illuminate/Validation/Rules/Url.php
@@ -17,7 +17,7 @@ class Url implements Stringable
     /**
      * Create a new array rule instance.
      *
-     * @param  array|null  $protocols
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $protocols
      * @return void
      */
     public function __construct($protocols = null)
@@ -33,7 +33,7 @@ class Url implements Stringable
     }
 
     /**
-     * @param  string[]|\Illuminate\Contracts\Support\Arrayable
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null $protocols
      */
     public function protocols($protocols = null)
     {

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Validation;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
 
 class ValidationUrlRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Validation\Rule;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -17,11 +17,11 @@ class ValidationUrlRuleTest extends TestCase
 
     #[TestWith([true, 'active_url'])]
     #[TestWith([false, 'url'])]
-    public function testActiveUrlRuleStringification(bool $active, string $rule)
+    public function testActiveUrlRuleStringification(bool $active, string $output)
     {
         $rule = Rule::url()->active($active);
 
-        $this->assertSame($rule, (string) $rule);
+        $this->assertSame($output, (string) $rule);
     }
 
     public function testUrlRuleConstructorProtocolsStringification()

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\TestWith;
 
 class ValidationUrlRuleTest extends TestCase

--- a/tests/Validation/ValidationUrlRuleTest.php
+++ b/tests/Validation/ValidationUrlRuleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use PHPUnit\Framework\Attributes\TestWith;
+
+class ValidationUrlRuleTest extends TestCase
+{
+    public function testUrlRuleStringification()
+    {
+        $rule = Rule::url();
+
+        $this->assertSame('url', (string) $rule);
+    }
+
+    #[TestWith([true, 'active_url'])]
+    #[TestWith([false, 'url'])]
+    public function testActiveUrlRuleStringification(bool $active, string $rule)
+    {
+        $rule = Rule::url()->active($active);
+
+        $this->assertSame($rule, (string) $rule);
+    }
+
+    public function testUrlRuleConstructorProtocolsStringification()
+    {
+        $rule = Rule::url('http', 'https');
+
+        $this->assertSame('url:http,https', (string) $rule);
+
+        $rule = Rule::url(['http', 'https']);
+
+        $this->assertSame('url:http,https', (string) $rule);
+
+        $rule = Rule::url(collect(['http', 'https']));
+
+        $this->assertSame('url:http,https', (string) $rule);
+    }
+
+    public function testUrlRuleProtocolsStringification()
+    {
+        $rule = Rule::url()->protocols('http', 'https');
+
+        $this->assertSame('url:http,https', (string) $rule);
+
+        $rule = Rule::url()->protocols(['http', 'https']);
+
+        $this->assertSame('url:http,https', (string) $rule);
+
+        $rule = Rule::url()->protocols(collect(['http', 'https']));
+
+        $this->assertSame('url:http,https', (string) $rule);
+
+        $rule = Rule::url('ftp')->protocols(collect(['http', 'https']));
+
+        $this->assertSame('url:http,https', (string) $rule);
+    }
+
+    #[TestWith(['http', 'url:http,https'])]
+    #[TestWith(['ftp', 'url:http,https,ftp'])]
+    public function testUrlRuleProtocolStringification(string $input, string $output)
+    {
+        $rule = Rule::url('http', 'https')->protocol($input);
+
+        $this->assertSame($output, (string) $rule);
+    }
+}


### PR DESCRIPTION
Similar to #54488, #53465, #54425, and #54517

Based on https://github.com/laravel/framework/pull/54488#discussion_r1944325705

# Examples
## Simplest case: Without constraints
```php
use Illuminate\Validation\Rule;

public function rules()
{
    return [
        'foo' => [
            'required',
            Rule::url(), // results in 'url'
        ],
    ];
}
```

## Active URL
```php
use Illuminate\Validation\Rule;

public function rules()
{
    return [
        'foo' => [
            'required',
            Rule::url()->active(), // results in 'active_url'
        ],
    ];
}
```

## With protocols
```php
use Illuminate\Validation\Rule;

public function rules()
{
    return [
        'foo' => [
            'required',
            Rule::url('http', 'https'), // results in 'url:http,https'
            // or: Rule::url(['http', 'https'])
            // or: Rule::url(collect(['http', 'https']))
            // or: Rule::url()->protocols('http', 'https')
        ],
    ];
}
```

### Modify protocols
```php
use Illuminate\Validation\Rule;

public function rules()
{
    $rule = Rule::url('http', 'https');
    $rule->protocol('ftp');
    return [
        'foo' => [
            'required',
            $rule, // results in 'url:http,https,ftp'
        ],
    ];
}
```