### PR TITLE
[12.x] Add support for nested array notation within `loadMissing`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Closure;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -263,19 +263,18 @@ class Collection extends BaseCollection implements QueueableCollection
         foreach ($relations as $key => $value) {
             $fullKey = $prefix ? "$prefix.$key" : $key;
 
-            // If the value is not an array, it must be a string or callable
-            // so we can use the relationship without any further processing
+            // If the value is not an array, it can be used as-is
             if (! is_array($value)) {
                 $preparedRelationships[$fullKey] = $value;
             } else {
-                // Check the array has a depth of 1, if not, recursively prepare the relationships
                 if (array_values($value) === $value) {
+                    // If the array has a depth of 1, we simply flatten the array
                     foreach ($value as $subValue) {
                         $preparedRelationships["$fullKey.$subValue"] = null;
                     }
                 } else {
-                    // At this point, we are working with a nested relation
-                    // so we must recursively prepare the relationships
+                    // We now know that the remaining relationships are nested arrays
+                    // so we must prepare them recursively
                     $preparedRelationships = array_merge($preparedRelationships, $this->prepareLoadMissingRelationships($value, $fullKey));
                 }
             }

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -148,9 +148,9 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         $users->loadMissing([
             'posts' => [
                 'postRelation' => [
-                    'postSubRelations.postSubSubRelations'
-                ]
-            ]
+                    'postSubRelations.postSubSubRelations',
+                ],
+            ],
         ]);
 
         $user = $users->first();


### PR DESCRIPTION
Currently `loadMissing` on collections and models does not work using the nested array syntax that is supported by `with` and `load`.

```php
$users = User::with(['posts'])->get();

$users->loadMissing(['posts' => ['comments']]);
```
The above code wouldn't load anything additional.

This pull request attempts to solve this by flattening the nested arrays into dot notation while still supporting attribute selecting.

Whilst it's not the prettiest solution but open to suggestions on how it could be improved, it is inline with how the `with` method prepares relations.

This PR will bring some welcomed consistency across the `with`, `load` and `loadMissing` methods to all support the same nested array syntax.