### PR TITLE
[12.x] Introduce Job@resolveQueuedJobClass()

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -133,13 +133,22 @@ interface Job
     public function getName();
 
     /**
-     * Get the resolved name of the queued job class.
+     * Get the display name of the queued job class.
      *
      * Resolves the name of "wrapped" jobs such as class-based handlers.
      *
      * @return string
      */
     public function resolveName();
+
+    /**
+     * Get the class of the queued job.
+     *
+     * Resolves the class of "wrapped" jobs such as class-based handlers.
+     *
+     * @return string
+     */
+    public function resolveQueuedJobClass();
 
     /**
      * Get the name of the connection the job belongs to.

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -218,7 +218,7 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        $class = $job->resolveName();
+        $class = $job->resolveQueuedJobClass();
 
         try {
             $reflectionClass = new ReflectionClass($class);

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -357,7 +357,7 @@ abstract class Job
     }
 
     /**
-     * Get the resolved name of the queued job class.
+     * Get the resolved display name of the queued job class.
      *
      * Resolves the name of "wrapped" jobs such as class-based handlers.
      *
@@ -367,6 +367,20 @@ abstract class Job
     {
         return JobName::resolve($this->getName(), $this->payload());
     }
+
+    /**
+     * Get the class of the queued job.
+     *
+     * Resolves the class of "wrapped" jobs such as class-based handlers.
+     *
+     * @return string
+     */
+    public function resolveQueuedJobClass()
+    {
+        return JobName::resolveClassName($this->getName(), $this->payload());
+    }
+
+
 
     /**
      * Get the name of the connection the job belongs to.

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -380,8 +380,6 @@ abstract class Job
         return JobName::resolveClassName($this->getName(), $this->payload());
     }
 
-
-
     /**
      * Get the name of the connection the job belongs to.
      *

--- a/src/Illuminate/Queue/Jobs/JobName.php
+++ b/src/Illuminate/Queue/Jobs/JobName.php
@@ -34,23 +34,6 @@ class JobName
     }
 
     /**
-     * Get the resolved name of the queued job class.
-     *
-     * @param  string  $name
-     * @param  array<string, mixed>  $payload
-     * @return string
-     */
-    public static function resolveQueuedJobClass($name, $payload)
-    {
-        if (is_string($payload['data']['commandName'] ?? null)) {
-            return $payload['data']['commandName'];
-        }
-
-        return $name;
-    }
-
-
-    /**
      * Get the class name for queued job class.
      *
      * @param  string  $name

--- a/src/Illuminate/Queue/Jobs/JobName.php
+++ b/src/Illuminate/Queue/Jobs/JobName.php
@@ -32,4 +32,37 @@ class JobName
 
         return $name;
     }
+
+    /**
+     * Get the resolved name of the queued job class.
+     *
+     * @param  string  $name
+     * @param  array<string, mixed>  $payload
+     * @return string
+     */
+    public static function resolveQueuedJobClass($name, $payload)
+    {
+        if (is_string($payload['data']['commandName'] ?? null)) {
+            return $payload['data']['commandName'];
+        }
+
+        return $name;
+    }
+
+
+    /**
+     * Get the class name for queued job class.
+     *
+     * @param  string  $name
+     * @param  array<string, mixed>  $payload
+     * @return string
+     */
+    public static function resolveClassName($name, $payload)
+    {
+        if (is_string($payload['data']['commandName'] ?? null)) {
+            return $payload['data']['commandName'];
+        }
+
+        return $name;
+    }
 }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -90,7 +90,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
