### PR TITLE
[12.x] Adds `Throws` trait

### DIFF
--- a/src/Illuminate/Support/Traits/Throws.php
+++ b/src/Illuminate/Support/Traits/Throws.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Closure;
+use RuntimeException;
+
+trait Throws
+{
+    /**
+     * Apply the callback if the given "value" is (or resolves to) truthy.
+     *
+     * @template TThrowable of \Throwable
+     *
+     * @param  (\Closure($this): mixed)|mixed  $value
+     * @param  TThrowable|class-string<TThrowable>|(\Closure($this):TThrowable|class-string<TThrowable>)|string  $throwable
+     * @param  mixed  ...$arguments
+     * @return $this
+     *
+     * @throws TThrowable
+     */
+    public function throwIf($value, $throwable, ...$arguments)
+    {
+        if ($value instanceof Closure ? $value($this) : $value) {
+            if ($throwable instanceof Closure) {
+                $throwable = $throwable($this);
+            }
+
+            if (! class_exists($throwable)) {
+                [$throwable, $arguments] = [RuntimeException::class, [$throwable]];
+            }
+
+            if (is_string($throwable)) {
+                $throwable = new $throwable(...$arguments);
+            }
+
+            throw $throwable;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the callback if the given "value" is (or resolves to) truthy.
+     *
+     * @template TThrowable of \Throwable
+     *
+     * @param  (\Closure($this): mixed)|mixed  $value
+     * @param  TThrowable|class-string<TThrowable>|(\Closure($this):TThrowable|class-string<TThrowable>)|string  $throwable
+     * @param  mixed  ...$arguments
+     * @return $this
+     *
+     * @throws TThrowable
+     */
+    public function throwUnless($value, $throwable, ...$arguments)
+    {
+        if (! ($value instanceof Closure ? $value($this) : $value)) {
+            if ($throwable instanceof Closure) {
+                $throwable = $throwable($this);
+            }
+
+            if (! class_exists($throwable)) {
+                [$throwable, $arguments] = [RuntimeException::class, [$throwable]];
+            }
+
+            if (is_string($throwable)) {
+                $throwable = new $throwable(...$arguments);
+            }
+
+            throw $throwable;
+        }
+
+        return $this;
+    }
+}

--- a/tests/Support/SupportThrowsTest.php
+++ b/tests/Support/SupportThrowsTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Exception;
+use Illuminate\Support\Traits\Throws;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SupportThrowsTest extends TestCase
+{
+    public function testThrowsIfWithDefault()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwIf(false, 'test-foo'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwIf(true, 'test-foo');
+    }
+
+    public function testThrowsIfWithCallback()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwIf(fn () => false, 'test-foo'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwIf(fn () => true, 'test-foo');
+    }
+
+    public function testThrowsIfWithExceptionInstance()
+    {
+        $throws = ThrowsClass::make();
+        $exception = new Exception('test-bar');
+
+        $this->assertSame($throws, $throws->throwIf(false, $exception));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test-bar');
+
+        $throws->throwIf(true, $exception);
+    }
+
+    public function testThrowsIfWithCallbackAsExceptionInstance()
+    {
+        $throws = ThrowsClass::make();
+        $exception = new Exception('test-bar');
+
+        $this->assertSame($throws, $throws->throwIf(false, fn () => $exception));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test-bar');
+
+        $throws->throwIf(true, function ($instance) use ($throws, $exception) {
+            $this->assertSame($throws, $instance);
+
+            return $exception;
+        });
+    }
+
+    public function testThrowsIfWithCallbackAsExceptionMessage()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwIf(false, fn () => 'test-foo'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwIf(true, fn () => 'test-foo');
+    }
+
+    public function testThrowsIfWithCallbackAsExceptionClassString()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwIf(false, fn () => Exception::class));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('');
+
+        $throws->throwIf(true, fn () => Exception::class);
+    }
+
+    public function testThrowsIfWithCallbackAsExceptionClassStringWithArguments()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwIf(false, fn () => Exception::class), 'test-foo');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwIf(true, fn () => Exception::class, 'test-foo');
+    }
+
+    public function testThrowsUnlessWithDefault()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwUnless(true, 'test-foo'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwUnless(false, 'test-foo');
+    }
+
+    public function testThrowsUnlessWithCallback()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwUnless(fn () => true, 'test-foo'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwUnless(fn () => false, 'test-foo');
+    }
+
+    public function testThrowsUnlessWithExceptionInstance()
+    {
+        $throws = ThrowsClass::make();
+        $exception = new Exception('test-bar');
+
+        $this->assertSame($throws, $throws->throwUnless(true, $exception));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test-bar');
+
+        $throws->throwUnless(false, $exception);
+    }
+
+    public function testThrowsUnlessWithCallbackAsExceptionInstance()
+    {
+        $throws = ThrowsClass::make();
+        $exception = new Exception('test-bar');
+
+        $this->assertSame($throws, $throws->throwUnless(true, fn () => $exception));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test-bar');
+
+        $throws->throwUnless(false, function ($instance) use ($throws, $exception) {
+            $this->assertSame($throws, $instance);
+
+            return $exception;
+        });
+    }
+
+    public function testThrowsUnlessWithCallbackAsExceptionMessage()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwUnless(true, fn () => 'test-foo'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwUnless(false, fn () => 'test-foo');
+    }
+
+    public function testThrowsUnlessWithCallbackAsExceptionClassString()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwUnless(true, fn () => Exception::class));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('');
+
+        $throws->throwUnless(false, fn () => Exception::class);
+    }
+
+    public function testThrowsUnlessWithCallbackAsExceptionClassStringWithArguments()
+    {
+        $throws = ThrowsClass::make();
+
+        $this->assertSame($throws, $throws->throwUnless(true, fn () => Exception::class), 'test-foo');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test-foo');
+
+        $throws->throwUnless(false, fn () => Exception::class, 'test-foo');
+    }
+}
+
+class ThrowsClass
+{
+    use Throws;
+
+    public static function make()
+    {
+        return new static;
+    }
+}


### PR DESCRIPTION
### What?

This is a small trait which aims to allow a class to throw an exception fluently. It adds `throwIf()` and `throwUnless()`. These methods are fluent and will return the instance if they do not throw.

By default, the exception to throw will be a `RuntimeException`, mostly because I assume it will be a runtime error rather than anything else.

```php
// Before
if ($else->missingValue()) {
    throw new RuntimeException('Does not have value');
}

return $object->doElse();

// After
return $object->throwIf($else->missingValue(), 'Does not have value')->doElse();
```

The exception can be changed using a secondary parameter, and leaving the rest of arguments to be passed the exception constructor parameters.

```php
$object->throwIf(true, InvalidArgumentException::class, 'Value is missing');
```

The second argument can also be used with a callback to return a `Throwable` instance or even a class string.

```php
$object->throwIf(true, fn () => new InvalidArgumentException('Value is missing'));
```

I also meant this trait to be used across the framework, like Collections or Requests.