### PR TITLE
[12.x] Addition of Granular Feedback/Messages on Fluent Dimension Rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -68,6 +68,8 @@ return [
         'numeric' => 'The :attribute field must be greater than or equal to :value.',
         'string' => 'The :attribute field must be greater than or equal to :value characters.',
     ],
+    'height' => 'The :attribute field must have a height of :value pixels',
+    'height_between' => 'The :attribute field must have a height between :min and :max pixels.',
     'hex_color' => 'The :attribute field must be a valid hexadecimal color.',
     'image' => 'The :attribute field must be an image.',
     'in' => 'The selected :attribute is invalid.',
@@ -99,6 +101,9 @@ return [
         'string' => 'The :attribute field must not be greater than :max characters.',
     ],
     'max_digits' => 'The :attribute field must not have more than :max digits.',
+    'max_height' => 'The :attribute field must have a maximum height of :max pixels.',
+    'max_ratio' => 'The :attribute field must have an aspect ratio less than :max.',
+    'max_width' => 'The :attribute field must have a maximum width of :max pixels.',
     'mimes' => 'The :attribute field must be a file of type: :values.',
     'mimetypes' => 'The :attribute field must be a file of type: :values.',
     'min' => [
@@ -108,6 +113,9 @@ return [
         'string' => 'The :attribute field must be at least :min characters.',
     ],
     'min_digits' => 'The :attribute field must have at least :min digits.',
+    'min_height' => 'The :attribute field must have a minimum height of :min pixels.',
+    'min_ratio' => 'The :attribute field must have an aspect ratio greater than :min.',
+    'min_width' => 'The :attribute field must have a minimum width of :min pixels.',
     'missing' => 'The :attribute field must be missing.',
     'missing_if' => 'The :attribute field must be missing when :other is :value.',
     'missing_unless' => 'The :attribute field must be missing unless :other is :value.',
@@ -133,6 +141,8 @@ return [
     'prohibited_if' => 'The :attribute field is prohibited when :other is :value.',
     'prohibited_unless' => 'The :attribute field is prohibited unless :other is in :values.',
     'prohibits' => 'The :attribute field prohibits :other from being present.',
+    'ratio' => 'The :attribute field must have an aspect ratio of :value',
+    'ratio_between' => 'The :attribute field must have an aspect ratio between :min and :max.',
     'regex' => 'The :attribute field format is invalid.',
     'required' => 'The :attribute field is required.',
     'required_array_keys' => 'The :attribute field must contain entries for: :values.',
@@ -160,6 +170,8 @@ return [
     'url' => 'The :attribute field must be a valid URL.',
     'ulid' => 'The :attribute field must be a valid ULID.',
     'uuid' => 'The :attribute field must be a valid UUID.',
+    'width' => 'The :attribute field must have a width of :value pixels',
+    'width_between' => 'The :attribute field must have width between :min and :max pixels.',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -812,6 +812,174 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace placeholder for the width constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceWidth($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $parameters[0], $message);
+    }
+
+    /**
+     * Replace placeholder for the width constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceMinWidth($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceMin($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace placeholder for the maximum width constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceMaxWidth($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceMax($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace placeholders for the width between constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceWidthBetween($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceBetween($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace placeholder for the height constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceHeight($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $parameters[0], $message);
+    }
+
+    /**
+     * Replace placeholder for the min height constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceMinHeight($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceMin($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace placeholder for the maximum height constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceMaxHeight($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceMax($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace placeholders for the height between constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceHeightBetween($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceBetween($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace placeholder for the ratio constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceRatio($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', round($parameters[0], 3), $message);
+    }
+
+    /**
+     * Replace placeholder for the minimum ratio constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceMinRatio($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceMin($message, $attribute, $rule, [round($parameters[0], 3)]);
+    }
+
+    /**
+     * Replace placeholder for the maximum ratio constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceMaxRatio($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceMax($message, $attribute, $rule, [round($parameters[0], 3)]);
+    }
+
+    /**
+     * Replace placeholders for the ratio between constraint on the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int, string>  $parameters
+     * @return string
+     */
+    protected function replaceRatioBetween($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceBetween($message, $attribute, $rule, [round($parameters[0], 3), round($parameters[1], 3)]);
+    }
+
+    /**
      * Replace all place-holders for the ends_with rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -713,11 +713,239 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate the dimensions of an image matches the given values.
+     * Validate the pixel width of an image is equal to a given size.
      *
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateWidth($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'width');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['width' => (int) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the pixel width of an image is greater than a given size.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<string, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMinWidth($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min_width');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['min_width' => (int) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the pixel width of an image is less than a given size.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMaxWidth($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max_width');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['max_width' => (int) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the pixel width of an image is between two values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateWidthBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'width_between');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['min_width' => (int) $parameters[0], 'max_width' => (int) $parameters[1]]
+        );
+    }
+
+    /**
+     * Validate the pixel height of an image is a given size.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateHeight($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'height');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['height' => (int) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the pixel height of an image is greater than a given size.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMinHeight($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min_height');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['min_height' => (int) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the pixel height of an image is less than a given size.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMaxHeight($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max_height');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['max_height' => (int) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the pixel height of an image is between a given size.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateHeightBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'height_between');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['min_height' => (int) $parameters[0], 'max_height' => (int) $parameters[1]]
+        );
+    }
+
+    /**
+     * Validate the ratio of an image is equal to a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|float|string>  $parameters
+     * @return bool
+     */
+    public function validateRatio($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'ratio');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['ratio' => (float) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the ratio of an image is greater than a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<string, int|float|string>  $parameters
+     * @return bool
+     */
+    public function validateMinRatio($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min_ratio');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['min_ratio' => (float) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the ratio of an image is less than a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|float|string>  $parameters
+     * @return bool
+     */
+    public function validateMaxRatio($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max_ratio');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['max_ratio' => (float) $parameters[0]]
+        );
+    }
+
+    /**
+     * Validate the ratio of an image is between two values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|float|string>  $parameters
+     * @return bool
+     */
+    public function validateRatioBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'ratio_between');
+
+        return $this->validateDimensions(
+            $attribute,
+            $value,
+            ['min_ratio' => (float) $parameters[0], 'max_ratio' => (float) $parameters[1]]
+        );
+    }
+
+    /**
+     * Validate the dimensions of an image matches the given values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|float|string>  $parameters
      * @return bool
      */
     public function validateDimensions($attribute, $value, $parameters)
@@ -738,11 +966,8 @@ trait ValidatesAttributes
             return false;
         }
 
