### PR TITLE
[11.x] fix: pagination generics

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -568,7 +568,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Get the paginator's underlying collection.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function getCollection()
     {
@@ -578,8 +578,13 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Set the paginator's underlying collection.
      *
-     * @param  \Illuminate\Support\Collection  $collection
+     * @template TSetKey of array-key
+     * @template TSetValue
+     *
+     * @param  \Illuminate\Support\Collection<TSetKey, TSetValue>  $collection
      * @return $this
+     *
+     * @phpstan-this-out static<TSetKey, TSetValue>
      */
     public function setCollection(Collection $collection)
     {
@@ -613,7 +618,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      * Get the item at the given offset.
      *
      * @param  TKey  $key
-     * @return TValue
+     * @return TValue|null
      */
     public function offsetGet($key): mixed
     {

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -738,7 +738,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      * Get the item at the given offset.
      *
      * @param  TKey  $key
-     * @return TValue
+     * @return TValue|null
      */
     public function offsetGet($key): mixed
     {

--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use UnexpectedValueException;
 
+/** @implements Arrayable<array-key, mixed> */
 class Cursor implements Arrayable
 {
     /**


### PR DESCRIPTION
Hello!

I was updating the Larastan stubs and noticed some slight errors in the pagination generics.

Thanks!