### PR TITLE
[11.x] Allow batching a Closure

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -98,7 +98,7 @@ class PendingBatch
     protected function ensureJobIsBatchable(object|array $job): void
     {
         foreach (Arr::wrap($job) as $job) {
-            if ($job instanceof PendingBatch) {
+            if ($job instanceof PendingBatch || $job instanceof Closure) {
                 return;
             }
 

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -244,6 +244,17 @@ class BusPendingBatchTest extends TestCase
             )
         );
     }
+
+    public function test_it_can_batch_a_closure(): void
+    {
+        new PendingBatch(
+            new Container,
+            new Collection([
+                function() {}
+            ])
+        );
+        $this->expectNotToPerformAssertions();
+    }
 }
 
 class BatchableJob


### PR DESCRIPTION
To close: https://github.com/laravel/framework/issues/54586

Added a test to replicate what was described in the issue. You can again batch a closure.