### PR TITLE
Inconsistent Accessor Attribute Name Conversion Solution

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2327,7 +2327,16 @@ trait HasAttributes
         $class = $reflection->getName();
 
         static::$getAttributeMutatorCache[$class] = (new Collection($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance)))
-            ->mapWithKeys(fn ($match) => [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true])
+            ->mapWithKeys(function ($match) {
+                $standardSnake = lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
+                $alternativeSnake = preg_replace('/(\d+)/', '_$1_', $standardSnake);
+                $alternativeSnake = str_replace('__', '_', $alternativeSnake);
+
+                return [
+                    $standardSnake => true,
+                    $alternativeSnake => true
+                ];
+            })
             ->all();
 
         static::$mutatorCache[$class] = (new Collection(static::getMutatorMethods($class)))

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -335,6 +335,28 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $this->assertNotSame($previous, $previous = $model->virtualDateTimeWithoutCachingFluent);
         }
     }
+
+    public function testInconsistentAccessorAttributeNameConversion()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $model->append('foo1_bar');
+
+        $model->append('foo_1_bar');
+
+        $model->append('foo12_bar');
+
+        $model->append('foo_12_bar');
+
+        $arr = $model->toArray();
+
+        $this->assertTrue(isset($arr['foo_1_bar']));
+        $this->assertTrue(isset($arr['foo_12_bar']));
+        $this->assertTrue(isset($arr['foo1_bar']));
+        $this->assertTrue(isset($arr['foo12_bar']));
+        $this->assertEquals($arr['foo_1_bar'],'yay');
+        $this->assertEquals($arr['foo_12_bar'],'another yay');
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -417,6 +439,24 @@ class TestEloquentModelWithAttributeCast extends Model
         return new Attribute(
             function () {
                 return collect();
+            }
+        );
+    }
+
+    public function foo1Bar(): Attribute
+    {
+        return new Attribute(
+            function () {
+                return "yay";
+            }
+        );
+    }
+
+    public function foo12Bar(): Attribute
+    {
+        return new Attribute(
+            function () {
+                return "another yay";
             }
         );
     }


### PR DESCRIPTION
Hello.

This PR is a solution to the issue [https://github.com/laravel/framework/issues/54570](url) where a custom model attribute is converted into different types of snake cases from camel cases. For example, a custom model attribute `foo1Bar` is converted into both the normal `foo1_bar` & `foo_1_bar` where the number is between the two underscores(_).

### **Purpose**

Developers very often use custom attribute accesors to access existing model attributes & their values. The custom attribute names(methods) are usually written in camel cases inside the Eloquent Model. However, they're usually accessed as snake cases because database table column names are usually accessed as snake cases. Hence it's quite convenient for developers if the camel case name in the Eloquent Model is converted into all types of snake cases when their values are accessed.

### **Usage**

This is how we can use the functionality. First make a custom attribute in the Model:

```
protected function foo1Bar(): Attribute
{
    return Attribute::make(
        get: fn () => 'yay',
    );
}
```

Then I can append the snake case, convert it to array and access the snake case like this:

```
echo $model->foo1_bar; // "yay"
$model->append('foo1_bar');
$model->toArray(); // Works fine.
echo $model['foo1_bar']; //value

echo $model->foo_1_bar; // "yay"
$model->append('foo_1_bar');
$model->toArray(); // Works fine
echo $model['foo_1_bar']; //value
```

### **Code Changes Explanation**

In the following, I show the file `HasAttributes.php` changes inside the `Illuminate/Database/Eloquent/Concerns` directory and the Integration test file `DatabaseEloquentModelAttributeCastingTest.php` inside the `tests/Integration/Database` directory:

`HasAttributes.php`

```
public static function cacheMutatedAttributes($classOrInstance)
    {
        $reflection = new ReflectionClass($classOrInstance);

        $class = $reflection->getName();

        static::$getAttributeMutatorCache[$class] = (new Collection($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance)))
            ->mapWithKeys(function ($match) {
                $standardSnake = lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
                $alternativeSnake = preg_replace('/(\d+)/', '_$1_', $standardSnake);
                $alternativeSnake = str_replace('__', '_', $alternativeSnake);

                return [
                    $standardSnake => true,
                    $alternativeSnake => true
                ];
            })
            ->all();

        static::$mutatorCache[$class] = (new Collection(static::getMutatorMethods($class)))
            ->merge($attributeMutatorMethods)
            ->map(fn ($match) => lcfirst(static::$snakeAttributes ? Str::snake($match) : $match))
            ->all();
    }
```

Here,

 `$standardSnake = lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);` converts the attribute name to snake_case if $snakeAttributes is true & `lcfirst` makes the first character lowercase.
 
 `$alternativeSnake = preg_replace('/(\d+)/', '_$1_', $standardSnake);` Takes any numbers in the string and wraps them with underscores.
 
 `$alternativeSnake = str_replace('__', '_', $alternativeSnake);` replaces any double underscores with single underscores.

This is the Integration Test File:

`DatabaseEloquentModelAttributeCastingTest.php`

```
public function testInconsistentAccessorAttributeNameConversion()
    {
        $model = new TestEloquentModelWithAttributeCast;

        $model->append('foo1_bar');

        $model->append('foo_1_bar');

        $model->append('foo12_bar');

        $model->append('foo_12_bar');

        $arr = $model->toArray();

        $this->assertTrue(isset($arr['foo_1_bar']));
        $this->assertTrue(isset($arr['foo_12_bar']));
        $this->assertTrue(isset($arr['foo1_bar']));
        $this->assertTrue(isset($arr['foo12_bar']));
        $this->assertEquals($arr['foo_1_bar'],'yay');
        $this->assertEquals($arr['foo_12_bar'],'another yay');
    }
```

Inside the `TestEloquentModelWithAttributeCast` Class:

```
public function foo1Bar(): Attribute
    {
        return new Attribute(
            function () {
                return "yay";
            }
        );
    }

    public function foo12Bar(): Attribute
    {
        return new Attribute(
            function () {
                return "another yay";
            }
        );
    }
```

This checks whether both type of snake case conversions from camel case are done when you run `./vendor/bin/phpunit tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php --filter testInconsistentAccessorAttributeNameConversion`

### **Wrap up:**

Overall, I think it is very handy if all types of snake case names in custom model attributes can be used when their values are accessed. I'd like to hear your thoughts.

Regards,
Saif

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
