### PR TITLE
[12.x] Do not loop through middleware when excluded is empty

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -829,7 +829,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function resolveMiddleware(array $middleware, array $excluded = [])
     {
-        $excluded = (new Collection($excluded))->map(function ($name) {
+        $excluded = $excluded === [] ? $excluded : (new Collection($excluded))->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
         })->flatten()->values()->all();
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -835,11 +835,10 @@ class Router implements BindingRegistrar, RegistrarContract
 
         $middleware = (new Collection($middleware))->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
-        })->flatten()->reject(function ($name) use ($excluded) {
-            if (empty($excluded)) {
-                return false;
-            }
-
+        })->flatten()
+            ->when(
+                ! empty($excluded),
+                fn ($collection) => $collection->reject(function ($name) use ($excluded) {
             if ($name instanceof Closure) {
                 return false;
             }
@@ -857,7 +856,7 @@ class Router implements BindingRegistrar, RegistrarContract
             return (new Collection($excluded))->contains(
                 fn ($exclude) => class_exists($exclude) && $reflection->isSubclassOf($exclude)
             );
-        })->values();
+        }))->values();
 
         return $this->sortMiddleware($middleware);
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -839,24 +839,25 @@ class Router implements BindingRegistrar, RegistrarContract
             ->when(
                 ! empty($excluded),
                 fn ($collection) => $collection->reject(function ($name) use ($excluded) {
-            if ($name instanceof Closure) {
-                return false;
-            }
+                    if ($name instanceof Closure) {
+                        return false;
+                    }
 
-            if (in_array($name, $excluded, true)) {
-                return true;
-            }
+                    if (in_array($name, $excluded, true)) {
+                        return true;
+                    }
 
-            if (! class_exists($name)) {
-                return false;
-            }
+                    if (! class_exists($name)) {
+                        return false;
+                    }
 
-            $reflection = new ReflectionClass($name);
+                    $reflection = new ReflectionClass($name);
 
-            return (new Collection($excluded))->contains(
-                fn ($exclude) => class_exists($exclude) && $reflection->isSubclassOf($exclude)
-            );
-        }))->values();
+                    return (new Collection($excluded))->contains(
+                        fn ($exclude) => class_exists($exclude) && $reflection->isSubclassOf($exclude)
+                    );
+                })
+            )->values();
 
         return $this->sortMiddleware($middleware);
     }


### PR DESCRIPTION
Just a minor optimization here. Each time the closure is called, it's checking if excluded is empty. We can just check that before starting the loop. Also, this avoids running filter functions on an empty excluded middleware array.

I recognize these are both relatively minor optimizations and probably wouldn't be noticeable for most applications.