-        $this->requireParameterCount(1, $parameters, 'dimensions');
-
         [$width, $height] = $dimensions;
 
-        $parameters = $this->parseNamedParameters($parameters);
 
         return ! (
             $this->failsBasicDimensionChecks($parameters, $width, $height) ||
@@ -753,19 +978,60 @@ trait ValidatesAttributes
     }
 
     /**
+     * Parse the string value parameters for the Dimensions rule.
+     *
+     * @param  array<int, string>  $parameters
+     * @return array<string, int|float>
+     */
+    protected function parseStringParameters($parameters)
+    {
+        return array_reduce($parameters, function ($carry, $parameter) {
+            if (str_contains($parameter, '=')) {
+                [$key, $value] = explode('=', $parameter, 2);
+                $value = str_contains($key, 'ratio')
+                    ? $this->parseRatio($value)
+                    : (int) $value;
+
+                return Arr::add($carry, $key, $value);
+            }
+
+            return $carry;
+        }, []);
+    }
+
+    /**
+     * Parse the ratio values to floats.
+     *
+     * @param  string  $ratio
+     * @return float
+     */
+    private function parseRatio($ratio)
+    {
+        if (str_contains($ratio, '/')) {
+            [$numerator, $denominator] = array_replace(
+                [1, 1], array_filter(sscanf($ratio, '%f/%d'))
+            );
+
+            return (float) ($numerator / $denominator);
+        }
+
+        return (float) $ratio;
+    }
+
+    /**
      * Test if the given width and height fail any conditions.
      *
-     * @param  array<string,string>  $parameters
+     * @param  array<string,int>  $parameters
      * @param  int  $width
      * @param  int  $height
      * @return bool
      */
     protected function failsBasicDimensionChecks($parameters, $width, $height)
     {
-        return (isset($parameters['width']) && $parameters['width'] != $width) ||
+        return (isset($parameters['width']) && $parameters['width'] !== $width) ||
                (isset($parameters['min_width']) && $parameters['min_width'] > $width) ||
                (isset($parameters['max_width']) && $parameters['max_width'] < $width) ||
-               (isset($parameters['height']) && $parameters['height'] != $height) ||
+               (isset($parameters['height']) && $parameters['height'] !== $height) ||
                (isset($parameters['min_height']) && $parameters['min_height'] > $height) ||
                (isset($parameters['max_height']) && $parameters['max_height'] < $height);
     }
