### PR TITLE
[11.x] Add isTtySupported to Process facade

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -329,11 +329,12 @@ class PendingProcess
     }
 
     /**
-     * Returns whether TTY is supported on the current operating system.
+     * Determine whether TTY is supported on the current operating system.
      *
      * @return bool
      */
-    public function isTtySupported() {
+    public function supportsTty()
+    {
         return Process::isTtySupported();
     }
 

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -329,6 +329,15 @@ class PendingProcess
     }
 
     /**
+     * Returns whether TTY is supported on the current operating system.
+     *
+     * @return bool
+     */
+    public function isTtySupported() {
+        return Process::isTtySupported();
+    }
+
+    /**
      * Specify the fake process result handlers for the pending process.
      *
      * @param  array  $fakeHandlers

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -21,7 +21,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\PendingProcess withFakeHandlers(array $fakeHandlers)
  * @method static \Illuminate\Process\PendingProcess|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Process\PendingProcess|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
- * @method static bool isTtySupported()
+ * @method static bool supportsTty()
  * @method static \Illuminate\Process\FakeProcessResult result(array|string $output = '', array|string $errorOutput = '', int $exitCode = 0)
  * @method static \Illuminate\Process\FakeProcessDescription describe()
  * @method static \Illuminate\Process\FakeProcessSequence sequence(array $processes = [])

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -21,6 +21,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\PendingProcess withFakeHandlers(array $fakeHandlers)
  * @method static \Illuminate\Process\PendingProcess|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Process\PendingProcess|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static bool isTtySupported()
  * @method static \Illuminate\Process\FakeProcessResult result(array|string $output = '', array|string $errorOutput = '', int $exitCode = 0)
  * @method static \Illuminate\Process\FakeProcessDescription describe()
  * @method static \Illuminate\Process\FakeProcessSequence sequence(array $processes = [])


### PR DESCRIPTION
I would like to conditionally turn on TTY for a process if it is supported like so,
```php
Process::when(\Symfony\Component\Process\Process::isTtySupported(), 
    fn (PendingProcess $process) => $process->tty()
)
```
 but currently have to reach for the symfony process class to do so. This exposes the symfony `Process::isTtySupported` to the Process facade.