### PR TITLE
Fix translation key for "Regards" in email view

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,7 +39,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards,')<br>
+@lang('Regards'),<br>
 {{ config('app.name') }}
 @endif
 


### PR DESCRIPTION
This pull request includes a small change to the `src/Illuminate/Notifications/resources/views/email.blade.php` file. The change modifies the salutation format in the email template.

* [`src/Illuminate/Notifications/resources/views/email.blade.php`](diffhunk://#diff-cb6bfd119e1cc2c8a67640e46029a60edeb57550d22ff9bb822d129b354326d6L42-R42): Changed the salutation from `@lang('Regards,')<br>` to `@lang('Regards'),<br>`.
