### PR TITLE
[10.x] Remove backticks for db::raw and set them for table.column

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -60,7 +60,9 @@ abstract class Grammar
     public function wrap($value, $prefixAlias = false)
     {
         if ($this->isExpression($value)) {
-            return $this->getValue($value);
+            return $this->wrapRaw(
+                (string) $this->getValue($value)
+            );
         }
 
         // If the value being wrapped has a column alias we will need to separate out
@@ -142,6 +144,21 @@ abstract class Grammar
     protected function wrapJsonSelector($value)
     {
         throw new RuntimeException('This database engine does not support JSON operations.');
+    }
+
+    /**
+     * Wrap raw string where table and columns are given. Will remove backticks.
+     *
+     * @param string $value
+     * @return string
+     */
+    public function wrapRaw(string $value): string
+    {
+        return preg_replace(
+            '/(\w+)[.](\w+)+/',
+            '`$1`.`$2`',
+            str_replace('`', '', $this->getValue($value))
+        );
     }
 
     /**


### PR DESCRIPTION
Discussion: https://github.com/laravel/framework/discussions/54814?sort=new

**Issue:**

The exception I got was: "SQLSTATE[H093] Invalid parameter number (Connection: mysq, select ...)". There where no reserved keywords.

The query builder throws errors in some cases where backticks are not used on raw queries on execution.
If you execute the dumped query by sentry it will execute in mysql.

**Products:**

- Mysql 8
- php8.3
- laravel 10

**Solution:**

Enforce backticks on raw expressions.
Remove all backticks and add them where the combination of table and column are used.

```php
$value = 'ROUND(cs`.credit)';

var_dump( preg_replace(
	'/(\w+)[.](\w+)+/',
	'`$1`.`$2`',
	str_replace('`', '', $value)
));
```

```php
public function wrap($value, $prefixAlias = false)
    {
        if ($this->isExpression($value)) {
            return $this->wrapRaw(
                (string) $this->getValue($value)
            );
        }

        .....
    }

public function wrapRaw(string $value): string
    {
        return preg_replace(
            '/(\w+)[.](\w+)+/',
            '`$1`.`$2`',
            str_replace('`', '', $this->getValue($value))
        );
    }
```