### PR TITLE
[11.x] Document hashedValue as non-nullable

### DIFF
--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -19,7 +19,7 @@ abstract class AbstractHasher
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string|null  $hashedValue
+     * @param  string  $hashedValue
      * @param  array  $options
      * @return bool
      */

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -10,7 +10,7 @@ class Argon2IdHasher extends ArgonHasher
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string|null  $hashedValue
+     * @param  string  $hashedValue
      * @param  array  $options
      * @return bool
      *


### PR DESCRIPTION
Follow up on #54614. Some hashers do mark hashedValue as nullable, but you shouldn't pass `null` to it.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
