### PR TITLE
[11.x] use value helper for $perPage as used for $total

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1013,10 +1013,7 @@ class Builder implements BuilderContract
 
         $total = value($total) ?? $this->toBase()->getCountForPagination();
 
-        $perPage = ($perPage instanceof Closure
-            ? $perPage($total)
-            : $perPage
-        ) ?: $this->model->getPerPage();
+        $perPage = value($perPage, $total) ?? $this->model->getPerPage();
 
         $results = $total
             ? $this->forPage($page, $perPage)->get($columns)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3150,7 +3150,7 @@ class Builder implements BuilderContract
 
         $total = value($total) ?? $this->getCountForPagination();
 
-        $perPage = $perPage instanceof Closure ? $perPage($total) : $perPage;
+        $perPage = value($perPage, $total);
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : new Collection;
 


### PR DESCRIPTION
When creating a `Paginator` from both `Illuminate\Database\Query\Builder` and  `Illuminate\Database\Eloquent\Builder`, the `$total` property uses the `value()` helper, as it can be a `\Closure`.

But the `$perPage` property replicates the same logic as the `value()` helper, as below:

https://github.com/laravel/framework/blob/17786ca25fa9080f0b4f03af7517e9fc72fa0b4a/src/Illuminate/Collections/helpers.php#L234-L237

This PR:

- Changes the `$perPage` calculation to use the `value()` helper

Note:

On `Illuminate\Database\Eloquent\Builder`, the previous code used the ternary shorthand operator (`?:`) instead of the null coalescing operator (`??`) to defer checking the model for the `$perPage` value, in case it wasn't defined.

It would allow a call like this:

```php
Model::paginate(0);
```

To make the  `Model@getPerPage()` method to be called, which would technically be a breaking change.

I opted to use the null coalescing operator (`??`) as `$total` uses it, and as, IMO, it is very unlikely someone to be calling `Model::paginate(...)` with a zero `$perPage` value.

But I can revert to the ternary shorthand operator (`?:`) if we want to avoid any breaking change.