### PR TITLE
[11.x] Enhance eventStream to Support Custom Events and Start Messages

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -129,7 +129,7 @@ class ResponseFactory implements FactoryContract
      * @param  string|null  $endStreamWith
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function eventStream(Closure $callback, array $headers = [], string $as = 'update', ?string $startStreamWith = '<stream>', ?string $endStreamWith = '</stream>')
+    public function eventStream(Closure $callback, array $headers = [], string $as = 'update', ?string $startStreamWith = null, ?string $endStreamWith = '</stream>')
     {
         return $this->stream(function () use ($callback, $as, $startStreamWith, $endStreamWith) {
             if (filled($startStreamWith)) {

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -124,15 +124,16 @@ class ResponseFactory implements FactoryContract
      *
      * @param  \Closure  $callback
      * @param  array  $headers
+     * @param  string $as
      * @param  string|null  $startStreamWith
      * @param  string|null  $endStreamWith
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function eventStream(Closure $callback, array $headers = [], ?string $startStreamWith = '<stream>', ?string $endStreamWith = '</stream>')
+    public function eventStream(Closure $callback, array $headers = [], string $as = 'update', ?string $startStreamWith = '<stream>', ?string $endStreamWith = '</stream>')
     {
         return $this->stream(function () use ($callback, $startStreamWith, $endStreamWith) {
             if (filled($startStreamWith)) {
-                echo "event: update\n";
+                echo "event: $as\n";
                 echo 'data: '.$startStreamWith;
                 echo "\n\n";
 
@@ -149,7 +150,7 @@ class ResponseFactory implements FactoryContract
                     $message = Js::encode($message);
                 }
 
-                echo "event: update\n";
+                echo "event: $as\n";
                 echo 'data: '.$message;
                 echo "\n\n";
 
@@ -158,7 +159,7 @@ class ResponseFactory implements FactoryContract
             }
 
             if (filled($endStreamWith)) {
-                echo "event: update\n";
+                echo "event: $as\n";
                 echo 'data: '.$endStreamWith;
                 echo "\n\n";
 

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -124,12 +124,22 @@ class ResponseFactory implements FactoryContract
      *
      * @param  \Closure  $callback
      * @param  array  $headers
-     * @param  string  $endStreamWith
+     * @param  string|null  $startStreamWith
+     * @param  string|null  $endStreamWith
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function eventStream(Closure $callback, array $headers = [], string $endStreamWith = '</stream>')
+    public function eventStream(Closure $callback, array $headers = [], ?string $startStreamWith = '<stream>', ?string $endStreamWith = '</stream>')
     {
-        return $this->stream(function () use ($callback, $endStreamWith) {
+        return $this->stream(function () use ($callback, $startStreamWith, $endStreamWith) {
+            if (filled($startStreamWith)) {
+                echo "event: update\n";
+                echo 'data: '.$startStreamWith;
+                echo "\n\n";
+
+                ob_flush();
+                flush();
+            }
+
             foreach ($callback() as $message) {
                 if (connection_aborted()) {
                     break;
@@ -147,12 +157,14 @@ class ResponseFactory implements FactoryContract
                 flush();
             }
 
-            echo "event: update\n";
-            echo 'data: '.$endStreamWith;
-            echo "\n\n";
+            if (filled($endStreamWith)) {
+                echo "event: update\n";
+                echo 'data: '.$endStreamWith;
+                echo "\n\n";
 
-            ob_flush();
-            flush();
+                ob_flush();
+                flush();
+            }
         }, 200, array_merge($headers, [
             'Content-Type' => 'text/event-stream',
             'Cache-Control' => 'no-cache',

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -124,7 +124,7 @@ class ResponseFactory implements FactoryContract
      *
      * @param  \Closure  $callback
      * @param  array  $headers
-     * @param  string $as
+     * @param  string  $as
      * @param  string|null  $startStreamWith
      * @param  string|null  $endStreamWith
      * @return \Symfony\Component\HttpFoundation\StreamedResponse

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -131,7 +131,7 @@ class ResponseFactory implements FactoryContract
      */
     public function eventStream(Closure $callback, array $headers = [], string $as = 'update', ?string $startStreamWith = '<stream>', ?string $endStreamWith = '</stream>')
     {
-        return $this->stream(function () use ($callback, $startStreamWith, $endStreamWith) {
+        return $this->stream(function () use ($callback, $as, $startStreamWith, $endStreamWith) {
             if (filled($startStreamWith)) {
                 echo "event: $as\n";
                 echo 'data: '.$startStreamWith;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### **[11.x] Enhance `eventStream` to Support Custom Events and Start Messages**

#### **Summary**

⚠️ BREAKING CHANGE: This PR changes the `eventStream` method in `ResponseFactory` by allowing customization of:  

- **Event Name (`$as`)** – Previously hardcoded as `"update"`, now configurable.  
- **Start Stream Message (`$startStreamWith`)** – Optional message sent before streaming begins.  
- **End Stream Message (`$endStreamWith`)** – Now optional instead of required.  

#### **Why This Change?**

- **More Flexible SSE Handling**: Developers can now specify custom event names, making it easier to differentiate between different types of SSE messages and also they can now decide if they want start/end messages.
- **Improved Client Communication**: Some clients expect an initial message when connecting. The `$startStreamWith` parameter allows for this. 

#### **Implementation Details**

The method signature now includes:  

  ```php
  public function eventStream(
      Closure $callback, 
      array $headers = [], 
      string $as = 'update', 
      ?string $startStreamWith = '<stream>', 
      ?string $endStreamWith = '</stream>'
  ) {}
```

Docs PR: https://github.com/laravel/docs/pull/10180