### PR TITLE
[12.x] Implement getKeyFromNotifiable to handle Stringable keys in NotificationFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -195,7 +195,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         }
 
         PHPUnit::assertEmpty(
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()] ?? [],
+            $this->notifications[get_class($notifiable)][$this->getKeyFromNotifiable($notifiable)] ?? [],
             'Notifications were sent unexpectedly.',
         );
     }
@@ -279,7 +279,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        return $this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification] ?? [];
+        return $this->notifications[get_class($notifiable)][$this->getKeyFromNotifiable($notifiable)][$notification] ?? [];
     }
 
     /**
@@ -326,7 +326,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 continue;
             }
 
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
+            $this->notifications[get_class($notifiable)][$this->getKeyFromNotifiable($notifiable)][get_class($notification)][] = [
                 'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
                     ? $this->serializeAndRestoreNotification($notification)
                     : $notification,
@@ -339,6 +339,17 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 }),
             ];
         }
+    }
+
+    public function getKeyFromNotifiable($notifiable): mixed
+    {
+        $key = $notifiable->getKey();
+
+        if ($key instanceof \Stringable) {
+            return (string) $key;
+        }
+
+        return $key;
     }
 
     /**

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -215,6 +215,17 @@ class SupportTestingNotificationFakeTest extends TestCase
         });
     }
 
+    public function testAssertSentToWhenNotifiableHasStringableKey()
+    {
+        $user = new UserWithStringableKeyStub;
+
+        $this->fake->send($user, new NotificationStub);
+
+        $this->fake->assertSentTo($user, NotificationStub::class, function ($notification, $channels, $notifiable) use ($user) {
+            return $notifiable === $user;
+        });
+    }
+
     public function testAssertSentToWhenNotifiableHasFalsyShouldSend()
     {
         $user = new LocalizedUserStub;
@@ -253,6 +264,22 @@ class NotificationWithFalsyShouldSendStub extends Notification
     public function shouldSend($notifiable, $channel)
     {
         return false;
+    }
+}
+
+class StringableKey
+{
+    public function __toString(): string
+    {
+        return 'key';
+    }
+}
+
+class UserWithStringableKeyStub extends User
+{
+    public function getKey(): StringableKey
+    {
+        return new StringableKey;
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Why

When attempting to test notification sending for a model where the key is a ValueObject, I encountered errors indicating that the array key is invalid.
```php
class StartJobTest extends TestCase
{
    public function testAssertNotificationSentOnJob(): void
    {
        Notification::fake();

        $user = $this->factory->user();

        $job = new StartJob($user);
        $job->handle();

        Notification::assertSentTo($user, Start::class);
    }
}
```
```
TypeError: Cannot access offset of type App\Infrastructure\Uuid\Uuid on array
/var/www/html/vendor/laravel/framework/src/Illuminate/Support/Testing/Fakes/NotificationFake.php:329
/var/www/html/vendor/laravel/framework/src/Illuminate/Support/Testing/Fakes/NotificationFake.php:294
/var/www/html/app/Telegram/Jobs/StartJob.php:24
/var/www/html/tests/Feature/Telegram/Jobs/StartJobTest.php:32
```

This Pull Request introduces support for handling Stringable keys.
