### PR TITLE
[12.x] Add mapping/aliasing to collections

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -602,12 +602,24 @@ class Arr
      * Run a map over each of the items in the array.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|array  $callback
      * @return array
      */
-    public static function map(array $array, callable $callback)
+    public static function map(array $array, callable|array $callback)
     {
         $keys = array_keys($array);
+
+        if (is_array($callback)) {
+            $callback = function ($value) use ($callback) {
+                $result = [];
+
+                foreach ($callback as $key => $alias) {
+                    $result[$alias] = is_object($value) ? $value->{$key} : static::get($value, $key);
+                }
+
+                return $result;
+            };
+        }
 
         try {
             $items = array_map($callback, $array, $keys);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -530,11 +530,15 @@ class Arr
         return static::map($array, function ($item) use ($keys) {
             $result = [];
 
-            foreach ($keys as $key) {
+            foreach ($keys as $key => $alias) {
+                if (!is_string($key)) {
+                    $key = $alias;
+                }
+
                 if (Arr::accessible($item) && Arr::exists($item, $key)) {
-                    $result[$key] = $item[$key];
+                    $result[$alias] = $item[$key];
                 } elseif (is_object($item) && isset($item->{$key})) {
-                    $result[$key] = $item->{$key};
+                    $result[$alias] = $item->{$key};
                 }
             }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -531,7 +531,7 @@ class Arr
             $result = [];
 
             foreach ($keys as $key => $alias) {
-                if (!is_string($key)) {
+                if (! is_string($key)) {
                     $key = $alias;
                 }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -792,10 +792,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @template TMapValue
      *
-     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @param  callable(TValue, TKey)|array<TKey, TKey>: TMapValue  $callback
      * @return static<TKey, TMapValue>
      */
-    public function map(callable $callback)
+    public function map(callable|array $callback)
     {
         return new static(Arr::map($this->items, $callback));
     }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1018,7 +1018,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     $result = [];
 
                     foreach ($keys as $key => $alias) {
-                        if (!is_string($key)) {
+                        if (! is_string($key)) {
                             $key = $alias;
                         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -380,10 +380,10 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @template TMapValue
      *
-     * @param  callable(TModel, TKey): TMapValue  $callback
+     * @param  callable(TModel, TKey)|array<TKey, TKey>: TMapValue  $callback
      * @return \Illuminate\Support\Collection<TKey, TMapValue>|static<TKey, TMapValue>
      */
-    public function map(callable $callback)
+    public function map(callable|array $callback)
     {
         $result = parent::map($callback);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2924,7 +2924,7 @@ class SupportCollectionTest extends TestCase
             ['name' => 'Taylor', 'surname' => 'Otwell'],
             ['name' => 'Jess', 'surname' => 'Archer'],
         ], $data->map([
-            'first' => 'name', 
+            'first' => 'name',
             'last' => 'surname',
         ])->all());
     }
@@ -4323,7 +4323,7 @@ class SupportCollectionTest extends TestCase
             ['name' => 'Taylor', 'surname' => 'Otwell'],
             ['name' => 'Jess', 'surname' => 'Archer'],
         ], $data->select([
-            'first' => 'name', 
+            'first' => 'name',
             'last' => 'surname',
         ])->all());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4295,6 +4295,23 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testSelectWithAlias($collection)
+    {
+        $data = new $collection([
+            ['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Jess', 'last' => 'Archer', 'email' => 'jessarcher@gmail.com'],
+        ]);
+
+        $this->assertEquals([
+            ['name' => 'Taylor', 'surname' => 'Otwell'],
+            ['name' => 'Jess', 'surname' => 'Archer'],
+        ], $data->select([
+            'first' => 'name', 
+            'last' => 'surname',
+        ])->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testGettingAvgItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2913,6 +2913,23 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testMapWithDictionary($collection)
+    {
+        $data = new $collection([
+            ['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Jess', 'last' => 'Archer', 'email' => 'jessarcher@gmail.com'],
+        ]);
+
+        $this->assertEquals([
+            ['name' => 'Taylor', 'surname' => 'Otwell'],
+            ['name' => 'Jess', 'surname' => 'Archer'],
+        ], $data->map([
+            'first' => 'name', 
+            'last' => 'surname',
+        ])->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testMapSpread($collection)
     {
         $c = new $collection([[1, 'a'], [2, 'b']]);


### PR DESCRIPTION
Fairly often I find myself doing this

```php
$collection->map(fn($item) => [
    'id' => $item->id,
    'name' => $item->title,
]);
```

While my actual intention would rather be described by something like 

```php
$collection->select('id as id', 'title as name')
```

So I decided to make an attempt at such mapping feature that would let one extract some columns while remapping the keys.

Currently this PR is a bit messy as it contains two competing implementations which are both modifications on existing methods

```php
// map() accepting an array (dictionary) instead of a callback
$collection->map([
    'id' => 'id',
    'title' => 'name',
]);

// select() accepting array with string keys which is then interpreted as $key=>$alias array
// this felt simpler, but might be a little less BC
$collection->select([
    'id' => 'id',
    'title' => 'name',
]);
```

Does any of these seem appropriate? Or should it be a separate (new) method? Or maybe the entire idea sucks?

P. S. If this feature already exists, let me know. I only found out about `select` few months ago :D 