### PR TITLE
Add Tests for Handling Null Primary Keys and Special Values in Unique Validation Rule

### DIFF
--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -103,6 +103,21 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->onlyTrashed('softdeleted_at');
         $this->assertSame('unique:table,NULL,NULL,id,softdeleted_at,"NOT_NULL"', (string) $rule);
     }
+
+    public function testItHandlesNullPrimaryKeyInIgnoreModel()
+    {
+        $model = new EloquentModelStub(['id_column' => null]);
+
+        $rule = new Unique('table', 'column');
+        $rule->ignore($model);
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:table,column,NULL,id_column,foo,"bar"', (string) $rule);
+
+        $rule = new Unique('table', 'column');
+        $rule->ignore($model, 'id_column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:table,column,NULL,id_column,foo,"bar"', (string) $rule);
+    }
 }
 
 class EloquentModelStub extends Model

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -118,6 +118,25 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('unique:table,column,NULL,id_column,foo,"bar"', (string) $rule);
     }
+
+    public function testItHandlesWhereWithSpecialValues()
+    {
+        $rule = new Unique('table', 'column');
+        $rule->where('foo', null);
+        $this->assertSame('unique:table,column,NULL,id,foo,"NULL"', (string) $rule);
+
+        $rule = new Unique('table', 'column');
+        $rule->whereNull('foo');
+        $this->assertSame('unique:table,column,NULL,id,foo,"NULL"', (string) $rule);
+
+        $rule = new Unique('table', 'column');
+        $rule->whereNotNull('foo');
+        $this->assertSame('unique:table,column,NULL,id,foo,"NOT_NULL"', (string) $rule);
+
+        $rule = new Unique('table', 'column');
+        $rule->where('foo', 0);
+        $this->assertSame('unique:table,column,NULL,id,foo,"0"', (string) $rule);
+    }
 }
 
 class EloquentModelStub extends Model


### PR DESCRIPTION
This PR adds two test cases to the `ValidationUniqueRuleTest` class to handle edge cases in the Unique validation rule:

**Null Primary Key in Ignored Models:**

The test `testItHandlesNullPrimaryKeyInIgnoreModel` ensures the Unique rule correctly handles models with a null primary key when using the ignore method. This is important for newly created but unsaved models.
Special Values in where Clauses:

The test `testItHandlesWhereWithSpecialValues` checks how the where method handles special values like null, 0, and NOT_NULL in conditions. This ensures the correct formatting of these values in the validation rule string.

**Why These Tests Are Important:**

These tests cover edge cases (like null primary keys and special values) that can lead to unexpected behavior or bugs if not handled correctly.

Proper handling of these cases ensures that validation and database queries are consistent and reliable.

**Expected Outcome:**

The tests ensure that the Unique validation rule formats validation strings correctly when handling models with null primary keys and special values in where clauses.

This improves test coverage and reduces the likelihood of issues in production.