### PR TITLE
Update modelKeys to unique

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -355,7 +355,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function modelKeys()
     {
-        return array_unique(array_map(fn ($model) => $model->getKey(), $this->items));
+        return array_values(array_unique(array_map(fn ($model) => $model->getKey(), $this->items)));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -355,7 +355,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function modelKeys()
     {
-        return array_map(fn ($model) => $model->getKey(), $this->items);
+        return array_unique(array_map(fn ($model) => $model->getKey(), $this->items));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -4,8 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
+Mockeryuse Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection as BaseCollection;
@@ -307,6 +306,25 @@ class DatabaseEloquentCollectionTest extends TestCase
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);
+
+        $this->assertEquals([1, 2, 3], $c->modelKeys());
+    }
+
+    public function testCollectionDictionaryReturnsUniqueModelKeys()
+    {
+        $one = Mockery::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = Mockery::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(1);
+
+        $three = Mockery::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturn(2);
+
+        $four = Mockery::mock(Model::class);
+        $four->shouldReceive('getKey')->andReturn(3);
+
+        $c = new Collection([$one, $two, $three, $four]);
 
         $this->assertEquals([1, 2, 3], $c->modelKeys());
     }


### PR DESCRIPTION
### Fix: Prevent Duplicate Keys in `modelKeys()` Method  

This PR updates the `modelKeys()` method in `Illuminate\Database\Eloquent\Collection` to return unique keys:  

```php
public function modelKeys()
{
    return array_unique(array_map(fn ($model) => $model->getKey(), $this->items));
}
```

### Reason for Change

Currently, modelKeys() may return duplicate keys, which can lead to issues in queries where the keys are used, such as:

```php
->toQuery() // Resulting in: WHERE IN (1, 1, 1)
```

These duplicate values are unnecessary and can produce inefficient or misleading queries.

### Benefits
- Prevents redundant where in clauses in queries.
- Improves query performance by reducing unnecessary repetitions.
- Maintains backward compatibility as the change only removes duplicates.

### Impact
This change is backward compatible since it only affects cases where duplicate keys were returned, which are typically redundant in most query scenarios.

