### PR TITLE
[11.x] Fix `serve` command with `PHP_CLI_SERVER_WORKERS`

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -88,7 +88,7 @@ class ServeCommand extends Command
      *
      * @var int|false
      */
-    protected $phpCliServerWorkers = 1;
+    protected $phpServerWorkers = 1;
 
     /**
      * Execute the console command.
@@ -99,7 +99,7 @@ class ServeCommand extends Command
      */
     public function handle()
     {
-        $this->phpCliServerWorkers = transform(env('PHP_CLI_SERVER_WORKERS', 1), function ($workers) {
+        $this->phpServerWorkers = transform(env('PHP_CLI_SERVER_WORKERS', 1), function ($workers) {
             if (! is_int($workers) || $workers < 2) {
                 return false;
             }
@@ -168,7 +168,7 @@ class ServeCommand extends Command
             }
 
             return in_array($key, static::$passthroughVariables) ? [$key => $value] : [$key => false];
-        })->merge(['PHP_CLI_SERVER_WORKERS' => $this->phpCliServerWorkers])->all());
+        })->merge(['PHP_CLI_SERVER_WORKERS' => $this->phpServerWorkers])->all());
 
         $this->trap(fn () => [SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT], function ($signal) use ($process) {
             if ($process->isRunning()) {
@@ -374,7 +374,7 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $regex = ! windows_os() && $this->phpCliServerWorkers > 1
+        $regex = ! windows_os() && $this->phpServerWorkers > 1
             ? '/^\[\d+]\s\[([a-zA-Z0-9: ]+)\]/'
             : '/^\[([^\]]+)\]/';
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -103,6 +103,8 @@ class ServeCommand extends Command
 
             return $workers > 1 && ! $this->option('no-reload') ? false : $workers;
         });
+
+        parent::initialize($input, $output);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -381,7 +381,7 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $regex = ! windows_os() && $this->phpServerWorkers > 1
+        $regex = ! windows_os() && is_int($this->phpServerWorkers)
             ? '/^\[\d+]\s\[([a-zA-Z0-9: ]+)\]/'
             : '/^\[([^\]]+)\]/';
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -88,7 +88,7 @@ class ServeCommand extends Command
     /**
      * The number of PHP_CLI_SERVER_WORKERS.
      *
-     * @var int|false
+     * @var int<2, max>|false
      */
     protected $phpServerWorkers = 1;
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -37,6 +37,13 @@ class ServeCommand extends Command
     protected $description = 'Serve the application on the PHP development server';
 
     /**
+     * The number of PHP CLI server workers.
+     *
+     * @var int<2, max>|false
+     */
+    protected $phpServerWorkers = 1;
+
+    /**
      * The current port offset.
      *
      * @var int
@@ -84,13 +91,6 @@ class ServeCommand extends Command
         'XDEBUG_MODE',
         'XDEBUG_SESSION',
     ];
-
-    /**
-     * The number of PHP_CLI_SERVER_WORKERS.
-     *
-     * @var int<2, max>|false
-     */
-    protected $phpServerWorkers = 1;
 
     /** {@inheritdoc} */
     #[\Override]

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -122,8 +122,7 @@ class ServeCommand extends Command
                 clearstatcache(false, $environmentFile);
             }
 
-            if (
-                ! $this->option('no-reload') &&
+            if (! $this->option('no-reload') &&
                 $hasEnvironment &&
                 filemtime($environmentFile) > $environmentLastModified) {
                 $environmentLastModified = filemtime($environmentFile);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+
 use function Illuminate\Support\php_binary;
 use function Termwind\terminal;
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -9,9 +9,10 @@ use Illuminate\Support\Env;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
-
 use function Illuminate\Support\php_binary;
 use function Termwind\terminal;
 
@@ -90,6 +91,19 @@ class ServeCommand extends Command
      */
     protected $phpServerWorkers = 1;
 
+    /** {@inheritdoc} */
+    #[\Override]
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->phpServerWorkers = transform(env('PHP_CLI_SERVER_WORKERS', 1), function ($workers) {
+            if (! is_int($workers) || $workers < 2) {
+                return false;
+            }
+
+            return $workers > 1 && ! $this->option('no-reload') ? false : $workers;
+        });
+    }
+
     /**
      * Execute the console command.
      *
@@ -99,14 +113,6 @@ class ServeCommand extends Command
      */
     public function handle()
     {
-        $this->phpServerWorkers = transform(env('PHP_CLI_SERVER_WORKERS', 1), function ($workers) {
-            if (! is_int($workers) || $workers < 2) {
-                return false;
-            }
-
-            return $workers > 1 && ! $this->option('no-reload') ? false : $workers;
-        });
-
         $environmentFile = $this->option('env')
             ? base_path('.env').'.'.$this->option('env')
             : base_path('.env');


### PR DESCRIPTION
By default, serve command would restart child process when there's modification to the `.env` file. However, with `PHP_CLI_SERVER_WORKERS` set to larger than 1 the process doesn't close properly (port is still being used) and this cause the restart process to pick an incremented port number.

The changes here will unset `PHP_CLI_SERVER_WORKERS` value unless the command is executed with `--no-reload` option.

fixes #54574

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
