### PR TITLE
[11.x] `assertOnlyJsonValidationErrors` / `assertOnlyInvalid`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -993,7 +993,7 @@ class TestResponse implements ArrayAccess
 
         $unexpectedErrorKeys = Arr::except($jsonErrors, $expectedErrorKeys);
 
-        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: ' . collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
+        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: '.collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
     }
 
     /**
@@ -1400,7 +1400,7 @@ class TestResponse implements ArrayAccess
 
         $unexpectedErrorKeys = Arr::except($sessionErrors, $expectedErrorKeys);
 
-        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: ' . collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
+        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: '.collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1384,9 +1384,7 @@ class TestResponse implements ArrayAccess
      * @param  string  $responseKey
      * @return $this
      */
-    public function assertOnlyInvalid($errors = null,
-                                  $errorBag = 'default',
-                                  $responseKey = 'errors')
+    public function assertOnlyInvalid($errors = null, $errorBag = 'default', $responseKey = 'errors')
     {
         if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
             return $this->assertOnlyJsonValidationErrors($errors, $responseKey);
@@ -1394,13 +1392,19 @@ class TestResponse implements ArrayAccess
 
         $this->assertSessionHas('errors');
 
-        $sessionErrors = $this->session()->get('errors')->getBag($errorBag)->getMessages();
+        $sessionErrors = $this->session()->get('errors')
+            ->getBag($errorBag)
+            ->getMessages();
 
-        $expectedErrorKeys = collect($errors)->map(fn ($value, $key) => is_int($key) ? $value : $key)->all();
+        $expectedErrorKeys = collect($errors)
+            ->map(fn ($value, $key) => is_int($key) ? $value : $key)->all();
 
         $unexpectedErrorKeys = Arr::except($sessionErrors, $expectedErrorKeys);
 
-        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: '.collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
+        PHPUnit::withResponse($this)->assertTrue(
+            count($unexpectedErrorKeys) === 0,
+            'Response has unexpected validation errors: '.collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', ')
+        );
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -977,6 +977,26 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has the given JSON validation errors but does not have any other JSON validation errors.
+     *
+     * @param  string|array  $errors
+     * @param  string  $responseKey
+     * @return $this
+     */
+    public function assertOnlyJsonValidationErrors($errors, $responseKey = 'errors')
+    {
+        $this->assertJsonValidationErrors($errors, $responseKey);
+
+        $jsonErrors = Arr::get($this->json(), $responseKey) ?? [];
+
+        $expectedErrorKeys = collect($errors)->map(fn ($value, $key) => is_int($key) ? $value : $key)->all();
+
+        $unexpectedErrorKeys = Arr::except($jsonErrors, $expectedErrorKeys);
+
+        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: ' . collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
+    }
+
+    /**
      * Assert the response has any JSON validation errors for the given key.
      *
      * @param  string  $key
@@ -1354,6 +1374,33 @@ class TestResponse implements ArrayAccess
         }
 
         return $this;
+    }
+
+    /**
+     * Assert that the response has the given validation errors but does not have any other validation errors.
+     *
+     * @param  string|array|null  $errors
+     * @param  string  $errorBag
+     * @param  string  $responseKey
+     * @return $this
+     */
+    public function assertOnlyInvalid($errors = null,
+                                  $errorBag = 'default',
+                                  $responseKey = 'errors')
+    {
+        if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
+            return $this->assertOnlyJsonValidationErrors($errors, $responseKey);
+        }
+
+        $this->assertSessionHas('errors');
+
+        $sessionErrors = $this->session()->get('errors')->getBag($errorBag)->getMessages();
+
+        $expectedErrorKeys = collect($errors)->map(fn ($value, $key) => is_int($key) ? $value : $key)->all();
+
+        $unexpectedErrorKeys = Arr::except($sessionErrors, $expectedErrorKeys);
+
+        PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: ' . collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
     }
 
     /**


### PR DESCRIPTION
Sometimes you want to test that a validation error is present but you want to be sure that no other validation error occurred. Currently, there is no easy way to do that, unless you provide every possible validation error key to a `assertJsonMissingValidationErrors` method call.

```php
// Will fail if 'email' error is missing OR if 'name' error is present
// BUT nothing will fail if 'phone' error is present
$this->post('/user')
    ->assertJsonValidationErrors(['email'])
    ->assertMissingJsonValidationErrors(['name']);
```

This PR fixes that by creating a method that checks if the provided errors are present but also asserts that no other validation errors occurred:
```php
// Will fail if 'email' error is missing OR if 'name' error is present OR if any other error is present
$this->post('/user')->assertOnlyJsonValidationErrors(['email']);
```