### PR TITLE
[11.x] Deprecate `Factory::$modelNameResolver`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -114,6 +114,13 @@ abstract class Factory
     public static $namespace = 'Database\\Factories\\';
 
     /**
+     * @deprecated use $modelNameResolvers
+     *
+     * @var callable(self): class-string<TModel>
+     */
+    protected static $modelNameResolver;
+
+    /**
      * The default model name resolvers.
      *
      * @var array<class-string, callable(self): class-string<TModel>>
@@ -810,7 +817,7 @@ abstract class Factory
             return $this->model;
         }
 
-        $resolver = static::$modelNameResolvers[static::class] ?? static::$modelNameResolvers[self::class] ?? function (self $factory) {
+        $resolver = static::$modelNameResolvers[static::class] ?? static::$modelNameResolvers[self::class] ?? static::$modelNameResolver ?? function (self $factory) {
             $namespacedFactoryBasename = Str::replaceLast(
                 'Factory', '', Str::replaceFirst(static::$namespace, '', $factory::class)
             );
@@ -931,6 +938,7 @@ abstract class Factory
      */
     public static function flushState()
     {
+        static::$modelNameResolver = null;
         static::$modelNameResolvers = [];
         static::$factoryNameResolver = null;
         static::$namespace = 'Database\\Factories\\';


### PR DESCRIPTION
Renaming the `$modelNameResolver` property entirely in #54644 was a backwards compatibility break for any user-land and 3rd-party code that happened to touch the original property (see #54665, #54698). While it was a protected, static property inside a framework class, it's a relatively high-touch interface as most developers will extend the `Factory` class, and it's reasonable to assume that there is going to be code out there which touches the model resolver directly.

This PR re-introduces the original property as a fallback without affecting the new methods, but marks it the property as deprecated so that developers and third parties have a chance to migrate correctly without having to avoid other Laravel updates >=v11.42.0.

The doesn't need to be migrated to 12.x - it's a deprecation, and any external libraries that touch the property can handle the change in their migration to supporting 12.x. For the vast majority of users the property change would appear to be a be a low-no impact change, but for anyone that's using any code or libraries that happen to touch the `$modelNameResolver` property on factories, this was a BC break that blows up primarily testing environments.