### PR TITLE
[11.x] Add tap method to Schedule Event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -867,6 +867,7 @@ class Event
     public function tap(Closure $callback)
     {
         $callback($this);
+
         return $this;
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -857,4 +857,16 @@ class Event
             preg_replace("#['\"]#", '', Application::artisanBinary()),
         ], $command);
     }
+
+    /**
+     * Tap the event.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function tap(Closure $callback)
+    {
+        $callback($this);
+        return $this;
+    }
 }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -104,4 +104,15 @@ class EventTest extends TestCase
 
         $this->assertSame('fancy-command-description', $event->mutexName());
     }
+
+    public function testTapMethodAllowsConditionalConfiguration()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $event->tap(function ($event) {
+            $event->twiceDaily(1, 13);
+        });
+
+        $this->assertSame('0 1,13 * * *', $event->expression);
+    }
 }


### PR DESCRIPTION
# Add tap() method to Scheduling Event

This PR adds a `tap()` method to the `Event` class in the scheduler, allowing for more elegant conditional configuration of scheduled events.

## Problem
Currently, when needing to conditionally configure scheduled events, developers must either:
1. Use the global `tap()` helper, which breaks the fluent chain readability
2. Use complex `when()` conditions that may need to check multiple conditions manually

## Solution
Adding a `tap()` method directly to the Event class allows for cleaner, more readable conditional configuration while maintaining the fluent interface.

Before:
```php
// Option 1: Using global tap() helper
tap($schedule->command('command')
    ->timezone('UTC')
    ->weekdays(), function ($event) {
        if ($condition) {
            $event->dailyAt('05:00');
        } else {
            $event->everyTwoHours();
        }
    })
    ->withoutOverlapping();

// Option 2: Using when() with complex conditions
$schedule->command('command')
    ->timezone('UTC')
    ->weekdays()
    ->everyMinute()
    ->when(function () {
        if ($condition1) {
            return now()->hour === 5;
        }
        return $condition2;
    })
    ->withoutOverlapping();
```

After:
```php
$schedule->command('command')
    ->timezone('UTC')
    ->weekdays()
    ->tap(function ($event) {
        if ($condition) {
            $event->dailyAt('05:00');
        } else {
            $event->everyTwoHours();
        }
    })
    ->withoutOverlapping();
```

## Additional Examples

The `tap()` method is useful for various conditional configurations, not just scheduling times. Here are some additional examples:

```php
// Example 1: Different environments with different configurations
$schedule->command('backup')
    ->tap(function ($event) {
        if (app()->environment('production')) {
            $event->dailyAt('01:00')
                  ->emailOutputTo('admin@example.com');
        } else {
            $event->weekly()
                  ->withoutOverlapping();
        }
    });

// Example 2: Feature flag dependent configuration
$schedule->command('sync-data')
    ->tap(function ($event) {
        if (config('features.new-sync-logic')) {
            $event->everyFiveMinutes()
                  ->runInBackground();
        } else {
            $event->hourly()
                  ->withoutOverlapping();
        }
    });

// Example 3: Different configurations based on server role
$schedule->command('process-queue')
    ->tap(function ($event) {
        if (config('queue.high-throughput')) {
            $event->everyMinute()
                  ->onOneServer()
                  ->runInBackground();
        } else {
            $event->everyFiveMinutes();
        }
    });
```

## Additional Context
- The implementation follows the same pattern as other Laravel `tap()` methods
- It maintains full backward compatibility
- No breaking changes are introduced
- The scheduling time differences in the initial example are just one use case - the method is useful for any conditional event configuration