### PR TITLE
Str::isEmail() added to check the email valid or not

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2020,8 +2020,7 @@ class Str
     public static function isEmail($value)
     {
 
-        if (!is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false)
-        {
+        if (!is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false){
             return false;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use Illuminate\Support\Traits\Macroable;
 use JsonException;
 use League\CommonMark\Environment\Environment;
@@ -18,8 +20,6 @@ use Symfony\Component\Uid\Ulid;
 use Throwable;
 use Traversable;
 use voku\helper\ASCII;
-use Egulias\EmailValidator\EmailValidator;
-use Egulias\EmailValidator\Validation\RFCValidation;
 
 class Str
 {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2022,7 +2022,7 @@ class Str
     public static function isEmail(string $value): bool
     {
         $validator = new EmailValidator();
-        
+
         return $validator->isValid($value, new RFCValidation());
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2019,12 +2019,12 @@ class Str
      */
     public static function isEmail($value)
     {
-
         if (! is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
             return false;
         }
 
         $tld = substr(strrchr($value, '.'), 1);
+
         return strlen($tld) >= 2;
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2022,6 +2022,7 @@ class Str
     public static function isEmail(string $value): bool
     {
         $validator = new EmailValidator();
+        
         return $validator->isValid($value, new RFCValidation());
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -18,6 +18,8 @@ use Symfony\Component\Uid\Ulid;
 use Throwable;
 use Traversable;
 use voku\helper\ASCII;
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 
 class Str
 {
@@ -2017,15 +2019,10 @@ class Str
      * @param  mixed  $value
      * @return bool
      */
-    public static function isEmail($value)
+    public static function isEmail(string $value): bool
     {
-        if (! is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
-            return false;
-        }
-
-        $tld = substr(strrchr($value, '.'), 1);
-
-        return strlen($tld) >= 2;
+        $validator = new EmailValidator();
+        return $validator->isValid($value, new RFCValidation());
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2020,7 +2020,7 @@ class Str
     public static function isEmail($value)
     {
 
-        if (!is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false){
+        if (! is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
             return false;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2012,6 +2012,24 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid Email.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isEmail($value)
+    {
+
+        if (!is_string($value) || filter_var($value, FILTER_VALIDATE_EMAIL) === false)
+        {
+            return false;
+        }
+
+        $tld = substr(strrchr($value, '.'), 1);
+        return strlen($tld) >= 2;
+    }
+
+    /**
      * Remove all strings from the casing caches.
      *
      * @return void

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1650,7 +1650,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isEmail('user_name@domain.com'));
         $this->assertTrue(Str::isEmail('user-name@domain.io'));
         $this->assertTrue(Str::isEmail('user@localhost'));
-        $this->assertTrue(Str::isEmail('user@123.123.123.123')); 
+        $this->assertTrue(Str::isEmail('user@123.123.123.123'));
         $this->assertTrue(Str::isEmail('"user@name"@example.com'));
         $this->assertTrue(Str::isEmail('"john.doe"@example.com'));
         $this->assertTrue(Str::isEmail('very.common@example.com'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1637,6 +1637,34 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    public function testIsEmail()
+    {
+        // Valid email cases
+        $this->assertTrue(Str::isEmail('example@laravel.com'));
+        $this->assertTrue(Str::isEmail('user.name+alias@domain.co.uk'));
+        $this->assertTrue(Str::isEmail('123456@domain.com'));
+        $this->assertTrue(Str::isEmail('user@sub.domain.com'));
+        $this->assertTrue(Str::isEmail('a@b.co'));
+        $this->assertTrue(Str::isEmail('user@domain.org'));
+
+        // Invalid email cases
+        $this->assertFalse(Str::isEmail('example.laravel.com'));
+        $this->assertFalse(Str::isEmail('example@laravel'));
+        $this->assertFalse(Str::isEmail('example@.com'));
+        $this->assertFalse(Str::isEmail('example@com.'));
+        $this->assertFalse(Str::isEmail('example@domain..com'));
+        $this->assertFalse(Str::isEmail(' example@laravel.com '));
+        $this->assertFalse(Str::isEmail('@domain.com'));
+        $this->assertFalse(Str::isEmail('example@domain.com@another.com'));
+        $this->assertFalse(Str::isEmail('example@domain.c'));
+        $this->assertFalse(Str::isEmail('example@domain.com.'));
+        $this->assertFalse(Str::isEmail('example@domain#com'));
+        $this->assertFalse(Str::isEmail('example@domain.com!'));
+        $this->assertFalse(Str::isEmail('example@domain.com@com'));
+        $this->assertFalse(Str::isEmail('user@sub.-domain.com'));
+        $this->assertFalse(Str::isEmail('user@subdomain.com.'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1678,11 +1678,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isEmail('user.@domain.com'));
         $this->assertFalse(Str::isEmail('user..name@domain.com'));
         $this->assertFalse(Str::isEmail('user@sub_domain.com'));
-        
     }
-
-
-
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1638,33 +1638,51 @@ class SupportStrTest extends TestCase
         }
     }
 
-    public function testIsEmail()
+    public function testValidEmails()
     {
-        // Valid email cases
+        // Standard valid email formats according to RFC 5322
         $this->assertTrue(Str::isEmail('example@laravel.com'));
         $this->assertTrue(Str::isEmail('user.name+alias@domain.co.uk'));
         $this->assertTrue(Str::isEmail('123456@domain.com'));
         $this->assertTrue(Str::isEmail('user@sub.domain.com'));
         $this->assertTrue(Str::isEmail('a@b.co'));
         $this->assertTrue(Str::isEmail('user@domain.org'));
+        $this->assertTrue(Str::isEmail('user_name@domain.com'));
+        $this->assertTrue(Str::isEmail('user-name@domain.io'));
+        $this->assertTrue(Str::isEmail('user@localhost'));
+        $this->assertTrue(Str::isEmail('user@123.123.123.123')); 
+        $this->assertTrue(Str::isEmail('"user@name"@example.com'));
+        $this->assertTrue(Str::isEmail('"john.doe"@example.com'));
+        $this->assertTrue(Str::isEmail('very.common@example.com'));
+        $this->assertTrue(Str::isEmail('disposable.style.email.with+symbol@example.com'));
+        $this->assertTrue(Str::isEmail('user@domain.toolongtld'));
+        $this->assertTrue(Str::isEmail('user@domain.c'));
+        $this->assertTrue(Str::isEmail('user@[192.168.1.1]'));
 
-        // Invalid email cases
-        $this->assertFalse(Str::isEmail('example.laravel.com'));
-        $this->assertFalse(Str::isEmail('example@laravel'));
-        $this->assertFalse(Str::isEmail('example@.com'));
-        $this->assertFalse(Str::isEmail('example@com.'));
-        $this->assertFalse(Str::isEmail('example@domain..com'));
-        $this->assertFalse(Str::isEmail(' example@laravel.com '));
-        $this->assertFalse(Str::isEmail('@domain.com'));
-        $this->assertFalse(Str::isEmail('example@domain.com@another.com'));
-        $this->assertFalse(Str::isEmail('example@domain.c'));
-        $this->assertFalse(Str::isEmail('example@domain.com.'));
-        $this->assertFalse(Str::isEmail('example@domain#com'));
-        $this->assertFalse(Str::isEmail('example@domain.com!'));
-        $this->assertFalse(Str::isEmail('example@domain.com@com'));
-        $this->assertFalse(Str::isEmail('user@sub.-domain.com'));
-        $this->assertFalse(Str::isEmail('user@subdomain.com.'));
+        $this->assertFalse(Str::isEmail('plainaddress'));
+        $this->assertFalse(Str::isEmail('@missinglocal.com'));
+        $this->assertFalse(Str::isEmail('username@.com'));
+        $this->assertFalse(Str::isEmail('username@com.'));
+        $this->assertFalse(Str::isEmail('username@domain..com'));
+        $this->assertFalse(Str::isEmail('user@domain,com'));
+        $this->assertFalse(Str::isEmail('user@domain@another.com'));
+        $this->assertFalse(Str::isEmail('username@-domain.com'));
+        $this->assertFalse(Str::isEmail('username@domain-.com'));
+        $this->assertFalse(Str::isEmail('user@domain.com '));
+        $this->assertFalse(Str::isEmail(' user@domain.com'));
+        $this->assertFalse(Str::isEmail('username@domain.com#'));
+        $this->assertFalse(Str::isEmail('username@domain..com'));
+        $this->assertFalse(Str::isEmail('user@sub..domain.com'));
+        $this->assertFalse(Str::isEmail('user@.com'));
+        $this->assertFalse(Str::isEmail('"user@name"@example..com'));
+        $this->assertFalse(Str::isEmail('user.@domain.com'));
+        $this->assertFalse(Str::isEmail('user..name@domain.com'));
+        $this->assertFalse(Str::isEmail('user@sub_domain.com'));
+        
     }
+
+
+
 }
 
 class StringableObjectStub


### PR DESCRIPTION
Check the email is valid or not using Str::isEmail()
I've used here [egulias/EmailValidator](https://github.com/egulias/EmailValidator) to check email validation

Now, we can check the email valid or not using Str::isEmail()

if email is valid then it's return true
else it's return false

Example: 
```php
$email = 'example@laravel.com';
Str::isEmail($email);
```
It's return true.

Another example:

```php
$email = 'example.laravel';
Str::isEmail($email);
```

It's return false.
