### PR TITLE
Added needed postgresql connection string options

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -91,7 +91,9 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $dsn .= ";application_name='".str_replace("'", "\'", $application_name)."'";
         }
 
-        return $this->addSslOptions($dsn, $config);
+        $dsn = $this->addSslOptions($dsn, $config);
+
+        return $this->addPostgresOptions($dsn, $config);
     }
 
     /**
@@ -103,7 +105,61 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function addSslOptions($dsn, array $config)
     {
-        foreach (['sslmode', 'sslcert', 'sslkey', 'sslrootcert'] as $option) {
+        foreach ([
+            'sslmode',
+            'sslcert',
+            'sslkey',
+            'sslrootcert',
+            'requiressl',
+            'sslnegotiation',
+            'sslcompression',
+            'sslpassword',
+            'sslcertmode',
+            'sslcrl',
+            'sslcrldir',
+            'sslsni',
+        ] as $option) {
+            if (isset($config[$option])) {
+                $dsn .= ";{$option}={$config[$option]}";
+            }
+        }
+
+        return $dsn;
+    }
+
+    /**
+     * Add Postgres specific options to the DSN.
+     *
+     * @param  string  $dsn
+     * @param  array  $config
+     * @return string
+     */
+    protected function addPostgresOptions($dsn, array $config)
+    {
+        foreach ([
+            'channel_binding',
+            'connect_timeout',
+            'fallback_application_name',
+            'gssdelegation',
+            'gssencmode',
+            'gsslib',
+            'hostaddr',
+            'keepalives',
+            'keepalives_count',
+            'keepalives_idle',
+            'keepalives_interval',
+            'krbsrvname',
+            'load_balance_hosts',
+            'passfile',
+            'replication',
+            'require_auth',
+            'requirepeer',
+            'service',
+            'ssl_max_protocol_version',
+            'ssl_min_protocol_version',
+            'target_session_attrs',
+            'tcp_user_timeout',
+        ] as $option) {
             if (isset($config[$option])) {
                 $dsn .= ";{$option}={$config[$option]}";
             }


### PR DESCRIPTION
I needed some ssl options to connect to my PostgreSQL database. I've searched for solutions and found [this](https://github.com/laravel/framework/pull/54101) attempt. Since the `option` option is an already used keyword I just removed it.
I would love to see this feature request being added.