### PR TITLE
[12.x] Add the ability to append/prepend middleware to top/end of middleware prioriry from the middleware configuration

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -291,12 +291,24 @@ class ApplicationBuilder
             }
 
             if ($priorityAppends = $middleware->getMiddlewarePriorityAppends()) {
+                foreach ($priorityAppends as $newMiddleware) {
+                    $kernel->appendToMiddlewarePriority($newMiddleware);
+                }
+            }
+
+            if ($priorityPrepends = $middleware->getMiddlewarePriorityPrepends()) {
+                foreach ($priorityPrepends as $newMiddleware) {
+                    $kernel->prependToMiddlewarePriority($newMiddleware);
+                }
+            }
+
+            if ($priorityAppends = $middleware->getMiddlewarePriorityRelativeAppends()) {
                 foreach ($priorityAppends as $newMiddleware => $after) {
                     $kernel->addToMiddlewarePriorityAfter($after, $newMiddleware);
                 }
             }
 
-            if ($priorityPrepends = $middleware->getMiddlewarePriorityPrepends()) {
+            if ($priorityPrepends = $middleware->getMiddlewarePriorityRelativePrepends()) {
                 foreach ($priorityPrepends as $newMiddleware => $before) {
                     $kernel->addToMiddlewarePriorityBefore($before, $newMiddleware);
                 }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -161,6 +161,20 @@ class Middleware
     protected $appendPriority = [];
 
     /**
+     * The middleware to prepend to the middleware priority definition relative to other middlewares.
+     *
+     * @var array
+     */
+    protected $prependPriorityRelative = [];
+
+    /**
+     * The middleware to append to the middleware priority definition relative to other middlewares.
+     *
+     * @var array
+     */
+    protected $appendPriorityRelative = [];
+
+    /**
      * Prepend middleware to the application's global middleware stack.
      *
      * @param  array|string  $middleware
@@ -422,9 +436,9 @@ class Middleware
      * @param  string  $prepend
      * @return $this
      */
-    public function prependToPriorityList($before, $prepend)
+    public function prependToPriority($middleware)
     {
-        $this->prependPriority[$prepend] = $before;
+        $this->prependPriority[] = $middleware;
 
         return $this;
     }
@@ -436,9 +450,37 @@ class Middleware
      * @param  string  $append
      * @return $this
      */
-    public function appendToPriorityList($after, $append)
+    public function appendToPriority($middleware)
     {
-        $this->appendPriority[$append] = $after;
+        $this->appendPriority[] = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Prepend middleware to the priority middleware relative to other middlewares.
+     *
+     * @param  array|string  $before
+     * @param  string  $prepend
+     * @return $this
+     */
+    public function prependToPriorityRelative($before, $prepend)
+    {
+        $this->prependPriorityRelative[$prepend] = $before;
+
+        return $this;
+    }
+
+    /**
+     * Append middleware to the priority middleware relative to other middlewares.
+     *
+     * @param  array|string  $after
+     * @param  string  $append
+     * @return $this
+     */
+    public function appendToPriorityRelative($after, $append)
+    {
+        $this->appendPriorityRelative[$append] = $after;
 
         return $this;
     }
@@ -829,5 +871,25 @@ class Middleware
     public function getMiddlewarePriorityAppends()
     {
         return $this->appendPriority;
+    }
+
+    /**
+     * Get the middleware to prepend to the middleware priority definition relative to other middlewares.
+     *
+     * @return array
+     */
+    public function getMiddlewarePriorityRelativePrepends()
+    {
+        return $this->prependPriorityRelative;
+    }
+
+    /**
+     * Get the middleware to append to the middleware priority definition relative to other middlewares.
+     *
+     * @return array
+     */
+    public function getMiddlewarePriorityRelativeAppends()
+    {
+        return $this->appendPriorityRelative;
     }
 }


### PR DESCRIPTION
The names of the methods in #53326 did'nt properly describe their functionality. So I renamed them to make more sense.
I also adds two methods to middleware configuration, allowing for easy access to the add middleware to top/end of middleware priority.

Example
```php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )
    ->withMiddleware(function (Middleware $middleware) {
        $middleware->appendToPriority(\App\Http\Middleware\CustomMiddleware::class);
        $middleware->prependToPriority(\App\Http\Middleware\CustomMiddleware::class);

        $middleware->appendToPriorityRelative(
            [
                \Illuminate\Cookie\Middleware\EncryptCookies::class,
                \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
            ],
            \Illuminate\Routing\Middleware\ValidateSignature::class
        );

        $middleware->prependToPriorityRelative(
            [
                \Illuminate\Cookie\Middleware\EncryptCookies::class,
                \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
            ],
            \Illuminate\Routing\Middleware\ValidateSignature::class
        );
    })
    ->withExceptions(function (Exceptions $exceptions) {
        //
    })->create();
```