### PR TITLE
Do not create file for in-memory database

### DIFF
--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -15,7 +15,7 @@ class SQLiteBuilder extends Builder
      */
     public function createDatabase($name)
     {
-        return File::put($name, '') !== false;
+        return $name === ':memory:' || File::put($name, '') !== false;
     }
 
     /**


### PR DESCRIPTION
For instance someone calls in a test (using sqlite with in-memory database):

```php 
Schema::createDatabase(config('database.connections.'.config('database.default').'.database');
```
Currently this would create a file called `:memory:` in `base_path()`.

No one could ever connect to that file with sqlite using the name `:memory:`, so this shouldn't be expected and should never happen. If someone wants create a file for a database called `base_path().'/:memory:'` it would be very strange (probably an error), but they still can. However I can not envision a scenario where one should want to attempt to create a file simply called `:memory:` for an sqlite database.

Why are we returning true? Well, unless you are completely out of `RAM`, you can depend on the database being there. 