### PR TITLE
[12.x] Add ```UseMiddleware``` Attribute for Controller Methods

### DIFF
--- a/src/Illuminate/Routing/Controllers/Attributes/UseMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/Attributes/UseMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Routing\Controllers\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class UseMiddleware
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array|string  $middlewares
+     * @return void
+     */
+    public function __construct(public array|string $middlewares)
+    {
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1142,12 +1142,18 @@ class Route
             return [];
         }
 
-        $method = new ReflectionMethod($this->getControllerClass(), $this->getControllerMethod());
+        [$controllerClass, $controllerMethod] = [$this->getControllerClass(), $this->getControllerMethod(),];
 
-        return (new Collection($method->getAttributes(UseMiddleware::class)))
-            ->map(fn ($attribute) => $attribute->getArguments())
-            ->flatten()
-            ->all();
+        if (method_exists($controllerClass, $controllerMethod)) {
+            $method = new ReflectionMethod($controllerClass, $controllerMethod);
+
+            return (new Collection($method->getAttributes(UseMiddleware::class)))
+                ->map(fn($attribute) => $attribute->getArguments())
+                ->flatten()
+                ->all();
+        }
+
+        return [];
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1142,13 +1142,13 @@ class Route
             return [];
         }
 
-        [$controllerClass, $controllerMethod] = [$this->getControllerClass(), $this->getControllerMethod(),];
+        [$controllerClass, $controllerMethod] = [$this->getControllerClass(), $this->getControllerMethod()];
 
         if (method_exists($controllerClass, $controllerMethod)) {
             $method = new ReflectionMethod($controllerClass, $controllerMethod);
 
             return (new Collection($method->getAttributes(UseMiddleware::class)))
-                ->map(fn($attribute) => $attribute->getArguments())
+                ->map(fn ($attribute) => $attribute->getArguments())
                 ->flatten()
                 ->all();
         }

--- a/tests/Integration/Routing/AttributeUseMiddlewareTest.php
+++ b/tests/Integration/Routing/AttributeUseMiddlewareTest.php
@@ -13,10 +13,10 @@ class AttributeUseMiddlewareTest extends TestCase
         $route = Route::get('/', [UseMiddlewareTestController::class, 'stringInput']);
         $this->assertEquals($route->methodMiddleware(), ['all']);
 
-        $route = Route::get('/', [HasMiddlewareTestController::class, 'arrayInput']);
+        $route = Route::get('/', [UseMiddlewareTestController::class, 'arrayInput']);
         $this->assertEquals($route->methodMiddleware(), ['all', 'middleware_1']);
 
-        $route = Route::get('/', [HasMiddlewareTestController::class, 'repeat']);
+        $route = Route::get('/', [UseMiddlewareTestController::class, 'repeat']);
         $this->assertEquals($route->methodMiddleware(), ['all', 'middleware_1', 'middleware_2', 'middleware_3']);
     }
 }

--- a/tests/Integration/Routing/AttributeUseMiddlewareTest.php
+++ b/tests/Integration/Routing/AttributeUseMiddlewareTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Controllers\Attributes\UseMiddleware;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class AttributeUseMiddlewareTest extends TestCase
+{
+    public function test_has_middleware_is_respected()
+    {
+        $route = Route::get('/', [UseMiddlewareTestController::class, 'stringInput']);
+        $this->assertEquals($route->methodMiddleware(), ['all']);
+
+        $route = Route::get('/', [HasMiddlewareTestController::class, 'arrayInput']);
+        $this->assertEquals($route->methodMiddleware(), ['all', 'middleware_1']);
+
+        $route = Route::get('/', [HasMiddlewareTestController::class, 'repeat']);
+        $this->assertEquals($route->methodMiddleware(), ['all', 'middleware_1', 'middleware_2', 'middleware_3']);
+    }
+}
+
+class UseMiddlewareTestController
+{
+    #[UseMiddleware('all')]
+    public function stringInput()
+    {
+        //
+    }
+
+    #[UseMiddleware(['all', 'middleware_1'])]
+    public function array()
+    {
+        //
+    }
+
+    #[UseMiddleware(['all'])]
+    #[UseMiddleware('middleware_1')]
+    #[UseMiddleware(['middleware_2', 'middleware_3'])]
+    public function repeat()
+    {
+        //
+    }
+}

--- a/tests/Integration/Routing/AttributeUseMiddlewareTest.php
+++ b/tests/Integration/Routing/AttributeUseMiddlewareTest.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 
 class AttributeUseMiddlewareTest extends TestCase
 {
-    public function test_has_middleware_is_respected()
+    public function test_attribute_use_middleware()
     {
         $route = Route::get('/', [UseMiddlewareTestController::class, 'stringInput']);
         $this->assertEquals($route->methodMiddleware(), ['all']);
@@ -30,7 +30,7 @@ class UseMiddlewareTestController
     }
 
     #[UseMiddleware(['all', 'middleware_1'])]
-    public function array()
+    public function arrayInput()
     {
         //
     }


### PR DESCRIPTION
This PR introduces a new attribute, ```#[UseMiddleware]```, to allow developers to declaratively assign middleware directly on controller methods.

I was spending too much time manually checking which middleware was applied to each controller method. When a controller file grows long and contains numerous methods, it's cumbersome to sift through the middleware assignments—especially when dealing with configurations like `only` and `except`. Or when using traits in controllers, methods defined in these traits often require middleware. I would have to repeatedly declare the necessary middleware in the route configuration or within the controller's middleware declarations.

**Key Features:**
- We can now annotate individual controller methods with the middleware we wish to apply, e.g., #[UseMiddleware('auth')], instead of configuring middleware through route files or centralized controllers
- The attribute supports passing middleware names or class-string

**Example Usage:**
```
use Illuminate\Routing\Controllers\Attributes\UseMiddleware;

class ExampleController extends Controller
{
    #[UseMiddleware('auth')]
    public function index()
    {
        //
    }
}
```

Welcome any feedback or suggestions for improvement on this feature.