### PR TITLE
[11.x] Allow can attribute on group

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route post(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route put(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
+ * @method \Illuminate\Routing\RouteRegistrar can(\UnitEnum|string  $ability, array|string $models = [])
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(\BackedEnum|string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
@@ -64,6 +65,7 @@ class RouteRegistrar
      */
     protected $allowedAttributes = [
         'as',
+        'can',
         'controller',
         'domain',
         'middleware',


### PR DESCRIPTION
```diff
<?php

Route::prefix('settings/users')
-    ->middleware(Authorize::using(Permission::MANAGE_USERS))
+    ->can(Permission::MANAGE_USERS)
    ->group(function (): void {
        Route::get('/', [UserController::class, 'index'])->name('settings.users.index');
        Route::post('update/{user}', [UserController::class, 'update'])->name('settings.users.update');
        Route::post('suspend/{user}', [UserController::class, 'suspend'])->name('settings.user.suspend');
        Route::post('restore/{user}', [UserController::class, 'restore'])->name('settings.user.restore');
    });
```