### PR TITLE
[11.x] Fix: Handles non nested explode of multiple Date and Numeric rules in ValidationRuleParser

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -94,6 +94,10 @@ class ValidationRuleParser
         }
 
         if (is_object($rule)) {
+            if ($rule instanceof Date || $rule instanceof Numeric) {
+                return explode('|', (string) $rule);
+            }
+
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
 

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -351,4 +351,122 @@ class ValidationRuleParserTest extends TestCase
             ],
         ], $results->implicitAttributes);
     }
+
+    public function testExplodeHandlesStringDateRule()
+    {
+        $parser = (new ValidationRuleParser([
+            'date' => '2021-01-01',
+        ]));
+
+        $rules = [
+            'date' => 'date|date_format:Y-m-d',
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'date' => [
+                'date',
+                'date_format:Y-m-d',
+            ],
+        ], $results->rules);
+    }
+
+    public function testExplodeHandlesDateRule()
+    {
+        $parser = (new ValidationRuleParser([
+            'date' => '2021-01-01',
+        ]));
+
+        $rules = [
+            'date' => Rule::date(),
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'date' => [
+                'date',
+            ],
+        ], $results->rules);
+    }
+
+    public function testExplodeHandlesDateRuleWithAdditionalRules()
+    {
+        $parser = (new ValidationRuleParser([
+            'date' => '2021-01-01',
+        ]));
+
+        $rules = [
+            'date' => Rule::date()->format('Y-m-d'),
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'date' => [
+                'date',
+                'date_format:Y-m-d',
+            ],
+        ], $results->rules);
+    }
+
+    public function testExplodeHandlesNumericStringRule()
+    {
+        $parser = (new ValidationRuleParser([
+            'number' => 42,
+        ]));
+
+        $rules = [
+            'number' => 'numeric|max:100',
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'number' => [
+                'numeric',
+                'max:100',
+            ],
+        ], $results->rules);
+    }
+
+    public function testExplodeHandlesNumericRule()
+    {
+        $parser = (new ValidationRuleParser([
+            'number' => 42,
+        ]));
+
+        $rules = [
+            'number' => Rule::numeric(),
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'number' => [
+                'numeric',
+            ],
+        ], $results->rules);
+    }
+
+    public function testExplodeHandlesNumericRuleWithAdditionalRules()
+    {
+        $parser = (new ValidationRuleParser([
+            'number' => 42,
+        ]));
+
+        $rules = [
+            'number' => Rule::numeric()->max(100),
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'number' => [
+                'numeric',
+                'max:100',
+            ],
+        ], $results->rules);
+    }
 }


### PR DESCRIPTION
This PR fixes #54717 

**Problem**
The current code in ValidationRuleParser explodeExplicitRule function does not handles the explode for multiple chained non-nested Date or Numeric Rule objects. It falls into the condtion that checks if the rule is an object and wraps the rule in an array as a string cast without exploding it at the pipe symbol.

**Fix Implementation**

My fix simply add an early exit condition for Date or Numeric rules in the logic if block for objects.
I added some test coverage for the problematic conditions.

I thought of checking against the Stringable interface but it may not be safe enough.

Please let me know if you need any changes to the fix.

Thanks !
