### PR TITLE
[11.x] Update ConcurrencyTest exception reference to use namespace

### DIFF
--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -44,7 +44,7 @@ PHP);
 
     public function testRunHandlerProcessErrorCode()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $app = new Application(__DIR__);
         $processDriver = new ProcessDriver($app->make(ProcessFactory::class));
         $processDriver->run([
@@ -54,7 +54,7 @@ PHP);
 
     public function testRunHandlerProcessErrorWithDefaultExceptionWithoutParam()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('This is a different exception');
 
         Concurrency::run([


### PR DESCRIPTION
It's imported via a use in the namespace already, so no need to use global, keeps consistency as elsewhere it's imported too.

Have a good one :)