### PR TITLE
[11.x] Remove temporary_url

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -85,13 +85,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
             $command, $expiration, $options
         )->getUri();
 
-        // If an explicit base URL has been set on the disk configuration then we will use
-        // it as the base URL instead of the default path. This allows the developer to
-        // have full control over the base path for this filesystem's generated URLs.
-        if (isset($this->config['temporary_url'])) {
-            $uri = $this->replaceBaseUrl($uri, $this->config['temporary_url']);
-        }
-
         return (string) $uri;
     }
 


### PR DESCRIPTION
Since host is always used in the signature, replacing it with temporary_url is considered an illegal access and Access denied.

Therefore, this code block is unnecessary and should be removed.