### PR TITLE
[11.x] New command env:change to switch environment files

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentChangeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentChangeCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'env:change')]
+class EnvironmentChangeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'env:change 
+                    {environment : The environment to change to}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Change the environment file .env to the specified environment file .env.{environment}';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $environment = $this->argument('environment');
+        $envFile = base_path('.env');
+        $envExampleFile = base_path(".env.$environment");
+
+        if (!File::exists($envExampleFile)) {
+            $this->fail("The environment file .env.$environment does not exist.");
+            return 1;
+        }
+
+        File::copy($envExampleFile, $envFile);
+        $this->info("Environment changed to .env.$environment");
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -45,6 +45,7 @@ use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnumMakeCommand;
+use Illuminate\Foundation\Console\EnvironmentChangeCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\EnvironmentDecryptCommand;
 use Illuminate\Foundation\Console\EnvironmentEncryptCommand;
@@ -132,6 +133,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'DbWipe' => WipeCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
+        'EnvironmentChange' => EnvironmentChangeCommand::class,
         'EnvironmentDecrypt' => EnvironmentDecryptCommand::class,
         'EnvironmentEncrypt' => EnvironmentEncryptCommand::class,
         'EventCache' => EventCacheCommand::class,

--- a/tests/Integration/Console/EnvironmentChangeCommandTest.php
+++ b/tests/Integration/Console/EnvironmentChangeCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class EnvironmentChangeCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = m::spy(Filesystem::class);
+        File::swap($this->filesystem);
+    }
+
+    public function testItFailsWhenEnvironmentFileDoesNotExist()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->with(base_path('.env.example'))
+            ->andReturn(false);
+
+        $this->artisan('env:change', ['environment' => 'example'])
+            ->expectsOutput('The environment file .env.example does not exist.')
+            ->assertExitCode(1);
+    }
+
+    public function testItChangesEnvironmentFileSuccessfully()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->with(base_path('.env.example'))
+            ->andReturn(true);
+
+        $this->filesystem->shouldReceive('copy')
+            ->once()
+            ->with(base_path('.env.example'), base_path('.env'))
+            ->andReturn(true);
+
+        $this->artisan('env:change', ['environment' => 'example'])
+            ->expectsOutput('Environment changed to .env.example')
+            ->assertExitCode(0);
+    }
+
+    public function testItFailsWhenCopyingFails()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->with(base_path('.env.example'))
+            ->andReturn(true);
+
+        $this->filesystem->shouldReceive('copy')
+            ->once()
+            ->with(base_path('.env.example'), base_path('.env'))
+            ->andReturn(false);
+
+        $this->artisan('env:change', ['environment' => 'example'])
+            ->expectsOutput('Failed to change environment to .env.example')
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
## Problem

Currently, switching between different environment configurations requires manually copying `.env` files. This can be cumbersome and error-prone, especially in development and deployment workflows.

## Proposed Solution

This PR introduces a new Artisan command `env:change` that allows developers to change between different environment files easily. The command copies the specified environment file (e.g., `.env.prod`) to `.env`.

### Usage

To change to the production environment, run:

```sh
php artisan env:change prod
```
### Breaking Changes

This change **does not introduce any breaking changes** to existing Laravel applications. The new `env:change` command is an **optional addition** that does not alter the default behavior of Laravel’s environment handling.

- **Existing commands and functionality remain unchanged.**  
- **No modifications are made to Laravel’s configuration loading process.**  
- **Applications that do not use this command will continue to function as expected.**
