### PR TITLE
Fix: Prevent Conflicting Use of onlyTrashed() and withoutTrashed() in Validation Rules

### DIFF
--- a/src/Illuminate/Validation/InvalidSoftDeleteQueryException.php
+++ b/src/Illuminate/Validation/InvalidSoftDeleteQueryException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use RuntimeException;
+
+class InvalidSoftDeleteQueryException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Validation/InvalidSoftDeleteQueryException.php
+++ b/src/Illuminate/Validation/InvalidSoftDeleteQueryException.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Validation;
 
-use RuntimeException;
+use LogicException;
 
-class InvalidSoftDeleteQueryException extends RuntimeException
+class InvalidSoftDeleteQueryException extends LogicException
 {
     //
 }

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -5,8 +5,8 @@ namespace Illuminate\Validation\Rules;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Validation\InvalidSoftDeleteQueryException;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\InvalidSoftDeleteQueryException;
 
 use function Illuminate\Support\enum_value;
 

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Validation;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\InvalidSoftDeleteQueryException;
 use Illuminate\Validation\Rules\Unique;
 use PHPUnit\Framework\TestCase;
 
@@ -103,6 +104,27 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->onlyTrashed('softdeleted_at');
         $this->assertSame('unique:table,NULL,NULL,id,softdeleted_at,"NOT_NULL"', (string) $rule);
     }
+
+    public function testItThrowsExceptionWhenUsingBothWithoutTrashedAndOnlyTrashed()
+    {
+        $this->expectException(InvalidSoftDeleteQueryException::class);
+        $this->expectExceptionMessage("Cannot use 'onlyTrashed()' when 'withoutTrashed()' is already applied.");
+
+        $rule = new Unique('table');
+        $rule->withoutTrashed();
+        $rule->onlyTrashed(); // This should trigger the exception
+    }
+
+    public function testItThrowsExceptionWhenUsingBothOnlyTrashedAndWithoutTrashed()
+    {
+        $this->expectException(InvalidSoftDeleteQueryException::class);
+        $this->expectExceptionMessage("Cannot use 'withoutTrashed()' when 'onlyTrashed()' is already applied.");
+
+        $rule = new Unique('table');
+        $rule->onlyTrashed();
+        $rule->withoutTrashed(); // This should trigger the exception
+    }
+
 }
 
 class EloquentModelStub extends Model

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -124,7 +124,6 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->onlyTrashed();
         $rule->withoutTrashed(); // This should trigger the exception
     }
-
 }
 
 class EloquentModelStub extends Model


### PR DESCRIPTION
This PR resolves this issue #54821 

## Fix Summary

- Added a validation check to throw an exception when both `onlyTrashed()` and `withoutTrashed()` are used on the same rule.
- Introduced new test cases to ensure the exception is correctly triggered.

### Before Fix

- No exception is thrown, leading to ambiguous behavior.

### After Fix

- An exception is raised, preventing invalid usage.

## Impact

This fix enforces logical consistency in validation rules and prevents developers from unknowingly writing invalid queries. It enhances code predictability and improves the overall developer experience.

## Tests Added

- Test for exception when both `onlyTrashed()` and `withoutTrashed()` are used together.
- Ensured backward compatibility by allowing each method independently.

