### PR TITLE
[12.x] Make the PendingCommand class tappable.

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -21,8 +22,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class PendingCommand
 {
-    use Conditionable;
-    use Macroable;
+    use Conditionable, Macroable, Tappable;
 
     /**
      * The test being run.

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -55,6 +55,16 @@ class ArtisanCommandTest extends TestCase
         Artisan::command('contains', function () {
             $this->line('My name is Taylor Otwell');
         });
+
+        Artisan::command('new-england', function () {
+            $this->line('The region of New England consists of the following states:');
+            $this->info('Connecticut');
+            $this->info('Maine');
+            $this->info('Massachusetts');
+            $this->info('New Hampshire');
+            $this->info('Rhode Island');
+            $this->info('Vermont');
+        });
     }
 
     public function test_console_command_that_passes()
@@ -273,6 +283,27 @@ class ArtisanCommandTest extends TestCase
                 ->expectsOutputToContain('Otwell Taylor')
                 ->assertExitCode(0);
         });
+    }
+
+    public function test_pending_command_can_be_tapped()
+    {
+        $newEngland = [
+            'Connecticut',
+            'Maine',
+            'Massachusetts',
+            'New Hampshire',
+            'Rhode Island',
+            'Vermont',
+        ];
+
+        $this->artisan('new-england')
+            ->expectsOutput('The region of New England consists of the following states:')
+            ->tap(function ($command) use ($newEngland) {
+                foreach ($newEngland as $state) {
+                    $command->expectsOutput($state);
+                }
+            })
+            ->assertExitCode(0);
     }
 
     /**


### PR DESCRIPTION
Similar to the following testing classes:
- `Illuminate\Testing\TestResponse`
- `Illuminate\Mail\Mailable`

I want to make the `Illuminate\Testing\PendingCommand` class tappable too. I find this useful when I have some logics around assertions, or want to assert against a set of items. So I can do all assertions in one go.

I got the following example:

```php
use App\Models\Order;

function test_refunding()
{
    $paidOrders = Order::factory()
        ->count(3)
        ->paid()
        ->create();

    $unpaidOrders = Order::factory()
        ->count(3)
        ->unpaid()
        ->create();

    $this->artisan('orders:refunding', ['--ids' => $paidOrders->merge($unpaidOrders)->implode('id', ', ')])
        ->expectsOutput('Start Refunding...')
        ->tap(function ($command) use ($paidOrders, $unpaidOrders) {
            foreach ($paidOrders as $order) {
                $command->expectsOutput("Order $order->id has been refunded.");
            }

            foreach ($unpaidOrders as $order) {
                $command->expectsOutput("Order $order->id is not yet paid.");
            }
        });
}
```