### PR TITLE
Fix Collection::implode with \Stringable objects (with exception for Eloquent models)

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -628,7 +628,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $first = $this->first();
 
-        if (is_array($first) || (is_object($first) && ! $first instanceof Stringable)) {
+        if (is_array($first) || (is_object($first) && ! $first instanceof \Stringable)) {
             return implode($glue ?? '', $this->pluck($value)->all());
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -628,13 +628,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         $first = $this->first();
+        $pluck = is_array($first) || is_object($first);
 
-        $pluck = match(true) {
-            $first instanceof Model => true,
-            $first instanceof \Stringable => false,
-            is_array($first), is_object($first) => true,
-            default => false,
-        };
+        if ($first instanceof \Stringable && ! $first instanceof Model) {
+            $pluck = false;
+        }
 
         if ($pluck) {
             return implode($glue ?? '', $this->pluck($value)->all());

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -628,7 +629,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $first = $this->first();
 
-        if (is_array($first) || (is_object($first) && ! $first instanceof \Stringable)) {
+        $pluck = match(true) {
+            $first instanceof Model => true,
+            $first instanceof \Stringable => false,
+            is_array($first), is_object($first) => true,
+            default => false,
+        };
+
+        if ($pluck) {
             return implode($glue ?? '', $this->pluck($value)->all());
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2317,16 +2317,19 @@ class SupportCollectionTest extends TestCase
 
 
         $data = new $collection([
-            ['name' => new ByteString('taylor'), 'email' => new ByteString('foo')],
-            ['name' => new ByteString('dayle'), 'email' => new ByteString('bar')],
+            ['name' => new Stringable('taylor'), 'email' => new Stringable('foo')],
+            ['name' => new Stringable('dayle'), 'email' => new Stringable('bar')],
         ]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
-        $data = new $collection([new ByteString('taylor'), new ByteString('dayle')]);
+        $data = new $collection([new Stringable('taylor'), new Stringable('dayle')]);
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
         $this->assertSame('taylor_dayle', $data->implode('_'));
+
+        $data = new $collection([new ByteString('taylor'), new ByteString('dayle')]);
+        $this->assertSame('taylordayle', $data->implode(''));
 
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2328,12 +2328,16 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylor,dayle', $data->implode(','));
         $this->assertSame('taylor_dayle', $data->implode('_'));
 
-        $data = new $collection([new ByteString('taylor'), new ByteString('dayle')]);
-        $this->assertSame('taylordayle', $data->implode(''));
-
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));
         $this->assertSame('taylor-foo,dayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email'], ','));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testImplodeStringable($collection)
+    {
+        $data = new $collection([new ByteString('taylor'), new ByteString('dayle')]);
+        $this->assertSame('taylordayle', $data->implode(''));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2315,7 +2315,6 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
 
-
         $data = new $collection([
             ['name' => new Stringable('taylor'), 'email' => new Stringable('foo')],
             ['name' => new Stringable('dayle'), 'email' => new Stringable('bar')],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
+use Symfony\Component\String\ByteString;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
@@ -2314,14 +2315,15 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
 
+
         $data = new $collection([
-            ['name' => new Stringable('taylor'), 'email' => new Stringable('foo')],
-            ['name' => new Stringable('dayle'), 'email' => new Stringable('bar')],
+            ['name' => new ByteString('taylor'), 'email' => new ByteString('foo')],
+            ['name' => new ByteString('dayle'), 'email' => new ByteString('bar')],
         ]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
-        $data = new $collection([new Stringable('taylor'), new Stringable('dayle')]);
+        $data = new $collection([new ByteString('taylor'), new ByteString('dayle')]);
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
         $this->assertSame('taylor_dayle', $data->implode('_'));


### PR DESCRIPTION
Reimplements https://github.com/laravel/framework/pull/54630, now accounting for Eloquent models, which are `\Stringable`.

Tests now exist for Colletions with `\Stringable`, `\Illuminate\Support\Stringable`, and `\Illuminate\Database\Eloquent\Model`.