### PR TITLE
Added a new initials method to the Str class that extracts the first …

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2076,8 +2076,8 @@ class Str
     }
 
     /**
-     * @param string $value
-     * @param string $separator
+     * @param  string  $value
+     * @param  string  $separator
      * @return string
      */
     public static function initials(string $value, string $separator = ''): string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2082,6 +2082,6 @@ class Str
      */
     public static function initials(string $value, string $separator = ''): string
     {
-        return implode($separator, array_map(fn($word) => mb_strtoupper(mb_substr($word, 0, 1)), preg_split('/\s+/', trim($value))));
+        return implode($separator, array_map(fn ($word) => mb_strtoupper(mb_substr($word, 0, 1)), preg_split('/\s+/', trim($value))));
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2074,4 +2074,14 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * @param string $value
+     * @param string $separator
+     * @return string
+     */
+    public static function initials(string $value, string $separator = ''): string
+    {
+        return implode($separator, array_map(fn($word) => mb_strtoupper(mb_substr($word, 0, 1)), preg_split('/\s+/', trim($value))));
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2064,6 +2064,16 @@ class Str
     }
 
     /**
+     * @param  string  $value
+     * @param  string  $separator
+     * @return string
+     */
+    public static function initials(string $value, string $separator = '')
+    {
+        return implode($separator, array_map(fn ($word) => mb_strtoupper(mb_substr($word, 0, 1)), preg_split('/\s+/', trim($value))));
+    }
+
+    /**
      * Remove all strings from the casing caches.
      *
      * @return void
@@ -2073,15 +2083,5 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
-    }
-
-    /**
-     * @param  string  $value
-     * @param  string  $separator
-     * @return string
-     */
-    public static function initials(string $value, string $separator = '')
-    {
-        return implode($separator, array_map(fn ($word) => mb_strtoupper(mb_substr($word, 0, 1)), preg_split('/\s+/', trim($value))));
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2080,7 +2080,7 @@ class Str
      * @param  string  $separator
      * @return string
      */
-    public static function initials(string $value, string $separator = ''): string
+    public static function initials(string $value, string $separator = '')
     {
         return implode($separator, array_map(fn ($word) => mb_strtoupper(mb_substr($word, 0, 1)), preg_split('/\s+/', trim($value))));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -471,36 +471,6 @@ class SupportStrTest extends TestCase
         $this->assertEmpty($property->getValue());
     }
 
-    public function testInitials()
-    {
-        // Basic tests
-        $this->assertSame('JD', Str::initials('John Doe'));
-        $this->assertSame('JD', Str::initials('  John   Doe  '));
-        $this->assertSame('J.D', Str::initials('John Doe', '.'));
-
-        // Single word name
-        $this->assertSame('J', Str::initials('John'));
-
-        // Multiple spaces and special characters
-        $this->assertSame('J-D', Str::initials(' John   Doe ', '-'));
-        $this->assertSame('A-B-C', Str::initials('Alice Bob Charlie', '-'));
-
-        // Unicode characters
-        $this->assertSame('ÇÖ', Str::initials('Çağrı Özkan'));
-        $this->assertSame('ÑG', Str::initials('Ñoño García'));
-
-        // Non-alphabetic characters should be ignored
-        $this->assertSame('J2D', Str::initials('John 2 Doe'));
-        $this->assertSame('A-B-C', Str::initials(' Alice! Bob? Charlie.', '-'));
-
-        // Empty string case
-        $this->assertSame('', Str::initials(''));
-
-        // Mixed case input
-        $this->assertSame('JD', Str::initials('john doe'));
-        $this->assertSame('JD', Str::initials('JOHN DOE'));
-    }
-
     public function testFinish()
     {
         $this->assertSame('abbc', Str::finish('ab', 'bc'));
@@ -1787,6 +1757,35 @@ class SupportStrTest extends TestCase
 
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
+    }
+
+    public function testInitials()
+    {
+        $this->assertSame('JD', Str::initials('John Doe'));
+        $this->assertSame('JD', Str::initials('  John   Doe  '));
+        $this->assertSame('J.D', Str::initials('John Doe', '.'));
+
+        // Single word name
+        $this->assertSame('J', Str::initials('John'));
+
+        // Multiple spaces and special characters
+        $this->assertSame('J-D', Str::initials(' John   Doe ', '-'));
+        $this->assertSame('A-B-C', Str::initials('Alice Bob Charlie', '-'));
+
+        // Unicode characters
+        $this->assertSame('ÇÖ', Str::initials('Çağrı Özkan'));
+        $this->assertSame('ÑG', Str::initials('Ñoño García'));
+
+        // Non-alphabetic characters should be ignored
+        $this->assertSame('J2D', Str::initials('John 2 Doe'));
+        $this->assertSame('A-B-C', Str::initials(' Alice! Bob? Charlie.', '-'));
+
+        // Empty string case
+        $this->assertSame('', Str::initials(''));
+
+        // Mixed case input
+        $this->assertSame('JD', Str::initials('john doe'));
+        $this->assertSame('JD', Str::initials('JOHN DOE'));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -471,6 +471,36 @@ class SupportStrTest extends TestCase
         $this->assertEmpty($property->getValue());
     }
 
+    public function testInitials()
+    {
+        // Basic tests
+        $this->assertSame('JD', Str::initials('John Doe'));
+        $this->assertSame('JD', Str::initials('  John   Doe  '));
+        $this->assertSame('J.D', Str::initials('John Doe', '.'));
+
+        // Single word name
+        $this->assertSame('J', Str::initials('John'));
+
+        // Multiple spaces and special characters
+        $this->assertSame('J-D', Str::initials(' John   Doe ', '-'));
+        $this->assertSame('A-B-C', Str::initials('Alice Bob Charlie', '-'));
+
+        // Unicode characters
+        $this->assertSame('ÇÖ', Str::initials('Çağrı Özkan'));
+        $this->assertSame('ÑG', Str::initials('Ñoño García'));
+
+        // Non-alphabetic characters should be ignored
+        $this->assertSame('J2D', Str::initials('John 2 Doe'));
+        $this->assertSame('A-B-C', Str::initials(' Alice! Bob? Charlie.', '-'));
+
+        // Empty string case
+        $this->assertSame('', Str::initials(''));
+
+        // Mixed case input
+        $this->assertSame('JD', Str::initials('john doe'));
+        $this->assertSame('JD', Str::initials('JOHN DOE'));
+    }
+
     public function testFinish()
     {
         $this->assertSame('abbc', Str::finish('ab', 'bc'));


### PR DESCRIPTION
### Overview
This PR introduces a new initials method in the Str class, allowing developers to extract and return the first letter of each word in a given string. The extracted initials are converted to uppercase, and an optional separator can be specified to customize the output format.

### Implementation Details
The method takes a string input and splits it into words based on whitespace.
It extracts the first character of each word, converts it to uppercase, and joins them using an optional separator.
This enhancement improves string manipulation capabilities within Laravel by providing an easy way to generate initials from names, titles, or phrases.
### Example Usage:


```
use Illuminate\Support\Str;

echo Str::initials('John Doe'); // Output: JD
echo Str::initials('Laravel Framework', '-'); // Output: L-F
```

### Why This Change?
Provides a convenient utility for generating initials from strings.
Enhances Laravel’s string manipulation functions.
Useful for cases like user profile initials, acronyms, and formatted abbreviations.
This addition aligns with Laravel's philosophy of developer-friendly utilities and enhances the framework's built-in string operations.
