### PR TITLE
[11.x] feat: add generics to Container methods

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -488,9 +488,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template TInstance of mixed
+     *
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  TInstance  $instance
+     * @return TInstance
      */
     public function instance($abstract, $instance)
     {
@@ -719,8 +721,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Get a closure to resolve the given type from the container.
      *
-     * @param  string  $abstract
-     * @return \Closure
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $abstract
+     * @return ($abstract is class-string<TClass> ? \Closure(): TClass : \Closure(): mixed)
      */
     public function factory($abstract)
     {
@@ -730,9 +734,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * An alias function name for make().
      *
-     * @param  string|callable  $abstract
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>|callable  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return ($abstract is class-string<TClass> ? TClass : mixed)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
@@ -744,9 +750,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return ($abstract is class-string<TClass> ? TClass : mixed)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
@@ -758,7 +766,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * {@inheritdoc}
      *
-     * @return mixed
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $id
+     * @return ($id is class-string<TClass> ? TClass : mixed)
      */
     public function get(string $id)
     {
@@ -776,10 +787,12 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string|callable  $abstract
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>|callable  $abstract
      * @param  array  $parameters
      * @param  bool  $raiseEvents
-     * @return mixed
+     * @return ($abstract is class-string<TClass> ? TClass : mixed)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \Illuminate\Contracts\Container\CircularDependencyException
@@ -919,8 +932,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Instantiate a concrete instance of the given type.
      *
-     * @param  \Closure|string  $concrete
-     * @return mixed
+     * @template TClass
+     *
+     * @param  \Closure(static, array): TClass|class-string<TClass>  $concrete
+     * @return TClass
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \Illuminate\Contracts\Container\CircularDependencyException

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -8,6 +8,16 @@ use Psr\Container\ContainerInterface;
 interface Container extends ContainerInterface
 {
     /**
+     * {@inheritdoc}
+     *
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $id
+     * @return ($id is class-string<TClass> ? TClass : mixed)
+     */
+    public function get(string $id);
+
+    /**
      * Determine if the given abstract type has been bound.
      *
      * @param  string  $abstract
@@ -122,9 +132,11 @@ interface Container extends ContainerInterface
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template TInstance of mixed
+     *
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  TInstance  $instance
+     * @return TInstance
      */
     public function instance($abstract, $instance);
 
@@ -149,8 +161,10 @@ interface Container extends ContainerInterface
     /**
      * Get a closure to resolve the given type from the container.
      *
-     * @param  string  $abstract
-     * @return \Closure
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $abstract
+     * @return ($abstract is class-string<TClass> ? \Closure(): TClass : \Closure(): mixed)
      */
     public function factory($abstract);
 
@@ -164,9 +178,11 @@ interface Container extends ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return ($abstract is class-string<TClass> ? TClass : mixed)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1043,9 +1043,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return ($abstract is class-string<TClass> ? TClass : mixed)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
@@ -1059,10 +1061,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template TClass
+     *
+     * @param  string|class-string<TClass>|callable  $abstract
      * @param  array  $parameters
      * @param  bool  $raiseEvents
-     * @return mixed
+     * @return ($abstract is class-string<TClass> ? TClass : mixed)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \Illuminate\Contracts\Container\CircularDependencyException

--- a/types/Container/Container.php
+++ b/types/Container/Container.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+
+use function PHPStan\Testing\assertType;
+
+$container = resolve(Container::class);
+
+assertType('stdClass', $container->instance('foo', new stdClass));
+
+assertType('mixed', $container->get('foo'));
+assertType('Illuminate\Config\Repository', $container->get(Repository::class));
+
+assertType('Closure(): mixed', $container->factory('foo'));
+assertType('Closure(): Illuminate\Config\Repository', $container->factory(Repository::class));
+
+assertType('mixed', $container->make('foo'));
+assertType('Illuminate\Config\Repository', $container->make(Repository::class));
+
+assertType('mixed', $container->makeWith('foo'));
+assertType('Illuminate\Config\Repository', $container->makeWith(Repository::class));
+
+assertType('Illuminate\Config\Repository', $container->build(Repository::class));
+assertType('Illuminate\Config\Repository', $container->build(function (Container $container, array $parameters) {
+    return new Repository($parameters);
+}));
+assertType('stdClass', $container->build(function () {
+    return new stdClass();
+}));

--- a/types/Contracts/Container/Container.php
+++ b/types/Contracts/Container/Container.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Container\Container;
+
+use function PHPStan\Testing\assertType;
+
+$container = resolve(Container::class);
+
+assertType('stdClass', $container->instance('foo', new stdClass));
+
+assertType('mixed', $container->get('foo'));
+assertType('Illuminate\Config\Repository', $container->get(Repository::class));
+
+assertType('Closure(): mixed', $container->factory('foo'));
+assertType('Closure(): Illuminate\Config\Repository', $container->factory(Repository::class));
+
+assertType('mixed', $container->make('foo'));
+assertType('Illuminate\Config\Repository', $container->make(Repository::class));

--- a/types/Contracts/Foundation/Application.php
+++ b/types/Contracts/Foundation/Application.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+
+use function PHPStan\Testing\assertType;
+
+$app = resolve(Application::class);
+
+assertType('stdClass', $app->instance('foo', new stdClass));
+
+assertType('mixed', $app->get('foo'));
+assertType('Illuminate\Config\Repository', $app->get(Repository::class));
+
+assertType('Closure(): mixed', $app->factory('foo'));
+assertType('Closure(): Illuminate\Config\Repository', $app->factory(Repository::class));
+
+assertType('mixed', $app->make('foo'));
+assertType('Illuminate\Config\Repository', $app->make(Repository::class));

--- a/types/Foundation/Application.php
+++ b/types/Foundation/Application.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Application;
+
+use function PHPStan\Testing\assertType;
+
+$app = resolve(Application::class);
+
+assertType('stdClass', $app->instance('foo', new stdClass));
+
+assertType('mixed', $app->get('foo'));
+assertType('Illuminate\Config\Repository', $app->get(Repository::class));
+
+assertType('Closure(): mixed', $app->factory('foo'));
+assertType('Closure(): Illuminate\Config\Repository', $app->factory(Repository::class));
+
+assertType('mixed', $app->make('foo'));
+assertType('Illuminate\Config\Repository', $app->make(Repository::class));
+
+assertType('mixed', $app->makeWith('foo'));
+assertType('Illuminate\Config\Repository', $app->makeWith(Repository::class));
+
+assertType('Illuminate\Config\Repository', $app->build(Repository::class));
+assertType('Illuminate\Config\Repository', $app->build(function (Application $app, array $parameters) {
+    return new Repository($parameters);
+}));
+assertType('stdClass', $app->build(function () {
+    return new stdClass();
+}));


### PR DESCRIPTION
After #51938 helpers app() and resolve() started to give nice auto completions, but if you have an instance of Application\Container your IDE still sees only mixed, for example in service providers:
```php
$this->app->bind(MyService::class, function (Application $app) {
    app(AnotherService::class)->someMethod(); // Has auto completion
    $app->make(AnotherService::class)->someMethod(); // Doesn't have auto completion
});
```
This PR adds same generics to methods of Container, there applicable 