### PR TITLE
[13.x] Add missing parameters to `Response` methods `throw()` and `throwIf()`

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -305,14 +305,13 @@ class Response implements ArrayAccess, Stringable
     /**
      * Throw an exception if a server or client error occurred.
      *
+     * @param  null|(\Closure(\Illuminate\Http\Client\Response, \Illuminate\Http\Client\RequestException): mixed)  $callback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throw()
+    public function throw($callback = null)
     {
-        $callback = func_get_args()[0] ?? null;
-
         if ($this->failed()) {
             throw tap($this->toException(), function ($exception) use ($callback) {
                 if ($callback && is_callable($callback)) {
@@ -328,13 +327,14 @@ class Response implements ArrayAccess, Stringable
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
      * @param  \Closure|bool  $condition
+     * @param  null|(\Closure(\Illuminate\Http\Client\Response, \Illuminate\Http\Client\RequestException): mixed)  $callback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throwIf($condition)
+    public function throwIf($condition, $callback = null)
     {
-        return value($condition, $this) ? $this->throw(func_get_args()[1] ?? null) : $this;
+        return value($condition, $this) ? $this->throw($callback) : $this;
     }
 
     /**


### PR DESCRIPTION
This adds a parameter for how `throw()` and `throwIf()` can modify an exception before it is thrown. These previously existed as virtual parameters. They cannot be accurately type-hinted, and the only way a developer would know to use them is if they looked at the source code.

I'm guessing that these were added in a way to not create a breaking change in the framework (~5 years ago). I figured they were worth documenting via the method signature.