### PR TITLE
[11.x] Add type hint for options parameter in toJson method across framework

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1266,7 +1266,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0);
+    public function toJson(int $options = 0);
 
     /**
      * Get a CachingIterator instance.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -976,7 +976,7 @@ trait EnumeratesValues
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
     }

--- a/src/Illuminate/Contracts/Support/Jsonable.php
+++ b/src/Illuminate/Contracts/Support/Jsonable.php
@@ -10,5 +10,5 @@ interface Jsonable
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0);
+    public function toJson(int $options = 0);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1675,7 +1675,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @throws \Illuminate\Database\Eloquent\JsonEncodingException
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         try {
             $json = json_encode($this->jsonSerialize(), $options | JSON_THROW_ON_ERROR);

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -143,7 +143,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      *
      * @throws \Illuminate\Database\Eloquent\JsonEncodingException
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         try {
             $json = json_encode($this->jsonSerialize(), $options | JSON_THROW_ON_ERROR);

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -177,7 +177,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
     }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -236,7 +236,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
     }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -181,7 +181,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
     }

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -184,7 +184,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
     }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -427,7 +427,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      * @param  int  $options
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
     }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -112,7 +112,7 @@ class HttpJsonResponseTest extends TestCase
 
 class JsonResponseTestJsonableObject implements Jsonable
 {
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return '{"foo":"bar"}';
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -242,7 +242,7 @@ class ArrayableStub implements Arrayable
 
 class ArrayableAndJsonableStub implements Arrayable, Jsonable
 {
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return '{"foo":"bar"}';
     }
@@ -255,7 +255,7 @@ class ArrayableAndJsonableStub implements Arrayable, Jsonable
 
 class JsonableStub implements Jsonable
 {
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return 'foo';
     }

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -554,7 +554,7 @@ class Settings
         );
     }
 
-    public function toJson($options = 0): string
+    public function toJson(int $options = 0): string
     {
         return json_encode(['foo' => $this->foo, 'bar' => $this->bar], $options);
     }

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -39,7 +39,7 @@ class JsonResponseTest extends TestCase
 
         $response->setData(new class implements Jsonable
         {
-            public function toJson($options = 0): string
+            public function toJson(int $options = 0): string
             {
                 return '{}';
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5697,7 +5697,7 @@ class TestArrayableObject implements Arrayable
 
 class TestJsonableObject implements Jsonable
 {
-    public function toJson($options = 0)
+    public function toJson(int $options = 0)
     {
         return '{"foo":"bar"}';
     }

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -86,7 +86,7 @@ class SupportJsTest extends TestCase
 
             public $bar = 'not world';
 
-            public function toJson($options = 0)
+            public function toJson(int $options = 0)
             {
                 return json_encode(['foo' => 'hello', 'bar' => 'world'], $options);
             }


### PR DESCRIPTION
Added parameter type hint for `toJson` function in `Illuminate\Contracts\Support\Jsonable` interface and implementing classes

This improves type safety and aligns with modern PHP standards.

#### Changes
![image](https://github.com/user-attachments/assets/dc6fb1f1-291f-4873-8ea6-85738fac9bb9)
