### PR TITLE
Revert "[11.x] Use Str::wrap() instead of nesting Str::start() inside Str::finish()"

### DIFF
--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -95,7 +95,7 @@ class Headers
     public function referencesString(): string
     {
         return (new Collection($this->references))
-            ->map(fn ($messageId) => Str::wrap($messageId, '<', '>'))
+            ->map(fn ($messageId) => Str::of($messageId)->start('<')->finish('>'))
             ->implode(' ');
     }
 }

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -95,7 +95,7 @@ class Headers
     public function referencesString(): string
     {
         return (new Collection($this->references))
-            ->map(fn ($messageId) => Str::of($messageId)->start('<')->finish('>'))
+            ->map(fn ($messageId) => Str::of($messageId)->start('<')->finish('>')->value())
             ->implode(' ');
     }
 }

--- a/tests/Mail/MailMailableHeadersTest.php
+++ b/tests/Mail/MailMailableHeadersTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Mail\Mailables\Headers;
+use PHPUnit\Framework\TestCase;
+
+class MailMailableHeadersTest extends TestCase
+{
+    public function test()
+    {
+        $headers = new Headers(
+            '434571BC.8070702@example.net',
+            [
+                '<19980506192030.26456.qmail@cr.yp.to>',
+                '<19980507220459.5655.qmail@warren.demon.co.uk>',
+                '<19980508103652.B21462@iconnect.co.ke>',
+                '<19980509035615.40087@rucus.ru.ac.za>',
+            ],
+        );
+
+        $this->assertSame(
+            '<19980506192030.26456.qmail@cr.yp.to> <19980507220459.5655.qmail@warren.demon.co.uk> <19980508103652.B21462@iconnect.co.ke> <19980509035615.40087@rucus.ru.ac.za>',
+            $headers->referencesString(),
+        );
+    }
+}


### PR DESCRIPTION
#53987 potentially changes the output of `Illuminate\Mail\Mailables\Headers::referencesString()`

As @tontonsb explained in https://github.com/laravel/framework/pull/53987#issuecomment-2557253882, previously, already wrapped strings would not be wrapped again, but now, they would, resulting in two leading and two trailing angle brackets.

This deviation wasn't discovered by a test, so I added one. 