### PR TITLE
[11.x] Feature: Get the current full URL with only selected query method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -139,16 +139,19 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the full URL for the request with the added query string parameters.
      *
-     * @param  array  $query
+     * @param  array|null  $query The query string parameters to add to the URL
+     * @param  array|null  $only When specified, only the given query parameters will be returned
      * @return string
      */
-    public function fullUrlWithQuery(array $query)
+    public function fullUrlWithQuery(array $query = [], array $only = [])
     {
         $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
+        $query = array_merge($this->query(), $query);
+        $query = $only ? Arr::only($query, $only) : $query;
 
-        return count($this->query()) > 0
-            ? $this->url().$question.Arr::query(array_merge($this->query(), $query))
-            : $this->fullUrl().$question.Arr::query($query);
+        return count($query) > 0
+            ? $this->url().$question.Arr::query($query)
+            : $this->url();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -10,7 +10,7 @@ namespace Illuminate\Support\Facades;
  * @method static string root()
  * @method static string url()
  * @method static string fullUrl()
- * @method static string fullUrlWithQuery(array $query)
+ * @method static string fullUrlWithQuery(array $query = [], array $only = [])
  * @method static string fullUrlWithoutQuery(array|string $keys)
  * @method static string path()
  * @method static string decodedPath()


### PR DESCRIPTION
This PR adds a new a new `$only` parameter to `fullUrlWithQuery` at `src/Illuminate/Http/Request.php`.

Currently we can use the following methods to get the current full URL:
 - `fullUrl`: Get the full URL without any query string parameter.
 - `fullUrlWithQuery`: Get the full URL with all the current query and the new ones provided to the method.
 - `fullUrlWithoutQuery`: Get the full URL without the specified parameters in the method.

This new `$only` parameter allow us to get the full URL with *only* the parameters specified in the method.
It's the opposite of the `fullUrlWithoutQuery` method, keeping the ability to add new parameters if required.

I've made the existing `$query` parameter optional so we can filter out all the query parameters, except of the specified ones, without requiring to add new ones or having to pass an empty array.

If you don't want to modify the current `fullUrlWithQuery` method, this functionality could be added to a new method something like `fullUrlSelectedQuery` (https://github.com/laravel/framework/compare/11.x...sertxudev:framework:feature/full-url-with-selected-query)