### PR TITLE
[11.x] convert closures to arrow functions in PendingRequest & PendingComman…

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -406,11 +406,9 @@ class PendingRequest
      */
     public function withHeaders(array $headers)
     {
-        return tap($this, function () use ($headers) {
-            $this->options = array_merge_recursive($this->options, [
-                'headers' => $headers,
-            ]);
-        });
+        return tap($this, fn() => $this->options = array_merge_recursive($this->options, [
+            'headers' => $headers,
+        ]));
     }
 
     /**

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -430,9 +430,7 @@ class PendingCommand
                 });
         }
 
-        $this->app->bind(OutputStyle::class, function () use ($mock) {
-            return $mock;
-        });
+        $this->app->bind(OutputStyle::class, fn() => $mock);
 
         return $mock;
     }


### PR DESCRIPTION
this PR refactors the PendingRequest & PendingCommand classes by converting closures to arrow functions for more readability in the following methods:
withHeaders
mockConsoleOutput

Changes:
Replaced closures with arrow functions in the withHeaders & mockConsoleOutput methods