### PR TITLE
[11.x] Add scalar type to collect method and Collection constructor

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -36,7 +36,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Create a new collection.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|scalar|null  $items
      * @return void
      */
     public function __construct($items = [])

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -10,7 +10,7 @@ if (! function_exists('collect')) {
      * @template TKey of array-key
      * @template TValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|scalar|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     function collect($value = [])


### PR DESCRIPTION
This commit adds support for scalar types (e.g., strings or integers) to the `collect` method and `Collection` constructor in the relevant code base. Specifically, it updates the parameter type annotations to include `scalar`, allowing these methods to handle scalar values without causing issues with static analysis tools like PhpStan. This improves type safety and compatibility for developers working with the `collect` function or `Collection` class. No functionality is changed; this is strictly an enhancement to improve type handling and tool support.
