### PR TITLE
[11.x] Document hashedValue as nullable

### DIFF
--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -25,7 +25,7 @@ interface Hasher
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      */

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -88,7 +88,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      *

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -60,7 +60,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      *

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -67,7 +67,7 @@ class HashManager extends Manager implements Hasher
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      */


### PR DESCRIPTION
All the `Hasher` implementations have a null check.

https://github.com/laravel/framework/blob/f21afbcd52067a3cd9ff249b42800058e4bfcc73/src/Illuminate/Hashing/Argon2IdHasher.php#L21

https://github.com/laravel/framework/blob/f21afbcd52067a3cd9ff249b42800058e4bfcc73/src/Illuminate/Hashing/ArgonHasher.php#L99

https://github.com/laravel/framework/blob/f21afbcd52067a3cd9ff249b42800058e4bfcc73/src/Illuminate/Hashing/BcryptHasher.php#L71

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
