### PR TITLE
[12.x] Add Redis scheme configuration to database settings

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -153,6 +153,7 @@ return [
         ],
 
         'default' => [
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'username' => env('REDIS_USERNAME'),
@@ -162,6 +163,7 @@ return [
         ],
 
         'cache' => [
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'username' => env('REDIS_USERNAME'),


### PR DESCRIPTION
This PR adds the Redis configuration in database.php by introducing a new option for setting the Redis scheme via an environment variable. 

This eliminates the need to copy and modify the entire Redis configuration in your project’s database.php file, allowing you to rely on the default config while only tweaking the scheme as needed.

I believe this small but useful enhancement will make managing Redis connections more flexible and reduce redundancy in project configurations.