### PR TITLE
Remove Incorrect @mixin Annotation in BuildsQueries Trait

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -22,7 +22,6 @@ use RuntimeException;
 /**
  * @template TValue
  *
- * @mixin \Illuminate\Database\Eloquent\Builder
  * @mixin \Illuminate\Database\Query\Builder
  */
 trait BuildsQueries


### PR DESCRIPTION
# Incorrect `@mixin` Annotation in BuildsQueries Trait

## Description
The `BuildsQueries` trait contains a PHPDoc annotation that incorrectly mixes in both Eloquent Builder and Query Builder methods. This causes IDEs like PHPStorm to suggest Eloquent-specific methods in contexts where only Query Builder methods are available, leading to potential runtime errors.

## Current Behavior
The trait currently has this annotation:
```php
/**
 * @template TValue
 *
 * @mixin \Illuminate\Database\Eloquent\Builder
 * @mixin \Illuminate\Database\Query\Builder
 */
trait BuildsQueries
```

This causes PHPStorm to suggest Eloquent-specific methods (like `whereBelongsTo`) even when working with a pure Query Builder instance, such as in validation rules:

```php
Rule::unique(User::class)
    ->where(function (\Illuminate\Database\Query\Builder $query) use ($relation): \Illuminate\Database\Query\Builder {
        return $query->whereBelongsTo($relation); // IDE incorrectly suggests this method
    })
```

## Expected Behavior
The trait should only mix in Query Builder methods since it's used in contexts where Eloquent Builder methods are not available. The annotation should be:

```php
/**
 * @template TValue
 *
 * @mixin \Illuminate\Database\Query\Builder
 */
trait BuildsQueries
```

## Steps to Reproduce
1. Use Laravel with PHPStorm
2. Create a validation rule using `Rule::unique()`
3. Inside the where callback, type-hint the query parameter as `\Illuminate\Database\Query\Builder`
4. Observe that PHPStorm suggests Eloquent-specific methods like `whereBelongsTo`
5. If you use these suggested methods, you'll get runtime errors like `ERROR: column "belongs_to" does not exist`

## Impact
This incorrect type annotation can lead developers to use Eloquent methods in Query Builder contexts, resulting in runtime errors that aren't caught during development.

## Additional Context
- Laravel Version: 11.41.3
- PHP Version: 8.3
- IDE: PHPStorm 2024.3.3, Build #PS-243.24978.50, built on February 12, 2025

The issue affects static analysis and IDE support, potentially causing developers to write code that will fail at runtime despite appearing valid to their IDE.