### PR TITLE
[11.x] Add a setAssetRoot method to the UrlGenerator class

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -759,7 +759,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string|null  $root
      * @return void
      *
-     * @deprecated Use useRootUrl
+     * @deprecated Use useOrigin
      */
     public function forceRootUrl($root)
     {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -717,17 +717,6 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Set the asset root.
-     *
-     * @param  string|null  $root
-     * @return void
-     */
-    public function setAssetRoot($root)
-    {
-        $this->assetRoot = $root ? rtrim($root, '/') : null;
-    }
-
-    /**
      * Force the scheme for URLs.
      *
      * @param  string|null  $scheme
@@ -754,16 +743,40 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Set the URL origin for all generated URLs.
+     *
+     * @param  string|null  $root
+     * @return void
+     */
+    public function useOrigin(?string $root)
+    {
+        $this->forceRootUrl($root);
+    }
+
+    /**
      * Set the forced root URL.
      *
      * @param  string|null  $root
      * @return void
+     *
+     * @deprecated Use useRootUrl
      */
     public function forceRootUrl($root)
     {
         $this->forcedRoot = $root ? rtrim($root, '/') : null;
 
         $this->cachedRoot = null;
+    }
+
+    /**
+     * Set the URL origin for all generated asset URLs.
+     *
+     * @param  string|null  $root
+     * @return void
+     */
+    public function useAssetOrigin(?string $root)
+    {
+        $this->assetRoot = $root ? rtrim($root, '/') : null;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -717,12 +717,12 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Set the asset URL.
+     * Set the asset root.
      *
      * @param  string|null  $root
      * @return void
      */
-    public function setAssetUrl($root)
+    public function setAssetRoot($root)
     {
         $this->assetRoot = $root ? rtrim($root, '/') : null;
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -717,6 +717,17 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Set the asset URL.
+     *
+     * @param  string|null  $root
+     * @return void
+     */
+    public function setAssetUrl($root)
+    {
+        $this->assetRoot = $root ? rtrim($root, '/') : null;
+    }
+
+    /**
      * Force the scheme for URLs.
      *
      * @param  string|null  $scheme

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -695,7 +695,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.bar.com/foo/bar', $url->to('foo/bar'));
         $this->assertSame('http://www.bar.com/foo/bar', $url->asset('foo/bar'));
 
-        $url->setAssetUrl('https://www.foo.com');
+        $url->setAssetRoot('https://www.foo.com');
         $this->assertNotSame('https://www.foo.com/foo/bar', $url->to('foo/bar'));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar'));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -684,6 +684,24 @@ class RoutingUrlGeneratorTest extends TestCase
         $url->route('foo', $parameters);
     }
 
+    public function testSetAssetUrl()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $url->forceRootUrl('https://www.bar.com');
+        $this->assertSame('http://www.bar.com/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('http://www.bar.com/foo/bar', $url->asset('foo/bar'));
+
+        $url->setAssetUrl('https://www.foo.com');
+        $this->assertNotSame('https://www.foo.com/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', false));
+    }
+
     public function testForceRootUrl()
     {
         $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -691,29 +691,29 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/')
         );
 
-        $url->forceRootUrl('https://www.bar.com');
+        $url->useOrigin('https://www.bar.com');
         $this->assertSame('http://www.bar.com/foo/bar', $url->to('foo/bar'));
         $this->assertSame('http://www.bar.com/foo/bar', $url->asset('foo/bar'));
 
-        $url->setAssetRoot('https://www.foo.com');
+        $url->useAssetOrigin('https://www.foo.com');
         $this->assertNotSame('https://www.foo.com/foo/bar', $url->to('foo/bar'));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar'));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', false));
     }
 
-    public function testForceRootUrl()
+    public function testUseRootUrl()
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             Request::create('http://www.foo.com/')
         );
 
-        $url->forceRootUrl('https://www.bar.com');
+        $url->useOrigin('https://www.bar.com');
         $this->assertSame('http://www.bar.com/foo/bar', $url->to('foo/bar'));
 
         // Ensure trailing slash is trimmed from root URL as UrlGenerator already handles this
-        $url->forceRootUrl('http://www.foo.com/');
+        $url->useOrigin('http://www.foo.com/');
         $this->assertSame('http://www.foo.com/bar', $url->to('/bar'));
 
         /*
@@ -730,7 +730,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('https://www.foo.com/foo', $url->route('plain'));
 
-        $url->forceRootUrl('https://www.bar.com');
+        $url->useOrigin('https://www.bar.com');
         $this->assertSame('https://www.bar.com/foo', $url->route('plain'));
     }
 


### PR DESCRIPTION
This is a simple PR that introduces a `setAssetRoot` method to the `UrlGenerator` class, which sets `UrlGenerator::assetRoot`. Before this, the only way to change that value was to update the config and for the `UrlGenerator` class to be resolved again if it had already been resolved.

This is particularly useful for fringe issues with things like Livewire and Filament, where sometimes assets are referenced with routes that break CORS.