### PR TITLE
[13.x] Fix scope removal in nested where conditions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -326,6 +326,9 @@ class Builder implements BuilderContract
 
             $this->eagerLoad = array_merge($this->eagerLoad, $query->getEagerLoads());
 
+            $this->withoutGlobalScopes(
+                $query->removedScopes()
+            );
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
             $this->query->where(...func_get_args());

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1042,6 +1042,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $nestedQuery->shouldReceive('getEagerLoads')->once()->andReturn([]);
+        $nestedQuery->shouldReceive('removedScopes')->once()->andReturn([]);
         $model = $this->getMockModel()->makePartial();
         $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();
@@ -1104,6 +1105,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $nestedQuery->shouldReceive('getEagerLoads')->once()->andReturn([]);
+        $nestedQuery->shouldReceive('removedScopes')->once()->andReturn([]);
         $model = $this->getMockModel()->makePartial();
         $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();
@@ -1133,6 +1135,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $nestedQuery->shouldReceive('getEagerLoads')->once()->andReturn([]);
+        $nestedQuery->shouldReceive('removedScopes')->once()->andReturn([]);
         $model = $this->getMockModel()->makePartial();
         $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -147,6 +147,38 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals($mainQuery, $query->toSql());
         $this->assertEquals(['bar', 1, 'baz', 1], $query->getBindings());
     }
+
+    public function testRegularScopesThatRemoveGlobalScopes()
+    {
+        $query = EloquentClosureGlobalScopesTestModel::where('foo', 'foo')->approved()->notApproved();
+
+        $this->assertSame('select * from "table" where "foo" = ? and ("approved" = ? or "should_approve" = ?) and ("approved" = ? or "should_approve" = ?) order by "name" asc', $query->toSql());
+        $this->assertEquals(['foo', 1, 0, 0, 1], $query->getBindings());
+    }
+
+    public function testRegularScopesThatRemoveGlobalScopesCalledInNestedWhereCondition()
+    {
+        $query = EloquentClosureGlobalScopesTestModel::where('foo', 'foo')->where(function ($query) {
+            $query->approved();
+            $query->orWhere(function ($query) {
+                $query->notApproved();
+            });
+        });
+
+        $this->assertSame('select * from "table" where "foo" = ? and (("approved" = ? or "should_approve" = ?) or (("approved" = ? or "should_approve" = ?))) order by "name" asc', $query->toSql());
+        $this->assertEquals(['foo', 1, 0, 0, 1], $query->getBindings());
+    }
+
+    public function testRemovingGlobalScopeInNestedWhereCondition()
+    {
+        $query = EloquentClosureGlobalScopesTestModel::where('foo', 'foo')->where(function ($query) {
+            $query->approved();
+            $query->withoutGlobalScope('active_scope');
+        });
+
+        $this->assertSame('select * from "table" where "foo" = ? and (("approved" = ? or "should_approve" = ?)) order by "name" asc', $query->toSql());
+        $this->assertEquals(['foo', 1, 0], $query->getBindings());
+    }
 }
 
 class EloquentClosureGlobalScopesTestModel extends Model
@@ -169,6 +201,11 @@ class EloquentClosureGlobalScopesTestModel extends Model
     public function scopeApproved($query)
     {
         return $query->where('approved', 1)->orWhere('should_approve', 0);
+    }
+
+    public function scopeNotApproved($query)
+    {
+        return $query->where('approved', 0)->orWhere('should_approve', 1)->withoutGlobalScope('active_scope');
     }
 
     public function scopeOrApproved($query)


### PR DESCRIPTION
If you remove a scope in a nested where condition, it is never copied over from the nested query builder and applied to the root query builder. This would happen when calling a scope like `onlyTrashed`, which removes the global soft deletes scope, in a nested where.

This could possibly be a breaking change since scopes that were previously not removed would start being removed.