### PR TITLE
[11.x] Do not serialize empty `data`/`hidden` fields when dehydrating Context

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -526,10 +526,10 @@ class Repository
 
         $serialize = fn ($value) => serialize($instance->getSerializedPropertyValue($value, withRelations: false));
 
-        return $instance->isEmpty() ? null : [
+        return $instance->isEmpty() ? null : array_filter([
             'data' => array_map($serialize, $instance->all()),
             'hidden' => array_map($serialize, $instance->allHidden()),
-        ];
+        ]);
     }
 
     /**

--- a/tests/Integration/Log/ContextIntegrationTest.php
+++ b/tests/Integration/Log/ContextIntegrationTest.php
@@ -49,6 +49,19 @@ class ContextIntegrationTest extends TestCase
         $this->assertSame([], Context::allHidden());
     }
 
+    public function test_it_does_not_serialize_empty_data(): void
+    {
+        Context::add('some-value', 'zzz');
+        $onlyPublic = Context::dehydrate();
+        $this->assertEqualsCanonicalizing(['data' => ['some-value' => 's:3:"zzz";']], $onlyPublic);
+
+        Context::flush();
+
+        Context::addHidden('some-hidden-value', null);
+        $onlyHidden = Context::dehydrate();
+        $this->assertEqualsCanonicalizing(['hidden' => ['some-hidden-value' => 'N;']], $onlyHidden);
+    }
+
     public function test_it_ignores_deleted_models_when_hydrating()
     {
         $user = UserFactory::new()->create(['name' => 'Tim']);

--- a/tests/Integration/Log/ContextIntegrationTest.php
+++ b/tests/Integration/Log/ContextIntegrationTest.php
@@ -36,7 +36,6 @@ class ContextIntegrationTest extends TestCase
                 'model' => 'O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:31:"Illuminate\Foundation\Auth\User";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}',
                 'number' => 'i:55;',
             ],
-            'hidden' => [],
         ], $dehydrated);
 
         Context::flush();
@@ -47,6 +46,7 @@ class ContextIntegrationTest extends TestCase
         $this->assertTrue($user->is(Context::get('model')));
         $this->assertNotSame($user, Context::get('model'));
         $this->assertSame(55, Context::get('number'));
+        $this->assertSame([], Context::allHidden());
     }
 
     public function test_it_ignores_deleted_models_when_hydrating()


### PR DESCRIPTION
We can avoid serializing either the `hidden` or `data` fields of Context if they are empty. When calling `Context\Repository@hydrate()`, if one or both of them is not in the dehydrated version, they are set as empty arrays.

The benefit here is that the serialization is slightly smaller before pushing onto Redis if only one or the other has data in it.

Without a doubt, this is a minor optimization, but figured I would offer it up.