### PR TITLE
[11.x] Ability to lock loaded model instances

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -358,10 +358,16 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get();
 
         if ($refresh) {
-            foreach ($refreshedModels as $model) {
-                $original = $this->find($model);
+            $refreshList = [];
 
-                $original->setRawAttributes($model->getAttributes());
+            foreach ($this as $original) {
+                if ($original->exists) {
+                    $refreshList[] = [$original, $refreshedModels->findOrFail($original)];
+                }
+            }
+
+            foreach ($refreshList as [$original, $new]) {
+                $original->setRawAttributes($new->getAttributes());
                 $original->syncOriginal();
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1743,6 +1743,56 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Lock the current model instance record and refresh the attributes
+     *
+     * @param bool|string $value
+     * @param bool $refresh
+     * @return $this
+     */
+    public function lock($value = true, bool $refresh = true)
+    {
+        if (! $this->exists) {
+            return $this;
+        }
+
+        $refreshedAttributes = $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
+            ->useWritePdo()
+            ->lock($value)
+            ->firstOrFail()
+            ->attributes;
+
+        if ($refresh) {
+            $this->setRawAttributes($refreshedAttributes);
+
+            $this->syncOriginal();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Lock the current model instance record for updating and refresh the attributes
+     *
+     * @param bool $refresh
+     * @return $this
+     */
+    public function lockForUpdate(bool $refresh = true)
+    {
+        return $this->lock(true, $refresh);
+    }
+
+    /**
+     * Share lock the current model instance record and refresh the attributes
+     *
+     * @param bool $refresh
+     * @return $this
+     */
+    public function sharedLock(bool $refresh = true)
+    {
+        return $this->lock(false, $refresh);
+    }
+
+    /**
      * Clone the model into a new, non-existing instance.
      *
      * @param  array|null  $except

--- a/tests/Database/DatabaseEloquentTransactionsTest.php
+++ b/tests/Database/DatabaseEloquentTransactionsTest.php
@@ -191,6 +191,7 @@ class DatabaseEloquentTransactionsTest extends TestCase
             EloquentTransactionModelStub::create(['foo' => 'Baz']),
         ]);
 
+        $collection[0]->foo = 'Changed';
         EloquentTransactionModelStub::whereKey($collection[1])->delete();
 
         try {
@@ -198,7 +199,7 @@ class DatabaseEloquentTransactionsTest extends TestCase
         } catch (ModelNotFoundException) {
         }
 
-        $this->assertSame('Baz', $collection[0]->foo);
+        $this->assertSame('Changed', $collection[0]->foo);
     }
 }
 

--- a/tests/Database/DatabaseEloquentTransactionsTest.php
+++ b/tests/Database/DatabaseEloquentTransactionsTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentTransactionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        $this->createSchema();
+    }
+
+    public function createSchema()
+    {
+        $this->schema()->create('stub', function ($table) {
+            $table->increments('id');
+            $table->string('foo');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->schema()->drop('stub');
+
+        Carbon::setTestNow(null);
+    }
+
+    protected function schema()
+    {
+        $connection = Model::getConnectionResolver()->connection();
+
+        return $connection->getSchemaBuilder();
+    }
+
+    public function testLockWithRefreshingModel()
+    {
+        $record = EloquentTransactionModelStub::create([
+            'foo' => 'Baz',
+        ]);
+
+        $record->foo = 'Changed';
+        $this->assertSame(['foo'], array_keys($record->getDirty()));
+
+        DB::connection()->transaction(fn() => $record->lockForUpdate());
+
+        $this->assertSame('Baz', $record->foo);
+        $this->assertSame([], array_keys($record->getDirty()));
+    }
+
+    public function testLockWithoutRefreshingModel()
+    {
+        $record = EloquentTransactionModelStub::create([
+            'foo' => 'Baz',
+        ]);
+
+        $record->foo = 'Changed';
+        $this->assertSame(['foo'], array_keys($record->getDirty()));
+
+        DB::connection()->transaction(fn() => $record->lockForUpdate(false));
+
+        $this->assertSame('Changed', $record->foo);
+        $this->assertSame(['foo'], array_keys($record->getDirty()));
+    }
+
+    public function testDontLockWhenRecordIsNotExists()
+    {
+        $record = new EloquentTransactionModelStub([
+            'foo' => 'Baz',
+        ]);
+
+        $record->foo = 'Changed';
+
+        DB::connection()->transaction(fn() => $record->lockForUpdate(true));
+
+        $this->assertSame('Changed', $record->foo);
+        $this->assertFalse($record->exists);
+    }
+
+    public function testCollectionLockWithRefresh()
+    {
+        $collection = new Collection([
+            EloquentTransactionModelStub::create(['foo' => '1']),
+            EloquentTransactionModelStub::create(['foo' => '2']),
+            EloquentTransactionModelStub::create(['foo' => '3']),
+        ]);
+
+        $collection[0]->foo = 'Changed';
+        $collection[2]->foo = 'Changed';
+        $this->assertSame(['foo'], array_keys($collection[0]->getDirty()));
+        $this->assertSame(['foo'], array_keys($collection[2]->getDirty()));
+
+        DB::connection()->transaction(fn() => $collection->lockForUpdate(true));
+
+        $this->assertSame(['1', '2', '3'], [
+            $collection[0]->foo,
+            $collection[1]->foo,
+            $collection[2]->foo,
+        ]);
+        $this->assertSame([], array_keys($collection[0]->getDirty()));
+        $this->assertSame([], array_keys($collection[2]->getDirty()));
+    }
+
+    public function testCollectionLockWithoutRefresh()
+    {
+        $collection = new Collection([
+            EloquentTransactionModelStub::create(['foo' => '1']),
+            EloquentTransactionModelStub::create(['foo' => '2']),
+            EloquentTransactionModelStub::create(['foo' => '3']),
+        ]);
+
+        $collection[0]->foo = 'Changed';
+        $collection[2]->foo = 'Changed';
+        $this->assertSame(['foo'], array_keys($collection[0]->getDirty()));
+        $this->assertSame(['foo'], array_keys($collection[2]->getDirty()));
+
+        DB::connection()->transaction(fn() => $collection->lockForUpdate(false));
+
+        $this->assertSame(['Changed', '2', 'Changed'], [
+            $collection[0]->foo,
+            $collection[1]->foo,
+            $collection[2]->foo,
+        ]);
+        $this->assertSame(['foo'], array_keys($collection[0]->getDirty()));
+        $this->assertSame(['foo'], array_keys($collection[2]->getDirty()));
+    }
+
+    public function testCollectionLockWithMissingRecords()
+    {
+        $collection = new Collection([
+            EloquentTransactionModelStub::create(['foo' => '1']),
+            EloquentTransactionModelStub::create(['foo' => '2']),
+            new EloquentTransactionModelStub(['foo' => '3']),
+        ]);
+
+        $collection[1]->delete();
+
+        $collection[0]->foo = 'Changed';
+        $collection[1]->foo = 'Changed';
+        $collection[2]->foo = 'Changed';
+
+        DB::connection()->transaction(fn() => $collection->lockForUpdate(true));
+
+        $this->assertSame(['1', 'Changed', 'Changed'], [
+            $collection[0]->foo,
+            $collection[1]->foo,
+            $collection[2]->foo,
+        ]);
+        $this->assertSame([], array_keys($collection[0]->getDirty()));
+        $this->assertSame(['foo'], array_keys($collection[1]->getDirty()));
+    }
+}
+
+class EloquentTransactionModelStub extends Model
+{
+    public $connection;
+    protected $table = 'stub';
+    protected $fillable = ['foo'];
+}


### PR DESCRIPTION
Hello ✋

This PR provides the lock methods available in Laravel's Query Builder in models.

To create a transaction, you must first load a model and you cannot lock a loaded model directly, and to do this you have to do this:
```php
    // Before changes
    public function buyProduct(User $user, Product $product)
    {
        DB::transaction(function () use ($user, $product) {
            $user = User::where('id', $user->id)
                ->lockForUpdate()
                ->firstOrFail();
            $product = Product::where('id', $product->id)
                ->lockForUpdate()
                ->firstOrFail();

            if ($user->amount < $product->price || $product->stock <= 0) {
                throw new \Exception;
            }

            // ...
        });
    }
```

With this change, you can do this in a simpler way:

```php
    public function buyProduct(User $user, Product $product)
    {
        DB::transaction(function () use ($user, $product) {
            $user->lockForUpdate();
            $product->lockForUpdate();

            if ($user->amount < $product->price || $product->stock <= 0) {
                throw new \Exception;
            }

            // ...
        });
    }
```

Or you can lock a set of records:
```php
    public function buyProducts(Collection $user, Collection $products)
    {
        DB::transaction(function () use ($user, $products) {
            $user->lockForUpdate();
            $products->lockForUpdate();

            // ...
        });
    }
```

Summary of what has been added:

```php
Model::lock($value, $refresh = true)
Model::sharedLock($refresh = true)
Model::lockForUpdate($refresh = true)
Collection::lock($value, $refresh = true)
Collection::sharedLock($refresh = true)
Collection::lockForUpdate($refresh = true)
```

I am eager to hear the criticism of my experienced friends :)