### PR TITLE
[11.x] Add parameter typing for closure to addGlobalScope method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -93,7 +93,7 @@ trait HasGlobalScopes
      * Get a global scope registered with the model.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return \Illuminate\Database\Eloquent\Scope|\Closure|null
+     * @return \Illuminate\Database\Eloquent\Scope|(\Closure(\Illuminate\Database\Eloquent\Builder<static>): mixed)|null
      */
     public static function getGlobalScope($scope)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -40,8 +40,8 @@ trait HasGlobalScopes
     /**
      * Register a new global scope on the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|string  $scope
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|null  $implementation
+     * @param  \Illuminate\Database\Eloquent\Scope|(\Closure(\Illuminate\Database\Eloquent\Builder<static>): mixed)|string  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope|(\Closure(\Illuminate\Database\Eloquent\Builder<static>): mixed)|null  $implementation
      * @return mixed
      *
      * @throws \InvalidArgumentException

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -25,6 +25,12 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
         return ['string' => 'string'];
     }));
 
+    User::addGlobalScope('ancient', function ($builder) {
+        assertType('Illuminate\Database\Eloquent\Builder<User>', $builder);
+
+        $builder->where('created_at', '<', now()->subYears(2000));
+    });
+
     assertType('Illuminate\Database\Eloquent\Builder<User>', User::query());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->newQuery());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->withTrashed());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Inspired by the efforts in #54452, this MR enhances the parameter typing on `addGlobalScope` so that inside the closure the builder parameter is correctly typed.

cc @calebdw FYI