### PR TITLE
add skip-ssl flag to mysql config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,6 +59,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                'skip-ssl' => env('SKIP_SSL', false),
             ]) : [],
         ],
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -115,6 +115,10 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 
+        if ($config['options']['skip-ssl'] ?? false) {
+            $value .= ' --skip-ssl';
+        }
+
         return $value;
     }
 


### PR DESCRIPTION
When running php artisan migrate:fresh, if I have a schema dump in the migrations directory, this error appears:

![Screenshot from 2025-02-09 13-41-31](https://github.com/user-attachments/assets/c7932f22-6653-43be-8115-e7f16fa2de7c)

I experienced this error in Laravel 9.x, 10.x, and 11.x.
Based on my research, two solutions exist:

1- Modify the database configuration in /etc/my.cnf by adding:

[client]
skip-ssl
2- Handle it in the MySQL command that is dispatched inside the code, which I addressed in this pull request.