### PR TITLE
[11.x] Introduce array `sortAsIn` to match order from provided array

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -832,6 +832,24 @@ class Arr
     }
 
     /**
+     * Sort the array to match the order as they are in given constant.
+     *
+     * @param  array  $array
+     * @param  array  $constant
+     * @return array
+     */
+    public static function sortAsIn($array, $constant)
+    {
+        $constant = array_flip($constant);
+
+        $callback = function (string $a, string $b) use ($constant) {
+            return ($constant[$a] ?? PHP_INT_MAX) - ($constant[$b] ?? PHP_INT_MAX);
+        };
+
+        return static::sort($array, $callback);
+    }
+
+    /**
      * Recursively sort an array by keys and values.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1124,6 +1124,17 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expected, $sortedWithDotNotation);
     }
 
+    public function testSortAsIn()
+    {
+        $constant = ['a', 'e', 'i', 'o', 'u', 'b', 'c', 'd', 'f', 'g'];
+
+        $unsorted = ['a', 'b', 'c', 'z', 'e', 'k'];
+        $expected = ['a', 'e', 'b', 'c', 'z', 'k'];
+
+        $sorted = array_values(Arr::sortAsIn($unsorted, $constant));
+        $this->assertEquals($expected, $sorted);
+    }
+
     public function testSortRecursive()
     {
         $array = [


### PR DESCRIPTION
The new method (sortAsIn) within `Illuminate\Support\Arr` will sort the values in the array provided as first parameter to the method to match how each of those values appear in the constant array.

Any values that are not part of the constant array will be placed at the end of sorted array as they appear within the original sequence.

Example:
```php
$constant = ['a', 'e', 'i', 'o', 'u', 'b', 'c', 'd', 'f', 'g'];
$unsorted = ['a', 'b', 'c', 'z', 'k', 'e', 'f', 'o', 'g', 'd'];

Arr::sortAsIn($unsorted, $constant);
// ['a', 'e', 'o', 'b', 'c', 'd', 'f', 'g', 'z', 'k']
```