### PR TITLE
[11.x] Handle aliases when appending attribute accessor 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -739,8 +739,7 @@ trait HasAttributes
     {
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif ($this->hasAttributeGetMutator($key)) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -51,7 +51,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
     }
 
-    public function testAppendToArrayHandlesAliases()
+    public function testAppendToArrayHandlesAttributeAliases()
     {
         $instance = new HasCacheableAttributeWithAccessor();
 

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -51,6 +51,17 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
     }
 
+    public function testAppendToArrayHandlesAliases()
+    {
+        $instance = new HasCacheableAttributeWithAccessor();
+
+        $instance->append('_cacheable_property');
+        $instance->append('cacheableproperty');
+        $instance->append('cacheable_property');
+
+        $this->assertEquals(['_cacheable_property' => 'foo', 'cacheableproperty' => 'foo', 'cacheable_property' => 'foo'], $instance->attributesToArray());
+    }
+
     public function testUnsettingCachedAttribute()
     {
         $instance = new HasCacheableAttributeWithAccessor();


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/54570

TLDR: 
- Using the `getFooBarQuzAttribute` way, appending with any alias works when casting to array
- Using the class way `return Attribute::make` it causes an exception for some aliases that work with the above way
- This makes it so either way you do it, its the same behaviour


### Why
Currently if you use the new style attribute accessor in a method, such as:
```php
protected function FooBarBaz(): Attribute
{
    return Attribute::make(
        get: fn () => 'yay',
    );
}
```
As we know, we can access it via the model with _various aliases_, such as :
```php 
> App\Models\Post::find(1)->foo_bar_baz
= "yay"
> App\Models\Post::find(1)->foobar_baz
= "yay"
> App\Models\Post::find(1)->foo_barbaz
= "yay"
> App\Models\Post::find(1)->foobarbaz
= "yay"
> App\Models\Post::find(1)->_foo_barbaz
= "yay"
```

 Appending works if you use the full snake of the method:
 ```php 
 > App\Models\Post::find(1)->first()->append('foo_bar_baz')->toArray()
= [
    "id" => 1,
    "title" => "AVTPC4BJnl",
    "created_at" => "2025-02-10T23:27:01.000000Z",
    "updated_at" => "2025-02-10T23:27:01.000000Z",
    "foo_bar_baz" => "yay",
  ]
```

However some aliases do not work, when using the this way of defining a attribute, which do work when you use the alternative way ie   `getFooBarBazAttribute()`:
  
```php
> App\Models\Post::find(1)->first()->append('foobarbaz')->toArray()

   BadMethodCallException  Call to undefined method App\Models\Post::getFoobarbazAttribute().
   
> App\Models\Post::find(1)->first()->append('_foo_barbaz')->toArray()

   BadMethodCallException  Call to undefined method App\Models\Post::getFooBarbazAttribute().   
   ``` 
   
   
   Where as if you used the alternative `get` notation: 
   
```php
protected function getFooBarQuzAttribute(): string
{
   return 'boo';
}
```

It works with all aliases: 

```php
> App\Models\Post::find(1)->first()->append('foobarquz')->toArray()
= [
    "id" => 1,
    "title" => "AVTPC4BJnl",
    "created_at" => "2025-02-10T23:27:01.000000Z",
    "updated_at" => "2025-02-10T23:27:01.000000Z",
    "foobarquz" => "boo",
  ]
> App\Models\Post::find(1)->first()->append('_foo_barquz')->toArray()
= [
    "id" => 1,
    "title" => "AVTPC4BJnl",
    "created_at" => "2025-02-10T23:27:01.000000Z",
    "updated_at" => "2025-02-10T23:27:01.000000Z",
    "_foo_barquz" => "boo",
  ]
```
   
### What it fixes
This PR fixes it so all the aliases work, regardless of how you're using the accessor - ie `getXAttribute` or the class, which is what I would expect.  Currently it does not work if you use the class way of doing it.

with fixes examples below:

```php
> App\Models\Post::take(3)->get()->append('foobarbaz')->toArray()
= [
    [
      "id" => 1,
      "title" => "AVTPC4BJnl",
      "created_at" => "2025-02-10T23:27:01.000000Z",
      "updated_at" => "2025-02-10T23:27:01.000000Z",
      "foobarbaz" => "yay",
    ],
    [
      "id" => 2,
      "title" => "UmcAQ1HTn8",
      "created_at" => "2025-02-10T23:27:06.000000Z",
      "updated_at" => "2025-02-10T23:27:06.000000Z",
      "foobarbaz" => "yay",
    ],
    [
      "id" => 3,
      "title" => "CbYubuFL2e",
      "created_at" => "2025-02-10T23:27:15.000000Z",
      "updated_at" => "2025-02-10T23:27:15.000000Z",
      "foobarbaz" => "yay",
    ],
  ]
```
   
```php
> App\Models\Post::find(1)->first()->append('_foo_barbaz')->toArray()
= [
    "id" => 1,
    "title" => "AVTPC4BJnl",
    "created_at" => "2025-02-10T23:27:01.000000Z",
    "updated_at" => "2025-02-10T23:27:01.000000Z",
    "_foo_barbaz" => "yay",
  ]
  
> App\Models\Post::find(1)->first()->append('foobarbaz')->toArray()
= [
    "id" => 1,
    "title" => "AVTPC4BJnl",
    "created_at" => "2025-02-10T23:27:01.000000Z",
    "updated_at" => "2025-02-10T23:27:01.000000Z",
    "foobarbaz" => "yay",
  ]
```
In a real world situation, it just means you can append the attribute with whatever alias you prefer, keeping it consistent with how you're accessing it from the model, which is a win win?  And if you're switching from the `get` notation to the class way, it will continue to work.

Doesn't break anything from my understanding, and just resolves this particular issue with aliasing, which already works via the other way ie `getFooBarBazAttribute()` 🕺🏻 

Hopefully tests are OK, but any issues let me know 🫡 
   