@@ -773,7 +1039,7 @@ trait ValidatesAttributes
     /**
      * Determine if the given parameters fail a dimension ratio check.
      *
-     * @param  array<string,string>  $parameters
+     * @param  array<string,float>  $parameters
      * @param  int  $width
      * @param  int  $height
      * @return bool
@@ -784,19 +1050,15 @@ trait ValidatesAttributes
             return false;
         }
 
-        [$numerator, $denominator] = array_replace(
-            [1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
-        );
-
         $precision = 1 / (max(($width + $height) / 2, $height) + 1);
 
-        return abs($numerator / $denominator - $width / $height) > $precision;
+        return abs($parameters['ratio'] - $width / $height) > $precision;
     }
 
     /**
      * Determine if the given parameters fail a dimension minimum ratio check.
      *
-     * @param  array<string,string>  $parameters
+     * @param  array<string,float>  $parameters
      * @param  int  $width
      * @param  int  $height
      * @return bool
@@ -807,17 +1069,13 @@ trait ValidatesAttributes
             return false;
         }
 
-        [$minNumerator, $minDenominator] = array_replace(
-            [1, 1], array_filter(sscanf($parameters['min_ratio'], '%f/%d'))
-        );
-
-        return ($width / $height) > ($minNumerator / $minDenominator);
+        return ($width / $height) > $parameters['min_ratio'];
     }
 
     /**
      * Determine if the given parameters fail a dimension maximum ratio check.
      *
-     * @param  array<string,string>  $parameters
+     * @param  array<string,float>  $parameters
      * @param  int  $width
      * @param  int  $height
      * @return bool
@@ -828,11 +1086,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        [$maxNumerator, $maxDenominator] = array_replace(
-            [1, 1], array_filter(sscanf($parameters['max_ratio'], '%f/%d'))
-        );
-
-        return ($width / $height) < ($maxNumerator / $maxDenominator);
+        return ($width / $height) < $parameters['max_ratio'];
     }
 
     /**
@@ -911,13 +1165,13 @@ trait ValidatesAttributes
         $validations = (new Collection($parameters))
             ->unique()
             ->map(fn ($validation) => match (true) {
-                $validation === 'strict' => new NoRFCWarningsValidation(),
-                $validation === 'dns' => new DNSCheckValidation(),
-                $validation === 'spoof' => new SpoofCheckValidation(),
-                $validation === 'filter' => new FilterEmailValidation(),
+                $validation === 'strict' => new NoRFCWarningsValidation,
+                $validation === 'dns' => new DNSCheckValidation,
+                $validation === 'spoof' => new SpoofCheckValidation,
+                $validation === 'filter' => new FilterEmailValidation,
                 $validation === 'filter_unicode' => FilterEmailValidation::unicode(),
                 is_string($validation) && class_exists($validation) => $this->container->make($validation),
-                default => new RFCValidation(),
+                default => new RFCValidation,
             })
             ->values()
             ->all() ?: [new RFCValidation];
@@ -1141,7 +1395,6 @@ trait ValidatesAttributes
     /**
      * Get the extra conditions for a unique / exists rule.
      *
-     * @param  array  $segments
      * @return array
      */
     protected function getExtraConditions(array $segments)
@@ -2375,7 +2628,6 @@ trait ValidatesAttributes
     /**
      * Determine if any of the given attributes fail the required test.
      *
-     * @param  array  $attributes
      * @return bool
      */
     protected function anyFailingRequired(array $attributes)
@@ -2392,7 +2644,6 @@ trait ValidatesAttributes
     /**
      * Determine if all of the given attributes fail the required test.
      *
-     * @param  array  $attributes
      * @return bool
      */
     protected function allFailingRequired(array $attributes)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -968,6 +968,12 @@ trait ValidatesAttributes
 
         [$width, $height] = $dimensions;
 
