### PR TITLE
[11.x] fix 'parsePipeString' in pipeline helper

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -51,6 +51,7 @@ class Pipeline implements PipelineContract
     /**
      * Create a new class instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
     public function __construct(?Container $container = null)
@@ -113,6 +114,7 @@ class Pipeline implements PipelineContract
     /**
      * Run the pipeline with a final destination callback.
      *
+     * @param  \Closure  $destination
      * @return mixed
      */
     public function then(Closure $destination)
@@ -145,6 +147,7 @@ class Pipeline implements PipelineContract
     /**
      * Set a final callback to be executed after the pipeline ends regardless of the outcome.
      *
+     * @param  \Closure  $callback
      * @return $this
      */
     public function finally(Closure $callback)
@@ -157,6 +160,7 @@ class Pipeline implements PipelineContract
     /**
      * Get the final piece of the Closure onion.
      *
+     * @param  \Closure  $destination
      * @return \Closure
      */
     protected function prepareDestination(Closure $destination)
@@ -261,6 +265,7 @@ class Pipeline implements PipelineContract
     /**
      * Set the container instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @return $this
      */
     public function setContainer(Container $container)
@@ -285,6 +290,7 @@ class Pipeline implements PipelineContract
      * Handle the given exception.
      *
      * @param  mixed  $passable
+     * @param  \Throwable  $e
      * @return mixed
      *
      * @throws \Throwable

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -51,7 +51,6 @@ class Pipeline implements PipelineContract
     /**
      * Create a new class instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
     public function __construct(?Container $container = null)
@@ -114,7 +113,6 @@ class Pipeline implements PipelineContract
     /**
      * Run the pipeline with a final destination callback.
      *
-     * @param  \Closure  $destination
      * @return mixed
      */
     public function then(Closure $destination)
@@ -147,7 +145,6 @@ class Pipeline implements PipelineContract
     /**
      * Set a final callback to be executed after the pipeline ends regardless of the outcome.
      *
-     * @param  \Closure  $callback
      * @return $this
      */
     public function finally(Closure $callback)
@@ -160,7 +157,6 @@ class Pipeline implements PipelineContract
     /**
      * Get the final piece of the Closure onion.
      *
-     * @param  \Closure  $destination
      * @return \Closure
      */
     protected function prepareDestination(Closure $destination)
@@ -225,10 +221,12 @@ class Pipeline implements PipelineContract
      */
     protected function parsePipeString($pipe)
     {
-        [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);
+        [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, null);
 
-        if (is_string($parameters)) {
+        if (! is_null($parameters)) {
             $parameters = explode(',', $parameters);
+        } else {
+            $parameters = [];
         }
 
         return [$name, $parameters];
@@ -263,7 +261,6 @@ class Pipeline implements PipelineContract
     /**
      * Set the container instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
      * @return $this
      */
     public function setContainer(Container $container)
@@ -288,7 +285,6 @@ class Pipeline implements PipelineContract
      * Handle the given exception.
      *
      * @param  mixed  $passable
-     * @param  \Throwable  $e
      * @return mixed
      *
      * @throws \Throwable


### PR DESCRIPTION
### Fix: Ensure parsePipeString() Returns an Empty Array Instead of an Empty String

Return Value of parsePipeString():

If the character is not present in the $pipe variable, explode(':', $pipe, 2) returns an array with a single element: [$pipe].
While array_pad() extends the array, the second value will be an empty string ('') instead of an empty array ([]).
This causes an issue when calling explode(',', $parameters), as explode(',', '') returns [''], not [].