### PR TITLE
[11.x] Rename Redis parse connection for cluster test method to follow naming conventions

### DIFF
--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -62,7 +62,7 @@ class RedisManagerExtensionTest extends TestCase
         );
     }
 
-    public function test_parse_connection_configuration_for_cluster()
+    public function testParseConnectionConfigurationForCluster()
     {
         $name = 'my-cluster';
         $config = [


### PR DESCRIPTION
This simply updates a test method to follow the consistency of the other methods in the same test class, found it on my travels.

Minor, I know, but keeps it consistent.  This can be aimed at 12.x if it's easier.

Also, while I'm here is it worth PR'ing a pint rule to ignore snake case issues? As if I run pint it tries to convert all method names to snake case and my IDE is blowing up:
![image](https://github.com/user-attachments/assets/2f722154-3c88-4c06-9835-8d9519e56adf)

Could be useful as not sure if you prefer snake case or camel atm?