### PR TITLE
[11.x] make the Eloquent missing attribute handler more accurate by changing offsetExists

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2281,8 +2281,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function offsetExists($offset): bool
     {
         $shouldPrevent = static::$modelsShouldPreventAccessingMissingAttributes;
+
         static::$modelsShouldPreventAccessingMissingAttributes = false;
+
         $result = ! is_null($this->getAttribute($offset));
+
         static::$modelsShouldPreventAccessingMissingAttributes = $shouldPrevent;
 
         return $result;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2280,11 +2280,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function offsetExists($offset): bool
     {
-        try {
-            return ! is_null($this->getAttribute($offset));
-        } catch (MissingAttributeException) {
-            return false;
-        }
+        $shouldPrevent = static::$modelsShouldPreventAccessingMissingAttributes;
+        static::$modelsShouldPreventAccessingMissingAttributes = false;
+        $result = ! is_null($this->getAttribute($offset));
+        static::$modelsShouldPreventAccessingMissingAttributes = $shouldPrevent;
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
We have recently implemented the `Model::handleMissingAttributeViolationUsing` callback in staging and production environments to allow the request to continue without exceptions, but still be notified about strict mode failures. However, due to the way the `offsetExists` method is currently implemented, we are getting a lot of false positives on missing attributes when using `isset` or `??` checks.

This PR aims to resolve that by temporarily disabling the check while retrieving the attribute, and then restoring it to the previous setting.