### PR TITLE
Check valid email or not using Str::isEmail()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2032,10 +2032,11 @@ class Str
      * @param  mixed  $value
      * @return bool
      */
-   public static function isEmail(string $value, ?EmailValidation $rule = null): bool
-   {
-       $validator = new EmailValidator();
-       $validationRule = $rule?->validation() ?? new RFCValidation();
-       return $validator->isValid($value, $validationRule);
-   }
+    public static function isEmail(string $value, ?EmailValidation $rule = null): bool
+    {
+        $validator = new EmailValidator();
+        $validationRule = $rule?->validation() ?? new RFCValidation();
+
+        return $validator->isValid($value, $validationRule);
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2,25 +2,25 @@
 
 namespace Illuminate\Support;
 
-use Closure;
-use Throwable;
-use Traversable;
-use JsonException;
-use Ramsey\Uuid\Uuid;
-use voku\helper\ASCII;
-use Ramsey\Uuid\UuidFactory;
-use Symfony\Component\Uid\Ulid;
-use Illuminate\Support\Traits\Macroable;
-use League\CommonMark\MarkdownConverter;
-use Ramsey\Uuid\Generator\CombGenerator;
-use Egulias\EmailValidator\EmailValidator;
-use League\CommonMark\Environment\Environment;
-use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
-use Illuminate\Validation\Rules\EmailValidation;
-use Egulias\EmailValidator\Validation\RFCValidation;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
-use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
+ use Closure;
+ use Egulias\EmailValidator\EmailValidator;
+ use Egulias\EmailValidator\Validation\RFCValidation;
+ use Illuminate\Support\Traits\Macroable;
+ use Illuminate\Validation\Rules\EmailValidation;
+ use JsonException;
+ use League\CommonMark\Environment\Environment;
+ use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+ use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
+ use League\CommonMark\GithubFlavoredMarkdownConverter;
+ use League\CommonMark\MarkdownConverter;
+ use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
+ use Ramsey\Uuid\Generator\CombGenerator;
+ use Ramsey\Uuid\Uuid;
+ use Ramsey\Uuid\UuidFactory;
+ use Symfony\Component\Uid\Ulid;
+ use Throwable;
+ use Traversable;
+ use voku\helper\ASCII;
 
 class Str
 {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,21 +3,24 @@
 namespace Illuminate\Support;
 
 use Closure;
-use Illuminate\Support\Traits\Macroable;
-use JsonException;
-use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
-use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
-use League\CommonMark\MarkdownConverter;
-use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
-use Ramsey\Uuid\Generator\CombGenerator;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidFactory;
-use Symfony\Component\Uid\Ulid;
 use Throwable;
 use Traversable;
+use JsonException;
+use Ramsey\Uuid\Uuid;
 use voku\helper\ASCII;
+use Ramsey\Uuid\UuidFactory;
+use Symfony\Component\Uid\Ulid;
+use Illuminate\Support\Traits\Macroable;
+use League\CommonMark\MarkdownConverter;
+use Ramsey\Uuid\Generator\CombGenerator;
+use Egulias\EmailValidator\EmailValidator;
+use League\CommonMark\Environment\Environment;
+use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
+use Illuminate\Validation\Rules\EmailValidation;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
 
 class Str
 {
@@ -2022,4 +2025,17 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Determine if a given value is a valid Email.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+   public static function isEmail(string $value, ?EmailValidation $rule = null): bool
+   {
+       $validator = new EmailValidator();
+       $validationRule = $rule?->validation() ?? new RFCValidation();
+       return $validator->isValid($value, $validationRule);
+   }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2,25 +2,25 @@
 
 namespace Illuminate\Support;
 
- use Closure;
- use Egulias\EmailValidator\EmailValidator;
- use Egulias\EmailValidator\Validation\RFCValidation;
- use Illuminate\Support\Traits\Macroable;
- use Illuminate\Validation\Rules\EmailValidation;
- use JsonException;
- use League\CommonMark\Environment\Environment;
- use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
- use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
- use League\CommonMark\GithubFlavoredMarkdownConverter;
- use League\CommonMark\MarkdownConverter;
- use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
- use Ramsey\Uuid\Generator\CombGenerator;
- use Ramsey\Uuid\Uuid;
- use Ramsey\Uuid\UuidFactory;
- use Symfony\Component\Uid\Ulid;
- use Throwable;
- use Traversable;
- use voku\helper\ASCII;
+use Closure;
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\EmailValidation;
+use JsonException;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
+use League\CommonMark\MarkdownConverter;
+use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
+use Ramsey\Uuid\Generator\CombGenerator;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidFactory;
+use Symfony\Component\Uid\Ulid;
+use Throwable;
+use Traversable;
+use voku\helper\ASCII;
 
 class Str
 {

--- a/src/Illuminate/Validation/Rules/EmailValidation.php
+++ b/src/Illuminate/Validation/Rules/EmailValidation.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Egulias\EmailValidator\Validation\RFCValidation;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
-use Illuminate\Validation\Concerns\FilterEmailValidation;
-use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
-use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
 use Egulias\EmailValidator\Validation\EmailValidation as EguliasEmailValidation;
+use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Illuminate\Validation\Concerns\FilterEmailValidation;
 
 enum EmailValidation
 {
@@ -17,7 +17,7 @@ enum EmailValidation
     case Filter;
     case Rfc;
 
-    public function validation() : EguliasEmailValidation
+    public function validation(): EguliasEmailValidation
     {
         return match ($this) {
             self::Strict => new NoRFCWarningsValidation(),

--- a/src/Illuminate/Validation/Rules/EmailValidation.php
+++ b/src/Illuminate/Validation/Rules/EmailValidation.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Illuminate\Validation\Concerns\FilterEmailValidation;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
+use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
+use Egulias\EmailValidator\Validation\EmailValidation as EguliasEmailValidation;
+
+enum EmailValidation
+{
+    case Strict;
+    case Dns;
+    case Spoof;
+    case Filter;
+    case Rfc;
+
+    public function validation() : EguliasEmailValidation
+    {
+        return match ($this) {
+            self::Strict => new NoRFCWarningsValidation(),
+            self::Dns => new DNSCheckValidation(),
+            self::Spoof => new SpoofCheckValidation(),
+            self::Filter => new FilterEmailValidation(),
+            self::Rfc => new RFCValidation(),
+            default => new RFCValidation(),
+        };
+    }
+}

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1641,7 +1641,6 @@ class SupportStrTest extends TestCase
 
     public function testValidEmails()
     {
-        // Standard valid email formats according to RFC 5322
         $this->assertTrue(Str::isEmail('example@laravel.com'));
         $this->assertTrue(Str::isEmail('user.name+alias@domain.co.uk'));
         $this->assertTrue(Str::isEmail('123456@domain.com'));
@@ -1679,7 +1678,6 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isEmail('user.@domain.com'));
         $this->assertFalse(Str::isEmail('user..name@domain.com'));
         $this->assertFalse(Str::isEmail('user@sub_domain.com'));
-
     }
 
     public function testValidEmailsWithRfc()
@@ -1690,12 +1688,10 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isEmail('user@sub.domain.com', EmailValidation::Rfc));
         $this->assertTrue(Str::isEmail('a@b.co', EmailValidation::Rfc));
 
-
         $this->assertFalse(Str::isEmail('plainaddress', EmailValidation::Rfc));
         $this->assertFalse(Str::isEmail('@missinglocal.com', EmailValidation::Rfc));
         $this->assertFalse(Str::isEmail('username@.com', EmailValidation::Rfc));
         $this->assertFalse(Str::isEmail('username@com.', EmailValidation::Rfc));
-
     }
 
     public function testValidEmailsWithStrict()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1746,12 +1746,12 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isEmail('user@sub.domain.com', EmailValidation::Filter));
         $this->assertTrue(Str::isEmail('a@b.co', EmailValidation::Filter));
 
-        $this->assertFalse(Str::isEmail('plainaddress', EmailValidation::Filter)); // Missing @ symbol
-        $this->assertFalse(Str::isEmail('@missinglocal.com', EmailValidation::Filter)); // Missing local part
-        $this->assertFalse(Str::isEmail('username@.com', EmailValidation::Filter)); // Invalid domain part
-        $this->assertFalse(Str::isEmail('username@com.', EmailValidation::Filter)); // Invalid domain end
-        $this->assertFalse(Str::isEmail('missingdomain@.com', EmailValidation::Filter)); // Missing domain name before the dot
-        $this->assertFalse(Str::isEmail('missingatsign.com', EmailValidation::Filter)); // Missing @ symbol
+        $this->assertFalse(Str::isEmail('plainaddress', EmailValidation::Filter));
+        $this->assertFalse(Str::isEmail('@missinglocal.com', EmailValidation::Filter));
+        $this->assertFalse(Str::isEmail('username@.com', EmailValidation::Filter));
+        $this->assertFalse(Str::isEmail('username@com.', EmailValidation::Filter));
+        $this->assertFalse(Str::isEmail('missingdomain@.com', EmailValidation::Filter));
+        $this->assertFalse(Str::isEmail('missingatsign.com', EmailValidation::Filter));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -3,13 +3,13 @@
 namespace Illuminate\Tests\Support;
 
 use Exception;
-use ValueError;
-use ReflectionClass;
 use Illuminate\Support\Str;
-use Ramsey\Uuid\UuidInterface;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Illuminate\Validation\Rules\EmailValidation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\UuidInterface;
+use ReflectionClass;
+use ValueError;
 
 class SupportStrTest extends TestCase
 {


### PR DESCRIPTION
We can now check valid email or not using `Str::isEmail()`

Here we used [egulias/EmailValidator](https://github.com/egulias/EmailValidator) to check email validation.

We can check email with some rules.

1. Strict
2. Dns
3. Spoof
4. Filter
5. Rfc

`Str::isEmail()` takes 2 parameters. first one is email we want to check and second one is rules we want to implement here. 2nd parameter is optional. By default it use `Rfc` rule to check email. 

Here we just passed only one parameter, which check email using `Rfc` rule by default.

Example:
```php
Str::isEmail('example@laravel.com')
```
Output: `true`

-----------

```php
Str::isEmail('plainaddress')
```
Output: `false`

------------

However, We can pass rules here like:

```php
use Illuminate\Validation\Rules\EmailValidation;

Str::isEmail('example@laravel.com', EmailValidation::Rfc)
```
Output: `true`

----------
```php
use Illuminate\Validation\Rules\EmailValidation;

Str::isEmail('example.laravel.com', EmailValidation::Rfc)
```
Output: `false`

------------

We can also use others rules.
Example: 
```php
use Illuminate\Validation\Rules\EmailValidation;

Str::isEmail('example@laravel.com', EmailValidation::Strict)
```
Output: `true`

-----------

```php
use Illuminate\Validation\Rules\EmailValidation;

Str::isEmail('user@sub..domain.com', EmailValidation::Strict)
```
Output: `false`




