### PR TITLE
Fix: Inconsistent accessor attribute name conversion

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -739,8 +739,7 @@ trait HasAttributes
     {
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif ($this->hasAttributeGetMutator($key)) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -78,6 +78,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $this->assertEquals('foo2Bar', $instance->getAttribute('foo2Bar'));
         $this->assertEquals('foo2Bar', $instance->getAttribute('foo2bar'));
         $this->assertEquals('foo2Bar', $instance->getAttribute('foo_2_bar'));
+        $this->assertEquals('foo2Bar', $instance->getAttribute('foo2_bar'));
         $this->assertEquals('foo2Bar', $instance->getAttribute('foo_2bar'));
     }
 }

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -151,5 +151,4 @@ class HasAttributesWithSnakeCaseConsistentCheck extends Model
     {
         return 'foo2Bar';
     }
-
 }

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -61,6 +61,25 @@ class DatabaseConcernsHasAttributesTest extends TestCase
 
         $this->assertFalse($instance->cachedAttributeIsset('cacheableProperty'));
     }
+
+    public function testSnakeCaseMutateAttributeMarkedAttribute()
+    {
+        $instance = new HasAttributesWithSnakeCaseConsistentCheck();
+        $this->assertEquals('foo1Bar', $instance->getAttribute('foo1Bar'));
+        $this->assertEquals('foo1Bar', $instance->getAttribute('foo1bar'));
+        $this->assertEquals('foo1Bar', $instance->getAttribute('foo_1_bar'));
+        $this->assertEquals('foo1Bar', $instance->getAttribute('foo1_bar'));
+        $this->assertEquals('foo1Bar', $instance->getAttribute('foo_1bar'));
+    }
+
+    public function testSnakeCaseMutateAttribute()
+    {
+        $instance = new HasAttributesWithSnakeCaseConsistentCheck();
+        $this->assertEquals('foo2Bar', $instance->getAttribute('foo2Bar'));
+        $this->assertEquals('foo2Bar', $instance->getAttribute('foo2bar'));
+        $this->assertEquals('foo2Bar', $instance->getAttribute('foo_2_bar'));
+        $this->assertEquals('foo2Bar', $instance->getAttribute('foo_2bar'));
+    }
 }
 
 class HasAttributesWithoutConstructor
@@ -117,4 +136,20 @@ class HasCacheableAttributeWithAccessor extends Model
     {
         return isset($this->attributeCastCache[$attribute]);
     }
+}
+
+class HasAttributesWithSnakeCaseConsistentCheck extends Model
+{
+    public function foo1Bar(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => 'foo1Bar'
+        );
+    }
+
+    public function getFoo2BarAttribute(): string
+    {
+        return 'foo2Bar';
+    }
+
 }


### PR DESCRIPTION
This goes with issue #54570 

Inconsistent accessor attribute name conversion for mutateAttributeMarkedAttribute