### PR TITLE
[11.x] Allow `readAt` method to use in database channel

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -36,8 +36,8 @@ class DatabaseChannel
                         ? $notification->databaseType($notifiable)
                         : get_class($notification),
             'data' => $this->getData($notifiable, $notification),
-            'read_at' => method_exists($notification, 'readAt')
-                        ? $notification->readAt($notifiable)
+            'read_at' => method_exists($notification, 'initialDatabaseReadAtValue')
+                        ? $notification->initialDatabaseReadAtValue($notifiable)
                         : null,
         ];
     }

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -36,7 +36,9 @@ class DatabaseChannel
                         ? $notification->databaseType($notifiable)
                         : get_class($notification),
             'data' => $this->getData($notifiable, $notification),
-            'read_at' => null,
+            'read_at' => method_exists($notification, 'readAt')
+                        ? $notification->readAt($notifiable)
+                        : null,
         ];
     }
 

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Carbon\Carbon;
 use Illuminate\Notifications\Channels\DatabaseChannel;
 use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Notification;
@@ -60,7 +61,7 @@ class NotificationDatabaseChannelTest extends TestCase
             'id' => 1,
             'type' => 'MONTHLY',
             'data' => ['invoice_id' => 1],
-            'read_at' => null,
+            'read_at' => Carbon::now()->toDateTimeString(),
             'something' => 'else',
         ]);
 
@@ -87,6 +88,11 @@ class NotificationDatabaseChannelCustomizeTypeTestNotification extends Notificat
     public function databaseType()
     {
         return 'MONTHLY';
+    }
+
+    public function readAt()
+    {
+        return Carbon::now();
     }
 }
 

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -90,7 +90,7 @@ class NotificationDatabaseChannelCustomizeTypeTestNotification extends Notificat
         return 'MONTHLY';
     }
 
-    public function readAt()
+    public function initialDatabaseReadAtValue()
     {
         return Carbon::now();
     }


### PR DESCRIPTION
Sometimes, you may want to create only the **markedAsRead** notification in the database driver.

To achieve this, follow these steps:

### Before
1. First way:
```php
protected $listen = [
    \Illuminate\Notifications\Events\NotificationSent::class => [
        \App\Listeners\NotificationSentListener::class,
    ],
];
```

```php
class NotificationSentListener
{
    public function handle(NotificationSent $event)
    {
        // Check if the notification was sent via the database channel
        if ($event->channel === 'database') {
            $notification = $event->notification;
            
            // The notification instance may not have an ID directly,
            // as the event is triggered after being sent to channels.
            // However, you can query the database using known data.
            
            // Mark the notification as read
        }
    }
}
```
2. Second way:
- Overwrite the `buildPayload` method, and whenever the service container requires `DatabaseChannel`, provide the overridden channel!

### After

```php
// In your notification
public function readAt(): Carbon
{
    Carbon::now();
}
```