### PR TITLE
🐛 Fix `InteractsWithDatabase::seed` method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -329,7 +329,7 @@ trait InteractsWithDatabase
     public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
     {
         foreach (Arr::wrap($class) as $class) {
-            $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
+            $this->artisan('db:seed', ['seeder' => $class, '--no-interaction' => true]);
         }
 
         return $this;


### PR DESCRIPTION
This will fix the `The "--class" option does not exist` error I received while calling `$this->seed()` from a TestCase.

> Symfony\Component\Console\Exception\InvalidOptionException: The "--class" option does not exist.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
