### PR TITLE
🐛 Fix InteractsWithDatabase Seed method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -329,7 +329,7 @@ trait InteractsWithDatabase
     public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
     {
         foreach (Arr::wrap($class) as $class) {
-            $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
+            $this->artisan('db:seed', ['seeder' => $class, '--no-interaction' => true]);
         }
 
         return $this;


### PR DESCRIPTION
This will fix the `The "--class" option does not exist` error I received while calling `$this->seed()` from TestCase.

> Symfony\Component\Console\Exception\InvalidOptionException: The "--class" option does not exist.