+        // This is to correctly parse string representations for dimensions
+        // like so "dimensions:min_width=100,min_height=200"
+        if (! Arr::isAssoc($parameters)) {
+            $this->requireParameterCount(1, $parameters, 'dimensions');
+            $parameters = $this->parseStringParameters($parameters);
+        }
 
         return ! (
             $this->failsBasicDimensionChecks($parameters, $width, $height) ||

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -2,29 +2,152 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
-use Stringable;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
-class Dimensions implements Stringable
+class Dimensions implements DataAwareRule, Rule, ValidatorAwareRule
 {
-    use Conditionable;
+    use Conditionable, Macroable;
 
     /**
-     * The constraints for the dimensions rule.
+     * The width constraint in pixels.
+     *
+     * @var null|int
+     */
+    protected $width = null;
+
+    /**
+     * The minimum size in pixels that the image can be.
+     *
+     * @var null|int
+     */
+    protected $minWidth = null;
+
+    /**
+     * The maximum size in pixels that the image can be.
+     *
+     * @var null|int
+     */
+    protected $maxWidth = null;
+
+    /**
+     * The width between constraint.
+     *
+     * @var null|array
+     */
+    protected $widthBetween = null;
+
+    /**
+     * The height constraint in pixels.
+     *
+     * @var null|int
+     */
+    protected $height = null;
+
+    /**
+     * The minimum size in pixels that the image can be.
+     *
+     * @var null|int
+     */
+    protected $minHeight = null;
+
+    /**
+     * The maximum size in pixels that the image can be.
+     *
+     * @var null|int
+     */
+    protected $maxHeight = null;
+
+    /**
+     * The height between constraint.
+     *
+     * @var null|array
+     */
+    protected $heightBetween = null;
+
+    /**
+     * The ratio constraint.
+     *
+     * @var null|float
+     */
+    protected $ratio = null;
+
+    /**
+     * The minimum aspect ratio constraint.
+     *
+     * @var null|float
+     */
+    protected $minRatio = null;
+
+    /**
+     * The maximum aspect ratio constraint.
+     *
+     * @var null|float
+     */
+    protected $maxRatio = null;
+
+    /**
+     * The aspect ratio range constraint.
+     *
+     * @var null|array
+     */
+    protected $ratioBetween = null;
+
+    /**
+     * The error message after validation, if any.
      *
      * @var array
      */
-    protected $constraints = [];
+    protected $messages = [];
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The callback that will generate the "default" version of the dimensions rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * Additional validation rules that should be merged into the default rules during validation.
+     *
+     * @var array
+     */
+    protected $customRules = [];
 
     /**
      * Create a new dimensions rule instance.
      *
-     * @param  array  $constraints
      * @return void
      */
     public function __construct(array $constraints = [])
     {
-        $this->constraints = $constraints;
+        foreach ($constraints as $key => $value) {
+            $key = Str::camel($key);
+            if (method_exists($this, $key)) {
+                $this->{$key}($value);
+            }
+        }
     }
 
     /**
@@ -35,7 +158,7 @@ class Dimensions implements Stringable
      */
     public function width($value)
     {
-        $this->constraints['width'] = $value;
+        $this->width = $value;
 
         return $this;
     }
@@ -48,7 +171,7 @@ class Dimensions implements Stringable
      */
     public function height($value)
     {
-        $this->constraints['height'] = $value;
+        $this->height = $value;
 
         return $this;
     }
@@ -61,7 +184,7 @@ class Dimensions implements Stringable
      */
     public function minWidth($value)
     {
-        $this->constraints['min_width'] = $value;
+        $this->minWidth = $value;
 
         return $this;
     }
@@ -74,7 +197,7 @@ class Dimensions implements Stringable
      */
     public function minHeight($value)
     {
-        $this->constraints['min_height'] = $value;
+        $this->minHeight = $value;
 
         return $this;
     }
@@ -87,7 +210,7 @@ class Dimensions implements Stringable
      */
     public function maxWidth($value)
     {
-        $this->constraints['max_width'] = $value;
+        $this->maxWidth = $value;
 
         return $this;
     }
@@ -100,7 +223,35 @@ class Dimensions implements Stringable
      */
     public function maxHeight($value)
     {
-        $this->constraints['max_height'] = $value;
+        $this->maxHeight = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the width between constraint.
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @return $this
+     */
+    public function widthBetween($min, $max)
+    {
+        $this->widthBetween = [$min, $max];
+
+        return $this;
+    }
+
+    /**
+     * Set the height between constraint.
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @return $this
+     */
+    public function heightBetween($min, $max)
+    {
+        $this->heightBetween = [$min, $max];
 
         return $this;
     }
@@ -113,39 +264,39 @@ class Dimensions implements Stringable
      */
     public function ratio($value)
     {
-        $this->constraints['ratio'] = $value;
+        $this->ratio = $value;
 
         return $this;
     }
 
     /**
-     * Set the minimum aspect ratio.
+     * Set the minimum aspect ratio constraint.
      *
      * @param  float  $value
      * @return $this
      */
     public function minRatio($value)
     {
-        $this->constraints['min_ratio'] = $value;
+        $this->minRatio = $value;
 
         return $this;
     }
 
     /**
-     * Set the maximum aspect ratio.
+     * Set the maximum aspect ratio constraint.
      *
      * @param  float  $value
      * @return $this
      */
     public function maxRatio($value)
     {
-        $this->constraints['max_ratio'] = $value;
+        $this->maxRatio = $value;
 
         return $this;
     }
 
     /**
-     * Set the aspect ratio range.
+     * Set the aspect ratio between constraint.
      *
      * @param  float  $min
      * @param  float  $max
@@ -153,25 +304,165 @@ class Dimensions implements Stringable
      */
     public function ratioBetween($min, $max)
     {
-        $this->constraints['min_ratio'] = $min;
-        $this->constraints['max_ratio'] = $max;
+        $this->ratioBetween = [$min, $max];
 
         return $this;
     }
 
     /**
-     * Convert the rule to a validation string.
+     * Build the array of underlying validation rules based on the current state.
      *
-     * @return string
+     * @return array
      */
-    public function __toString()
+    protected function buildValidationRules()
     {
-        $result = '';
+        $rules = [];
 
-        foreach ($this->constraints as $key => $value) {
-            $result .= "$key=$value,";
+        $validationRules = [
+            'width', 'minWidth', 'maxWidth', 'widthBetween',
+            'height', 'minHeight', 'maxHeight', 'heightBetween',
+            'ratio', 'minRatio', 'maxRatio', 'ratioBetween',
+        ];
+
+        foreach ($validationRules as $property) {
+            if ($this->{$property} !== null) {
+                $value = $this->{$property};
+
+                if (is_array($value)) {
+                    $value = implode(',', $value);
+                }
+
+                $ruleName = Str::snake($property);
+                $rules[] = "{$ruleName}:{$value}";
+            }
         }
 
-        return 'dimensions:'.substr($result, 0, -1);
+        return array_merge($rules, $this->customRules);
+    }
+
+    /**
+     * Set the default callback to be used for determining default rules.
+     *
+     * If no arguments are passed, the default dimensions rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|void
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the dimensions rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $dimensions = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $dimensions instanceof Rule ? $dimensions : new self;
+    }
+
+    /**
+     * Specify additional validation rules that should be merged with the default rules during validation.
+     *
+     * @param  string|array  $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        $this->customRules = array_merge($this->customRules, Arr::wrap($rules));
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     * */
+    public function passes($attribute, $value)
+    {
+        $this->messages = [];
+
+        $validator = Validator::make(
+            $this->data,
+            [$attribute => $this->buildValidationRules()],
+            $this->validator->customMessages,
+            $this->validator->customAttributes
+        );
+
+        if ($validator->fails()) {
+            return $this->fail($validator->messages()->all());
+        }
+
+        return true;
+    }
+
+    /**
+     * Adds the given failures, and return false.
+     *
+     * @param  array|string  $messages
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $messages = collect(Arr::wrap($messages))->map(
+            fn ($message) => $this->validator->getTranslator()->get($message)
+        )->all();
+
+        $this->messages = array_merge($this->messages, $messages);
+
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the current data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
     }
 }

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -2,87 +2,395 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Container\Container;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class ValidationDimensionsRuleTest extends TestCase
 {
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    #[Test]
+    public function width_constraint()
     {
-        $rule = new Dimensions(['min_width' => 100, 'min_height' => 100]);
+        $rule = Dimensions::defaults()->width(100);
 
-        $this->assertSame('dimensions:min_width=100,min_height=100', (string) $rule);
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
 
-        $rule = Rule::dimensions()->width(200)->height(100);
-
-        $this->assertSame('dimensions:width=200,height=100', (string) $rule);
-
-        $rule = Rule::dimensions()->maxWidth(1000)->maxHeight(500)->ratio(3 / 2);
-
-        $this->assertSame('dimensions:max_width=1000,max_height=500,ratio=1.5', (string) $rule);
-
-        $rule = new Dimensions(['ratio' => '2/3']);
-
-        $this->assertSame('dimensions:ratio=2/3', (string) $rule);
-
-        $rule = Rule::dimensions()->minWidth(300)->minHeight(400);
-
-        $this->assertSame('dimensions:min_width=300,min_height=400', (string) $rule);
-
-        $rule = Rule::dimensions()
-            ->when(true, function ($rule) {
-                $rule->height('100');
-            })
-            ->unless(true, function ($rule) {
-                $rule->width('200');
-            });
-        $this->assertSame('dimensions:height=100', (string) $rule);
-
-        $rule = Rule::dimensions()
-            ->minRatio(1 / 2)
-            ->maxRatio(1 / 3);
-        $this->assertSame('dimensions:min_ratio=0.5,max_ratio=0.33333333333333', (string) $rule);
-
-        $rule = Rule::dimensions()
-            ->ratioBetween(min: 1 / 2, max: 1 / 3);
-        $this->assertSame('dimensions:min_ratio=0.5,max_ratio=0.33333333333333', (string) $rule);
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 99, 101),
+            messages: ['validation.width']
+        );
     }
 
-    public function testGeneratesTheCorrectValidationMessages()
+    #[Test]
+    public function min_width_constraint()
     {
-        $rule = Rule::dimensions()
-            ->width(100)->height(100)
-            ->ratioBetween(min: 1 / 2, max: 2 / 5);
+        $rule = Dimensions::defaults()->minWidth(100);
 
-        $trans = new Translator(new ArrayLoader, 'en');
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
 
-        $image = UploadedFile::fake();
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 99, 101),
+            messages: ['validation.min_width']
+        );
+    }
+
+    #[Test]
+    public function max_width_constraint()
+    {
+        $rule = Dimensions::defaults()->maxWidth(100);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 101, 101),
+            messages: ['validation.max_width']
+        );
+    }
+
+    #[Test]
+    public function width_between_constraint()
+    {
+        $rule = Dimensions::defaults()->widthBetween(100, 200);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 99, 201),
+            messages: ['validation.width_between']
+        );
+    }
+
+    #[Test]
+    public function height_constraint()
+    {
+        $rule = Dimensions::defaults()->height(100);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 99, 101),
+            messages: ['validation.height']
+        );
+    }
+
+    #[Test]
+    public function min_height_constraint()
+    {
+        $rule = Dimensions::defaults()->minHeight(100);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 99),
+            messages: ['validation.min_height']
+        );
+    }
+
+    #[Test]
+    public function max_height_constraint()
+    {
+        $rule = Dimensions::defaults()->maxHeight(100);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 101),
+            messages: ['validation.max_height'],
+        );
+    }
+
+    #[Test]
+    public function height_between_constraint()
+    {
+        $rule = Dimensions::defaults()->heightBetween(100, 200);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 99),
+            messages: ['validation.height_between']
+        );
+    }
+
+    #[test]
+    public function ratio_constraint()
+    {
+        $rule = Dimensions::defaults()->ratio(1 / 2);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 200),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+            messages: ['validation.ratio']
+        );
+    }
+
+    #[Test]
+    public function min_ratio_constraint()
+    {
+        $rule = Dimensions::defaults()->minRatio(1 / 2);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 200),
+        );
+
+        $this->fails($rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+            messages: ['validation.min_ratio']
+        );
+    }
+
+    #[Test]
+    public function max_ratio_constraint()
+    {
+        $rule = Dimensions::defaults()->maxRatio(1 / 1);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 200),
+            messages: ['validation.max_ratio']
+        );
+    }
+
+    #[Test]
+    public function ratio_between_constraint()
+    {
+        $rule = Dimensions::defaults()->ratioBetween(1 / 2, 2 / 5);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 200),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+            messages: ['validation.ratio_between']
+        );
+    }
+
+    #[Test]
+    public function legacy_string_format_is_supported()
+    {
+        $rule = 'dimensions:min_width=100,max_width=200,min_height=100,max_height=200,ratio=1/1,min_ratio=1/1,max_ratio=2/5';
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 150, 150),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 190, 210),
+            messages: ['validation.dimensions']
+        );
+    }
+
+    #[Test]
+    public function legacy_string_based_format_with_custom_message()
+    {
+        $rule = 'dimensions:width=200,height=200';
+        $message = 'Side of the image must be exactly 200px square';
+        $translator = resolve('translator');
 
         $validator = new Validator(
-            $trans,
-            ['image' => $image],
-            ['image' => $rule]
+            $translator,
+            ['image' => UploadedFile::fake()->image('image.jpg', 100, 100)],
+            ['image' => $rule],
+            ['image' => $message]
         );
 
         $this->assertSame(
-            $trans->get('validation.dimensions', ['width' => 100, 'height' => 100, 'min_ratio' => 0.5, 'max_ratio' => 0.4]),
-            $validator->errors()->first('image')
+            expected: $message,
+            actual: $validator->errors()->first('image')
         );
+    }
+
+    #[Test]
+    public function legacy_constraints_passed_into_constructor_via_rule_supported()
+    {
+        $rule = Rule::dimensions([
+            'min_width' => 100,
+            'max_width' => 200,
+            'min_height' => 100,
+            'max_height' => 200,
+            'ratio' => 1 / 1,
+        ]);
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 150, 150),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 190, 210),
+            messages: ['validation.max_height', 'validation.ratio']
+        );
+    }
+
+    #[Test]
+    public function legacy_constructor_based_format_with_custom_message()
+    {
+        $rule = Rule::dimensions([
+            'width' => 200,
+            'height' => 200,
+        ]);
+
+        $message = 'Side of the image must be exactly 200px square';
+        $translator = resolve('translator');
 
         $validator = new Validator(
-            $trans,
-            ['image' => $image],
-            ['image' => [$rule]]
+            $translator,
+            ['image' => UploadedFile::fake()->image('image.jpg', 100, 100)],
+            ['image' => $rule],
+            ['image' => $message]
         );
 
-        $this->assertSame(
-            $trans->get('validation.dimensions', ['width' => 100, 'height' => 100, 'min_ratio' => 0.5, 'max_ratio' => 0.4]),
-            $validator->errors()->first('image')
+        $this->assertSame($message, $validator->errors()->first('image'));
+        $this->assertTrue($validator->fails());
+    }
+
+    #[Test]
+    public function custom_rules_added()
+    {
+        $this->passes(
+            Dimensions::defaults()
+                ->width(100)->height(100)
+                ->rules(['mimes:jpg']),
+            UploadedFile::fake()->image('image.jpg', 100, 100),
         );
+
+        $this->fails(
+            Dimensions::defaults()
+                ->width(100)->height(100)
+                ->rules(['mimes:png']),
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+            messages: ['validation.mimes']
+        );
+    }
+
+    #[Test]
+    public function rule_is_macroable()
+    {
+        Dimensions::macro('thumbnail', function () {
+            return $this->width(100)->height(100);
+        });
+
+        $rule = Dimensions::defaults()->thumbnail();
+
+        $this->passes(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 100, 100),
+        );
+
+        $this->fails(
+            $rule,
+            UploadedFile::fake()->image('image.jpg', 99, 101),
+            messages: ['validation.width', 'validation.height']
+        );
+    }
+
+    public function fails(Dimensions|string $rule, UploadedFile $value, array $messages)
+    {
+        $this->assertValidationRules($rule, $value, false, $messages);
+    }
+
+    public function passes(Dimensions|string $rule, UploadedFile $value)
+    {
+        $this->assertValidationRules($rule, $value, true);
+    }
+
+    protected function assertValidationRules(Dimensions|string $rule, UploadedFile $values, $result, $messages = [])
+    {
+        $values = Arr::wrap($values);
+
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['my_file' => $value],
+                ['my_file' => is_object($rule) ? clone $rule : $rule],
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['my_file' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(new ArrayLoader, 'en');
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
     }
 }

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationImageFileRuleTest extends TestCase
 {
-
     #[Test]
     public function dimensions()
     {

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -12,16 +12,19 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class ValidationImageFileRuleTest extends TestCase
 {
-    public function testDimensions()
+
+    #[Test]
+    public function dimensions()
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
             UploadedFile::fake()->image('foo.png', 101, 101),
-            ['validation.dimensions'],
+            ['validation.width', 'validation.height'],
         );
 
         $this->passes(
@@ -30,12 +33,13 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
-    public function testDimensionsWithCustomImageSizeMethod()
+    #[Test]
+    public function dimensions_with_custom_image_size_method()
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
             new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data($tmpFile = tmpfile())['uri'], 'foo.png'),
-            ['validation.dimensions'],
+            ['validation.width', 'validation.height'],
         );
 
         $this->passes(
@@ -44,12 +48,13 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
-    public function testDimentionWithTheRatioMethod()
+    #[Test]
+    public function dimension_with_the_ratio_method()
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->ratio(1)),
             UploadedFile::fake()->image('foo.png', 105, 100),
-            ['validation.dimensions'],
+            ['validation.ratio'],
         );
 
         $this->passes(
@@ -58,12 +63,13 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
-    public function testDimentionWithTheMinRatioMethod()
+    #[Test]
+    public function dimension_with_the_min_ratio_method()
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->minRatio(1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 100),
-            ['validation.dimensions'],
+            ['validation.min_ratio'],
         );
 
         $this->passes(
@@ -72,12 +78,13 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
-    public function testDimentionWithTheMaxRatioMethod()
+    #[Test]
+    public function dimension_with_the_max_ratio_method()
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->maxRatio(1 / 2)),
             UploadedFile::fake()->image('foo.png', 100, 300),
-            ['validation.dimensions'],
+            ['validation.max_ratio'],
         );
 
         $this->passes(
@@ -86,12 +93,13 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
-    public function testDimentionWithTheRatioBetweenMethod()
+    #[Test]
+    public function dimension_with_the_ratio_between_method()
     {
         $this->fails(
             File::image()->dimensions(Rule::dimensions()->ratioBetween(1 / 2, 1 / 3)),
             UploadedFile::fake()->image('foo.png', 100, 100),
-            ['validation.dimensions'],
+            ['validation.ratio_between'],
         );
 
         $this->passes(


### PR DESCRIPTION
The PR changes the Dimension rule, by adding the ability to use newly added translation strings to give users granular error message feedback when using the Dimension validation rule on uploaded images.  This granularity provides more precise validation feedback, allowing the end user to more clearly understand what the errors are related to and how to rectify any issues related to the validation constraints for the image file uploaded. 

Currently, no matter how many constraints you set for the `Dimensions` rule, the framework only provides 1 validation message advising that the image upload is not within the constraints set. Eg:
```php
// Rule
Rule::dimension()->minWidth(100)->minHeight(100)->maxWidth(1000)->maxHeight(1000)->ratioBetween(5/2, 2/5)
//Message
'image.dimension' => 'The image must be between :min_width x :min_height pixels and :max_width x :max_height pixels, and have an aspect ratio between :min_ratio and :max_ratio'
```

I believe it's important to bring the `Dimensions` rule in line with the recent changes to make the other fluent rules `Macroable`, `DataAware` & `ValidatorAware`, as seen in PR’s like #54067 all following the initial implementation created by @lukeraymonddowning on #43271 by and implemented in many other PR's on the other Fluent validation rules to create consistency. 

`Test Coverage` has been added to ensure that custom messages, granulated translation strings & support for the existing string representation of the rule is still provided,

>[!NOTE]
>There is a behavioural change that will effect a small subset of users, anyone who set a custom validation message for the `Dimensions` rule, to fluently build constraints, will notice that rather than their custom validation message, for the `validation.dimension` translation string, will be bypassed and default to the new granular translation string for each of the constraints that they added on the rule

> Although this is not a breaking change, it is new behaviour that should be noted on any changelog / upgrade guide. 

I think that the additional granularity in feedback far outweighs the possibility of defaulting to the granular message string in instances where the users has added a custom messages & given the new behaviour. This is a improved resubmit of my work from #52707 - which I believe is more suited version 12, a major release.