### PR TITLE
make withoutScopedBindings usable on RouteRegistrar

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -74,6 +74,7 @@ class RouteRegistrar
         'scopeBindings',
         'where',
         'withoutMiddleware',
+        'withoutScopedBindings',
     ];
 
     /**
@@ -84,6 +85,7 @@ class RouteRegistrar
     protected $aliases = [
         'name' => 'as',
         'scopeBindings' => 'scope_bindings',
+        'withoutScopedBindings' => 'scope_bindings',
         'withoutMiddleware' => 'excluded_middleware',
     ];
 
@@ -125,6 +127,10 @@ class RouteRegistrar
             $value = array_merge(
                 (array) ($this->attributes[$attributeKey] ?? []), Arr::wrap($value)
             );
+        }
+
+        if ($key === 'withoutScopedBindings') {
+            $value = false;
         }
 
         if ($value instanceof BackedEnum && ! is_string($value = $value->value)) {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -516,6 +516,50 @@ class RouteRegistrarTest extends TestCase
         });
     }
 
+    public function testCanSetWithoutScopedBindings()
+    {
+        $route = $this->router->withoutScopedBindings()->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->assertTrue($route->preventsScopedBindings());
+    }
+
+    public function testCanSetWithoutScopedBindingsOnGroup()
+    {
+        $this->router->withoutScopedBindings()->group(function ($router) {
+            $router->get('foo', function () {
+                return 'hello';
+            });
+        });
+
+        $route = $this->router->getRoutes()->getRoutes()[0];
+
+        $this->assertTrue($route->preventsScopedBindings());
+    }
+
+    public function testCanSetScopeBindings()
+    {
+        $route = $this->router->scopeBindings()->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->assertTrue($route->enforcesScopedBindings());
+    }
+
+    public function testCanSetScopeBindingsOnGroup()
+    {
+        $this->router->scopeBindings()->group(function ($router) {
+            $router->get('foo', function () {
+                return 'hello';
+            });
+        });
+
+        $route = $this->router->getRoutes()->getRoutes()[0];
+
+        $this->assertTrue($route->enforcesScopedBindings());
+    }
+
     public function testCanRegisterResource()
     {
         $this->router->middleware('resource-middleware')


### PR DESCRIPTION
The withoutScopedBindings method was available according to DocBlock but not usable, this PR aims to fix that