### PR TITLE
[11.x] Job Batches with Redis Cluster

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Queue\Jobs\RedisJob;
+use Illuminate\Redis\Connections\PhpRedisClusterConnection;
+use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Str;
 
 class RedisQueue extends Queue implements QueueContract, ClearableQueue
@@ -118,17 +120,25 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function bulk($jobs, $data = '', $queue = null)
     {
-        $this->getConnection()->pipeline(function () use ($jobs, $data, $queue) {
-            $this->getConnection()->transaction(function () use ($jobs, $data, $queue) {
-                foreach ((array) $jobs as $job) {
-                    if (isset($job->delay)) {
-                        $this->later($job->delay, $job, $data, $queue);
-                    } else {
-                        $this->push($job, $data, $queue);
-                    }
+        $connection = $this->getConnection();
+        $bulk = function () use ($jobs, $data, $queue) {
+            foreach ((array) $jobs as $job) {
+                if (isset($job->delay)) {
+                    $this->later($job->delay, $job, $data, $queue);
+                } else {
+                    $this->push($job, $data, $queue);
                 }
-            });
-        });
+            }
+        };
+        if ($connection instanceof PhpRedisClusterConnection) {
+            // PhpRedis supports transactions, but not pipelining with Redis Cluster.
+            $connection->transaction($bulk);
+        } elseif ($connection instanceof PredisClusterConnection) {
+            // Predis supports pipelining, but not transactions with Redis Cluster.
+            $connection->pipeline($bulk);
+        } else {
+            $connection->pipeline(fn () => $connection->transaction($bulk));
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -121,6 +121,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     public function bulk($jobs, $data = '', $queue = null)
     {
         $connection = $this->getConnection();
+
         $bulk = function () use ($jobs, $data, $queue) {
             foreach ((array) $jobs as $job) {
                 if (isset($job->delay)) {
@@ -130,11 +131,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
                 }
             }
         };
+
         if ($connection instanceof PhpRedisClusterConnection) {
-            // PhpRedis supports transactions, but not pipelining with Redis Cluster.
             $connection->transaction($bulk);
         } elseif ($connection instanceof PredisClusterConnection) {
-            // Predis supports pipelining, but not transactions with Redis Cluster.
             $connection->pipeline($bulk);
         } else {
             $connection->pipeline(fn () => $connection->transaction($bulk));

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -9,8 +9,6 @@ use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Queue\RedisQueue;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -517,11 +515,6 @@ class RedisQueueTest extends TestCase
     #[DataProvider('redisDriverProvider')]
     public function testBulkJobQueuedEvent($driver)
     {
-        if ($this->redis[$driver]->connection() instanceof PhpRedisClusterConnection
-            || $this->redis[$driver]->connection() instanceof PredisClusterConnection
-        ) {
-            $this->markTestSkipped('RedisQueue::bulk currently does not support cluster connections');
-        }
         $events = m::mock(Dispatcher::class);
         $events->shouldReceive('dispatch')->with(m::type(JobQueueing::class))->andReturnNull()->times(3);
         $events->shouldReceive('dispatch')->with(m::type(JobQueued::class))->andReturnNull()->times(3);


### PR DESCRIPTION
Previously discussed in https://github.com/laravel/framework/pull/54205

Currently it is not possible to use job batches with Redis Cluster, both with Predis and Phpredis.

PhpRedis does not supports pipelining for Redis Cluster (https://github.com/phpredis/phpredis/blob/develop/cluster.md#pipelining), but supports transaction (making separate transaction for each node, https://github.com/phpredis/phpredis/blob/develop/cluster.md#transactions)

Predis does not supports transactions for Redis Cluster (https://github.com/predis/predis/blob/v2.x/src/Transaction/MultiExec.php#L77). But it pretty well works with pipelining (https://github.com/predis/predis?tab=readme-ov-file#command-pipelines)

This PR uses transaction, pipelining or both, depending on connection type.

Since https://github.com/laravel/framework/pull/54218 RedisQueue with Redis Cluster is covered with tests. Batch test was skipped for Redis Cluster. Now this test do not fail.