### PR TITLE
[11.x] Replace MD5 with xxh128 in File::hasSameHash()

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -547,9 +547,9 @@ class Filesystem
      */
     public function hasSameHash($firstFile, $secondFile)
     {
-        $hash = @md5_file($firstFile);
+        $hash = @hash_file('xxh128', $firstFile);
 
-        return $hash && hash_equals($hash, (string) @md5_file($secondFile));
+        return $hash && hash_equals($hash, (string) @hash_file('xxh128', $secondFile));
     }
 
     /**


### PR DESCRIPTION
In `File::hasSameHash()`, replace MD5 with [xxh128](https://xxhash.com/), which has been available since PHP 8.1.

xxh128 has the same 128-bit length, but is much faster and avoids the security issues associated with MD5. See also [this article](https://fastcompression.blogspot.com/2019/03/presenting-xxh3.html).

Quick benchmark for comparing 100 MB files:

<details>
<summary>Benchmark code</summary>

```php
// Using MD5 hashes

$start = microtime(true);

$hash1 = md5_file('./random_100MB_file_1.bin');
$hash2 = md5_file('./random_100MB_file_2.bin');
$areHashesIdentical = ($hash1 === $hash2);

$timeMd5Hash = microtime(true) - $start;

// Using xxh128 hashes

$start = microtime(true);

$hash1 = hash_file('xxh128', './random_100MB_file_3.bin');
$hash2 = hash_file('xxh128', './random_100MB_file_4.bin');
$areHashesIdentical = ($hash1 === $hash2);

$timeXxh128Hash = microtime(true) - $start;

// Direct comparison of contents

$start = microtime(true);

$content1 = file_get_contents('./random_100MB_file_5.bin');
$content2 = file_get_contents('./random_100MB_file_6.bin');
$areContentsIdentical = ($content1 === $content2);

$timeContent = microtime(true) - $start;

// Results

echo 'MD5 hashes: ' . round($timeMd5Hash * 1000) . " ms\n";
echo 'xxh128 hashes: ' . round($timeXxh128Hash * 1000) . " ms\n";
echo 'file_get_contents(): ' . round($timeContent * 1000) . " ms\n";
```
</details>

Results:
```
MD5 hashes: 375 ms
xxh128 hashes: 76 ms
file_get_contents(): 69 ms
```

(The code using `file_get_contents()` is only for reference. Large files would exhaust memory, and [`hash_equals()`](https://www.php.net/manual/en/function.hash-equals.php) (#49721) is designed for short, **same-length** parameters.)

Using xxh128 virtually removes the hashing overhead. 🚀

xxh128 is already used in some places in Laravel, for instance see #45371 and discussion https://github.com/laravel/framework/discussions/46074.