### PR TITLE
[11.x] add after fail callback for DB::transaction

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -32,9 +32,9 @@ trait ManagesTransactions
                 $callbackResult = $callback($this);
             }
 
-                // If we catch an exception we'll rollback this transaction and try again if we
-                // are not out of attempts. If we are out of attempts we will just throw the
-                // exception back out, and let the developer handle an uncaught exception.
+            // If we catch an exception we'll rollback this transaction and try again if we
+            // are not out of attempts. If we are out of attempts we will just throw the
+            // exception back out, and let the developer handle an uncaught exception.
             catch (Throwable $e) {
                 try {
                     $this->handleTransactionException($e, $currentAttempt, $attempts);

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -20,7 +20,7 @@ trait ManagesTransactions
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1, Closure $afterFail = null)
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $afterFail = null)
     {
         for ($currentAttempt = 1; $currentAttempt <= $attempts; $currentAttempt++) {
             $this->beginTransaction();

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -135,7 +135,7 @@ interface ConnectionInterface
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1,Closure $afterFail = null);
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $afterFail = null);
 
     /**
      * Start a new database transaction.

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -135,7 +135,7 @@ interface ConnectionInterface
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1);
+    public function transaction(Closure $callback, $attempts = 1,Closure $afterFail = null);
 
     /**
      * Start a new database transaction.

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -49,9 +49,9 @@ class SqlServerConnection extends Connection
                 $this->getPdo()->exec('COMMIT TRAN');
             }
 
-                // If we catch an exception, we will rollback so nothing gets messed
-                // up in the database. Then we'll re-throw the exception so it can
-                // be handled how the developer sees fit for their applications.
+            // If we catch an exception, we will rollback so nothing gets messed
+            // up in the database. Then we'll re-throw the exception so it can
+            // be handled how the developer sees fit for their applications.
             catch (Throwable $e) {
                 $this->getPdo()->exec('ROLLBACK TRAN');
                 $afterFail();

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -31,7 +31,7 @@ class SqlServerConnection extends Connection
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1, Closure $afterFail = null)
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $afterFail = null)
     {
         for ($a = 1; $a <= $attempts; $a++) {
             if ($this->getDriverName() === 'sqlsrv') {

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -31,7 +31,7 @@ class SqlServerConnection extends Connection
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1)
+    public function transaction(Closure $callback, $attempts = 1, Closure $afterFail = null)
     {
         for ($a = 1; $a <= $attempts; $a++) {
             if ($this->getDriverName() === 'sqlsrv') {
@@ -49,12 +49,12 @@ class SqlServerConnection extends Connection
                 $this->getPdo()->exec('COMMIT TRAN');
             }
 
-            // If we catch an exception, we will rollback so nothing gets messed
-            // up in the database. Then we'll re-throw the exception so it can
-            // be handled how the developer sees fit for their applications.
+                // If we catch an exception, we will rollback so nothing gets messed
+                // up in the database. Then we'll re-throw the exception so it can
+                // be handled how the developer sees fit for their applications.
             catch (Throwable $e) {
                 $this->getPdo()->exec('ROLLBACK TRAN');
-
+                $afterFail();
                 throw $e;
             }
 

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -54,7 +54,9 @@ class SqlServerConnection extends Connection
             // be handled how the developer sees fit for their applications.
             catch (Throwable $e) {
                 $this->getPdo()->exec('ROLLBACK TRAN');
-                $afterFail();
+                if($afterFail) {
+                    $afterFail();
+                }
                 throw $e;
             }
 

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -54,7 +54,7 @@ class SqlServerConnection extends Connection
             // be handled how the developer sees fit for their applications.
             catch (Throwable $e) {
                 $this->getPdo()->exec('ROLLBACK TRAN');
-                if($afterFail) {
+                if ($afterFail) {
                     $afterFail();
                 }
                 throw $e;


### PR DESCRIPTION

Add afterException callback to database transactions

This PR adds a new optional parameter `$afterFail` to the `transaction` method in `ConnectionInterface`. 
When a transaction fails, this callable will be executed after the exception is caught but before it's rethrown.

Inspired by @nunomaduro 

Example usage:
```php
DB::transaction(function() {
    // transaction logic
}, 5, function() {
    // This will run if transaction fails
    Log::info('Transaction failed');
});
