### PR TITLE
Add additional tests for Rule::array validation scenarios

### DIFF
--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -18,6 +18,9 @@ class ValidationArrayRuleTest extends TestCase
 
         $this->assertSame('array', (string) $rule);
 
+        $rule = Rule::array([]);
+        $this->assertSame('array', (string) $rule);
+
         $rule = Rule::array('key_1', 'key_2', 'key_3');
 
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
@@ -37,6 +40,12 @@ class ValidationArrayRuleTest extends TestCase
         $rule = Rule::array([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2, ArrayKeysBacked::key_3]);
 
         $this->assertSame('array:key_1,key_2,key_3', (string) $rule);
+
+        $rule = Rule::array(['key_1', 'key_1']);
+        $this->assertSame('array:key_1,key_1', (string) $rule);
+
+        $rule = Rule::array([1, 2, 3]);
+        $this->assertSame('array:1,2,3', (string) $rule);
     }
 
     public function testArrayValidation()

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -55,6 +55,18 @@ class ValidationArrayRuleTest extends TestCase
         $v = new Validator($trans, ['foo' => 'not an array'], ['foo' => Rule::array()]);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['foo' => (object) ['key_1' => 'bar']], ['foo' => Rule::array()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => null], ['foo' => ['nullable', Rule::array()]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => Rule::array()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['key_1' => []]], ['foo' => Rule::array(['key_1'])]);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => ['bar']], ['foo' => (string) Rule::array()]);
         $this->assertTrue($v->passes());
 

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -60,4 +60,18 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 
         $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
     }
+
+    public function testGetCountWithValidExcludeId()
+    {
+        $verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));
+        $verifier->setConnection('connection');
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(stdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(stdClass::class));
+        $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
+        $builder->shouldReceive('where')->with('id', '<>', 123)->andReturn($builder);
+        $builder->shouldReceive('count')->once()->andReturn(100);
+
+        $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', 123, 'id', []));
+    }
 }


### PR DESCRIPTION
This PR adds new test cases for the Rule::array validation to cover a variety of scenarios and ensure correct behavior:

Formatting Tests:

- Ensures that an empty array ([]) is formatted as 'array'.
- Verifies that arrays with duplicate keys (e.g., ['key_1', 'key_1']) are correctly formatted with repeated keys.
- Confirms that arrays with numeric values (e.g., [1, 2, 3]) are formatted as expected.
- Object Input: Verifies that Rule::array fails validation when an object is provided instead of an array.
- Nullable Arrays: Ensures that arrays marked as nullable pass validation when given a null value.
- Empty Arrays: Confirms that empty arrays pass validation with Rule::array.
- Nested Empty Values: Tests Rule::array with nested empty arrays to ensure correct behavior.

These additions improve the test coverage for Rule::array validation, ensuring it handles different input types and edge cases as expected.

