### PR TITLE
[12.x] Bind abstract from concrete's return type 

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -56,7 +56,7 @@ interface Container extends ContainerInterface
     /**
      * Register a binding with the container.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
@@ -75,7 +75,7 @@ interface Container extends ContainerInterface
     /**
      * Register a binding if it hasn't already been registered.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
@@ -85,7 +85,7 @@ interface Container extends ContainerInterface
     /**
      * Register a shared binding in the container.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */
@@ -94,7 +94,7 @@ interface Container extends ContainerInterface
     /**
      * Register a shared binding if it hasn't already been registered.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */
@@ -103,7 +103,7 @@ interface Container extends ContainerInterface
     /**
      * Register a scoped binding in the container.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */
@@ -112,7 +112,7 @@ interface Container extends ContainerInterface
     /**
      * Register a scoped binding if it hasn't already been registered.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */
@@ -121,7 +121,7 @@ interface Container extends ContainerInterface
     /**
      * "Extend" an abstract type in the container.
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure  $closure
      * @return void
      *
@@ -134,7 +134,7 @@ interface Container extends ContainerInterface
      *
      * @template TInstance of mixed
      *
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  TInstance  $instance
      * @return TInstance
      */
@@ -144,7 +144,7 @@ interface Container extends ContainerInterface
      * Add a contextual binding to the container.
      *
      * @param  string  $concrete
-     * @param  string  $abstract
+     * @param  \Closure|string  $abstract
      * @param  \Closure|string  $implementation
      * @return void
      */

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -40,6 +40,24 @@ class ContainerTest extends TestCase
         $this->assertSame('Taylor', $container->make('name'));
     }
 
+    public function testAbstractCanBeBoundFromConcreteReturnType()
+    {
+        $container = new Container;
+        $container->bind(function (): IContainerContractStub|ContainerImplementationStub {
+            return new ContainerImplementationStub;
+        });
+        $container->singleton(function (): ContainerConcreteStub {
+            return new ContainerConcreteStub;
+        });
+
+        $this->assertInstanceOf(
+            IContainerContractStub::class,
+            $container->make(IContainerContractStub::class)
+        );
+
+        $this->assertTrue($container->isShared(ContainerConcreteStub::class));
+    }
+
     public function testBindIfDoesntRegisterIfServiceAlreadyRegistered()
     {
         $container = new Container;


### PR DESCRIPTION
# Changes

* Updates the params for the container contract and implementation
* Adds the `closureReturnTypes` method to the Container
* changes the container's `bind` method to allow a Closure in the abstract parameter and process the closure's return types to call bind
* Adds a test covering the `bind` and `singleton` methods to show they work.

# Why

I thought this would be a cool thing to use when it comes to the container, I've had it in mind for a while. It follows the same idea as how some test assertion methods use reflection to know what events/jobs etc to expect. Instead this looks at the return type for the concrete Closures for the container.

**TDLR;** You would be able to provide a type hinted closure and it would use the return type to assign the abstract rather than specifying it with a string.

Example code:

```php
$this->bind(function (): \FooContract {
     return new FooInstance();
});
```

This would allow you to also handle multiple contracts with one Closure:

```php
$this->bind(function (): \FooContract|\BarContract {
     return new FooAndBarInstance();
});
```

This could also lead to some future benefits where the container can be more transparent about what abstracts will return without having to call the closure itself.

## Notes

Mainly a proof of concept PR, happy to clean up and add additional tests where there might be additional edge cases.

I've added this to Laravel 12. Nothing stopping it going to Laravel 11 but it feels like something to launch with a new version.