### PR TITLE
[11.x] use exec function if the symlink function is unavailable

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -355,7 +355,7 @@ class Filesystem
             if (function_exists('symlink')) {
                 return symlink($target, $link);
             }else{
-                return exec("ln -s ".escapeshellarg($target).' '.escapeshellarg($link));
+                return exec("ln -s ".escapeshellarg($target).' '.escapeshellarg($link)) !== false;
             }
         }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -352,7 +352,7 @@ class Filesystem
     public function link($target, $link)
     {
         if (! windows_os()) {
-            if(function_exists('symlink')) {
+            if (function_exists('symlink')) {
                 return symlink($target, $link);
             }else{
                 return exec("ln -s ".escapeshellarg($target).' '.escapeshellarg($link));

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -352,7 +352,11 @@ class Filesystem
     public function link($target, $link)
     {
         if (! windows_os()) {
-            return symlink($target, $link);
+            if(function_exists('symlink')) {
+                return symlink($target, $link);
+            }else{
+                return exec("ln -s ".escapeshellarg($target).' '.escapeshellarg($link));
+            }
         }
 
         $mode = $this->isDirectory($target) ? 'J' : 'H';


### PR DESCRIPTION
 If the `symlink` function is unavailable, it falls back to using the `exec` function to run the `ln -s` command, creating a symbolic link using the shell.

I have tried both GitHub actions and cpanel. By default, the symlink() function does not exist for security reasons. We usually fix it by manually using the bash command "ln -s" to fix this issue.

GitHub action image below.
![image](https://github.com/user-attachments/assets/1d0b567c-999b-4f34-99f0-01bd35d5c573)

Cpanel image below.
![image](https://github.com/user-attachments/assets/128096ad-4cfa-43ea-956b-2798ed94f10e)
