### PR TITLE
[11.x] Fix parsing `PHP_CLI_SERVER_WORKERS` as `string` instead of `int`

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -96,7 +96,7 @@ class ServeCommand extends Command
     #[\Override]
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $this->phpServerWorkers = transform(env('PHP_CLI_SERVER_WORKERS', 1), function ($workers) {
+        $this->phpServerWorkers = transform((int) env('PHP_CLI_SERVER_WORKERS', 1), function (int $workers) {
             if (! is_int($workers) || $workers < 2) {
                 return false;
             }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -97,7 +97,7 @@ class ServeCommand extends Command
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->phpServerWorkers = transform((int) env('PHP_CLI_SERVER_WORKERS', 1), function (int $workers) {
-            if (! is_int($workers) || $workers < 2) {
+            if ($workers < 2) {
                 return false;
             }
 


### PR DESCRIPTION
fixes #54723

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
