### PR TITLE
[12.x] Add Model::query($fetchModes) syntactic sugar

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1609,7 +1609,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query, ?array $fetchModes = [])
     {
-        return new static::$builder($query, $fetchModes);
+        return new static::$builder($query, fetchUsing: $fetchModes);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1506,43 +1506,48 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Begin querying the model.
      *
+     * @param  array|null  $fetchModes
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
-    public static function query()
+    public static function query(?array $fetchModes = [])
     {
-        return (new static)->newQuery();
+        return (new static)->newQuery($fetchModes);
     }
 
     /**
      * Get a new query builder for the model's table.
      *
+     * @param  array|null  $fetchModes
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
-    public function newQuery()
+    public function newQuery(?array $fetchModes = [])
     {
-        return $this->registerGlobalScopes($this->newQueryWithoutScopes());
+        return $this->registerGlobalScopes($this->newQueryWithoutScopes($fetchModes));
     }
 
     /**
      * Get a new query builder that doesn't have any global scopes or eager loading.
      *
+     * @param  array|null  $fetchModes
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
-    public function newModelQuery()
+    public function newModelQuery(?array $fetchModes = [])
     {
         return $this->newEloquentBuilder(
-            $this->newBaseQueryBuilder()
+            $this->newBaseQueryBuilder(),
+            $fetchModes
         )->setModel($this);
     }
 
     /**
      * Get a new query builder with no relationships loaded.
      *
+     * @param  array|null  $fetchModes
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
-    public function newQueryWithoutRelationships()
+    public function newQueryWithoutRelationships(?array $fetchModes = [])
     {
-        return $this->registerGlobalScopes($this->newModelQuery());
+        return $this->registerGlobalScopes($this->newModelQuery($fetchModes));
     }
 
     /**
@@ -1563,11 +1568,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get a new query builder that doesn't have any global scopes.
      *
+     * @param  array|null  $fetchModes
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
-    public function newQueryWithoutScopes()
+    public function newQueryWithoutScopes(?array $fetchModes = [])
     {
-        return $this->newModelQuery()
+        return $this->newModelQuery($fetchModes)
             ->with($this->with)
             ->withCount($this->withCount);
     }
@@ -1598,11 +1604,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array|null  $fetchModes
      * @return \Illuminate\Database\Eloquent\Builder<*>
      */
-    public function newEloquentBuilder($query)
+    public function newEloquentBuilder($query, ?array $fetchModes = [])
     {
-        return new static::$builder($query);
+        return new static::$builder($query, $fetchModes);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -258,7 +258,7 @@ class Builder implements BuilderContract
         ConnectionInterface $connection,
         ?Grammar $grammar = null,
         ?Processor $processor = null,
-        ?array $fetchUsing = [],
+        public ?array $fetchUsing = [],
     ) {
         $this->connection = $connection;
         $this->grammar = $grammar ?: $connection->getQueryGrammar();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -250,13 +250,6 @@ class Builder implements BuilderContract
     public $useWritePdo = false;
 
     /**
-     * The custom arguments for the PDOStatement::fetchAll / fetch functions.
-     *
-     * @var array
-     */
-    public array $fetchUsing = [];
-
-    /**
      * Create a new query builder instance.
      *
      * @return void
@@ -265,6 +258,7 @@ class Builder implements BuilderContract
         ConnectionInterface $connection,
         ?Grammar $grammar = null,
         ?Processor $processor = null,
+        ?array $fetchUsing = [],
     ) {
         $this->connection = $connection;
         $this->grammar = $grammar ?: $connection->getQueryGrammar();

--- a/tests/Database/DatabaseEloquentDynamicRelationsTest.php
+++ b/tests/Database/DatabaseEloquentDynamicRelationsTest.php
@@ -101,7 +101,7 @@ class DynamicRelationModel2 extends Model
         //
     }
 
-    public function newQuery()
+    public function newQuery(?array $fetchModes = [])
     {
         $query = new class extends Query
         {


### PR DESCRIPTION
Follow-up to #54734 resp. #54443

Based on comments https://github.com/laravel/framework/pull/54734#issuecomment-2672501873 and https://github.com/laravel/framework/pull/54443#issuecomment-2644726839

You can then do
```php
User::query([PDO::FETCH_UNIQUE])->select(['id','users.*'])->get();
```
without an additional call to `fetchUsing()`

As bert-w has pointed out, this only applies to queries created via a model's `query()` method (or other public methods in that chain), so it may not be an alternative for all cases.