### PR TITLE
[11.x] Omit iteration in `@foreach` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -108,11 +108,11 @@ trait CompilesLoops
 
         $iteratee = trim($matches[1]);
 
-        $iteration = trim($matches[2] ?? '') ?: '$it';
+        $iteration = trim($matches[2] ?? '') ?: '$__currentLoop';
 
         $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
 
-        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getLastLoop();';
+        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData();';
 
         return "<?php {$initLoop} foreach(\$__currentLoopData as {$iteration}): {$iterateLoop} ?>";
     }
@@ -168,7 +168,7 @@ trait CompilesLoops
      */
     protected function compileEndforeach()
     {
-        return '<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        return '<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -100,15 +100,15 @@ trait CompilesLoops
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.+) +as +(.*)\)$/is', $expression ?? '', $matches);
+        preg_match('/\( *(.+?)(?: +as *(.*))?\)$/is', $expression ?? '', $matches);
 
-        if (count($matches) === 0) {
+        if (count($matches) === 0 || trim($matches[1]) === 'as') {
             throw new ViewCompilationException('Malformed @foreach statement.');
         }
 
         $iteratee = trim($matches[1]);
 
-        $iteration = trim($matches[2]);
+        $iteration = trim($matches[2]) ?: '$it';
 
         $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -108,7 +108,7 @@ trait CompilesLoops
 
         $iteratee = trim($matches[1]);
 
-        $iteration = trim($matches[2]) ?: '$it';
+        $iteration = trim($matches[2] ?? '') ?: '$it';
 
         $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
 

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Concerns;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\LazyCollection;
 
@@ -93,6 +94,8 @@ trait ManagesLoops
     public function getIterationData()
     {
         if ($data = $this->getLastLoop()?->data) {
+            $data = $data instanceof Arrayable ? $data->toArray() : $data;
+
             return array_values($data)[$this->getLastLoop()->index];
         }
     }

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -31,6 +31,7 @@ trait ManagesLoops
         $this->loopsStack[] = [
             'iteration' => 0,
             'index' => 0,
+            'data' => $data,
             'remaining' => $length ?? null,
             'count' => $length,
             'first' => true,
@@ -81,6 +82,18 @@ trait ManagesLoops
     {
         if ($last = Arr::last($this->loopsStack)) {
             return (object) $last;
+        }
+    }
+
+    /**
+     * Get the iteration data of the current loop.
+     *
+     * @return mixed
+     */
+    public function getIterationData()
+    {
+        if ($data = $this->getLastLoop()?->data) {
+            return array_values($data)[$this->getLastLoop()?->index];
         }
     }
 

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -92,7 +92,7 @@ trait ManagesLoops
      */
     public function getIterationData()
     {
-        if ($data = $this->getLastLoop()->data) {
+        if ($data = $this->getLastLoop()?->data) {
             return array_values($data)[$this->getLastLoop()->index];
         }
     }

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -92,8 +92,8 @@ trait ManagesLoops
      */
     public function getIterationData()
     {
-        if ($data = $this->getLastLoop()?->data) {
-            return array_values($data)[$this->getLastLoop()?->index];
+        if ($data = $this->getLastLoop()->data) {
+            return array_values($data)[$this->getLastLoop()->index];
         }
     }
 

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -96,6 +96,20 @@ class BladeTest extends TestCase
 </span>', trim($view));
     }
 
+    public function test_rendering_a_nested_foreach_loop_without_iteration()
+    {
+        $view = View::make('foreach')->render();
+
+        $this->assertSame('First
+            foo
+            bar
+        First
+    Second
+            bar
+            baz
+        Second', trim($view));
+    }
+
     public function test_inline_link_type_attributes_dont_add_extra_spacing_at_end()
     {
         $view = View::make('uses-link')->render();

--- a/tests/Integration/View/templates/foreach.blade.php
+++ b/tests/Integration/View/templates/foreach.blade.php
@@ -1,0 +1,7 @@
+@foreach(['foo' => ['title' => 'First', 'words' => ['foo', 'bar']], 'bar' => ['title' => 'Second', 'words' => ['bar', 'baz']]])
+    {{ $it['title'] }}
+    @foreach($it['words'])
+        {{ $it }}
+    @endforeach
+    {{ $it['title'] }}
+@endforeach

--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -26,11 +26,11 @@ class BladeEscapedTest extends AbstractBladeTestCase
     @@endforeach
 @endforeach';
         $compiled = '
-<?php $__currentLoopData = $cols; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $col): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+<?php $__currentLoopData = $cols; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $col): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
     @foreach($issues as $issue_45915)
         👋 سلام 👋
     @endforeach
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertSame($compiled, $this->compiler->compileString($template));
     }
 }

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -12,9 +12,9 @@ class BladeForeachStatementsTest extends AbstractBladeTestCase
         $string = '@foreach ($this->getUsers() as $user)
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -23,9 +23,9 @@ test
         $string = '@foreach ($this->getUsers())
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -34,9 +34,9 @@ test
         $string = '@foreach ($this->getUsers() as)
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -45,9 +45,9 @@ test
         $string = '@foreach ($this->getUsers() as )
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -56,9 +56,9 @@ test
         $string = '@foreach ($this->getUsers() AS $user)
 test
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -73,9 +73,9 @@ test
         $expected = '<?php $__currentLoopData = [
 foo,
 bar,
-]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $label): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $label): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -90,9 +90,9 @@ test
         $expected = '<?php $__currentLoopData = [
 foo,
 bar,
