### PR TITLE
[12.x] Add QueriesExecuted to expose cumulative query information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ Thumbs.db
 /.idea
 /.fleet
 /.vscode
+/.zed
 .phpunit.result.cache

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -811,9 +811,9 @@ class Connection implements ConnectionInterface
             return $callback($query, $bindings);
         }
 
-            // If an exception occurs when attempting to run a query, we'll format the error
-            // message to include the bindings with SQL, which will make this exception a
-            // lot more helpful to the developer instead of just the database's errors.
+        // If an exception occurs when attempting to run a query, we'll format the error
+        // message to include the bindings with SQL, which will make this exception a
+        // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
             if ($this->isUniqueConstraintError($e)) {
                 throw new UniqueConstraintViolationException(

--- a/src/Illuminate/Database/Events/QueriesExecuted.php
+++ b/src/Illuminate/Database/Events/QueriesExecuted.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class QueriesExecuted
+{
+    /**
+     * Queries that were run.
+     *
+     * @var array
+     */
+    public $queryLog;
+
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    public $connection;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $sql
+     * @param  array  $bindings
+     * @param  float|null  $time
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($queryLog, $connection)
+    {
+        $this->queryLog = $queryLog;
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+    }
+}

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Events\QueriesExecuted;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
@@ -468,7 +469,13 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection();
         $connection->logQuery('foo', [], time());
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch')->once()->with(m::type(QueriesExecuted::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(QueryExecuted::class));
+
+        $connection->enableQueryLog();
+        $connection->logQuery('foo', [], time());
+        $events->shouldReceive('dispatch')->once()->with(m::type(QueryExecuted::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(QueriesExecuted::class));
         $connection->logQuery('foo', [], null);
     }
 

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -28,6 +28,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = 0;
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(1.1), function () use (&$called) {
             $called++;
@@ -45,6 +46,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = 0;
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called++;
@@ -63,6 +65,7 @@ class QueryDurationThresholdTest extends TestCase
 
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = 0;
         $connection->whenQueryingForLongerThan($this->now->addMilliseconds(1), function () use (&$called) {
             $called++;
@@ -79,6 +82,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = [];
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called['a'] = true;
@@ -100,6 +104,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = [];
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called['a'] = true;
@@ -125,6 +130,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'), '', '', ['name' => 'expected-name']);
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $name = null;
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(1), function ($connection) use (&$name) {
             $name = $connection->getName();
@@ -140,6 +146,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = false;
         $connection->whenQueryingForLongerThan(1.1, function () use (&$called) {
             $called = true;
@@ -156,6 +163,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = false;
         $connection->whenQueryingForLongerThan(2, function () use (&$called) {
             $called = true;
@@ -186,6 +194,7 @@ class QueryDurationThresholdTest extends TestCase
     {
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
+        $connection->enableQueryLog();
         $called = 0;
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called++;
@@ -217,7 +226,7 @@ class QueryDurationThresholdTest extends TestCase
         $queries = [];
         $connection->whenQueryingForLongerThan(CarbonInterval::milliseconds(2), function ($connection, $event) use (&$queries) {
             $queries = Arr::pluck($connection->getQueryLog(), 'query');
-            $queries[] = $event->sql;
+            $queries = Arr::pluck($event->queryLog, 'query');
         });
 
         $connection->logQuery('foo', [], 1);


### PR DESCRIPTION
⚠️ **BREAKING CHANGE**: This PR changes the event type dispatched by `DB::whenQueryingForLongerThan()` and requires `DB::enableQueryLog()` to be called.

## Background

While investigating long-running queries using `DB::whenQueryingForLongerThan()`, I discovered that the method only provides information about individual queries. This can be misleading since the threshold is actually triggered by cumulative query time across the request lifecycle, not just a single long query.

For example, if you set a threshold of 500ms:
- A single 600ms query will trigger the method
- Ten 60ms queries (totaling 600ms) will also trigger it
- However, in the second case, you only see details for one of those queries (probably the last query before the method is triggered)

## Changes

This PR introduces:

1. A new `QueriesExecuted` class that replaces `QueryExecuted` in the `whenQueryingForLongerThan` callback
2. The new event provides:
  - List of all queries executed up to the threshold with individual query metrics and bindings
  - Database connection details

## Why This Matters

While Laravel does provide `getQueryLog()` and `totalQueryDuration()`, developers new to the framework may not discover these methods without diving into the source code. Having comprehensive query information directly in the method from the event makes the feature more intuitive and useful.

## Breaking Changes
- `whenQueryingForLongerThan()` now passes `QueriesExecuted` instead of `QueryExecuted`
- Existing callback implementations will need to be updated to handle the new event type
- Query logging must be explicitly enabled via `DB::enableQueryLog()` for this feature to function

## Note
This PR builds upon and extends the groundwork laid in #42744. Many thanks to @timacdonald for implementing the query duration monitoring feature that made this enhancement possible.