### PR TITLE
[11.x] Introduce WithBuilder attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/WithBuilder.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/WithBuilder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class WithBuilder
+{
+    /**
+     * Creates a new attribute instance.
+     *
+     * @param  class-string<\Illuminate\Database\Eloquent\Builder>  $builderClass
+     * @return void
+     */
+    public function __construct(public string $builderClass)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/HasBuilder.php
+++ b/src/Illuminate/Database/Eloquent/HasBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Database\Eloquent\Attributes\WithBuilder;
+
 /**
  * @template TBuilder of \Illuminate\Database\Eloquent\Builder
  */
@@ -25,7 +27,29 @@ trait HasBuilder
      */
     public function newEloquentBuilder($query)
     {
-        return parent::newEloquentBuilder($query);
+        $builderClass = $this->getBuilderClass($query);
+
+        return $builderClass ?? parent::newEloquentBuilder($query);
+    }
+
+    /**
+     * Get builder from the UseBuilder attribute.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return TBuilder|null
+     */
+    protected static function getBuilderClass($query)
+    {
+        $attributes = (new \ReflectionClass(static::class))
+            ->getAttributes(WithBuilder::class);
+
+        if ($attributes !== []) {
+            $withBuilder = $attributes[0]->newInstance();
+
+            return new $withBuilder->builderClass($query);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
# Description

Excited to introduce the WithBuilder attribute - a clean solution for connecting your Eloquent models with builders using PHP attributes! When working with large projects, keeping code organized is crucial for maintainability. `WithBuilder` simplifies this by letting developers link models and builders with just a single line of code. It's all about making your codebase cleaner!

# How to use

```php
<?php

namespace Domain\Models\Company;

use Domain\Models\QueryBuilders\CompanyBuilder;
use Illuminate\Database\Eloquent\Attributes\WithBuilder;

#[WithBuilder(CompanyBuilder::class)]
class Company extends Model
{
    use HasBuilder;
    // 
}
```

### Requirement
- Required for attribute support (PHP 8.0+)

### Testing
- Added test to cover returning of a new builder using `WithBuilder` attribute
- Also covered `newEloquentBuilder` method takes priority over `WithBuilder` attribute.

So this is fully backward compatible.
