### PR TITLE
[11.x] Update Broadcasting Install Command For Bun Version 1.1.39^

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -187,7 +187,7 @@ class BroadcastingInstallCommand extends Command
                 'yarn add --dev laravel-echo pusher-js',
                 'yarn run build',
             ];
-        } elseif (file_exists(base_path('bun.lockb'))) {
+        } elseif (file_exists(base_path('bun.lock')) || file_exists(base_path('bun.lockb'))) {
             $commands = [
                 'bun add --dev laravel-echo pusher-js',
                 'bun run build',


### PR DESCRIPTION
This is a quick fix for new installations using Bun version `1.1.39^` since Bun now creates a JSONC `bun.lock` file. Also keep support for older projects with `bun.lockb` and users that wants to use the binary lock file.