### PR TITLE
[12.x] Prevent Class Creation with Numeric Starting Names in Artisan Commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -159,6 +159,12 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             return false;
         }
 
+        if ($this->doesNotStartWithLetter($this->getNameInput())) {
+            $this->components->error('The name "'.$this->getNameInput().'" must start with a letter, and not a number or special character.');
+
+            return false;
+        }
+
         $name = $this->qualifyClass($this->getNameInput());
 
         $path = $this->getPath($name);
@@ -465,6 +471,17 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
                 ->transform(fn ($name) => strtolower($name))
                 ->all()
         );
+    }
+
+    /**
+     * Checks whether the given name starts with letter.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function doesNotStartWithLetter($name)
+    {
+        return !preg_match('/^[a-zA-Z].*/', $name);
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -159,8 +159,8 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             return false;
         }
 
-        if ($this->doesNotStartWithLetter($this->getNameInput())) {
-            $this->components->error('The name "'.$this->getNameInput().'" must start with a letter, and not a number or special character.');
+        if ($this->doesNotStartWithLetterOrUnderscore($this->getNameInput())) {
+            $this->components->error('The name "'.$this->getNameInput().'" must start with a letter or underscore, and not a number or special character.');
 
             return false;
         }
@@ -479,9 +479,9 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      * @param  string  $name
      * @return bool
      */
-    protected function doesNotStartWithLetter($name)
+    protected function doesNotStartWithLetterOrUnderscore($name)
     {
-        return !preg_match('/^[a-zA-Z].*/', $name);
+        return !preg_match('/(?:^|\/)[_a-zA-Z]/', $name);
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -481,7 +481,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function doesNotStartWithLetterOrUnderscore($name)
     {
-        return !preg_match('/(?:^|\/)[_a-zA-Z]/', $name);
+        return ! preg_match('/(?:^|\/)[_a-zA-Z]/', $name);
     }
 
     /**


### PR DESCRIPTION
### Description:
This PR adds validation to prevent class creation when the provided class name starts with a number. Currently, commands like `make:cast`, `make:enum`, and others allow creating invalid class names (e.g., `123Example`), which leads to errors in PHP as class names cannot start with numeric characters.

**Changes Implemented:**

- Added a validation check to ensure class names do not start with a number.

- Applied this check across all relevant `make:*` commands (e.g., `make:cast`, `make:enum`, `make:controller`, etc.).

- Improved error messaging to inform the user about invalid class names.

**Affected Commands:**

`php artisan make:cast`
`php artisan make:enum`

Other` make:*` commands generating classes.

**Why is this needed?**

- Ensures compliance with PHP naming conventions.

- Prevents invalid class names that would break the application.

- Improves developer experience by providing immediate feedback.

**Testing:**

- Verified class creation works for valid names (ExampleCast).

- Confirmed validation prevents class creation with numeric starting names (123Example).

- Ensured error messages display correctly across different `make:*` commands.

**Checklist:**

-  Validation logic implemented.

-  Error messaging improved.

-  Tested across all applicable commands.

### Before

![image](https://github.com/user-attachments/assets/0a054fd3-f072-4a31-8445-4336d1459530)

![image](https://github.com/user-attachments/assets/cda27ce4-c24d-47bd-9c49-fa4f17226b27)


### After
![image](https://github.com/user-attachments/assets/4aa30acf-66ca-4d1b-9e69-34f239773705)

![image](https://github.com/user-attachments/assets/f4f7da07-a35b-4ea5-ac0a-da0798984611)

