### PR TITLE
[12.x] Fix incorrect typehints in `BuildsWhereDateClauses` traits

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -99,6 +99,8 @@ trait BuildsWhereDateClauses
      * Add an "where" clause to determine if a "date" column is in the past or future.
      *
      * @param  array|string  $columns
+     * @param  string  $operator
+     * @param  string  $boolean
      * @return $this
      */
     protected function wherePastOrFuture($columns, $operator, $boolean)
@@ -197,7 +199,6 @@ trait BuildsWhereDateClauses
      * Add an "or where date" clause to determine if a "date" column is today or before to the query.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
     public function orWhereTodayOrBefore($columns)
@@ -209,7 +210,6 @@ trait BuildsWhereDateClauses
      * Add an "or where date" clause to determine if a "date" column is after today.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
     public function orWhereAfterToday($columns)
@@ -221,7 +221,6 @@ trait BuildsWhereDateClauses
      * Add an "or where date" clause to determine if a "date" column is today or after to the query.
      *
      * @param  array|string  $columns
-     * @param  string  $boolean
      * @return $this
      */
     public function orWhereTodayOrAfter($columns)

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -100,7 +100,7 @@ trait BuildsWhereDateClauses
      *
      * @param  array|string  $columns
      * @param  string  $operator
-     * @param  string  $boolean
+     * @param  string  $boolean 
      * @return $this
      */
     protected function wherePastOrFuture($columns, $operator, $boolean)

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -100,7 +100,7 @@ trait BuildsWhereDateClauses
      *
      * @param  array|string  $columns
      * @param  string  $operator
-     * @param  string  $boolean 
+     * @param  string  $boolean
      * @return $this
      */
     protected function wherePastOrFuture($columns, $operator, $boolean)


### PR DESCRIPTION
Adding a missing `@param` typehints at `wherePastOrFuture` method, and remove the incorrect `@param` typehints for `orWhereTodayOrAfter`, `orWhereAfterToday`, and `orWhereTodayOrBefore` methods