### PR TITLE
[11.x] Introduce storing log channel name on Context

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -127,6 +127,8 @@ class Repository
     }
 
     /**
+     * Retrieve the log name.
+     *
      * @return string|null
      */
     public function name()
@@ -243,6 +245,8 @@ class Repository
     }
 
     /**
+     * Set the log name.
+     *
      * @param  string|null  $name
      * @return $this
      */

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -145,29 +145,29 @@ class LogManager implements LoggerInterface
 
                 if (method_exists($loggerWithContext->getLogger(), 'pushProcessor')) {
                     $loggerWithContext->pushProcessor(
-                    /**
-                     * @param LogRecord $record
-                     */
-                        function ($record) use ($logger) {
-                        if (! $this->app->bound(ContextRepository::class)) {
-                            return $record;
-                        }
+                        /**
+                         * @param  LogRecord  $record
+                         */
+                        function ($record) {
+                            if (! $this->app->bound(ContextRepository::class)) {
+                                return $record;
+                            }
 
-                        $contextRepository = $this->app[ContextRepository::class];
+                            $contextRepository = $this->app[ContextRepository::class];
 
-                        $params = [
-                            'extra' => [
-                                ...$record->extra,
-                                ...$contextRepository->all(),
-                            ]
-                        ];
+                            $params = [
+                                'extra' => [
+                                    ...$record->extra,
+                                    ...$contextRepository->all(),
+                                ],
+                            ];
 
-                        if ($contextRepository->name() && $record->channel !== $logger->getName()) {
-                            $params['channel'] = $contextRepository->name();
-                        }
+                            if ($contextRepository->name()) {
+                                $params['channel'] = $contextRepository->name();
+                            }
 
-                        return $record->with(...$params);
-                    });
+                            return $record->with(...$params);
+                        });
                 }
 
                 return $this->channels[$name] = $loggerWithContext;

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -18,7 +18,6 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Handler\WhatFailureGroupHandler;
 use Monolog\Logger as Monolog;
-use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\LoggerInterface;
@@ -146,7 +145,8 @@ class LogManager implements LoggerInterface
                 if (method_exists($loggerWithContext->getLogger(), 'pushProcessor')) {
                     $loggerWithContext->pushProcessor(
                         /**
-                         * @param  LogRecord  $record
+                         * @param  \Monolog\LogRecord  $record
+                         * @return \Monolog\LogRecord
                          */
                         function ($record) {
                             if (! $this->app->bound(ContextRepository::class)) {
@@ -162,8 +162,8 @@ class LogManager implements LoggerInterface
                                 ],
                             ];
 
-                            if ($contextRepository->name()) {
-                                $params['channel'] = $contextRepository->name();
+                            if ($channelName = $contextRepository->name()) {
+                                $params['channel'] = $channelName;
                             }
 
                             return $record->with(...$params);


### PR DESCRIPTION
The Context facade is _nearly perfect_. I love that I can carry about contextual information from function to function without having to a pass an instance of a LogInterface or the contextual information as an array.

However, the one missing piece is that I cannot set the channel name via Context. So for instance, I currently have to write code like this:

```php
Context::add(['user_id' => 1234, 'team' => 'Blackhawks']);
Log::withName('user-sync')->info('Preparing team sync.');
// ... other stuff
Log::withName('user-sync')->info('Team sync complete.');
```

which will produce logs like this (when written to a log file)
```text
[2025-02-19 03:20:11] user-sync.INFO: Preparing team sync.  {"user_id":1234,"team":"Blackhawks"}
[2025-02-19 03:20:11] user-sync.INFO: Team sync complete.  {"user_id":1234,"team":"Blackhawks"}
```

Obviously, within a single function this isn't too bad, but when the information has multiple calls to other services, it can be unwieldy.

## Why would you need to use this?
In a large application, observability tools like DataDog make it possible to query just by the channel name. If your application writes thousands of logs per hour, being able to filter down to only the relevant logs is incredibly helpful. This is like adding additional context, except it is standardized for logging platforms.

## A solution
Introducing `Context::setName()`. We can pass a string here, and now all of our logs with shared context will be under the same name.

```php
Context::setName('user-sync');
Context::add(['user_id' => 1234, 'team' => 'Blackhawks']);
Log::info('Preparing team sync.');
// ... other stuff
Log::info('Team sync complete.');
```

## Limitations
You cannot override the channel name without modifying the Context. So, if I want to change the channel name for just a single log (`Log::withName('not-user-sync')->info('Doing something else.')`), the name set by the context will override the value specified. I considered some options for this, but didn't really have any clear approach. I thought about maybe storing a reference to channel name on Log\Logger, but not sure how I feel about that.