### PR TITLE
[11.x] Enhance eventStream to Support Custom Events and Start Messages

### DIFF
--- a/src/Illuminate/Contracts/Routing/EventStreamable.php
+++ b/src/Illuminate/Contracts/Routing/EventStreamable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+interface EventStreamable
+{
+    /**
+     * Get the name for event streams.
+     *
+     * @return string
+     */
+    public function streamVia();
+}

--- a/src/Illuminate/Contracts/Routing/EventStreamable.php
+++ b/src/Illuminate/Contracts/Routing/EventStreamable.php
@@ -9,5 +9,5 @@ interface EventStreamable
      *
      * @return string
      */
-    public function streamVia();
+    public function streamAs();
 }

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -148,13 +148,13 @@ class ResponseFactory implements FactoryContract
                     break;
                 }
 
-                $streamAs = $message instanceof EventStreamable ? $message->streamVia() : $as;
+                $streamVia = $message instanceof EventStreamable ? $message->streamVia() : $as;
 
                 if (! is_string($message) && ! is_numeric($message)) {
                     $message = Js::encode($message);
                 }
 
-                echo "event: $streamAs\n";
+                echo "event: $streamVia\n";
                 echo 'data: '.$message;
                 echo "\n\n";
 

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -124,12 +124,24 @@ class ResponseFactory implements FactoryContract
      *
      * @param  \Closure  $callback
      * @param  array  $headers
+     * @param  string  $as
+     * @param  string|null  $startStreamWith
+     * @param  string|null  $endStreamWith
      * @param  string  $endStreamWith
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function eventStream(Closure $callback, array $headers = [], string $endStreamWith = '</stream>')
+    public function eventStream(Closure $callback, array $headers = [], string $as = 'update', ?string $startStreamWith = null, ?string $endStreamWith = '</stream>')
     {
-        return $this->stream(function () use ($callback, $endStreamWith) {
+        return $this->stream(function () use ($callback, $as, $startStreamWith, $endStreamWith) {
+            if (filled($startStreamWith)) {
+                echo "event: $as\n";
+                echo 'data: '.$startStreamWith;
+                echo "\n\n";
+
+                ob_flush();
+                flush();
+            }
+
             foreach ($callback() as $message) {
                 if (connection_aborted()) {
                     break;
@@ -147,12 +159,14 @@ class ResponseFactory implements FactoryContract
                 flush();
             }
 
-            echo "event: update\n";
-            echo 'data: '.$endStreamWith;
-            echo "\n\n";
+            if (filled($endStreamWith)) {
+                echo "event: $as\n";
+                echo 'data: '.$endStreamWith;
+                echo "\n\n";
 
-            ob_flush();
-            flush();
+                ob_flush();
+                flush();
+            }
         }, 200, array_merge($headers, [
             'Content-Type' => 'text/event-stream',
             'Cache-Control' => 'no-cache',

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Contracts\Routing\EventStreamable;
 use Illuminate\Contracts\Routing\ResponseFactory as FactoryContract;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Http\JsonResponse;
@@ -147,11 +148,13 @@ class ResponseFactory implements FactoryContract
                     break;
                 }
 
+                $streamAs = $message instanceof EventStreamable ? $message->streamVia() : $as;
+
                 if (! is_string($message) && ! is_numeric($message)) {
                     $message = Js::encode($message);
                 }
 
-                echo "event: update\n";
+                echo "event: $streamAs\n";
                 echo 'data: '.$message;
                 echo "\n\n";
 

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -148,13 +148,13 @@ class ResponseFactory implements FactoryContract
                     break;
                 }
 
-                $streamVia = $message instanceof EventStreamable ? $message->streamVia() : $as;
+                $streamAs = $message instanceof EventStreamable ? $message->streamAs() : $as;
 
                 if (! is_string($message) && ! is_numeric($message)) {
                     $message = Js::encode($message);
                 }
 
-                echo "event: $streamVia\n";
+                echo "event: $streamAs\n";
                 echo 'data: '.$message;
                 echo "\n\n";
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### **[11.x] Enhance `eventStream` to Support Custom Events and Start Messages**

#### **Summary**

⚠️ BREAKING CHANGE: This PR changes the `eventStream` method in `ResponseFactory` by allowing customization of:  

- **Event Name (`$as`)** – Previously hardcoded as `"update"`, now configurable and each message can also implement the `Illuminate\Contracts\Routing\EventStreamable` interface to customize the name using `streamAs` method.
- **Start Stream Message (`$startStreamWith`)** – Optional message sent before streaming begins.  
- **End Stream Message (`$endStreamWith`)** – Now optional instead of required.  

#### **Why This Change?**

- **More Flexible SSE Handling**: Developers can now specify custom event names, making it easier to differentiate between different types of SSE messages and also they can now decide if they want start/end messages.
- **Improved Client Communication**: Some clients expect an initial message when connecting. The `$startStreamWith` parameter allows for this. 


#### **Implementation Details**

The method signature now includes:  

  ```php
  public function eventStream(
      Closure $callback, 
      array $headers = [], 
      string $as = 'update', 
      ?string $startStreamWith = null, 
      ?string $endStreamWith = '</stream>'
  ) {}
```

This has also been updated to fix the issue raised in the last PR:

> Reverted this PR. The update "as" name should be customizable per update, not for the entire event stream.

I have added the following interface that each message can implement to override the function `$as` parameter.

```php
<?php

namespace Illuminate\Contracts\Routing;

interface EventStreamable
{
    /**
     * Get the name for event streams.
     *
     * @return string
     */
    public function streamAs();
}
```

Example:

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Model;
use Illuminate\Contracts\Routing\EventStreamable;

class Notification extends Model implements EventStreamable
{
    public function streamAs()
    {
        return 'notification';
    }
}
```

Docs PR: https://github.com/laravel/docs/pull/10190