### PR TITLE
[11.x] Add `withWhereRelation` method to builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -180,21 +180,6 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a basic where clause to a relationship query and eager-load the relationship.
-     *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function withWhereRelation($relation, $column, $operator = null, $value = null)
-    {
-        return $this->whereRelation($relation, $column, $operator, $value)
-            ->with([$relation => fn ($query) => $column instanceof Closure ? $column($query) : $query->where($column, $operator, $value)]);
-    }
-
-    /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -450,6 +435,25 @@ trait QueriesRelationships
                 $query->where($column, $operator, $value);
             }
         });
+    }
+
+    /**
+     * Add a basic where clause to a relationship query and eager-load the relationship with the same conditions.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function withWhereRelation($relation, $column, $operator = null, $value = null)
+    {
+        return $this->whereRelation($relation, $column, $operator, $value)
+            ->with([
+                $relation => fn ($query) => $column instanceof Closure
+                    ? $column($query)
+                    : $query->where($column, $operator, $value)
+            ]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -180,6 +180,21 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a basic where clause to a relationship query and eager-load the relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function withWhereRelation($relation, $column, $operator = null, $value = null)
+    {
+        return $this->whereRelation($relation, $column, $operator, $value)
+            ->with([$relation => fn ($query) => $column instanceof Closure ? $column($query) : $query->where($column, $operator, $value)]);
+    }
+
+    /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -150,6 +150,23 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $this->assertSame($exists->first()->current_state->state, $currentState->state);
     }
 
+    public function testWithWhereRelation()
+    {
+        $product = MorphOneOfManyTestProduct::create();
+        $currentState = $product->states()->create([
+            'state' => 'active',
+        ]);
+
+        $exists = MorphOneOfManyTestProduct::withWhereRelation('current_state', 'state', 'active')->exists();
+        $this->assertTrue($exists);
+
+        $exists = MorphOneOfManyTestProduct::withWhereRelation('current_state', 'state', 'active')->get();
+
+        $this->assertCount(1, $exists);
+        $this->assertTrue($exists->first()->relationLoaded('current_state'));
+        $this->assertSame($exists->first()->current_state->state, $currentState->state);
+    }
+
     public function testWithExists()
     {
         $product = MorphOneOfManyTestProduct::create();


### PR DESCRIPTION
```php
class Consumer extends Model
{
    public function company(): BelongsTo
    {
        return $this->belongsTo(Company::class)->withTrashed();
    }
}
```

```diff
Consumer::query()
-    ->withWhereHas('company', function (Builder|BelongsTo $query): void {
-       $query->whereNull('deleted_at');
-   })
+    ->withWhereRelation('company', 'deleted_at' null);
