### PR TITLE
added `Arr::intersect` collection helper method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -428,6 +428,18 @@ class Arr
     }
 
     /**
+     * Return the values common to all arrays.
+     *
+     * @param  array  $array
+     * @param  array  ...$arrays
+     * @return array
+     */
+    public static function intersect($array, array ...$arrays)
+    {
+        return array_intersect($array, ...$arrays);
+    }
+
+    /**
      * Determines if an array is associative.
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -636,6 +636,36 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isList(['foo' => 'bar', 'baz' => 'qux']));
     }
 
+    public function testIntersectMethod()
+    {
+        // Basic intersection of indexed arrays
+        $array1 = ['a', 'b', 'c'];
+        $array2 = ['b', 'c', 'd'];
+        $this->assertEquals(['1' => 'b', '2' => 'c'], Arr::intersect($array1, $array2));
+
+        // Intersection of multiple arrays
+        $array3 = ['b', 'c', 'e'];
+        $this->assertEquals(['1' => 'b', '2' => 'c'], Arr::intersect($array1, $array2, $array3));
+
+        // Test with associative arrays - keys from first array should be preserved
+        $array4 = ['id1' => 'a', 'id2' => 'b', 'id3' => 'c'];
+        $array5 = ['key1' => 'b', 'key2' => 'c', 'key3' => 'd'];
+        $this->assertEquals(['id2' => 'b', 'id3' => 'c'], Arr::intersect($array4, $array5));
+
+        // Test with numeric arrays with non-sequential keys
+        $array6 = [1 => 'a', 3 => 'b', 5 => 'c'];
+        $array7 = [0 => 'a', 2 => 'b', 4 => 'd'];
+        $this->assertEquals([1 => 'a', 3 => 'b'], Arr::intersect($array6, $array7));
+
+        // Test with empty array
+        $this->assertEquals([], Arr::intersect([], ['a', 'b', 'c']));
+        $this->assertEquals([], Arr::intersect(['a', 'b', 'c'], []));
+
+        // Test with same array (should return all elements)
+        $array8 = ['a', 'b', 'c'];
+        $this->assertEquals($array8, Arr::intersect($array8, $array8));
+    }
+
     public function testOnly()
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];


### PR DESCRIPTION
## Add `Arr::intersect` Method

This PR adds an `Arr::intersect` method to the `Illuminate\Support\Arr` class to provide a consistent wrapper around PHP's native `array_intersect` function.

## Description

We have to switch between Laravel's elegant `Arr` helpers and PHP's native array functions mid-workflow. Adding `Arr::intersect` means one less context switch in the codebase, keeping the API experience consistent and code more readable.

## Tests

Test cases covers the following scenarios:

- Basic intersection between arrays
- Intersections across multiple arrays
- Preserving keys from the first array
- Non-sequential numeric keys
- Edge cases like empty arrays
- Self-intersection
