### PR TITLE
[11.x] Adds to customize a model on instancing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
-use Closure;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -217,6 +218,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $isBroadcasting = true;
 
     /**
+     * Customizes the model after is completely booted and instanced.
+     *
+     * @var array<class-string, (\Closure(static):void)>
+     */
+    protected static $customizations = [];
+
+    /**
      * The Eloquent query builder class to use for the model.
      *
      * @var class-string<\Illuminate\Database\Eloquent\Builder<*>>
@@ -259,6 +267,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->syncOriginal();
 
         $this->fill($attributes);
+
+        if (isset(static::$customizations[static::class])) {
+            (static::$customizations[static::class])($this);
+        }
     }
 
     /**
@@ -515,6 +527,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         } finally {
             static::$isBroadcasting = $isBroadcasting;
         }
+    }
+
+
+    /**
+     * Sets a callback to execute after the model is fully booted and initialized.
+     *
+     * @param  (\Closure(static):void)|null  $customization
+     * @return void
+     */
+    public static function customize($customization)
+    {
+        static::$customizations[static::class] = $customization;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -528,7 +528,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
     }
 
-
     /**
      * Sets a callback to execute after the model is fully booted and initialized.
      *

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3217,6 +3217,21 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(EloquentModelWithUseFactoryAttribute::class, $factory->modelName());
         $this->assertEquals('test name', $instance->name); // Small smoke test to ensure the factory is working
     }
+
+    public function testCustomizableCallback()
+    {
+        EloquentModelWithCustomization::customize(function (EloquentModelWithCustomization $model) {
+            $model->setTable('test_table');
+        });
+
+        $this->assertSame('test_table', (new EloquentModelWithCustomization)->getTable());
+        $this->assertNotSame('test_table', (new EloquentModelStub)->getTable());
+
+        EloquentModelWithCustomization::customize(null);
+
+        $this->assertNotSame('test_table', (new EloquentModelWithCustomization)->getTable());
+        $this->assertNotSame('test_table', (new EloquentModelStub)->getTable());
+    }
 }
 
 class EloquentTestObserverStub
@@ -4029,4 +4044,9 @@ class EloquentModelWithUseFactoryAttributeFactory extends Factory
 class EloquentModelWithUseFactoryAttribute extends Model
 {
     use HasFactory;
+}
+
+class EloquentModelWithCustomization extends Model
+{
+    // ...
 }


### PR DESCRIPTION
# What?

Allows a developer to further customize a third-party model on instancing using the `customize()` method.

```php
use Vendor\Package\Models\PackageModel;

PackageModel::customize(function ($model) {
   $model->setTable('my-custom-table');
});
```

This is not intended for the end-developer to use, since he will have total control on the models created. It's intended for package authors to let the end-user customize the Model table, casts, and other attributes, on the `ApplicationServiceProvider::boot()` method.