### PR TITLE
Fix translation key for "Regards" in email view

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,7 +39,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards,')<br>
+@lang('Regards'),<br>
 {{ config('app.name') }}
 @endif
 


### PR DESCRIPTION
This pull request includes a small change to the `src/Illuminate/Notifications/resources/views/email.blade.php` file. The change modifies the salutation format in the email template.

* Changed the salutation from `@lang('Regards,')<br>` to `@lang('Regards'),<br>`.