### PR TITLE
Add Str::isEmail() method to validate email addresses

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2041,14 +2041,15 @@ class Str
     }
 
     /**
-     * @param  string  $string
+     * Determine if a given value is valid Email.
+     *
+     * @param  string  $value
      * @return bool
      */
-    public static function isEmail(string $string)
+    public static function isEmail(string $value)
     {
-        return filter_var($string, FILTER_VALIDATE_EMAIL) !== false;
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
     }
-
 
     /**
      * Always return the same ULID when generating new ULIDs.

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2041,6 +2041,16 @@ class Str
     }
 
     /**
+     * @param  string  $string
+     * @return bool
+     */
+    public static function isEmail(string $string)
+    {
+        return filter_var($string, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+
+    /**
      * Always return the same ULID when generating new ULIDs.
      *
      * @param  Closure|null  $callback

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1677,6 +1677,20 @@ class SupportStrTest extends TestCase
         Str::createUlidsNormally();
     }
 
+    public function testIsEmail()
+    {
+        $this->assertTrue(Str::isEmail('test@example.com'));
+        $this->assertTrue(Str::isEmail('user.name+tag+sorting@example.com'));
+        $this->assertTrue(Str::isEmail('x@example.com'));
+        $this->assertTrue(Str::isEmail('example@s.solutions'));
+        $this->assertFalse(Str::isEmail('plainaddress'));
+        $this->assertFalse(Str::isEmail('missing@domain'));
+        $this->assertFalse(Str::isEmail('@missinguser.com'));
+        $this->assertFalse(Str::isEmail('user@.com'));
+        $this->assertFalse(Str::isEmail('user@domain..com'));
+        $this->assertFalse(Str::isEmail(''));
+    }
+
     public function testItCanSpecifyAFallbackForAUlidSequence()
     {
         Str::createUlidsUsingSequence(


### PR DESCRIPTION

This PR introduces a new helper method, Str::isEmail(), to the Illuminate\Support\Str class. The method validates whether a given string is a valid email address using PHP's filter_var() function with the FILTER_VALIDATE_EMAIL flag.

**Motivation & Use Case**
Provides a convenient and expressive way to check if a string is a valid email address without needing to use filter_var() manually.
Improves code readability and consistency when validating email addresses in Laravel applications.
**Implementation Details**
The method uses filter_var($string, FILTER_VALIDATE_EMAIL) !== false to determine if a string is a valid email.
Returns true if the string is a valid email, otherwise returns false.
****Example Usage****

```
use Illuminate\Support\Str;

Str::isEmail('user@example.com'); // true
Str::isEmail('invalid-email');    // false
Str::isEmail('user@domain');      // false
Str::isEmail('user@.com');        // false
```

