### PR TITLE
[11.x] Add `assertJsonFragments` assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -786,6 +786,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response contains the given JSON fragments.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertJsonFragments(array $data)
+    {
+        foreach ($data as $fragment) {
+            $this->assertJsonFragment($fragment);
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response contains the given JSON fragment.
      *
      * @param  array  $data

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1416,6 +1416,20 @@ class TestResponseTest extends TestCase
         $response->assertJsonFragment(['id' => 10]);
     }
 
+    public function testAssertJsonFragments()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonFragments([
+            ['foo' => 'foo 0'],
+        ]);
+
+        $response->assertJsonFragments([
+            ['foo' => 'foo 0'],
+            ['foo' => 'foo 1'],
+        ]);
+    }
+
     public function testAssertJsonFragmentCanFail()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
## Problem
Sometimes when asserting a JSON response, it can be helpful when you're looking for multiple fragments at once. A concrete example is when you want to assert some `meta` values regarding pagination.

The current test looks like this;
```php
it('can paginate teams', function () {
    $user = User::factory()->create();

    $teams = Team::factory()->count(26)->create();

    actingAs($user)
        ->getJson('v2/teams?page[size]=25&page[number]=2')
        ->assertSuccessful()
        ->assertJsonStructure([
            // ...
        ])->assertJsonFragment([
            'current_page' => 2,
        ])->assertJsonFragment([
            'per_page' => 25,
        ])->assertJsonFragment([
            'total' => 26,
        ]);
});
```

Now the `meta` key in the response will contain all of the pagination data but it's hard to prepare an assertion for that entire part of the response. Particularly, often you only want to assert a handful of the key/value pairs of the response.

## Solution
By adding the `assertJsonFragments` method, it means you don't have to chain the `assertJsonFragment` calls;

```php
it('can paginate teams', function () {
    $user = User::factory()->create();

    $teams = Team::factory()->count(26)->create();

    actingAs($user)
        ->getJson('v2/teams?page[size]=25&page[number]=2')
        ->assertSuccessful()
        ->assertJsonStructure([
            // ...
        ])->assertJsonFragments([
            ['current_page' => 2],
            ['per_page' => 25],
            ['total' => 26]
        ]);
});
```