### PR TITLE
[11.x] `assertStreamed` and `assertNotStreamed`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -532,7 +532,6 @@ class TestResponse implements ArrayAccess
         return $this;
     }
 
-
     /**
      * Assert that the response was streamed.
      *

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -532,6 +532,37 @@ class TestResponse implements ArrayAccess
         return $this;
     }
 
+
+    /**
+     * Assert that the response was streamed.
+     *
+     * @return $this
+     */
+    public function assertStreamed()
+    {
+        PHPUnit::withResponse($this)->assertTrue(
+            $this->baseResponse instanceof StreamedResponse || $this->baseResponse instanceof StreamedJsonResponse,
+            'Failed assertion that the response was streamed.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response was not streamed.
+     *
+     * @return $this
+     */
+    public function assertNotStreamed()
+    {
+        PHPUnit::withResponse($this)->assertTrue(
+            ! $this->baseResponse instanceof StreamedResponse && ! $this->baseResponse instanceof StreamedJsonResponse,
+            'Failed assertion that the response was not streamed.'
+        );
+
+        return $this;
+    }
+
     /**
      * Assert that the given string matches the streamed response content.
      *

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -541,7 +541,7 @@ class TestResponse implements ArrayAccess
     {
         PHPUnit::withResponse($this)->assertTrue(
             $this->baseResponse instanceof StreamedResponse || $this->baseResponse instanceof StreamedJsonResponse,
-            'Failed assertion that the response was streamed.'
+            'Expected the response to be streamed, but it wasn\'t.'
         );
 
         return $this;
@@ -556,7 +556,7 @@ class TestResponse implements ArrayAccess
     {
         PHPUnit::withResponse($this)->assertTrue(
             ! $this->baseResponse instanceof StreamedResponse && ! $this->baseResponse instanceof StreamedJsonResponse,
-            'Failed assertion that the response was not streamed.'
+            'Response was unexpectedly streamed.'
         );
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -283,14 +283,14 @@ class TestResponseTest extends TestCase
             $notStreamedResponse->assertStreamed();
             $this->fail('xxxx');
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Failed assertion that the response was streamed.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Expected the response to be streamed, but it wasn't.\nFailed asserting that false is true.", $e->getMessage());
         }
 
         try {
             $streamedResponse->assertNotStreamed();
             $this->fail('xxxx');
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Failed assertion that the response was not streamed.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Response was unexpectedly streamed.\nFailed asserting that false is true.", $e->getMessage());
         }
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -261,6 +261,39 @@ class TestResponseTest extends TestCase
         }
     }
 
+    public function testAssertStreamedAndAssertNotStreamed()
+    {
+        $notStreamedResponse = $this->makeMockResponse([
+            'render' => 'expected response data',
+        ]);
+
+        $streamedResponse = TestResponse::fromBaseResponse(
+            new StreamedResponse(function () {
+                $stream = fopen('php://memory', 'r+');
+                fwrite($stream, 'expected response data');
+                rewind($stream);
+                fpassthru($stream);
+            })
+        );
+
+        $notStreamedResponse->assertNotStreamed();
+        $streamedResponse->assertStreamed();
+
+        try {
+            $notStreamedResponse->assertStreamed();
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Failed assertion that the response was streamed.\nFailed asserting that false is true.", $e->getMessage());
+        }
+
+        try {
+            $streamedResponse->assertNotStreamed();
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Failed assertion that the response was not streamed.\nFailed asserting that false is true.", $e->getMessage());
+        }
+    }
+
     public function testAssertStreamedContent()
     {
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
Currently, there is no easy way to check if a response was streamed without asserting the complete response content (using `assertStreamedContent()` or `assertStreamedJsonContent()`). This PR fixes that.
```php
$this->getJson('/users')->assertStreamed();

$this->getJson('/users')->assertNotStreamed();
```