### PR TITLE
[12.x] Fix pluck on `EloquentBuilder`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3348,9 +3348,10 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string|null  $key
+     * @param  bool  $returnOriginal
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */
-    public function pluck($column, $key = null)
+    public function pluck($column, $key = null, $returnOriginal = false)
     {
         // First, we will need to select the results of the query accounting for the
         // given columns / key. Once we have the results, we will be able to take
@@ -3377,8 +3378,8 @@ class Builder implements BuilderContract
 
         return $this->applyAfterQueryCallbacks(
             is_array($queryResult[0])
-                    ? $this->pluckFromArrayColumn($queryResult, $column, $key)
-                    : $this->pluckFromObjectColumn($queryResult, $column, $key)
+                    ? $this->pluckFromArrayColumn($queryResult, $column, $key, $returnOriginal)
+                    : $this->pluckFromObjectColumn($queryResult, $column, $key, $returnOriginal)
         );
     }
 
@@ -3409,19 +3410,20 @@ class Builder implements BuilderContract
      * @param  array  $queryResult
      * @param  string  $column
      * @param  string  $key
+     * @param  bool  $needFullObject
      * @return \Illuminate\Support\Collection
      */
-    protected function pluckFromObjectColumn($queryResult, $column, $key)
+    protected function pluckFromObjectColumn($queryResult, $column, $key, $needFullObject)
     {
         $results = [];
 
         if (is_null($key)) {
             foreach ($queryResult as $row) {
-                $results[] = $row->$column;
+                $results[] = $needFullObject ? $row : $row->$column;
             }
         } else {
             foreach ($queryResult as $row) {
-                $results[$row->$key] = $row->$column;
+                $results[$row->$key] = $needFullObject ? $row : $row->$column;
             }
         }
 
@@ -3434,19 +3436,20 @@ class Builder implements BuilderContract
      * @param  array  $queryResult
      * @param  string  $column
      * @param  string  $key
+     * @param  bool  $needFullArray
      * @return \Illuminate\Support\Collection
      */
-    protected function pluckFromArrayColumn($queryResult, $column, $key)
+    protected function pluckFromArrayColumn($queryResult, $column, $key, $needFullArray)
     {
         $results = [];
 
         if (is_null($key)) {
             foreach ($queryResult as $row) {
-                $results[] = $row[$column];
+                $results[] = $needFullArray ? $row : $row[$column];
             }
         } else {
             foreach ($queryResult as $row) {
-                $results[$row[$key]] = $row[$column];
+                $results[$row[$key]] = $needFullArray ? $row : $row[$column];
             }
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3348,10 +3348,9 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string|null  $key
-     * @param  bool  $returnOriginal
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */
-    public function pluck($column, $key = null, $returnOriginal = false)
+    public function pluck($column, $key = null)
     {
         // First, we will need to select the results of the query accounting for the
         // given columns / key. Once we have the results, we will be able to take
@@ -3378,8 +3377,8 @@ class Builder implements BuilderContract
 
         return $this->applyAfterQueryCallbacks(
             is_array($queryResult[0])
-                    ? $this->pluckFromArrayColumn($queryResult, $column, $key, $returnOriginal)
-                    : $this->pluckFromObjectColumn($queryResult, $column, $key, $returnOriginal)
+                    ? $this->pluckFromArrayColumn($queryResult, $column, $key)
+                    : $this->pluckFromObjectColumn($queryResult, $column, $key)
         );
     }
 
@@ -3410,20 +3409,19 @@ class Builder implements BuilderContract
      * @param  array  $queryResult
      * @param  string  $column
      * @param  string  $key
-     * @param  bool  $needFullObject
      * @return \Illuminate\Support\Collection
      */
-    protected function pluckFromObjectColumn($queryResult, $column, $key, $needFullObject)
+    protected function pluckFromObjectColumn($queryResult, $column, $key)
     {
         $results = [];
 
         if (is_null($key)) {
             foreach ($queryResult as $row) {
-                $results[] = $needFullObject ? $row : $row->$column;
+                $results[] = $row->$column;
             }
         } else {
             foreach ($queryResult as $row) {
-                $results[$row->$key] = $needFullObject ? $row : $row->$column;
+                $results[$row->$key] = $row->$column;
             }
         }
 
@@ -3436,20 +3434,19 @@ class Builder implements BuilderContract
      * @param  array  $queryResult
      * @param  string  $column
      * @param  string  $key
-     * @param  bool  $needFullArray
      * @return \Illuminate\Support\Collection
      */
-    protected function pluckFromArrayColumn($queryResult, $column, $key, $needFullArray)
+    protected function pluckFromArrayColumn($queryResult, $column, $key)
     {
         $results = [];
 
         if (is_null($key)) {
             foreach ($queryResult as $row) {
-                $results[] = $needFullArray ? $row : $row[$column];
+                $results[] = $row[$column];
             }
         } else {
             foreach ($queryResult as $row) {
-                $results[$row[$key]] = $needFullArray ? $row : $row[$column];
+                $results[$row[$key]] = $row[$column];
             }
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -638,10 +638,15 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheMutatedAttributesOfAModel()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('name', '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
+        $builder->getQuery()->shouldReceive('get')->with(['name'])->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(true);
+        $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
+        $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'baz'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'baz']));
 
@@ -650,8 +655,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheCastedAttributesOfAModel()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('name', '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
+        $builder->getQuery()->shouldReceive('get')->with(['name'])->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
@@ -663,8 +672,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheDateAttributesOfAModel()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->created_at = '2010-01-01 00:00:00';
+        $results[1]->created_at = '2011-01-01 00:00:00';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('created_at', '', true)->andReturn(new BaseCollection([['created_at' => '2010-01-01 00:00:00'], ['created_at' => '2011-01-01 00:00:00']]));
+        $builder->getQuery()->shouldReceive('get')->with(['created_at'])->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('created_at')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('created_at')->andReturn(false);
@@ -680,8 +693,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('name')->andReturn('foo_table.name');
 
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('name'), '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
+        $builder->getQuery()->shouldReceive('get')->with([$model->qualifyColumn('name')])->andReturn(new BaseCollection($results));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
@@ -695,8 +712,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('name')->andReturn('foo_table.name');
 
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('name'), '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
+        $builder->getQuery()->shouldReceive('get')->with([$model->qualifyColumn('name')])->andReturn(new BaseCollection($results));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
@@ -711,8 +732,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('created_at')->andReturn('foo_table.created_at');
 
+        $results = [new stdClass, new stdClass];
+        $results[0]->created_at = '2010-01-01 00:00:00';
+        $results[1]->created_at = '2011-01-01 00:00:00';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('created_at'), '', true)->andReturn(new BaseCollection([['created_at' => '2010-01-01 00:00:00'], ['created_at' => '2011-01-01 00:00:00']]));
+        $builder->getQuery()->shouldReceive('get')->with([$model->qualifyColumn('created_at')])->andReturn(new BaseCollection($results));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('created_at')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('created_at')->andReturn(false);
@@ -725,8 +750,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckWithoutModelGetterJustReturnsTheAttributesFoundInDatabase()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('name', '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
+        $builder->getQuery()->shouldReceive('get')->with(['name'])->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(false);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -638,8 +638,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheMutatedAttributesOfAModel()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
@@ -650,8 +654,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheCastedAttributesOfAModel()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
@@ -663,8 +671,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheDateAttributesOfAModel()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->created_at = '2010-01-01 00:00:00';
+        $results[1]->created_at = '2011-01-01 00:00:00';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('created_at', '')->andReturn(new BaseCollection(['2010-01-01 00:00:00', '2011-01-01 00:00:00']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('created_at')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('created_at')->andReturn(false);
@@ -680,8 +692,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('name')->andReturn('foo_table.name');
 
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('name'), '')->andReturn(new BaseCollection(['bar', 'baz']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
@@ -695,8 +711,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('name')->andReturn('foo_table.name');
 
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('name'), '')->andReturn(new BaseCollection(['bar', 'baz']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
@@ -711,8 +731,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('created_at')->andReturn('foo_table.created_at');
 
+        $results = [new stdClass, new stdClass];
+        $results[0]->created_at = '2010-01-01 00:00:00';
+        $results[1]->created_at = '2011-01-01 00:00:00';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('created_at'), '')->andReturn(new BaseCollection(['2010-01-01 00:00:00', '2011-01-01 00:00:00']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('created_at')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('created_at')->andReturn(false);
@@ -725,8 +749,12 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckWithoutModelGetterJustReturnsTheAttributesFoundInDatabase()
     {
+        $results = [new stdClass, new stdClass];
+        $results[0]->name = 'bar';
+        $results[1]->name = 'baz';
+
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(new BaseCollection(['bar', 'baz']));
+        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(false);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -638,12 +638,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheMutatedAttributesOfAModel()
     {
-        $results = [new stdClass, new stdClass];
-        $results[0]->name = 'bar';
-        $results[1]->name = 'baz';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with('name', '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
@@ -654,12 +650,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheCastedAttributesOfAModel()
     {
-        $results = [new stdClass, new stdClass];
-        $results[0]->name = 'bar';
-        $results[1]->name = 'baz';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with('name', '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
@@ -671,12 +663,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckReturnsTheDateAttributesOfAModel()
     {
-        $results = [new stdClass, new stdClass];
-        $results[0]->created_at = '2010-01-01 00:00:00';
-        $results[1]->created_at = '2011-01-01 00:00:00';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with('created_at', '', true)->andReturn(new BaseCollection([['created_at' => '2010-01-01 00:00:00'], ['created_at' => '2011-01-01 00:00:00']]));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('created_at')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('created_at')->andReturn(false);
@@ -692,12 +680,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('name')->andReturn('foo_table.name');
 
-        $results = [new stdClass, new stdClass];
-        $results[0]->name = 'bar';
-        $results[1]->name = 'baz';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('name'), '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
@@ -711,12 +695,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('name')->andReturn('foo_table.name');
 
-        $results = [new stdClass, new stdClass];
-        $results[0]->name = 'bar';
-        $results[1]->name = 'baz';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('name'), '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(true);
@@ -731,12 +711,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('qualifyColumn')->with('created_at')->andReturn('foo_table.created_at');
 
-        $results = [new stdClass, new stdClass];
-        $results[0]->created_at = '2010-01-01 00:00:00';
-        $results[1]->created_at = '2011-01-01 00:00:00';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with($model->qualifyColumn('created_at'), '', true)->andReturn(new BaseCollection([['created_at' => '2010-01-01 00:00:00'], ['created_at' => '2011-01-01 00:00:00']]));
         $builder->setModel($model);
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('created_at')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('created_at')->andReturn(false);
@@ -749,12 +725,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testPluckWithoutModelGetterJustReturnsTheAttributesFoundInDatabase()
     {
-        $results = [new stdClass, new stdClass];
-        $results[0]->name = 'bar';
-        $results[1]->name = 'baz';
-
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('get')->andReturn(new BaseCollection($results));
+        $builder->getQuery()->shouldReceive('pluck')->with('name', '', true)->andReturn(new BaseCollection([['name' => 'bar'], ['name' => 'baz']]));
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasAnyGetMutator')->with('name')->andReturn(false);
         $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(false);


### PR DESCRIPTION
## Issue: `pluck` Returns Empty Values  

When trying to `pluck` data from the `users` table, the output is broken after a team member added a new attribute. Even when using `select`, the issue persists.  

### Problematic Behavior  

#### `users` Table  

| `id` | `name`       | `first_name` | `last_name` | `created_at`          |  
|------|-------------|-------------|------------|-----------------------|  
| 1    | John Doe    | John        | Doe        | 2024-02-27 10:00:00   |  
| 2    | Alice Smith | Alice       | Smith      | 2024-02-26 12:30:45   |  
| 3    | Bob Johnson | Bob         | Johnson    | 2024-02-25 08:15:20   |  

#### `App\Models\User`  
```php
class User extends Model
{
    protected function name(): Attribute
    {
        return Attribute::make(
            get: fn () => $this->first_name . ' ' . $this->last_name
        );
    }
}
```

#### Usage
```php
User::query()
    ->select('id', 'first_name', 'last_name', 'name')
    // ->get()
    ->pluck('name', 'id');
```

#### Output
```json
{
    "1": " ",
    "2": " ",
    "3": " "
}
```