### PR TITLE
[11.x] Add support for middlewares & failed handler on broadcastable events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionProperty;
+use Throwable;
 
 class BroadcastEvent implements ShouldQueue
 {
@@ -178,6 +179,30 @@ class BroadcastEvent implements ShouldQueue
     public function displayName()
     {
         return get_class($this->event);
+    }
+
+    /**
+     * Get the middleware for the underlying event
+     */
+    public function middleware(): array
+    {
+        if (! method_exists($this->event, 'middleware')) {
+            return [];
+        }
+
+        return $this->event->middleware();
+    }
+
+    /**
+     * Process failure when the job has failed.
+     */
+    public function failed(?Throwable $e = null): void
+    {
+        if (! method_exists($this->event, 'failed')) {
+            return;
+        }
+
+        $this->event->failed($e);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -172,16 +172,6 @@ class BroadcastEvent implements ShouldQueue
     }
 
     /**
-     * Get the display name for the queued job.
-     *
-     * @return string
-     */
-    public function displayName()
-    {
-        return get_class($this->event);
-    }
-
-    /**
      * Get the middleware for the underlying event.
      *
      * @return array<int, object>
@@ -196,7 +186,10 @@ class BroadcastEvent implements ShouldQueue
     }
 
     /**
-     * Process failure when the job has failed.
+     * Handle a job failure.
+     *
+     * @param  \Throwable  $e
+     * @return void
      */
     public function failed(?Throwable $e = null): void
     {
@@ -205,6 +198,16 @@ class BroadcastEvent implements ShouldQueue
         }
 
         $this->event->failed($e);
+    }
+
+    /**
+     * Get the display name for the queued job.
+     *
+     * @return string
+     */
+    public function displayName()
+    {
+        return get_class($this->event);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -182,7 +182,9 @@ class BroadcastEvent implements ShouldQueue
     }
 
     /**
-     * Get the middleware for the underlying event
+     * Get the middleware for the underlying event.
+     *
+     * @return array<int, object>
      */
     public function middleware(): array
     {

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -90,7 +90,7 @@ class BroadcastEventTest extends TestCase
         (new BroadcastEvent($event))->handle($manager);
     }
 
-    public function testMiddlewareForwardsMiddlewareFromUnderlyingEvent()
+    public function testMiddlewareProxiesMiddlewareFromUnderlyingEvent()
     {
         $event = new class {
             public function middleware(): array
@@ -104,7 +104,7 @@ class BroadcastEventTest extends TestCase
         $this->assertSame(['foo', 'bar'], $job->middleware());
     }
 
-    public function testMiddlewareForwardsFailedHandlerFromUnderlyingEvent()
+    public function testMiddlewareProxiesFailedHandlerFromUnderlyingEvent()
     {
         $event = new class {
             public function failed(?Throwable $e = null): void

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -7,7 +7,6 @@ use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\InteractsWithBroadcasting;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Throwable;

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -92,7 +92,8 @@ class BroadcastEventTest extends TestCase
 
     public function testMiddlewareProxiesMiddlewareFromUnderlyingEvent()
     {
-        $event = new class {
+        $event = new class
+        {
             public function middleware(): array
             {
                 return ['foo', 'bar'];
@@ -106,7 +107,8 @@ class BroadcastEventTest extends TestCase
 
     public function testMiddlewareProxiesFailedHandlerFromUnderlyingEvent()
     {
-        $event = new class {
+        $event = new class
+        {
             public function failed(?Throwable $e = null): void
             {
                 $e->validateCall();


### PR DESCRIPTION
This PR introduces support for using middlewares & a failure handler on broadcastable events.

Currently, classes utilizing the `ShouldBroadcast` interface are internally transformed to a `BroadcastEvent` job. This job supports proxying a few of job-specific properties, such as `$queue`, `$connection`, `$tries`, etc., to allow customizing when/how the queueable job is processed. One of the big drawbacks is not being able to define middlewares & job failures, which I, in fact, already expected to work as this can be very handy.
As this should be possible by proxying the data from the original event, just as is the case for some of the aforementioned properties, I would expect to this work when using broadcasting via queue. 

## Solution
This PR solves this issue by forwarding the middlewares defined on the original event via the `middlewares` method to the `BroadcastEvent` job.
The other drawback, job failure, can also now be solved by defining a `failed` method on the original event.

In summary, the following is now possible:
```php
class TestEvent implements ShouldBroadcast
{
    //

    public function middleware(): array
    {
        return [
            new TestEventMiddleware,
        ];
    }

    public function failed(?Throwable $e = null): void
    {
        Log::error('Test event failed to broadcast!');
    }
}
```

```php
class TestEventMiddleware
{
    public function handle(object $job, Closure $next)
    {
        Log::info('Handling broadcast event...');

        return $next($job);
    }
}
```

## Possible drawback
The underlying middleware will instead receive a `BroadcastEvent`, instead of the `TestEvent`, as the actual job that is processed by our selected queue driver is used on is the `BroadcastEvent` job, which wraps the original event. Meaning, the event is easily accessible via `$job->event`, so I'd, in fact, say this should be completely fine and a little mention in the docs should be enough.

## Discussion
I'm not 100% decided whether using methods, or properties, should be preferred. Perhaps.. both could work? I'm unsure on what the priority is between `$middleware` & `middleware()` on a job.