### PR TITLE
[11.x] new: `ddJson` method on `TestResponse` class

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1126,16 +1126,6 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Die and dump the JSON payload for the request.
-     *
-     * @param  string|null  $key
-     */
-    public function ddJson($key = null)
-    {
-        dd($this->json($key));
-    }
-
-    /**
      * Get the JSON decoded body of the response as a collection.
      *
      * @param  string|null  $key
@@ -1602,6 +1592,16 @@ class TestResponse implements ArrayAccess
         $this->dumpHeaders();
 
         exit(1);
+    }
+
+    /**
+     * Die and dump the JSON payload for the request.
+     *
+     * @param  string|null  $key
+     */
+    public function ddJson($key = null)
+    {
+        dd($this->json($key));
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1595,7 +1595,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Die and dump the JSON payload for the request.
+     * Dump the JSON payload from the response and end the script.
      *
      * @param  string|null  $key
      */

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1126,6 +1126,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Die and dump the JSON payload for the request.
+     *
+     * @param  string|null  $key
+     */
+    public function ddJson($key = null)
+    {
+        dd($this->json($key));
+    }
+
+    /**
      * Get the JSON decoded body of the response as a collection.
      *
      * @param  string|null  $key


### PR DESCRIPTION
This PR adds a `ddJson()` method to the `TestResponse` class. This is a `dd()` wrapper around the existing `json()` which would be very handy if you just want to quickly see what the json response is when writing tests.

Instead of doing this:
```php
$response = $this->getJson('/api/test-api');

dd($response->json());
```

you could just do this:
```php
$this->getJson('/api/test-api')->ddJson();
```

I wasn't sure it was possible to write a test for this because the function uses dd() but if it is possible could someone please explain how to do it and I'll add a test.

The benefit of this is to reduce the time it takes to see the result of the response when testing, instead of having to use a variable. it won't break any existing logic as its a new function.