### PR TITLE
Add eloquent last method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -427,6 +427,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Retrieve the last record by timestamp.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return TModel|null
+     */
+    public function last($column = null)
+    {
+        return $this->latest($column)->first();
+    }
+
+    /**
      * Create a collection of models from plain arrays.
      *
      * @param  array  $items

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2293,6 +2293,44 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->oldest('foo');
     }
 
+    public function testLastWithoutColumnWithCreatedAt()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
+        $builder->shouldReceive('first')->andReturn('bar');
+
+        $result = $builder->last();
+        $this->assertSame('bar', $result);
+    }
+
+    public function testLastWithoutColumnWithoutCreatedAt()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at');
+        $builder->shouldReceive('first')->andReturn('bar');
+
+        $result = $builder->last();
+        $this->assertSame('bar', $result);
+    }
+
+    public function testLastWithColumn()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
+        $builder->shouldReceive('first')->andReturn('bar');
+
+        $result = $builder->last('foo');
+        $this->assertSame('bar', $result);
+    }
+
     public function testUpdate()
     {
         Carbon::setTestNow($now = '2017-10-10 10:10:10');


### PR DESCRIPTION
Since we frequently use `->latest()->first()` in our code, this PR introduces a new Eloquent method `->last()` that achieves the same functionality, enhancing readability.

**Before:**

```php
$lastPodcast = Podcast::latest()->first();
```

**After:**

```php
$lastPodcast = Podcast::last();
```

---

**Before:**

```php
$lastPodcast = Podcast::latest('published_at')->first();
```

**After:**

```php
$lastPodcast = Podcast::last('published_at');
```