### PR TITLE
[11.x] Fix: Custom Exceptions with Multiple Arguments does not properly rein…

### DIFF
--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -54,17 +54,14 @@ class InvokeSerializedClosureCommand extends Command
 
             $reflection = new ReflectionClass($e);
             $constructor = $reflection->getConstructor();
-            $params = [];
+            $parameters = [];
 
             if ($constructor) {
                 $declaringClass = $constructor->getDeclaringClass()->getName();
 
-                // Ensure we're only getting parameters from the current class, not inherited ones
                 if ($declaringClass === $reflection->getName()) {
-                    $args = $constructor->getParameters();
-                    foreach ($args as $param) {
-                        $property = $param->name;
-                        $params[$property] = $e->{$property} ?? null;
+                    foreach ($constructor->getParameters() as $parameter) {
+                        $parameters[$parameter->name] = $e->{$parameter->name} ?? null;
                     }
                 }
             }
@@ -75,7 +72,7 @@ class InvokeSerializedClosureCommand extends Command
                 'message' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
-                'params' => $params,
+                'parameters' => $parameters,
             ]));
         }
     }

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -50,7 +50,7 @@ class ProcessDriver implements Driver
             if (! $result['successful']) {
                 throw new $result['exception'](
                     ...! empty(array_filter($result['params']))
-                    ?  $result['params']
+                    ? $result['params']
                     : [$result['message']]
                 );
             }

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -48,9 +48,9 @@ class ProcessDriver implements Driver
 
             if (! $result['successful']) {
                 throw new $result['exception'](
-                    ...! empty(array_filter($result['params']))
-                    ? $result['params']
-                    : [$result['message']]
+                    ...(! empty(array_filter($result['parameters']))
+                        ? $result['parameters']
+                        : [$result['message']])
                 );
             }
 

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Defer\DeferredCallback;
 use Laravel\SerializableClosure\SerializableClosure;
 
+use ReflectionClass;
 use function Illuminate\Support\defer;
 
 class ProcessDriver implements Driver
@@ -48,7 +49,7 @@ class ProcessDriver implements Driver
 
             if (! $result['successful']) {
                 $exceptionClass = $result['exception'];
-                $reflection = new \ReflectionClass($exceptionClass);
+                $reflection = new ReflectionClass($exceptionClass);
 
                 $args = $result['params'] ?? [];
 

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -11,7 +11,6 @@ use Illuminate\Process\Pool;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Defer\DeferredCallback;
 use Laravel\SerializableClosure\SerializableClosure;
-use ReflectionClass;
 
 use function Illuminate\Support\defer;
 

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -48,31 +48,11 @@ class ProcessDriver implements Driver
             $result = json_decode($result->output(), true);
 
             if (! $result['successful']) {
-                $exceptionClass = $result['exception'];
-                $reflection = new ReflectionClass($exceptionClass);
-
-                $args = $result['params'] ?? [];
-
-                if (empty($args)) {
-                    throw new $result['exception'](
-                        $result['message']
-                    );
-                }
-
-                $constructor = $reflection->getConstructor();
-                if ($constructor) {
-                    $constructorParams = $constructor->getParameters();
-                    $finalArgs = [];
-
-                    foreach ($constructorParams as $param) {
-                        $paramName = $param->getName();
-                        $finalArgs[] = $args[$paramName] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
-                    }
-                } else {
-                    $finalArgs = [];
-                }
-
-                throw $reflection->newInstanceArgs($finalArgs);
+                throw new $result['exception'](
+                    ...! empty(array_filter($result['params']))
+                    ?  $result['params']
+                    : [$result['message']]
+                );
             }
 
             return unserialize($result['result']);

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -11,8 +11,8 @@ use Illuminate\Process\Pool;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Defer\DeferredCallback;
 use Laravel\SerializableClosure\SerializableClosure;
-
 use ReflectionClass;
+
 use function Illuminate\Support\defer;
 
 class ProcessDriver implements Driver

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -31,7 +31,7 @@ PHP);
         parent::setUp();
     }
 
-    public function test_work_can_be_distributed()
+    public function testWorkCanBeDistributed()
     {
         $response = $this->get('concurrency')
             ->assertOk();
@@ -42,7 +42,7 @@ PHP);
         $this->assertEquals(4, $second);
     }
 
-    public function test_run_handler_process_error_code()
+    public function testRunHandlerProcessErrorCode()
     {
         $this->expectException(\Exception::class);
         $app = new Application(__DIR__);
@@ -52,7 +52,7 @@ PHP);
         ]);
     }
 
-    public function test_run_handler_process_error_code_with_custom_exception_without_param()
+    public function testRunHandlerProcessErrorWithCustomExceptionWithoutParam()
     {
         $this->expectException(ExceptionWithoutParam::class);
         $this->expectExceptionMessage('Test');
@@ -61,7 +61,7 @@ PHP);
         ]);
     }
 
-    public function test_run_handler_process_error_code_with_custom_exception_with_param()
+    public function testRunHandlerProcessErrorWithCustomExceptionWithParam()
     {
         $this->expectException(ExceptionWithParam::class);
         $this->expectExceptionMessage('API request to https://api.example.com failed with status 400 Bad Request');

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -76,7 +76,8 @@ PHP);
     }
 }
 
-class ExceptionWithoutParam extends Exception {}
+class ExceptionWithoutParam extends Exception {
+}
 
 class ExceptionWithParam extends Exception
 {

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -52,6 +52,18 @@ PHP);
         ]);
     }
 
+    public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('This is a different exception');
+
+        Concurrency::run([
+            fn () => throw new Exception(
+                'This is a different exception',
+            ),
+        ]);
+    }
+
     public function testRunHandlerProcessErrorWithCustomExceptionWithoutParam()
     {
         $this->expectException(ExceptionWithoutParam::class);

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -76,7 +76,8 @@ PHP);
     }
 }
 
-class ExceptionWithoutParam extends Exception {
+class ExceptionWithoutParam extends Exception
+{
 }
 
 class ExceptionWithParam extends Exception


### PR DESCRIPTION
This PR resolves this issue #54500 

#### **Problem:**  
In Concurrency Run When the custom exception is serialized and rethrown, Laravel only passes the `message` argument, missing other required parameters (custom parameters), causing an `ArgumentCountError`.

---

### **Fix Implementation:**  

- Uses reflection to inspect the exception's constructor and extract required parameters.  
- Ensures correct reconstruction of the exception with all expected arguments.  
- Handles optional parameters and defaults gracefully.  


### **Impact:**  
This fix ensures that exceptions with multiple arguments are correctly rethrown in the main process, preventing runtime errors and improving the reliability of concurrent tasks in Laravel.