### PR TITLE
Add support for limitRaw in QueryBuilder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -72,6 +72,7 @@ class Builder implements BuilderContract
         'where' => [],
         'groupBy' => [],
         'having' => [],
+        'limit' => [],
         'order' => [],
         'union' => [],
         'unionOrder' => [],
@@ -2748,6 +2749,23 @@ class Builder implements BuilderContract
         if ($value >= 0) {
             $this->$property = ! is_null($value) ? (int) $value : null;
         }
+
+        return $this;
+    }
+
+    /**
+     * Set the "limit" value of the query as a raw SQL statement.
+     *
+     * @param  string  $sql
+     * @param  array  $bindings
+     * @return $this
+     */
+    public function limitRaw($sql, $bindings = [])
+    {
+        $property = $this->unions ? 'unionLimit' : 'limit';
+
+        $this->$property = $sql;
+        $this->addBinding($bindings, $property);
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -994,7 +994,7 @@ class Grammar extends BaseGrammar
      */
     protected function compileLimit(Builder $query, $limit)
     {
-        return 'limit '. $limit;
+        return 'limit '.$limit;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -994,7 +994,7 @@ class Grammar extends BaseGrammar
      */
     protected function compileLimit(Builder $query, $limit)
     {
-        return 'limit '.(int) $limit;
+        return 'limit '. $limit;
     }
 
     /**


### PR DESCRIPTION
I have a use case for supporting `LIMIT 100 - (SELECT count(*) FROM foobar)` but we don't have support for raw expressions in `limit` yet.

This will support queries such as:

```
DB::table('foo')->limitRaw('? - (SELECT COUNT(*) FROM bar)', self::MAX_RESULTS)
```