### PR TITLE
[12.x] Remove return statement 

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -454,7 +454,7 @@ class Batch implements Arrayable, JsonSerializable
     protected function invokeHandlerCallback($handler, Batch $batch, ?Throwable $e = null)
     {
         try {
-            return $handler($batch, $e);
+            $handler($batch, $e);
         } catch (Throwable $e) {
             if (function_exists('report')) {
                 report($e);


### PR DESCRIPTION
Since the return type in the `Illuminate\Bus\Batch.invokeHandlerCallback` method is `void`. There is no need to write a `return` statement. I think this will make the codes much clearer