-        $job->shouldReceive('resolveName')->andReturn(__CLASS__);
+        $job->shouldReceive('resolveQueuedJobClass')->andReturn(__CLASS__);
         $job->shouldReceive('fail')->once();
 
         $instance->call($job, [
@@ -106,7 +106,7 @@ class CallQueuedHandlerTest extends TestCase
 
         $job = m::mock(Job::class);
         $job->shouldReceive('getConnectionName')->andReturn('connection');
-        $job->shouldReceive('resolveName')->andReturn(CallQueuedHandlerExceptionThrower::class);
+        $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerExceptionThrower::class);
         $job->shouldReceive('markAsFailed')->never();
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('delete')->once();
@@ -127,7 +127,7 @@ class CallQueuedHandlerTest extends TestCase
 
         $job = m::mock(Job::class);
         $job->shouldReceive('getConnectionName')->andReturn('connection');
-        $job->shouldReceive('resolveName')->andReturn(CallQueuedHandlerAttributeExceptionThrower::class);
+        $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerAttributeExceptionThrower::class);
         $job->shouldReceive('markAsFailed')->never();
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('delete')->once();

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('queue')]
+//#[WithMigration('cache')]
+class DeleteModelWhenMissingTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+        $app['config']->set('queue.default', 'database');
+        $this->driver = 'database';
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        Schema::create('delete_model_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('delete_model_test_models');
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        DeleteMissingModelJob::$handled = false;
+    }
+
+    public function test_deleteModelWhenMissing_and_display_name(): void
+    {
+        $model = MyTestModel::query()->create(['name' => 'test']);
+        $this->assertNotNull(MyTestModel::first());
+
+        DeleteMissingModelJob::dispatch($model);
+        MyTestModel::query()->where('name', 'test')->delete();
+        $this->assertFalse(DeleteMissingModelJob::$handled);
+        $this->runQueueWorkerCommand(['--once' => '1']);
+        $this->assertFalse(DeleteMissingModelJob::$handled);
+        $this->assertNull(\DB::table('failed_jobs')->first());
+    }
+}
+
+class DeleteMissingModelJob implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Dispatchable;
+    use SerializesModels;
+
+    public static bool $handled = false;
+
+    public $deleteWhenMissingModels = true;
+
+    public function __construct(public MyTestModel $model)
+    {
+    }
+
+    public function displayName(): string
+    {
+        return 'sorry-ma-forgot-to-take-out-the-trash';
+    }
+
+    public function handle()
+    {
+        self::$handled = true;
+    }
+}
+
+class MyTestModel extends Model
+{
+    protected $table = 'delete_model_test_models';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -8,13 +8,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Attributes\WithMigration;
 
 #[WithMigration]
 #[WithMigration('queue')]
-//#[WithMigration('cache')]
 class DeleteModelWhenMissingTest extends QueueTestCase
 {
     protected function defineEnvironment($app)
@@ -48,12 +46,13 @@ class DeleteModelWhenMissingTest extends QueueTestCase
     public function test_deleteModelWhenMissing_and_display_name(): void
     {
         $model = MyTestModel::query()->create(['name' => 'test']);
-        $this->assertNotNull(MyTestModel::first());
 
         DeleteMissingModelJob::dispatch($model);
+
         MyTestModel::query()->where('name', 'test')->delete();
-        $this->assertFalse(DeleteMissingModelJob::$handled);
+
         $this->runQueueWorkerCommand(['--once' => '1']);
+
         $this->assertFalse(DeleteMissingModelJob::$handled);
         $this->assertNull(\DB::table('failed_jobs')->first());
     }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -662,6 +662,11 @@ class WorkerFakeJob implements QueueJobContract
     {
         return time() + 60;
     }
+
+    public function resolveQueuedJobClass()
+    {
+        return 'WorkerFakeJob';
+    }
 }
 
 class LoopBreakerException extends RuntimeException


### PR DESCRIPTION
This will resolve: https://github.com/laravel/framework/issues/54502

This adds a method to the Job interface which is used for determining the class-name for the wrapped job. `Job@resolveName()` was modified to return the displayName, which works for most cases. However, when we are checking if a Job should be silently deleted if a model no longer exists, we use reflection. Since the displayName may not be a class, this won't work.

## Alternate solution
To avoid modifying the contract on the Job interface, we could simply add another check to `CallQueuedHandler@handleModelNotFound()` where it checks that the class exists before we reflect the `$class` name.