### PR TITLE
[11.x] Add patterns for table name guesser in update migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -103,7 +103,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      * Write the migration file to disk.
      *
      * @param  string  $name
-     * @param  string  $table
+     * @param  string|null  $table
      * @param  bool  $create
      * @return void
      */

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -12,13 +12,15 @@ class TableGuesser
     const CHANGE_PATTERNS = [
         '/.+_(to|from|in)_(\w+)_table$/',
         '/.+_(to|from|in)_(\w+)$/',
+        '/^(update)_(\w+)_table_?\w*$/',
+        '/^(update)_(\w+)_(add|change|remove|set|update)_?\w+$/',
     ];
 
     /**
      * Attempt to guess the table name and "creation" status of the given migration.
      *
      * @param  string  $migration
-     * @return array
+     * @return array<string|null, bool>
      */
     public static function guess($migration)
     {
@@ -33,5 +35,7 @@ class TableGuesser
                 return [$matches[2], $create = false];
             }
         }
+
+        return [null, false];
     }
 }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -28,6 +28,14 @@ class TableGuesserTest extends TestCase
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('update_users_table');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('update_users_table_with_indexes');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
@@ -49,6 +57,14 @@ class TableGuesserTest extends TestCase
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('update_users_set_status_nullable');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('update_users_remove_status');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
     }


### PR DESCRIPTION
Some commonly used update migration names couldn't be properly parsed with the correct table name extracted, such as:

- `update_users_table`
- `update_users_table_with_indexes`

- `update_users_set_status_nullable`
- `update_users_remove_status`

This PR adds patterns for guessing changed table name during migration creation. All existing templates retain the same functionality with new patterns extending guessing ability.

There were also some minor changes to affected methods and their signatures to ensure compliance with each other.