### PR TITLE
[12.x] Add "whereBoolean" support in route path

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -31,6 +31,17 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters must be boolean.
+     *
+     * @param  array|string  $parameters
+     * @return $this
+     */
+    public function whereBoolean($parameters)
+    {
+        return $this->assignExpressionToParameters($parameters, 'true|false');
+    }
+
+    /**
      * Specify that the given route parameters must be numeric.
      *
      * @param  array|string  $parameters

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -84,6 +84,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar attribute(string $key, mixed $value)
  * @method static \Illuminate\Routing\RouteRegistrar whereAlpha(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereAlphaNumeric(array|string $parameters)
+ * @method static \Illuminate\Routing\RouteRegistrar whereBoolean(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereNumber(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUlid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUuid(array|string $parameters)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1032,6 +1032,19 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereBooleanRegistration()
+    {
+        $wheres = ['foo' => 'true|false', 'bar' => 'true|false'];
+
+        $this->router->get('/{foo}/{bar}')->whereBoolean(['foo', 'bar']);
+        $this->router->get('/api/{bar}/{foo}')->whereBoolean(['bar', 'foo']);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testWhereInRegistration()
     {
         $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];


### PR DESCRIPTION
Add support for boolean in route param:

```php
Route::get('/resource/{active}')->whereBoolean('active');
Route::get('/api/resource/{foo}/{bar}')->whereBoolean(['foo', 'bar']);
```

An minor feature that are fully compatible with the current release (12.x) and previous (11.x)

