### PR TITLE
[12.x] Test Improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "league/flysystem-read-only": "^3.25.1",
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
-        "orchestra/testbench-core": "^10.0",
+        "orchestra/testbench-core": "^10.0.0",
         "pda/pheanstalk": "^5.0.6",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -16,7 +16,9 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->serveFiles();
+        $this->booted(function () {
+            $this->serveFiles();
+        });
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -16,9 +16,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->booted(function () {
-            $this->serveFiles();
-        });
+        $this->serveFiles();
     }
 
     /**

--- a/tests/Integration/Cache/Psr6RedisTest.php
+++ b/tests/Integration/Cache/Psr6RedisTest.php
@@ -21,9 +21,9 @@ class Psr6RedisTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
+
+        parent::tearDown();
     }
 
     #[DataProvider('redisClientDataProvider')]

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -25,10 +25,9 @@ class RedisStoreTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
-        m::close();
+
+        parent::tearDown();
     }
 
     public function testCacheTtl(): void

--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -45,13 +45,6 @@ class CallbackSchedulingTest extends TestCase
         $container->instance(SchedulingMutex::class, new CacheSchedulingMutex($cache));
     }
 
-    protected function tearDown(): void
-    {
-        Container::setInstance(null);
-
-        parent::tearDown();
-    }
-
     public function testExecutionOrder()
     {
         $event = $this->app->make(Schedule::class)

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -156,11 +156,9 @@ class ScheduleListCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         putenv('SHELL_VERBOSITY');
 
-        ScheduleListCommand::resolveTerminalWidthUsing(null);
+        parent::tearDown();
     }
 }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -15,13 +15,6 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        Carbon::setTestNow(null);
-    }
-
     protected function afterRefreshingDatabase()
     {
         Schema::create('users', function (Blueprint $table) {

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
@@ -19,13 +18,11 @@ class EloquentMassPrunableTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Container::setInstance($container = new Container);
-
-        $container->singleton(Dispatcher::class, function () {
+        $this->app->singleton(Dispatcher::class, function () {
             return m::mock(Dispatcher::class);
         });
 
-        $container->alias(Dispatcher::class, 'events');
+        $this->app->alias(Dispatcher::class, 'events');
     }
 
     protected function afterRefreshingDatabase()
@@ -92,15 +89,6 @@ class EloquentMassPrunableTest extends DatabaseTestCase
         $this->assertEquals(3000, $count);
         $this->assertEquals(0, MassPrunableSoftDeleteTestModel::count());
         $this->assertEquals(2000, MassPrunableSoftDeleteTestModel::withTrashed()->count());
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        Container::setInstance(null);
-
-        m::close();
     }
 }
 

--- a/tests/Integration/Events/ListenerTest.php
+++ b/tests/Integration/Events/ListenerTest.php
@@ -11,8 +11,6 @@ class ListenerTest extends TestCase
 {
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         ListenerTestListener::$ran = false;
         ListenerTestListenerAfterCommit::$ran = false;
 

--- a/tests/Integration/Foundation/Console/OptimizeCommandTest.php
+++ b/tests/Integration/Foundation/Console/OptimizeCommandTest.php
@@ -14,6 +14,7 @@ class OptimizeCommandTest extends TestCase
     protected $files = [
         'bootstrap/cache/config.php',
         'bootstrap/cache/events.php',
+        'bootstrap/cache/routes-v7.php',
     ];
 
     protected function getPackageProviders($app): array

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -4,8 +4,10 @@ namespace Illuminate\Tests\Integration\Foundation\Support\Providers;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
+#[WithConfig('filesystems.disks.local.serve', false)]
 class RouteServiceProviderHealthTest extends TestCase
 {
     /**

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderTest.php
@@ -8,8 +8,10 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Testing\Assert;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
+#[WithConfig('filesystems.disks.local.serve', false)]
 class RouteServiceProviderTest extends TestCase
 {
     /**

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -32,8 +32,9 @@ class MigratorTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
         Migrator::withoutMigrations([]);
+
+        parent::tearDown();
     }
 
     public function testMigrate()

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -38,9 +38,9 @@ class DeleteModelWhenMissingTest extends QueueTestCase
     #[\Override]
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         DeleteMissingModelJob::$handled = false;
+
+        parent::tearDown();
     }
 
     public function test_deleteModelWhenMissing_and_display_name(): void

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Queue\Console\WorkCommand;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Exceptions;
@@ -32,13 +31,6 @@ class WorkCommandTest extends QueueTestCase
         parent::setUp();
 
         $this->markTestSkippedWhenUsingSyncQueueDriver();
-    }
-
-    protected function tearDown(): void
-    {
-        WorkCommand::flushState();
-
-        parent::tearDown();
     }
 
     public function testRunningOneJob()

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -9,9 +9,11 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 
+#[WithConfig('app.key', 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF')]
 class ImplicitModelRouteBindingTest extends TestCase
 {
     use InteractsWithPublishedFiles;
@@ -19,18 +21,6 @@ class ImplicitModelRouteBindingTest extends TestCase
     protected $files = [
         'routes/testbench.php',
     ];
-
-    protected function tearDown(): void
-    {
-        $this->tearDownInteractsWithPublishedFiles();
-
-        parent::tearDown();
-    }
-
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set(['app.key' => 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF']);
-    }
 
     protected function defineDatabaseMigrations(): void
     {

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -14,13 +14,6 @@ use Orchestra\Testbench\TestCase;
 
 class UrlSigningTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        Carbon::setTestNow(null);
-    }
-
     protected function defineEnvironment($app): void
     {
         $app['config']->set(['app.key' => 'AckfSECXIvnK5r28GVIWUAxmbBSjTsmF']);

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -9,8 +9,10 @@ use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Facade;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
+#[WithConfig('filesystems.disks.local.serve', false)]
 class RouteListCommandTest extends TestCase
 {
     use InteractsWithDeprecationHandling;


### PR DESCRIPTION
* Improves `tearDown()` usage, remove redundant action already handled by `parent::tearDown()`.
* Fix `bootstrap/cache/routes-v7.php` file not removed after testing `optimize` command.