### PR TITLE
[11.x] Ensure that events are fired when bulk dispatching jobs onto the database queue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -137,31 +137,6 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Push an array of jobs onto the queue.
-     *
-     * @param  array  $jobs
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return mixed
-     */
-    public function bulk($jobs, $data = '', $queue = null)
-    {
-        $queue = $this->getQueue($queue);
-
-        $now = $this->availableAt();
-
-        return $this->database->table($this->table)->insert((new Collection((array) $jobs))->map(
-            function ($job) use ($queue, $data, $now) {
-                return $this->buildDatabaseRecord(
-                    $queue,
-                    $this->createPayload($job, $this->getQueue($queue), $data),
-                    isset($job->delay) ? $this->availableAt($job->delay) : $now,
-                );
-            }
-        )->all());
-    }
-
-    /**
      * Release a reserved job back onto the queue after (n) seconds.
      *
      * @param  string  $queue


### PR DESCRIPTION
Fixes #52689 by removing the custom [bulk method](https://github.com/laravel/framework/blob/b7c628776754a7d861dd48ff18768e1c1f2d5f5f/src/Illuminate/Queue/DatabaseQueue.php#L144) from the `DatabaseQueue` class. The default implementation of the [bulk method](https://github.com/laravel/framework/blob/b7c628776754a7d861dd48ff18768e1c1f2d5f5f/src/Illuminate/Queue/Queue.php#L84) from the abstract `Queue` class will now be used.
 
Benefits:
1. The [JobQueueing](https://github.com/laravel/framework/blob/b7c628776754a7d861dd48ff18768e1c1f2d5f5f/src/Illuminate/Queue/Events/JobQueueing.php) and [JobQueued](https://github.com/laravel/framework/blob/b7c628776754a7d861dd48ff18768e1c1f2d5f5f/src/Illuminate/Queue/Events/JobQueued.php) events are now fired as expected when bulk dispatching jobs onto the database queue (as elaborated upon in #52689).
2. The logic in the [enqueueUsing method](https://github.com/laravel/framework/blob/b7c628776754a7d861dd48ff18768e1c1f2d5f5f/src/Illuminate/Queue/Queue.php#L325) is no longer bypassed when bulk dispatching jobs.
3. The `DatabaseQueue` class has fewer lines of code now.

Drawback:
1. Bulk dispatching jobs may be less performant than before, as multiple database inserts are required. However, performance can still be improved by wrapping the bulk method in a transaction if needed.

In my opinion, the benefits clearly outweigh the drawback. Consistency is more important than performance in this case, and performance can still be optimized by wrapping the bulk method in a transaction when necessary.

One unit test was slightly modified to accommodate this change, and an integration test was added.