### PR TITLE
[11.x] Fix routeCollection get method return value when searching by dot not…

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -4,7 +4,6 @@ namespace Illuminate\Routing;
 
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 
 class RouteCollection extends AbstractRouteCollection
 {

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -170,7 +170,7 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function get($method = null)
     {
-        return is_null($method) ? $this->getRoutes() : $this->routes[$method] ?? [];
+        return is_null($method) ? $this->getRoutes() : ($this->routes[$method] ?? []);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -171,7 +171,7 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function get($method = null)
     {
-        return is_null($method) ? $this->getRoutes() : Arr::get($this->routes, $method, []);
+        return is_null($method) ? $this->getRoutes() : $this->routes[$method] ?? [];
     }
 
     /**

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -66,6 +66,24 @@ class RouteCollectionTest extends TestCase
         $this->assertSame($action, $routeIndex->getAction());
     }
 
+    public function testRouteCollectionCanRetrieveByMethod()
+    {
+        $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', $action = [
+            'uses' => 'FooController@index',
+            'as' => 'route_name',
+        ]));
+
+        $this->assertCount(1, $this->routeCollection->get('GET'));
+        $this->assertCount(0, $this->routeCollection->get('GET.foo/index'));
+        $this->assertSame($routeIndex, $this->routeCollection->get('GET')['foo/index']);
+
+        $this->routeCollection->add($routeShow = new Route('GET', 'bar/show', [
+            'uses' => 'BarController@show',
+            'as' => 'bar_show',
+        ]));
+        $this->assertCount(2, $this->routeCollection->get('GET'));
+    }
+
     public function testRouteCollectionCanGetIterator()
     {
         $this->routeCollection->add(new Route('GET', 'foo/index', [


### PR DESCRIPTION
**Changes**

- Remove the use of `Arr::get($this->routes, $method, [])` from the get method in `\Illuminate\Routing\RouteCollection::get`   because it allows to return a `route` object when searching with "dot" notation. despite the method name,  parameter, and PHPDoc indicating that the search is performed by `$method`  (e.g GET , POST ...)  and should return  array of Route objects when found

**Changes**
as described and discussed in https://github.com/laravel/framework/discussions/54541

- The current implementation of the `get` method in `\Illuminate\Routing\RouteCollection::get` has a side effect that allows us to search by "dot" notation 
example: `$this->routeCollectionget->('GET.foo/index');` will return an object instance of `Route` (not array)
which contradict:

1. The parameter name ($method)
2. The phpDoc that says it should return \Illuminate\Routing\Route[]  and not \Illuminate\Routing\Route  object as it is in this case

**Solution**
- Eliminate the side effect by removing the search by "dot" notation that is provided by `Arr::get()`  and use null-coalescing operator instead to perform a search on the routes collection (first level that contains the methods)