### PR TITLE
[11x.] Improved typehints for `InteractsWithDatabase`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -19,7 +19,7 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
@@ -43,7 +43,7 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
@@ -69,7 +69,7 @@ trait InteractsWithDatabase
     /**
      * Assert the count of table entries.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  int  $count
      * @param  string|null  $connection
      * @return $this
@@ -86,7 +86,7 @@ trait InteractsWithDatabase
     /**
      * Assert that the given table has no entries.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  string|null  $connection
      * @return $this
      */
@@ -102,7 +102,7 @@ trait InteractsWithDatabase
     /**
      * Assert the given record has been "soft deleted".
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @param  string|null  $deletedAtColumn
@@ -134,7 +134,7 @@ trait InteractsWithDatabase
     /**
      * Assert the given record has not been "soft deleted".
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @param  string|null  $deletedAtColumn
@@ -166,7 +166,7 @@ trait InteractsWithDatabase
     /**
      * Assert the given model exists in the database.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $model
      * @return $this
      */
     protected function assertModelExists($model)
@@ -177,7 +177,7 @@ trait InteractsWithDatabase
     /**
      * Assert the given model does not exist in the database.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $model
      * @return $this
      */
     protected function assertModelMissing($model)
@@ -255,7 +255,7 @@ trait InteractsWithDatabase
      * Get the database connection.
      *
      * @param  string|null  $connection
-     * @param  string|null  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @return \Illuminate\Database\Connection
      */
     protected function getConnection($connection = null, $table = null)
@@ -270,7 +270,7 @@ trait InteractsWithDatabase
     /**
      * Get the table name from the given model or string.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @return string
      */
     protected function getTable($table)
@@ -285,7 +285,7 @@ trait InteractsWithDatabase
     /**
      * Get the table connection specified in the given model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @return string|null
      */
     protected function getTableConnection($table)
@@ -300,7 +300,7 @@ trait InteractsWithDatabase
     /**
      * Get the table column name used for soft deletes.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @param  string  $defaultColumnName
      * @return string
      */
@@ -312,7 +312,7 @@ trait InteractsWithDatabase
     /**
      * Get the model entity from the given model or string.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
      * @return \Illuminate\Database\Eloquent\Model|null
      */
     protected function newModelFor($table)
@@ -323,7 +323,7 @@ trait InteractsWithDatabase
     /**
      * Seed a given database connection.
      *
-     * @param  array|string  $class
+     * @param  list<string>|class-string<\Illuminate\Database\Seeder>|string  $class
      * @return $this
      */
     public function seed($class = 'Database\\Seeders\\DatabaseSeeder')

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -20,7 +20,7 @@ trait InteractsWithDatabase
      * Assert that a given where condition exists in the database.
      *
      * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @param  string|null  $connection
      * @return $this
      */
@@ -44,7 +44,7 @@ trait InteractsWithDatabase
      * Assert that a given where condition does not exist in the database.
      *
      * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @param  string|null  $connection
      * @return $this
      */
@@ -103,7 +103,7 @@ trait InteractsWithDatabase
      * Assert the given record has been "soft deleted".
      *
      * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @param  string|null  $connection
      * @param  string|null  $deletedAtColumn
      * @return $this
@@ -135,7 +135,7 @@ trait InteractsWithDatabase
      * Assert the given record has not been "soft deleted".
      *
      * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @param  string|null  $connection
      * @param  string|null  $deletedAtColumn
      * @return $this

--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -25,7 +25,7 @@ class HasInDatabase extends Constraint
     /**
      * The data that will be used to narrow the search in the database table.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $data;
 
@@ -33,7 +33,7 @@ class HasInDatabase extends Constraint
      * Create a new constraint instance.
      *
      * @param  \Illuminate\Database\Connection  $database
-     * @param  array  $data
+     * @param  array<string, mixed>  $data
      * @return void
      */
     public function __construct(Connection $database, array $data)


### PR DESCRIPTION
When I'm using the DB helper functions, if it's been a while, I usually have to check if it accepts a table name, a model instance, or a class-string of the Model. I thought I may help others by making the docblocks more explicit.

Technically class-string is a subtype of string, but I think being a bit more explicit is helpful.

Furthermore, I have made the mistake more than once where I thought I could pass a list of associative arrays to see if they all exist. 😅 