### PR TITLE
Added pascal alias for studly string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -980,6 +980,17 @@ class Str
     }
 
     /**
+     * Pluralize the last word of an English, pascal caps case string.
+     * 
+     * @param string $value
+     * @param int|array
+     */
+    public static function pluralPascal($value, $count = 2)
+    {
+        return static::pluralStudly($value, $count);
+    }
+
+    /**
      * Generate a random, secure password.
      *
      * @param  int  $length
@@ -1625,6 +1636,18 @@ class Str
 
         return static::$studlyCache[$key] = implode($studlyWords);
     }
+
+    /**
+     * Convert a value to pascal case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function pascal($value)
+    {
+        return static::studly($value);
+    }
+
 
     /**
      * Returns the portion of the string specified by the start and length parameters.

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -635,6 +635,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         return new static(Str::pluralStudly($this->value, $count));
     }
 
+    /** 
+     * Pluralize the last word of an English, pascal caps case string.
+     * 
+     * @param  int|array|\Countable  $count
+     * @return static
+     */
+    public function pluralPascal($count = 2)
+    {
+        return new static(Str::pluralStudly($this->value, $count));
+    }
+
     /**
      * Find the multi-byte safe position of the first occurrence of the given substring.
      *
@@ -933,7 +944,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Returns the portion of the string specified by the start and length parameters.
+     * Convert the string to pascal case.
+     *
+     * @return static
+     */
+    public function pascal()
+    {
+        return new static(Str::pascal($this->value));
+    }
+
+    /**
+     * Returns the portion of string specified by the start and length parameters.
      *
      * @param  int  $start
      * @param  int|null  $length

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -987,6 +987,21 @@ class SupportStrTest extends TestCase
         $this->assertSame('ÖffentlicheÜberraschungen', Str::studly('öffentliche-überraschungen'));
     }
 
+    public function testPascal()
+    {
+        $this->assertSame('LaravelPhpFramework', Str::pascal('laravel_php_framework'));
+        $this->assertSame('LaravelPhpFramework', Str::pascal('laravel-php-framework'));
+        $this->assertSame('LaravelPhpFramework', Str::pascal('laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('FooBar', Str::pascal('fooBar'));
+        $this->assertSame('FooBar', Str::pascal('foo_bar'));
+        $this->assertSame('FooBar', Str::pascal('foo_bar')); // test cache
+        $this->assertSame('FooBarBaz', Str::pascal('foo-barBaz'));
+        $this->assertSame('FooBarBaz', Str::pascal('foo-bar_baz'));
+
+        $this->assertSame('ÖffentlicheÜberraschungen', Str::pascal('öffentliche-überraschungen'));
+    }
+
     public function testMask()
     {
         $this->assertSame('tay*************', Str::mask('taylor@email.com', '*', 3));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -109,6 +109,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame('LaraCons', (string) $this->stringable('LaraCon')->pluralStudly(-2));
     }
 
+    public function testPluralPascal()
+    {
+        $this->assertSame('LaraCons', (string) $this->stringable('LaraCon')->pluralPascal(2));
+        $this->assertSame('LaraCon', (string) $this->stringable('LaraCon')->pluralPascal(1));
+        $this->assertSame('LaraCons', (string) $this->stringable('LaraCon')->pluralPascal(-2));
+        $this->assertSame('LaraCon', (string) $this->stringable('LaraCon')->pluralPascal(-1));
+    }
+
     public function testMatch()
     {
         $stringable = $this->stringable('foo bar');
@@ -986,6 +994,20 @@ class SupportStringableTest extends TestCase
         $this->assertSame('FooBar', (string) $this->stringable('foo_bar')->studly()); // test cache
         $this->assertSame('FooBarBaz', (string) $this->stringable('foo-barBaz')->studly());
         $this->assertSame('FooBarBaz', (string) $this->stringable('foo-bar_baz')->studly());
+    }
+
+    public function testPascal()
+    {
+        $this->assertSame('LaravelPHPFramework', (string) $this->stringable('laravel_p_h_p_framework')->pascal());
+        $this->assertSame('LaravelPhpFramework', (string) $this->stringable('laravel_php_framework')->pascal());
+        $this->assertSame('LaravelPhPFramework', (string) $this->stringable('laravel-phP-framework')->pascal());
+        $this->assertSame('LaravelPhpFramework', (string) $this->stringable('laravel  -_-  php   -_-   framework   ')->pascal());
+
+        $this->assertSame('FooBar', (string) $this->stringable('fooBar')->pascal());
+        $this->assertSame('FooBar', (string) $this->stringable('foo_bar')->pascal());
+        $this->assertSame('FooBar', (string) $this->stringable('foo_bar')->pascal()); // test cache
+        $this->assertSame('FooBarBaz', (string) $this->stringable('foo-barBaz')->pascal());
+        $this->assertSame('FooBarBaz', (string) $this->stringable('foo-bar_baz')->pascal());
     }
 
     public function testCamel()


### PR DESCRIPTION
Following on from[ this discussion ](https://github.com/laravel/framework/discussions/54622), I've created this PR to add a pascal alias for the studly string helper.