### PR TITLE
Add Refresh to Eloquent Collections and Factory create() Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -830,4 +830,16 @@ class Collection extends BaseCollection implements QueueableCollection
 
         return $model->newModelQuery()->whereKey($this->modelKeys());
     }
+
+    /**
+     * Refresh each model in the collection.
+     *
+     * @return $this
+     */
+    public function refresh()
+    {
+        return $this->map(function (Model $model) {
+            return $model->refresh();
+        });
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -302,7 +302,7 @@ abstract class Factory
             $this->callAfterCreating($results, $parent);
         }
 
-        return $results;
+        return $results->refresh();
     }
 
     /**


### PR DESCRIPTION
## Summary
This update introduces a refresh call to Eloquent collections and integrates it into the create() method within Eloquent's factory.

## Rationale

The primary goal is to maintain consistency between models instantiated by the factory and those created within the application.

## Issue

When using MySQL with an ENUM column that stores only lowercase values (e.g., "test_a", "test_b"), MySQL’s case insensitivity for ENUM values can lead to discrepancies. For instance, if a record is created with "TEST_A" or "TEST_b", MySQL will automatically convert these values to the accepted format ("test_a", "test_b").

Since a factory manually creates a model instance before persisting it, a mismatch can occur between the model's in-memory value and the stored database value:
```PHP
$testModel = TestModel::factory()->create(['enum_col' => 'TEST_A']);

// Model's value
$testModel->enum_col; // "TEST_A"

// Database's value
TestModel::first()->enum_col; // "test_a"
```
## Solution

Adding a refresh() call ensures the model aligns with the database state immediately after creation, preventing inconsistencies.

### Additional Notes

- This change does not introduce new functionality but enhances data integrity.
- Due to MySQL's specific behavior, testing this scenario requires a MySQL instance, which is why this PR does not include automated tests.

Let me know if any further clarification is needed.