### PR TITLE
[12.x] Add `Context::scope()`

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -455,7 +455,7 @@ class Repository
      * @param  callable  $callback
      * @return mixed
      */
-    public function with($data, $hidden, callable $callback): mixed
+    public function with($data, $hidden, callable $callback)
     {
         $dataBefore = $this->data;
         $hiddenBefore = $this->hidden;

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -448,7 +448,7 @@ class Repository
     }
 
     /**
-     * Run the callback function with the given context values and restores to original values when complete.
+     * Run the callback function with the given context values and restore to original state when complete.
      *
      * @param  array<string, mixed>  $data
      * @param  array<string, mixed>  $hidden

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -455,7 +455,7 @@ class Repository
      * @param  array<string, mixed>  $hidden
      * @return mixed
      */
-    public function with(callable $callback, array $data = [], array $hidden = [])
+    public function scope(callable $callback, array $data = [], array $hidden = [])
     {
         $dataBefore = $this->data;
         $hiddenBefore = $this->hidden;

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -450,12 +450,12 @@ class Repository
     /**
      * Run the callback function with the given context values and restore to original state when complete.
      *
+     * @param  callable  $callback
      * @param  array<string, mixed>  $data
      * @param  array<string, mixed>  $hidden
-     * @param  callable  $callback
      * @return mixed
      */
-    public function with($data, $hidden, callable $callback)
+    public function with(callable $callback, array $data = [], array $hidden = [])
     {
         $dataBefore = $this->data;
         $hiddenBefore = $this->hidden;

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -448,6 +448,33 @@ class Repository
     }
 
     /**
+     * Run the callback function with the given context values and restores to original values when complete.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $hidden
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function with($data, $hidden, callable $callback): mixed
+    {
+        $dataBefore = $this->data;
+        $hiddenBefore = $this->hidden;
+
+        if ($data !== []) {
+            $this->add($data);
+        }
+        if ($hidden !== []) {
+            $this->addHidden($hidden);
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $this->data = $dataBefore;
+            $this->hidden = $hiddenBefore;
+        }
+    }
+    /**
      * Determine if the repository is empty.
      *
      * @return bool

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -448,7 +448,7 @@ class Repository
     }
 
     /**
-     * Run the callback function with the given context values and restore to original state when complete.
+     * Run the callback function with the given context values and restore the original context state when complete.
      *
      * @param  callable  $callback
      * @param  array<string, mixed>  $data
@@ -463,6 +463,7 @@ class Repository
         if ($data !== []) {
             $this->add($data);
         }
+
         if ($hidden !== []) {
             $this->addHidden($hidden);
         }

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -474,6 +474,7 @@ class Repository
             $this->hidden = $hiddenBefore;
         }
     }
+
     /**
      * Determine if the repository is empty.
      *

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -513,9 +513,9 @@ class ContextTest extends TestCase
 
         try {
             Context::with(
+                $callback,
                 ['key1' => 'with', 'key3' => 'also-with'],
                 ['hiddenKey3' => 'foobar'],
-                $callback
             );
 
             $this->fail('No exception was thrown.');

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -501,7 +501,7 @@ class ContextTest extends TestCase
         $callback = function () use (&$contextInClosure) {
             $contextInClosure = ['data' => Context::all(), 'hidden' => Context::allHidden()];
 
-            throw new Exception("test_with_sets_keys_and_restores");
+            throw new Exception('test_with_sets_keys_and_restores');
         };
 
         Context::add('key1', 'value1');
@@ -518,8 +518,9 @@ class ContextTest extends TestCase
                 $callback
             );
 
-            $this->fail("No exception was thrown.");
-        } catch (Exception) {}
+            $this->fail('No exception was thrown.');
+        } catch (Exception) {
+        }
 
         $this->assertEqualsCanonicalizing([
             'data' => [

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -494,6 +494,55 @@ class ContextTest extends TestCase
         file_put_contents($path, '');
         Str::createUuidsNormally();
     }
+
+    public function test_with_sets_keys_and_restores()
+    {
+        $contextInClosure = [];
+        $callback = function () use (&$contextInClosure) {
+            $contextInClosure = ['data' => Context::all(), 'hidden' => Context::allHidden()];
+
+            throw new Exception("test_with_sets_keys_and_restores");
+        };
+
+        Context::add('key1', 'value1');
+        Context::add('key2', 123);
+        Context::addHidden([
+            'hiddenKey1' => 'hello',
+            'hiddenKey2' => 'world',
+        ]);
+
+        try {
+            Context::with(
+                ['key1' => 'with', 'key3' => 'also-with'],
+                ['hiddenKey3' => 'foobar'],
+                $callback
+            );
+
+            $this->fail("No exception was thrown.");
+        } catch (Exception) {}
+
+        $this->assertEqualsCanonicalizing([
+            'data' => [
+                'key1' => 'with',
+                'key2' => 123,
+                'key3' => 'also-with',
+            ],
+            'hidden' => [
+                'hiddenKey1' => 'hello',
+                'hiddenKey2' => 'world',
+                'hiddenKey3' => 'foobar',
+            ],
+        ], $contextInClosure);
+
+        $this->assertEqualsCanonicalizing([
+            'key1' => 'value1',
+            'key2' => 123,
+        ], Context::all());
+        $this->assertEqualsCanonicalizing([
+            'hiddenKey1' => 'hello',
+            'hiddenKey2' => 'world',
+        ], Context::allHidden());
+    }
 }
 
 enum Suit

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -495,7 +495,7 @@ class ContextTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function test_with_sets_keys_and_restores()
+    public function test_scope_sets_keys_and_restores()
     {
         $contextInClosure = [];
         $callback = function () use (&$contextInClosure) {
@@ -512,7 +512,7 @@ class ContextTest extends TestCase
         ]);
 
         try {
-            Context::with(
+            Context::scope(
                 $callback,
                 ['key1' => 'with', 'key3' => 'also-with'],
                 ['hiddenKey3' => 'foobar'],


### PR DESCRIPTION
First time using Context outside of request level values, and I have a particularly hairy function that can throw lots of exceptions and calls lots of dependencies. Just for the duration of this action I need logs to contain a particular id, and then it can restore the context once the action is completed.

<details>
<summary>An example similar to what is in our app code</summary>

```php
class PublishSnsNotificationAction
{
    public function __construct(private SnsClient $snsClient) {}

    public function handle($event)
    {
        Context::add('event_id', $event->id);

        try {
            $this->innerHandle($event);
        } finally {
            Context::forget(['event_id', 'sns_message_id']);
        }
    }

    private function innerHandle($event)
    {
        $payload = $this->convertToSnsPayload($event);
        \Log::debug("Created payload", ['payload' => $payload]);

        $result = $this->snsClient->publish($payload);

        \Log::debug("Message ID received: " . $result->get('MessageId'));
        Context::add('sns_message_id', $result->get('MessageId'));

        $this->updateEvent($event, $result);

        \Log::debug("Event updated in DB.");
    }
}
```

</details>

Which could become something like this instead:
```php
public function handle($event)
{
    Context::scope(
        fn () => $this->innerHandle($event),
        ['event_id' => $event->id]
    );
}
```

Not sure how much other people would use this, or how much our team would even use it outside of this particular use case.

It dawns on me as I'm typing this up I have the ability to macro it in, which will be a workable solution if this isn't accepted.

## Documentation
I'm happy to take a run at updating the docs for this, if it is accepted.