### PR TITLE
[11.x] json assertions on streamed content

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1049,8 +1049,8 @@ class TestResponse implements ArrayAccess
      */
     public function decodeResponseJson()
     {
-        if ($this->baseResponse instanceof StreamedResponse
-            || $this->baseResponse instanceof StreamedJsonResponse) {
+        if ($this->baseResponse instanceof StreamedResponse || 
+            $this->baseResponse instanceof StreamedJsonResponse) {
             $testJson = new AssertableJsonString($this->streamedContent());
         } else {
             $testJson = new AssertableJsonString($this->getContent());

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1049,7 +1049,12 @@ class TestResponse implements ArrayAccess
      */
     public function decodeResponseJson()
     {
-        $testJson = new AssertableJsonString($this->getContent());
+        if ($this->baseResponse instanceof StreamedResponse
+            || $this->baseResponse instanceof StreamedJsonResponse) {
+            $testJson = new AssertableJsonString($this->streamedContent());
+        } else {
+            $testJson = new AssertableJsonString($this->getContent());
+        }
 
         $decodedResponse = $testJson->json();
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -325,6 +325,40 @@ class TestResponseTest extends TestCase
         }
     }
 
+    public function testJsonAssertionsOnStreamedJsonContent()
+    {
+        $response = TestResponse::fromBaseResponse(
+            new StreamedJsonResponse([
+                'data' => $this->yieldTestModels(),
+            ])
+        );
+
+        $response->assertJsonPath('data', [
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+        ]);
+
+        try {
+            $response->assertJsonPath('data', [
+                ['id' => 1],
+                ['id' => 2],
+            ]);
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two arrays are identical.', $e->getMessage());
+        }
+
+        $response->assertJsonCount(3, 'data');
+
+        try {
+            $response->assertJsonCount(2, 'data');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Failed to assert that the response count matched the expected 2\nFailed asserting that actual size 3 matches expected size 2.", $e->getMessage());
+        }
+    }
+
     public function yieldTestModels()
     {
         yield new TestModel(['id' => 1]);


### PR DESCRIPTION
Currently it is not possible to use all json assertions on a streamed json response. This PR fixes that.
```php
Route::get('/users', function () {
    return response()->streamJson([
        'data' => User::cursor(),
    ]);
});
```
```php
$this->getJson('/users')
    ->assertJsonCount(10, 'data')
    ->assertJsonPath('data.*.id', $users->pluck('id')->all());
```