### PR TITLE
[11.x] fix: specify type of TClass generic in Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -721,7 +721,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Get a closure to resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $abstract
      * @return ($abstract is class-string<TClass> ? \Closure(): TClass : \Closure(): mixed)
@@ -734,7 +734,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * An alias function name for make().
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>|callable  $abstract
      * @param  array  $parameters
@@ -750,7 +750,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $abstract
      * @param  array  $parameters
@@ -766,7 +766,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * {@inheritdoc}
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $id
      * @return ($id is class-string<TClass> ? TClass : mixed)
@@ -787,7 +787,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>|callable  $abstract
      * @param  array  $parameters
@@ -932,7 +932,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Instantiate a concrete instance of the given type.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  \Closure(static, array): TClass|class-string<TClass>  $concrete
      * @return TClass

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -10,7 +10,7 @@ interface Container extends ContainerInterface
     /**
      * {@inheritdoc}
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $id
      * @return ($id is class-string<TClass> ? TClass : mixed)
@@ -161,7 +161,7 @@ interface Container extends ContainerInterface
     /**
      * Get a closure to resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $abstract
      * @return ($abstract is class-string<TClass> ? \Closure(): TClass : \Closure(): mixed)
@@ -178,7 +178,7 @@ interface Container extends ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $abstract
      * @param  array  $parameters

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1043,7 +1043,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $abstract
      * @param  array  $parameters
@@ -1061,7 +1061,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Resolve the given type from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>|callable  $abstract
      * @param  array  $parameters

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -109,7 +109,7 @@ if (! function_exists('app')) {
     /**
      * Get the available container instance.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>|null  $abstract
      * @param  array  $parameters
@@ -793,7 +793,7 @@ if (! function_exists('resolve')) {
     /**
      * Resolve a service from the container.
      *
-     * @template TClass
+     * @template TClass of object
      *
      * @param  string|class-string<TClass>  $name
      * @param  array  $parameters


### PR DESCRIPTION
After #54543 docblocks for App facade generated incorrect return values (void). With this PR diff looks like that
```diff
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -53,7 +53,7 @@
  * @method static void loadDeferredProviders()
  * @method static void loadDeferredProvider(string $service)
  * @method static void registerDeferredProvider(string $provider, string|null $service = null)
- * @method static mixed make(string $abstract, array $parameters = [])
+ * @method static object|mixed make(string $abstract, array $parameters = [])
  * @method static bool bound(string $abstract)
  * @method static bool isBooted()
  * @method static void boot()
@@ -120,10 +120,10 @@
  * @method static mixed refresh(string $abstract, mixed $target, string $method)
  * @method static \Closure wrap(\Closure $callback, array $parameters = [])
  * @method static mixed call(callable|string $callback, array $parameters = [], string|null $defaultMethod = null)
- * @method static \Closure factory(string $abstract)
- * @method static mixed makeWith(string|callable $abstract, array $parameters = [])
- * @method static mixed get(string $id)
- * @method static mixed build(\Closure|string $concrete)
+ * @method static \Closure|\Closure factory(string $abstract)
+ * @method static object|mixed makeWith(string|callable $abstract, array $parameters = [])
+ * @method static object|mixed get(string $id)
+ * @method static object build(\Closure|string $concrete)
  * @method static mixed resolveFromAttribute(\ReflectionAttribute $attribute)
  * @method static void beforeResolving(\Closure|string $abstract, \Closure|null $callback = null)
  * @method static void resolving(\Closure|string $abstract, \Closure|null $callback = null)
```
```
@method static \Closure|\Closure factory(string $abstract)
```
factory looks a little weird, maybe it could be fixed in facade-documenter

I also changed generics in app() and resolve() helper for consistency
