### PR TITLE
docs: fix return type documentation for initializeSignal method

### DIFF
--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -72,7 +72,7 @@ class Signals
     /**
      * Gets the signal's existing handler in array format.
      *
-     * @return array<int, callable(int $signal): void>
+     * @return array<int, callable(int $signal): void>|null
      */
     protected function initializeSignal($signal)
     {


### PR DESCRIPTION
This PR fixes the return type documentation for `initializeSignal` method.
The current docblock indicates it only returns an array, but the implementation can also return null.

- Before: @return array<int, callable(int $signal): void>
- After: @return array<int, callable(int $signal): void>|null