### PR TITLE
[11.x] fix: getQualified{Created,Updated}AtColumn never returning null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -161,7 +161,9 @@ trait HasTimestamps
      */
     public function getQualifiedCreatedAtColumn()
     {
-        return $this->qualifyColumn($this->getCreatedAtColumn());
+        $column = $this->getCreatedAtColumn();
+
+        return $column ? $this->qualifyColumn($column) : null;
     }
 
     /**
@@ -171,7 +173,9 @@ trait HasTimestamps
      */
     public function getQualifiedUpdatedAtColumn()
     {
-        return $this->qualifyColumn($this->getUpdatedAtColumn());
+        $column = $this->getUpdatedAtColumn();
+
+        return $column ? $this->qualifyColumn($column) : null;
     }
 
     /**


### PR DESCRIPTION
Hello!

The `getQualified{Created,Updated}AtColumn` methods allow `null` as a return type, however, `qualifyColumn` always returns `string`---a malformed string is returned if one of the timestamp columns is null.

This checks for this case and properly returns null if needed.

Thanks!