### PR TITLE
[12.x] Add `whereIf()` method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -335,6 +335,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Apply a "where" condition if the given condition is true.
+     *
+     * @param  bool  $condition
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function whereIf($condition, $column, $operator = '=', $value = null)
+    {
+        return $condition ? $this->where($column, $operator, $value) : $this;
+    }
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  (\Closure(static): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2642,6 +2642,38 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         return $query;
     }
+
+    public function testWhereIfAppliesConditionWhenTrue()
+    {
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['where'])
+            ->getMock();
+
+        $builder->expects($this->once())
+            ->method('where')
+            ->with('foo', '=', 'bar')
+            ->willReturnSelf();
+
+        $result = $builder->whereIf(true, 'foo', '=', 'bar');
+
+        $this->assertSame($builder, $result);
+    }
+
+    public function testWhereIfDoesNotApplyConditionWhenFalse()
+    {
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['where'])
+            ->getMock();
+
+        $builder->expects($this->never())
+            ->method('where');
+
+        $result = $builder->whereIf(false, 'foo', '=', 'bar');
+
+        $this->assertSame($builder, $result);
+    }
 }
 
 class EloquentBuilderTestStub extends Model


### PR DESCRIPTION
This PR introduces the `whereIf()` method in `Illuminate\Database\Eloquent\Builder`.

### 🔹 Purpose:
The `whereIf()` method allows conditionally applying a `where()` clause based on a boolean condition.  
This improves readability and eliminates the need for using `when()` for simple conditional filters.

### 🔹 Usage:
```php
// If condition is true, it applies the where clause
User::whereIf(true, 'status', '=', 'active')->get(); 
// Equivalent to ->where('status', '=', 'active')

// If condition is false, it does NOT apply the where clause
User::whereIf(false, 'status', '=', 'active')->get(); 
// Equivalent to User::query()->get() (no additional filter)
