### PR TITLE
Created simple pagination view for semantic-ui (fomantic-ui)

### DIFF
--- a/src/Illuminate/Pagination/resources/views/semantic-ui.blade.php
+++ b/src/Illuminate/Pagination/resources/views/semantic-ui.blade.php
@@ -2,9 +2,18 @@
     <div class="ui pagination menu" role="navigation">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
-            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+            <a class="icon item disabled"
+               aria-disabled="true"
+               aria-label="@lang('pagination.previous')">
+                @lang('pagination.previous')
+            </a>
         @else
-            <a class="icon item" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')"> <i class="left chevron icon"></i> </a>
+            <a class="icon item"
+               href="{{ $paginator->previousPageUrl() }}"
+               aria-label="@lang('pagination.previous')"
+               rel="prev">
+                @lang('pagination.previous')
+            </a>
         @endif
 
         {{-- Pagination Elements --}}
@@ -18,7 +27,9 @@
             @if (is_array($element))
                 @foreach ($element as $page => $url)
                     @if ($page == $paginator->currentPage())
-                        <a class="item active" href="{{ $url }}" aria-current="page">{{ $page }}</a>
+                        <a class="item active"
+                           href="{{ $url }}"
+                           aria-current="page">{{ $page }}</a>
                     @else
                         <a class="item" href="{{ $url }}">{{ $page }}</a>
                     @endif
@@ -28,9 +39,18 @@
 
         {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
-            <a class="icon item" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+            <a class="icon item"
+               href="{{ $paginator->nextPageUrl() }}"
+               aria-label="@lang('pagination.next')"
+               rel="next">
+                @lang('pagination.next')
+            </a>
         @else
-            <a class="icon item disabled" aria-disabled="true" aria-label="@lang('pagination.next')"> <i class="right chevron icon"></i> </a>
+            <a class="icon item disabled"
+               aria-disabled="true"
+               aria-label="@lang('pagination.next')">
+                @lang('pagination.next')
+            </a>
         @endif
     </div>
 @endif

--- a/src/Illuminate/Pagination/resources/views/simple-semantic-ui.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-semantic-ui.blade.php
@@ -1,0 +1,25 @@
+@if ($paginator->hasPages())
+    <div class="ui equal width grid">
+        {{-- Previous Page Link --}}
+        <div class="left floated column">
+            @if ($paginator->onFirstPage())
+                <a class="ui disabled button" aria-disabled="true"><span>@lang('pagination.previous')</span></a>
+            @else
+                <a class="ui button"
+                   href="{{ $paginator->previousPageUrl() }}"
+                   rel="prev"><i class="left chevron icon"></i>@lang('pagination.previous')</a>
+            @endif
+        </div>
+
+        {{-- Next Page Link --}}
+        <div class="right floated right aligned column">
+            @if ($paginator->hasMorePages())
+                <a class="ui button"
+                   href="{{ $paginator->nextPageUrl() }}"
+                   rel="next">@lang('pagination.next')<i class="right chevron icon"></i></a>
+            @else
+                <a class="ui disabled button" aria-disabled="true"><span>@lang('pagination.next')</span></a>
+            @endif
+        </div>
+    </div>
+@endif

--- a/src/Illuminate/Pagination/resources/views/simple-semantic-ui.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-semantic-ui.blade.php
@@ -7,7 +7,7 @@
             @else
                 <a class="ui button"
                    href="{{ $paginator->previousPageUrl() }}"
-                   rel="prev"><i class="left chevron icon"></i>@lang('pagination.previous')</a>
+                   rel="prev">@lang('pagination.previous')</a>
             @endif
         </div>
 
@@ -16,7 +16,7 @@
             @if ($paginator->hasMorePages())
                 <a class="ui button"
                    href="{{ $paginator->nextPageUrl() }}"
-                   rel="next">@lang('pagination.next')<i class="right chevron icon"></i></a>
+                   rel="next">@lang('pagination.next')</a>
             @else
                 <a class="ui disabled button" aria-disabled="true"><span>@lang('pagination.next')</span></a>
             @endif


### PR DESCRIPTION
Simple pagination view for semantic-ui ([fomantic-ui](https://github.com/fomantic/fomantic-ui))

**First page**
![first_page](https://github.com/user-attachments/assets/6ba37407-b74b-448e-9b4d-c47ad8c56709)

**Between pages**
![between](https://github.com/user-attachments/assets/8d6c022d-de2f-4d17-9346-ad5ed9909f46)

**Last page**
![last_page](https://github.com/user-attachments/assets/fd8ace93-1b8e-4bcd-945c-4a2aef5cced6)

Utilise `equal grid` with `floated column` class so the button link placed between left and right based on the container

