### PR TITLE
[11.x] Adds unless helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -255,3 +255,18 @@ if (! function_exists('when')) {
         return value($default, $condition);
     }
 }
+
+if (! function_exists('unless')) {
+    /**
+     * Return a value unless the given condition is true.
+     *
+     * @param  mixed  $condition
+     * @param  \Closure|mixed  $value
+     * @param  \Closure|mixed  $default
+     * @return mixed
+     */
+    function unless($condition, $value, $default = null)
+    {
+        return when(! $condition, $value, $default);
+    }
+}

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -267,6 +267,10 @@ if (! function_exists('unless')) {
      */
     function unless($condition, $value, $default = null)
     {
-        return when(! $condition, $value, $default);
+        if (! $condition) {
+            return value($value, $condition);
+        }
+
+        return value($default, $condition);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -146,14 +146,14 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(unless('1', fn () => null));
         $this->assertNull(unless(0, fn () => null));
         $this->assertNull(unless([1, 2, 3, 4], 'True')); // Array
-        $this->assertEquals('True', unless([], 'True')); // Empty Array = Falsy
+        $this->assertEquals('True', unless([], 'True')); // Empty Array = True
         $this->assertNull(unless(new StdClass, fn () => 'True')); // Object
         $this->assertEquals('Hello', unless(false, 'Hello', 'World'));
         $this->assertEquals('Hello', unless(1 === 0, 'Hello', 'World')); // strict types
         $this->assertEquals('Hello', unless(1 == '0', 'Hello', 'World')); // loose types
         $this->assertEquals('There', unless('', fn () => 'There', fn () => null));
         $this->assertEquals('There', unless(0, fn () => 'There', fn () => null));
-        $this->assertEquals('True', unless([], 'True', 'False'));  // Empty Array = Falsy
+        $this->assertEquals('True', unless([], 'True', 'False'));  // Empty Array = True
         $this->assertFalse(unless(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
         $this->assertFalse(unless(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
         $this->assertEquals('Empty', unless(collect()->isEmpty(), 'Not Empty', 'Empty')); // For good measure

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -154,10 +154,10 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('There', unless('', fn () => 'There', fn () => null));
         $this->assertEquals('There', unless(0, fn () => 'There', fn () => null));
         $this->assertEquals('True', unless([], 'True', 'False'));  // Empty Array = Falsy
-        $this->assertEquals('Default', unless(true, fn ($value) => $value, fn ($value) => 'Default')); // lazy evaluation
-        $this->assertTrue(unless(false, fn ($value) => $value, fn ($value) => 'Default')); // lazy evaluation
-        $this->assertEquals('Empty', unless(collect()->isEmpty(), 'Not Empty', 'Empty'));
-        $this->assertEquals('Not Empty', unless(collect([1])->isEmpty(), 'Not Empty', 'Empty'));
+        $this->assertFalse(unless(true, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
+        $this->assertFalse(unless(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
+        $this->assertEquals('Empty', unless(collect()->isEmpty(), 'Not Empty', 'Empty')); // For good measure
+        $this->assertEquals('Not Empty', unless(collect([1])->isEmpty(), 'Not Empty', 'Empty')); // For good measure
     }
 
     public function testFilled()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -136,6 +136,30 @@ class SupportHelpersTest extends TestCase
         $this->assertTrue(when(false, fn ($value) => $value, fn ($value) => ! $value)); // lazy evaluation
     }
 
+    public function testUnless()
+    {
+        $this->assertEquals('Hello', unless(false, 'Hello'));
+        $this->assertNull(unless(true, 'Hello'));
+        $this->assertEquals('There', unless(1 !== 1, 'There')); // strict types
+        $this->assertEquals('There', unless(1 != '1', 'There')); // loose types
+        $this->assertNull(unless(1 == 1, 'There'));
+        $this->assertNull(unless('1', fn () => null));
+        $this->assertNull(unless(0, fn () => null));
+        $this->assertNull(unless([1, 2, 3, 4], 'True')); // Array
+        $this->assertEquals('True', unless([], 'True')); // Empty Array = Falsy
+        $this->assertNull(unless(new StdClass, fn () => 'True')); // Object
+        $this->assertEquals('Hello', unless(false, 'Hello', 'World'));
+        $this->assertEquals('Hello', unless(1 === 0, 'Hello', 'World')); // strict types
+        $this->assertEquals('Hello', unless(1 == '0', 'Hello', 'World')); // loose types
+        $this->assertEquals('There', unless('', fn () => 'There', fn () => null));
+        $this->assertEquals('There', unless(0, fn () => 'There', fn () => null));
+        $this->assertEquals('True', unless([], 'True', 'False'));  // Empty Array = Falsy
+        $this->assertEquals('Default', unless(true, fn ($value) => $value, fn ($value) => 'Default')); // lazy evaluation
+        $this->assertTrue(unless(false, fn ($value) => $value, fn ($value) => 'Default')); // lazy evaluation
+        $this->assertEquals('Empty', unless(collect()->isEmpty(), 'Not Empty', 'Empty'));
+        $this->assertEquals('Not Empty', unless(collect([1])->isEmpty(), 'Not Empty', 'Empty'));
+    }
+
     public function testFilled()
     {
         $this->assertFalse(filled(null));


### PR DESCRIPTION
This is a continuation of https://github.com/laravel/framework/pull/52665, but the opposite!

Adds an `unless` helper, which brings the `when` helper in line with when/unless in the `Conditionable` trait.

Prevents the need for `when(! $someCondition, ...)` negation, improving readability.