### PR TITLE
[12.x] Add 'encodeHtmlEntities' and 'decodeHtmlEntities' to Str helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1839,6 +1839,33 @@ class Str
     }
 
     /**
+     * Decode HTML entities in a string.
+     *
+     * @param  string  $flags
+     * @param  int  $flags
+     * @param  string  $encoding
+     * @return string
+     */
+    public static function decodeHtmlEntities(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8')
+    {
+        return html_entity_decode($string);
+    }
+
+    /**
+     * Encode special characters in a string as HTML entities.
+     *
+     * @param  string  $flags
+     * @param  int  $flags
+     * @param  string  $encoding
+     * @param  bool  $doubleEncode
+     * @return string
+     */
+    public static function encodeHtmlEntities(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8', bool $doubleEncode = true)
+    {
+        return htmlentities($string);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1841,7 +1841,7 @@ class Str
     /**
      * Decode HTML entities in a string.
      *
-     * @param  string  $flags
+     * @param  string  $string
      * @param  int  $flags
      * @param  string  $encoding
      * @return string
@@ -1854,7 +1854,7 @@ class Str
     /**
      * Encode special characters in a string as HTML entities.
      *
-     * @param  string  $flags
+     * @param  string  $string
      * @param  int  $flags
      * @param  string  $encoding
      * @param  bool  $doubleEncode

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1848,7 +1848,7 @@ class Str
      */
     public static function decodeHtmlEntities(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8')
     {
-        return html_entity_decode($string);
+        return html_entity_decode($string, $flags, $encoding);
     }
 
     /**
@@ -1862,7 +1862,7 @@ class Str
      */
     public static function encodeHtmlEntities(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8', bool $doubleEncode = true)
     {
-        return htmlentities($string);
+        return htmlentities($string, $flags, $encoding, $doubleEncode);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1303,7 +1303,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function encodeHtmlEntities(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8', bool $doubleEncode = true)
     {
-        return new static(Str::encodeHtmlEntities($this->value, $flags, $encoding));
+        return new static(Str::encodeHtmlEntities($this->value, $flags, $encoding, $doubleEncode));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1297,8 +1297,8 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Encode special characters in a string as HTML entities.
      *
      * @param  int  $flags
-     * @param  string $encoding
-     * @param  bool $doubleEncode
+     * @param  string  $encoding
+     * @param  bool  $doubleEncode
      * @return static
      */
     public function encodeHtmlEntities(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8', bool $doubleEncode = true)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1284,9 +1284,9 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Decode HTML entities in a string.
      *
-     * @param  int  $flags  A bitmask of flags (e.g., ENT_QUOTES, ENT_HTML5) to control decoding behavior
-     * @param  string  $encoding  The character encoding to use (e.g., 'UTF-8')
-     * @return string The decoded string
+     * @param  int  $flags
+     * @param  string  $encoding
+     * @return static
      */
     public function decodeHtmlEntities(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8')
     {
@@ -1296,9 +1296,10 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Encode special characters in a string as HTML entities.
      *
-     * @param  int  $flags  A bitmask of flags (e.g., ENT_QUOTES, ENT_HTML5) to control decoding behavior
-     * @param  string  $encoding  The character encoding to use (e.g., 'UTF-8')
-     * @return string The decoded string
+     * @param  int  $flags
+     * @param  string $encoding
+     * @param  bool $doubleEncode
+     * @return static
      */
     public function encodeHtmlEntities(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8', bool $doubleEncode = true)
     {

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1282,6 +1282,30 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Decode HTML entities in a string.
+     *
+     * @param  int  $flags  A bitmask of flags (e.g., ENT_QUOTES, ENT_HTML5) to control decoding behavior
+     * @param  string  $encoding  The character encoding to use (e.g., 'UTF-8')
+     * @return string The decoded string
+     */
+    public function decodeHtmlEntities(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8')
+    {
+        return new static(Str::decodeHtmlEntities($this->value, $flags, $encoding));
+    }
+
+    /**
+     * Encode special characters in a string as HTML entities.
+     *
+     * @param  int  $flags  A bitmask of flags (e.g., ENT_QUOTES, ENT_HTML5) to control decoding behavior
+     * @param  string  $encoding  The character encoding to use (e.g., 'UTF-8')
+     * @return string The decoded string
+     */
+    public function encodeHtmlEntities(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, string $encoding = 'UTF-8', bool $doubleEncode = true)
+    {
+        return new static(Str::encodeHtmlEntities($this->value, $flags, $encoding));
+    }
+
+    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $before

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1306,6 +1306,21 @@ class SupportStrTest extends TestCase
         $this->assertEquals('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
     }
 
+    public function testDecodeHtmlEntities()
+    {
+        $this->assertEquals('Hello & World', Str::decodeHtmlEntities('Hello &amp; World'));
+        $this->assertEquals('Hello & "World"', Str::decodeHtmlEntities('Hello &amp; &quot;World&quot;', ENT_QUOTES));
+        $this->assertEquals('Hello ñ', Str::decodeHtmlEntities('Hello &#241;'));
+        $this->assertEquals('Hello ñ☆❤☆❤☆❤', Str::decodeHtmlEntities('Hello &#241;☆❤☆❤☆❤'));
+    }
+
+    public function testEncodeHtmlEntities()
+    {
+        $this->assertEquals('Hello &amp; World', Str::encodeHtmlEntities('Hello & World'));
+        $this->assertEquals('Hello &amp; &quot;World&quot;', Str::encodeHtmlEntities('Hello & "World"'));
+        $this->assertEquals('Hello &ntilde; &amp; World', Str::encodeHtmlEntities('Hello ñ & World'));
+    }
+
     public static function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
@@ -1280,6 +1281,20 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('value', $this->stringable('"value"')->unwrap('"'));
         $this->assertEquals('bar', $this->stringable('foo-bar-baz')->unwrap('foo-', '-baz'));
         $this->assertEquals('some: "json"', $this->stringable('{some: "json"}')->unwrap('{', '}'));
+    }
+
+    public function testDecodeHtmlEntities()
+    {
+        $this->assertEquals('value & bar', $this->stringable('value &amp; bar')->decodeHtmlEntities());
+        $this->assertEquals('love & "laravel"', $this->stringable('love &amp; &quot;laravel&quot;')->decodeHtmlEntities());
+        $this->assertEquals('laravel ñ', $this->stringable('laravel &#241;')->decodeHtmlEntities());
+    }
+
+    public function testEncodeHtmlEntities()
+    {
+        $this->assertEquals('love &amp; laravel', $this->stringable('love & laravel')->encodeHtmlEntities());
+        $this->assertEquals('love &amp; &quot;laravel&quot;', $this->stringable('love & "laravel"')->encodeHtmlEntities());
+        $this->assertEquals('love &ntilde; &amp; laravel', $this->stringable('love ñ & laravel')->encodeHtmlEntities());
     }
 
     public function testToHtmlString()


### PR DESCRIPTION
## Add `decodeHtmlEntities` and `encodeHtmlEntities` methods to the `Str` Helper Class

### Summary

This PR introduces two new methods, `decodeHtmlEntities` and `encodeHtmlEntities`, to the `Str` helper class in Laravel. These methods allow for easy encoding and decoding of HTML entities within strings.

### Usage

The new methods can be used as follows:

```php
// Decoding HTML entities
str('Hello &amp; World')->decodeHtmlEntities()->value(); // returns: 'Hello & World'

// Encoding HTML entities
str('Hello & World')->encodeHtmlEntities()->value(); // returns: 'Hello &amp; World'
```

## Motivation

Currently, Laravel does not provide a direct method for encoding or decoding HTML entities using the `Str` helper. As a result, developers have to manually call the html_entity_decode or html_entity_encode functions. 

### Current Approach

Wrapping the chained methods with `html_entity_decode()`:
```php
html_entity_decode(str($someString)->lower()->trim()->value());
```

or, assigning to a variable and overriding it:
```php
$transformedString = str($someString)->lower()->trim()->value();
$transformedString = html_entity_decode($transformedString);
```

