### PR TITLE
[11.x] Add fluent RegExp validation class rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -245,8 +245,14 @@ class Rule
         return new Numeric;
     }
 
-    public static function regex(string $regExp, array $flags = [])
+    /**
+     * Get a regex rule builder rule instance.
+     *
+     * @param  string  $regExp
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable  $extraFlags
+     */
+    public static function regex(string $regExp, array|Arrayable $extraFlags = [])
     {
-        return new RegExp($regExp, $flags);
+        return new RegExp($regExp, $extraFlags);
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -18,6 +18,7 @@ use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
+use Illuminate\Validation\Rules\RegExp;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
 
@@ -242,5 +243,10 @@ class Rule
     public static function numeric()
     {
         return new Numeric;
+    }
+
+    public static function regex(string $regExp, array $flags = [])
+    {
+        return new RegExp($regExp, $flags);
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -248,11 +248,11 @@ class Rule
     /**
      * Get a regex rule builder rule instance.
      *
-     * @param  string  $regExp
+     * @param  string  $expression
      * @param  string[]|\Illuminate\Contracts\Support\Arrayable  $extraFlags
      */
-    public static function regex(string $regExp, array|Arrayable $extraFlags = [])
+    public static function regex(string $expression, array|Arrayable $extraFlags = [])
     {
-        return new RegExp($regExp, $extraFlags);
+        return new RegExp($expression, $extraFlags);
     }
 }

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -25,7 +25,6 @@ class RegExp implements Stringable
      */
     public function __construct(string $expression, array|Arrayable $extraFlags = [])
     {
-        $this->expression = $expression;
         $str = Str::of($expression);
         $currentFlags = str_split($str->afterLast('/'));
 

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -37,9 +37,9 @@ class RegExp implements Stringable
     }
 
     /**
-     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $flags
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable  $flags
      */
-    public function flags($flags = null)
+    public function flags($flags = [])
     {
         $this->flags = match (true) {
             $flags instanceof Arrayable => $flags->toArray(),

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -30,13 +30,6 @@ class RegExp implements Stringable
         $this->flags(...$flags);
     }
 
-    public function active(bool $active)
-    {
-        $this->active = $active;
-
-        return $this;
-    }
-
     /**
      * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $flags
      */

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Str;
-use Illuminate\Contracts\Support\Stringable as SupportStringable;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable as SupportStringable;
 use Stringable;
 
 class RegExp implements Stringable

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -40,7 +40,7 @@ class RegExp implements Stringable
     /**
      * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $flags
      */
-    public function flags($flags)
+    public function flags($flags = null)
     {
         $this->flags = match (true) {
             $flags instanceof Arrayable => $flags->toArray(),

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -72,7 +72,7 @@ class RegExp implements Stringable
      */
     public function __toString()
     {
-        return (string) Str::of($this->not ? 'not_regex' : 'regex')
+        return (string) Str::of($this->negated ? 'not_regex' : 'regex')
             ->append(
                 ':',
                 $this->regExp,

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -4,7 +4,6 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
-use Illuminate\Support\Stringable as SupportStringable;
 use Stringable;
 
 class RegExp implements Stringable

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -79,7 +79,7 @@ class RegExp implements Stringable
             )
             ->when($this->flags, function (SupportStringable $str) {
                 $end = $str->afterLast('/');
-                $flags = explode('', $end);
+                $flags = str_split($end);
                 $flags = array_unique([...$this->flags, $flags]);
 
                 return $str->replaceEnd('/'.$end, '/'.implode('', $flags));

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -80,7 +80,7 @@ class RegExp implements Stringable
             ->when($this->flags, function (SupportStringable $str) {
                 $end = $str->afterLast('/');
                 $flags = str_split($end);
-                $flags = array_unique([...$this->flags, $flags]);
+                $flags = array_unique([...$this->flags, ...$flags]);
 
                 return $str->replaceEnd('/'.$end, '/'.implode('', $flags));
             });

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Str;
+use Illuminate\Contracts\Support\Stringable as SupportStringable;
+use Stringable;
+
+class RegExp implements Stringable
+{
+    protected string $regExp;
+    protected bool $negated = false;
+
+    /**
+     * @var string[]
+     */
+    protected array $flags = [];
+
+    /**
+     * Create a new array rule instance.
+     *
+     * @param  string  $regExp
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $flags
+     * @return void
+     */
+    public function __construct(string $regExp, $flags = null)
+    {
+        $this->regExp = $regExp;
+        $this->flags(...$flags);
+    }
+
+    public function active(bool $active)
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    /**
+     * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $flags
+     */
+    public function flags($flags)
+    {
+        $this->flags = match (true) {
+            $flags instanceof Arrayable => $flags->toArray(),
+            ! is_array($flags) => func_get_args(),
+            default => $flags,
+        };
+
+        return $this;
+    }
+
+    public function flag(string $flag)
+    {
+        $this->flags = array_unique([...$this->flags, $flag]);
+
+        return $this;
+    }
+
+    public function not()
+    {
+        $this->negated = true;
+
+        return $this;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) Str::of($this->not ? 'not_regex' : 'regex')
+            ->append(
+                ':',
+                $this->regExp,
+            )
+            ->when($this->flags, function (SupportStringable $str) {
+                $end = $str->afterLast('/');
+                $flags = explode('', $end);
+                $flags = array_unique([...$this->flags, $flags]);
+
+                return $str->replaceEnd('/'.$end, '/'.implode('', $flags));
+            });
+    }
+}

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -32,7 +32,7 @@ class RegExp implements Stringable
         if ($extraFlags instanceof Arrayable) {
             $extraFlags = $extraFlags->toArray();
         }
-        
+
         $this->expression = $str->beforeLast('/')->append('/')->toString();
         $this->flags = array_unique([...$currentFlags, ...$extraFlags]);
     }

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -9,7 +9,7 @@ use Stringable;
 
 class RegExp implements Stringable
 {
-    protected string $regExp;
+    protected string $expression;
     protected bool $negated = false;
 
     /**
@@ -20,21 +20,21 @@ class RegExp implements Stringable
     /**
      * Create a new regex rule instance.
      *
-     * @param  string  $regExp
+     * @param  string  $expression
      * @param  string[]|\Illuminate\Contracts\Support\Arrayable  $extraFlags
      * @return void
      */
-    public function __construct(string $regExp, array|Arrayable $extraFlags = [])
+    public function __construct(string $expression, array|Arrayable $extraFlags = [])
     {
-        $this->regExp = $regExp;
-        $str = Str::of($regExp);
+        $this->expression = $expression;
+        $str = Str::of($expression);
         $currentFlags = str_split($str->afterLast('/'));
 
         if ($extraFlags instanceof Arrayable) {
             $extraFlags = $extraFlags->toArray();
         }
         
-        $this->regExp = $str->beforeLast('/')->append('/')->toString();
+        $this->expression = $str->beforeLast('/')->append('/')->toString();
         $this->flags = array_unique([...$currentFlags, ...$extraFlags]);
     }
 
@@ -76,7 +76,7 @@ class RegExp implements Stringable
         return sprintf(
             '%s:%s%s',
             $this->negated ? 'not_regex' : 'regex',
-            $this->regExp,
+            $this->expression,
             implode('', $this->flags),
         );
     }

--- a/src/Illuminate/Validation/Rules/RegExp.php
+++ b/src/Illuminate/Validation/Rules/RegExp.php
@@ -18,7 +18,7 @@ class RegExp implements Stringable
     protected array $flags = [];
 
     /**
-     * Create a new array rule instance.
+     * Create a new regex rule instance.
      *
      * @param  string  $regExp
      * @param  string[]|\Illuminate\Contracts\Support\Arrayable|null  $flags

--- a/tests/Validation/ValidationRegExpRuleTest.php
+++ b/tests/Validation/ValidationRegExpRuleTest.php
@@ -49,7 +49,7 @@ class ValidationRegExpRuleTest extends TestCase
 
     public function testRegExpRuleFlagsStringification()
     {
-        $rule = Rule::regex('/[a-z]/')->flags(null);
+        $rule = Rule::regex('/[a-z]/')->flags();
 
         $this->assertSame('regex:/[a-z]/', (string) $rule);
 

--- a/tests/Validation/ValidationRegExpRuleTest.php
+++ b/tests/Validation/ValidationRegExpRuleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rule;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class ValidationRegExpRuleTest extends TestCase
+{
+    public function testRegExpRuleStringification()
+    {
+        $rule = Rule::regex('/[a-z]/i');
+
+        $this->assertSame('regex:/[a-z]/i', (string) $rule);
+    }
+
+    public function testNotRegExpRuleStringification()
+    {
+        $rule = Rule::regex('/[a-z]/i')->not();
+
+        $this->assertSame('not_regex:/[a-z]/i', (string) $rule);
+    }
+
+    #[TestWith(['/[a-z]/', ['i'], 'regex:/[a-z]/i'])]
+    #[TestWith(['/[a-z]/i', ['i'], 'regex:/[a-z]/i'])]
+    #[TestWith(['/[a-z]/g', ['i'], 'regex:/[a-z]/gi'])]
+    public function testRegExpRuleConstructorFlagsStringification(string $input, array $flags, string $output)
+    {
+        $rule = Rule::regex($input, $flags);
+
+        $this->assertSame($output, (string) $rule);
+    }
+
+    public function tesRegExpRuleConstructorFlagDataTypesStringification()
+    {
+        $rule = Rule::regex('/[a-z]/', null);
+
+        $this->assertSame('regex:/[a-z]/', (string) $rule);
+
+        $rule = Rule::regex('/[a-z]/', []);
+
+        $this->assertSame('regex:/[a-z]/', (string) $rule);
+
+        $rule = Rule::regex('/[a-z]/', ['i']);
+
+        $this->assertSame('regex:/[a-z]/i', (string) $rule);
+
+        $rule = Rule::regex('/[a-z]/', collect(['i']));
+
+        $this->assertSame('regex:/[a-z]/i', (string) $rule);
+    }
+
+    public function testRegExpRuleProtocolsStringification()
+    {
+        $rule = Rule::regex('/[a-z]/')->flags(null);
+
+        $this->assertSame('regex:/[a-z]/', (string) $rule);
+
+        $rule = Rule::regex('/[a-z]/')->flags([]);
+
+        $this->assertSame('regex:/[a-z]/', (string) $rule);
+
+        $rule = Rule::regex('/[a-z]/')->flags(['i']);
+
+        $this->assertSame('regex:/[a-z]/i', (string) $rule);
+
+        $rule = Rule::regex('/[a-z]/')->flags(collect(['i']));
+
+        $this->assertSame('regex:/[a-z]/i', (string) $rule);
+    }
+
+    #[TestWith(['i', 'regex:/[a-z]/i'])]
+    #[TestWith(['g', 'regex:/[a-z]/gi'])]
+    public function testUrlRuleProtocolStringification(string $input, string $output)
+    {
+        $rule = Rule::regex('/[a-z]/i')->flag($input);
+
+        $this->assertSame($output, (string) $rule);
+    }
+}

--- a/tests/Validation/ValidationRegExpRuleTest.php
+++ b/tests/Validation/ValidationRegExpRuleTest.php
@@ -24,7 +24,7 @@ class ValidationRegExpRuleTest extends TestCase
 
     #[TestWith(['/[a-z]/', ['i'], 'regex:/[a-z]/i'])]
     #[TestWith(['/[a-z]/i', ['i'], 'regex:/[a-z]/i'])]
-    #[TestWith(['/[a-z]/g', ['i'], 'regex:/[a-z]/ig'])]
+    #[TestWith(['/[a-z]/g', ['i'], 'regex:/[a-z]/gi'])]
     public function testRegExpRuleConstructorFlagsStringification(string $input, array $flags, string $output)
     {
         $rule = Rule::regex($input, $flags);
@@ -34,10 +34,6 @@ class ValidationRegExpRuleTest extends TestCase
 
     public function tesRegExpRuleConstructorFlagDataTypesStringification()
     {
-        $rule = Rule::regex('/[a-z]/', null);
-
-        $this->assertSame('regex:/[a-z]/', (string) $rule);
-
         $rule = Rule::regex('/[a-z]/', []);
 
         $this->assertSame('regex:/[a-z]/', (string) $rule);
@@ -71,7 +67,7 @@ class ValidationRegExpRuleTest extends TestCase
     }
 
     #[TestWith(['i', 'regex:/[a-z]/i'])]
-    #[TestWith(['g', 'regex:/[a-z]/gi'])]
+    #[TestWith(['g', 'regex:/[a-z]/ig'])]
     public function testRegExpRuleFlagStringification(string $input, string $output)
     {
         $rule = Rule::regex('/[a-z]/i')->flag($input);

--- a/tests/Validation/ValidationRegExpRuleTest.php
+++ b/tests/Validation/ValidationRegExpRuleTest.php
@@ -51,7 +51,7 @@ class ValidationRegExpRuleTest extends TestCase
         $this->assertSame('regex:/[a-z]/i', (string) $rule);
     }
 
-    public function testRegExpRuleProtocolsStringification()
+    public function testRegExpRuleFlagsStringification()
     {
         $rule = Rule::regex('/[a-z]/')->flags(null);
 
@@ -72,7 +72,7 @@ class ValidationRegExpRuleTest extends TestCase
 
     #[TestWith(['i', 'regex:/[a-z]/i'])]
     #[TestWith(['g', 'regex:/[a-z]/gi'])]
-    public function testUrlRuleProtocolStringification(string $input, string $output)
+    public function testRegExpRuleFlagStringification(string $input, string $output)
     {
         $rule = Rule::regex('/[a-z]/i')->flag($input);
 

--- a/tests/Validation/ValidationRegExpRuleTest.php
+++ b/tests/Validation/ValidationRegExpRuleTest.php
@@ -24,7 +24,7 @@ class ValidationRegExpRuleTest extends TestCase
 
     #[TestWith(['/[a-z]/', ['i'], 'regex:/[a-z]/i'])]
     #[TestWith(['/[a-z]/i', ['i'], 'regex:/[a-z]/i'])]
-    #[TestWith(['/[a-z]/g', ['i'], 'regex:/[a-z]/gi'])]
+    #[TestWith(['/[a-z]/g', ['i'], 'regex:/[a-z]/ig'])]
     public function testRegExpRuleConstructorFlagsStringification(string $input, array $flags, string $output)
     {
         $rule = Rule::regex($input, $flags);


### PR DESCRIPTION
Similar to #54488, #53465, #54425, #54517, and #54519

# Examples
## Simplest case
```php
use Illuminate\Validation\Rule;

public function rules()
{
    return [
        'foo' => [
            'required',
            Rule::regex('/[a-z]/'), // results in 'regex:/[a-z]/'
        ],
    ];
}
```

## Negation
```php
use Illuminate\Validation\Rule;

public function rules()
{
    return [
        'foo' => [
            'required',
            Rule::regex('/[a-z]/')->not(), // results in 'not_regex:/[a-z]/'
        ],
    ];
}
```

## Flags
```php
use Illuminate\Validation\Rule;

public function rules()
{
    return [
        'foo' => [
            'required',
            Rule::regex('/[a-z]/i'), // results in 'regex:/[a-z]/i'
            // or Rule::regex('/[a-z]/', ['i'])
            // or Rule::regex('/[a-z]/')->flags(['i'])
        ],
    ];
}
```

### Modify flags
```php
use Illuminate\Validation\Rule;

public function rules()
{
    $rule = Rule::regex('/[a-z]/i');
    $rule->flag('g');
    return [
        'foo' => [
            'required',
            $rule, // results in 'regex:/[a-z]/gi'
        ],
    ];
}
```