### PR TITLE
[12.x] Bump minimum `brick/math`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
+        "brick/math": "^0.11|^0.12",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^3.2.1|^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.2",
         "ext-pdo": "*",
-        "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
+        "brick/math": "^0.11|^0.12",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",
         "illuminate/contracts": "^12.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-mbstring": "*",
-        "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
+        "brick/math": "^0.11|^0.12",
         "egulias/email-validator": "^3.2.5|^4.0",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",


### PR DESCRIPTION
Version | PHP       | Link
:--------|:--------|:--------
`0.9.x`   | 7.1, 7.2, 7.3, 7.4, 8.0 | https://github.com/brick/math/blob/ca57d18f028f84f777b2168cd1911b0dee2343ae/.github/workflows/ci.yml#L33-L38
`0.10.x` | 7.4, 8.0, 8.1 | https://github.com/brick/math/blob/459f2781e1a08d52ee56b0b1444086e038561e3f/.github/workflows/ci.yml#L33-L36
`0.11.x`  | 8.0, 8.1, 8.2 | https://github.com/brick/math/blob/0ad82ce168c82ba30d1c01ec86116ab52f589478/.github/workflows/ci.yml#L33-L36
`0.12.x`  | 8.1, 8.2, 8.3 | https://github.com/brick/math/blob/f510c0a40911935b77b86859eb5223d58d660df1/.github/workflows/ci.yml#L37-L40

PHP 8.4 has been merged to `master` but it not yet tagged as a release: https://github.com/brick/math/compare/0.12.1...master