### PR TITLE
[11.x] Run Tests with Redis 7.4

### DIFF
--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -87,7 +87,7 @@ jobs:
 
     services:
       redis:
-        image: redis:7.0
+        image: redis:7.4
         ports:
           - 6379:6379
         options: --entrypoint redis-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       redis:
-        image: redis:7.0
+        image: redis:7.4
         ports:
           - 6379:6379
         options: --entrypoint redis-server


### PR DESCRIPTION
## Redis EOL

The redis version 7.0 no longer receives security support, so maybe it is time to update the versions in the Github Actions to the latest version, to make sure everything works with these versions

Old: Redis 7.0 (EOL: 29th July 2024)
New: Redis 7.4 (EOL: 30th November 2026)

Alternative: Redis 7.2 (EOL: 28th February 2026)

According to https://endoflife.date/redis

## Redis License Changes

Starting from 7.4, Redis will be dual-licensed under the RSALv2 and SSPLv1 licenses. 7.2 is the last release under the old 3-BSD license. So not sure if there are any implications for Laravel (Probably not).

Redis Blog Post about the license change:
https://redis.io/blog/redis-adopts-dual-source-available-licensing/

