### PR TITLE
[11.x] Assert Database Has Sole

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -91,7 +91,7 @@ trait InteractsWithDatabase
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseOnlyHas($table, array $data = [], $connection = null)
+    protected function assertDatabaseHasSole($table, array $data = [], $connection = null)
     {
         $this->assertDatabaseHas($table, $data, $connection);
         $this->assertDatabaseCount($table, 1, $connection);

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -84,7 +84,7 @@ trait InteractsWithDatabase
     }
 
     /**
-     * Assert that a given where condition exists in the database.
+     * Assert that the given record is the only one in the database.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -84,6 +84,22 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert that a given where condition exists in the database.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  array  $data
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseOnlyHas($table, array $data = [], $connection = null)
+    {
+        $this->assertDatabaseHas($table, $data, $connection);
+        $this->assertDatabaseCount($table, 1, $connection);
+
+        return $this;
+    }
+
+    /**
      * Assert that the given table has no entries.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $table

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -393,6 +393,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertEquals('trashed_at', $this->getDeletedAtColumn(new CustomProductStub()));
     }
 
+    public function testAssertTableOnlyHas()
+    {
+        $this->mockCountBuilder(true);
+
+        $this->assertDatabaseOnlyHas($this->table, $this->data);
+    }
+
     public function testExpectsDatabaseQueryCount()
     {
         $case = new class('foo') extends TestingTestCase

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -393,11 +393,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertEquals('trashed_at', $this->getDeletedAtColumn(new CustomProductStub()));
     }
 
-    public function testAssertTableOnlyHas()
+    public function testAssertTableHasSole()
     {
         $this->mockCountBuilder(true);
 
-        $this->assertDatabaseOnlyHas($this->table, $this->data);
+        $this->assertDatabaseHasSole($this->table, $this->data);
     }
 
     public function testExpectsDatabaseQueryCount()


### PR DESCRIPTION
Tiny method to make it quicker to check that the provided data is the only data in the table.