### PR TITLE
[11.x] Add Recursive Hierarchy Root ID Retrieval Method for Model `getHierarchyRootId`

### DIFF
--- a/src/Illuminate/Database/Eloquent/HasHierarchy.php
+++ b/src/Illuminate/Database/Eloquent/HasHierarchy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Support\Facades\DB;
+
+trait HasHierarchy
+{
+    /**
+     * Get the root parent ID of the hierarchy for the given model.
+     *
+     * @param  string  $parentField The name of the parent ID field.
+     * @return  int|null The root parent ID or null if not found.
+     */
+    public function getHierarchyParentId(string $parentField): ?int
+    {
+        $table = $this->getTable();
+        $id = $this->id;
+
+        $result = DB::select("
+            WITH RECURSIVE parent_hierarchy AS (
+                SELECT $parentField
+                FROM $table
+                WHERE id = ?
+
+                UNION ALL
+
+                SELECT c.$parentField
+                FROM $table c
+                INNER JOIN parent_hierarchy ch ON c.id = ch.$parentField
+            )
+            SELECT $parentField
+            FROM parent_hierarchy
+            WHERE $parentField IS NOT NULL
+            ORDER BY $parentField
+            LIMIT 1;
+        ", [$id]);
+
+        if (isset($result[0])) {
+            return $result[0]->$parentField;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Add method `getHierarchyRootId(string $parentFieldName = 'parent_id')` to get the root ID of the hierarchy for the given model.

### Category Table

| ID  | Name             | Parent ID |
|-----|-----------------|-----------|
| 1   | Electronics     | NULL      |
| 2   | Laptops         | 1         |
| 3   | Gaming Laptops  | 2         |
| 4   | Ultrabooks      | 2         |
| 5   | Smartphones     | 1         |
| 6   | Accessories     | NULL      |
| 7   | Headphones      | 6         |

Scenario: Finding the root parent of id = 3 (Gaming Laptops)

1️⃣ Gaming Laptops (id=3) → Parent ID = 2 (Laptops)
2️⃣ Laptops (id=2) → Parent ID = 1 (Electronics)
3️⃣ Electronics (id=1) → Parent ID = NULL (Root Parent Found)

Final Output: 1 (Electronics)

### Usage:
---

```
class Category extends Model
{
    use HasFactory, HasHierarchy;

    protected $fillable = ['name', 'parent_id'];
}

$rootId = Category::find(3)->getHierarchyRootId();
echo "Root Parent ID: " . $rootId;
```