### PR TITLE
[11.x] Feature: Array reject

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -943,6 +943,20 @@ class Arr
     }
 
     /**
+     * Filter the array using the negation of the given callback.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function reject($array, callable $callback)
+    {
+        $negated = fn ($value, $key) => ! $callback($value, $key);
+
+        return static::where($array, $negated);
+    }
+
+    /**
      * Filter items where the value is not null.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -939,9 +939,7 @@ class Arr
      */
     public static function reject($array, callable $callback)
     {
-        $negated = fn ($value, $key) => ! $callback($value, $key);
-
-        return static::where($array, $negated);
+        return static::where($array, fn ($value, $key) => ! $callback($value, $key));
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -931,6 +931,18 @@ class Arr
     }
 
     /**
+     * Alias for the "where" method.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function filter($array, callable $callback)
+    {
+        return static::where($array, $callback);
+    }
+
+    /**
      * Filter items where the value is not null.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -931,18 +931,6 @@ class Arr
     }
 
     /**
-     * Alias for the "where" method.
-     *
-     * @param  array  $array
-     * @param  callable  $callback
-     * @return array
-     */
-    public static function filter($array, callable $callback)
-    {
-        return static::where($array, $callback);
-    }
-
-    /**
      * Filter the array using the negation of the given callback.
      *
      * @param  array  $array


### PR DESCRIPTION
Hey, this PR adds a `reject` method to the Array helper. 

This will allow users to simplify array filtering code like so:

```php
// Declare array
$array = ['Liam Duckett', 'Liam Doe', 'John Doe', 'John Liam'];

// -- Previously --
$liams = Arr::where($array, fn($value) => str_contains($value, 'Liam'));
$notLiams = Arr::where($array, fn($value) => ! str_contains($value, 'Liam'));

// -- With this PR --
$liams = Arr::where($array, fn($value) => str_contains($value, 'Liam'));
$notLiams = Arr::reject($array, fn($value) => str_contains($value, 'Liam'));
```

This also brings it more aligned with Collections which already have a reject method. I also thought about adding an alias `filter` for the `where` method, but decided this was better done in another PR (thoughts welcome)?