-]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -107,9 +107,9 @@ test
         $expected = '<?php $__currentLoopData = [
 foo,
 bar,
-]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 test
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -121,12 +121,12 @@ user info
 tag info
 @endforeach
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 user info
-<?php $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+<?php $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 tag info
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -134,59 +134,59 @@ tag info
     {
         $string = '@foreach ($this->getUsers())
 user info
-@foreach ($it->tags as $tag)
+@foreach ($__currentLoop->tags)
 tag info
 @endforeach
 @endforeach';
-        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 user info
-<?php $__currentLoopData = $it->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+<?php $__currentLoopData = $__currentLoop->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
 tag info
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
-<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testLoopContentHolderIsExtractedFromForeachStatements()
     {
         $string = '@foreach ($some_uSers1 as $user)';
-        $expected = '<?php $__currentLoopData = $some_uSers1; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = $some_uSers1; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach ($users->get() as $user)';
-        $expected = '<?php $__currentLoopData = $users->get(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = $users->get(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (range(1, 4) as $user)';
-        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (range(1, 4))';
-        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (   $users as $user)';
-        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (   $users   )';
-        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach (   $users as   )';
-        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $__currentLoop): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach ($tasks as $task)';
-        $expected = '<?php $__currentLoopData = $tasks; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $task): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $expected = '<?php $__currentLoopData = $tasks; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $task): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $it = $__env->getIterationData(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "@foreach(resolve('App\\\\DataProviders\\\\'.\$provider)->data() as \$key => \$value)
     <input {{ \$foo ? 'bar': 'baz' }}>
 @endforeach";
-        $expected = "<?php \$__currentLoopData = resolve('App\\\\DataProviders\\\\'.\$provider)->data(); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$key => \$value): \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); ?>
+        $expected = "<?php \$__currentLoopData = resolve('App\\\\DataProviders\\\\'.\$provider)->data(); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$key => \$value): \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); \$it = \$__env->getIterationData(); ?>
     <input <?php echo e(\$foo ? 'bar': 'baz'); ?>>
-<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); ?>";
+<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); \$it = \$__env->getIterationData(); ?>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -18,6 +18,39 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testForeachStatementsAreCompiledWithoutIteration()
+    {
+        $string = '@foreach ($this->getUsers())
+test
+@endforeach';
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+test
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testForeachStatementsAreCompiledWithoutIterationWithAs()
+    {
+        $string = '@foreach ($this->getUsers() as)
+test
+@endforeach';
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+test
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testForeachStatementsAreCompiledWithoutIterationWithAsAndSpace()
+    {
+        $string = '@foreach ($this->getUsers() as )
+test
+@endforeach';
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+test
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testForeachStatementsAreCompileWithUppercaseSyntax()
     {
         $string = '@foreach ($this->getUsers() AS $user)
@@ -46,6 +79,40 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testForeachStatementsAreCompiledWithMultipleLineWithoutIteration()
+    {
+        $string = '@foreach ([
+foo,
+bar,
+])
+test
+@endforeach';
+        $expected = '<?php $__currentLoopData = [
+foo,
+bar,
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+test
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testForeachStatementsAreCompiledWithMultipleLineWithoutIterationWithAs()
+    {
+        $string = '@foreach ([
+foo,
+bar,
+] as)
+test
+@endforeach';
+        $expected = '<?php $__currentLoopData = [
+foo,
+bar,
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+test
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testNestedForeachStatementsAreCompiled()
     {
         $string = '@foreach ($this->getUsers() as $user)
@@ -57,6 +124,23 @@ tag info
         $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
 user info
 <?php $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+tag info
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testNestedForeachStatementsAreCompiledWithoutIteration()
+    {
+        $string = '@foreach ($this->getUsers())
+user info
+@foreach ($it->tags as $tag)
+tag info
+@endforeach
+@endforeach';
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+user info
+<?php $__currentLoopData = $it->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
 tag info
 <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>
 <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
@@ -77,8 +161,20 @@ tag info
         $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
+        $string = '@foreach (range(1, 4))';
+        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
         $string = '@foreach (   $users as $user)';
         $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@foreach (   $users   )';
+        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@foreach (   $users as   )';
+        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $it): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '@foreach ($tasks as $task)';
@@ -112,8 +208,6 @@ test
             ['@foreach'],
             ['@foreach()'],
             ['@foreach ()'],
-            ['@foreach($test)'],
-            ['@foreach($test as)'],
             ['@foreach(as)'],
             ['@foreach ( as )'],
         ];

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\LazyCollection;
 use Illuminate\View\Compilers\CompilerInterface;
@@ -1083,6 +1084,22 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
 
         $factory->addLoop(['foo' => '123', 'bar' => '456']);
+
+        $factory->incrementLoopIndices();
+        $this->assertEquals('123', $factory->getIterationData());
+
+        $factory->incrementLoopIndices();
+        $this->assertEquals('456', $factory->getIterationData());
+
+        $factory->incrementLoopIndices();
+        $this->assertNull($factory->getIterationData());
+    }
+
+    public function testGettingIterationDataForCollection()
+    {
+        $factory = $this->getFactory();
+
+        $factory->addLoop(new Collection(['foo' => '123', 'bar' => '456']));
 
         $factory->incrementLoopIndices();
         $this->assertEquals('123', $factory->getIterationData());

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -919,6 +919,7 @@ class ViewFactoryTest extends TestCase
         $expectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'data' => [1, 2, 3],
             'remaining' => 3,
             'count' => 3,
             'first' => true,
@@ -936,6 +937,7 @@ class ViewFactoryTest extends TestCase
         $secondExpectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'data' => [1, 2, 3, 4],
             'remaining' => 4,
             'count' => 4,
             'first' => true,
@@ -982,6 +984,7 @@ class ViewFactoryTest extends TestCase
         $expectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'data' => '',
             'remaining' => null,
             'count' => null,
             'first' => true,
@@ -1006,6 +1009,9 @@ class ViewFactoryTest extends TestCase
         $expectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'data' => new LazyCollection(function () {
+                $this->fail('LazyCollection\'s generator should not have been called');
+            }),
             'remaining' => null,
             'count' => null,
             'first' => true,
@@ -1070,6 +1076,22 @@ class ViewFactoryTest extends TestCase
         $this->assertFalse($factory->getLoopStack()[0]['first']);
         $this->assertNull($factory->getLoopStack()[0]['remaining']);
         $this->assertNull($factory->getLoopStack()[0]['last']);
+    }
+
+    public function testGettingIterationData()
+    {
+        $factory = $this->getFactory();
+
+        $factory->addLoop(['foo' => '123', 'bar' => '456']);
+
+        $factory->incrementLoopIndices();
+        $this->assertEquals('123', $factory->getIterationData());
+
+        $factory->incrementLoopIndices();
+        $this->assertEquals('456', $factory->getIterationData());
+
+        $factory->incrementLoopIndices();
+        $this->assertNull($factory->getIterationData());
     }
 
     public function testMacro()


### PR DESCRIPTION
Let's give it a shot based on the discussion right here: https://x.com/Philo01/status/1887988333990572309
This PR allows you to skip the iteration parameter in a `@foreach` directive.

![GjN7KfxWUAAPThH](https://github.com/user-attachments/assets/668ee2e1-6e86-4979-ab77-30a231ce849f)
