### PR TITLE
[12.x] Adds a new method "getRawSql" (with embedded bindings) to the QueryException class

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -65,7 +65,7 @@ class QueryException extends PDOException
      */
     protected function formatMessage($connectionName, $sql, $bindings, Throwable $previous)
     {
-        return $previous->getMessage() . ' (Connection: ' . $connectionName . ', SQL: ' . Str::replaceArray('?', $bindings, $sql) . ')';
+        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.Str::replaceArray('?', $bindings, $sql) . ')';
     }
 
     /**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database;
 use Illuminate\Support\Str;
 use PDOException;
 use Throwable;
+use Illuminate\Support\Facades\DB;
 
 class QueryException extends PDOException
 {
@@ -95,5 +96,15 @@ class QueryException extends PDOException
     public function getBindings()
     {
         return $this->bindings;
+    }
+
+    /**
+     * Get the raw SQL representation of the query with embedded bindings.
+     */
+    public function getRawSql(): string
+    {
+        return DB::connection($this->getConnectionName())
+            ->getQueryGrammar()
+            ->substituteBindingsIntoRawSql($this->getSql(), $this->getBindings());
     }
 }

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -65,7 +65,7 @@ class QueryException extends PDOException
      */
     protected function formatMessage($connectionName, $sql, $bindings, Throwable $previous)
     {
-        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.Str::replaceArray('?', $bindings, $sql) . ')';
+        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.Str::replaceArray('?', $bindings, $sql).')';
     }
 
     /**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use PDOException;
 use Throwable;
-use Illuminate\Support\Facades\DB;
 
 class QueryException extends PDOException
 {
@@ -65,7 +65,7 @@ class QueryException extends PDOException
      */
     protected function formatMessage($connectionName, $sql, $bindings, Throwable $previous)
     {
-        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+        return $previous->getMessage() . ' (Connection: ' . $connectionName . ', SQL: ' . Str::replaceArray('?', $bindings, $sql) . ')';
     }
 
     /**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -89,16 +89,6 @@ class QueryException extends PDOException
     }
 
     /**
-     * Get the bindings for the query.
-     *
-     * @return array
-     */
-    public function getBindings()
-    {
-        return $this->bindings;
-    }
-
-    /**
      * Get the raw SQL representation of the query with embedded bindings.
      */
     public function getRawSql(): string
@@ -106,5 +96,15 @@ class QueryException extends PDOException
         return DB::connection($this->getConnectionName())
             ->getQueryGrammar()
             ->substituteBindingsIntoRawSql($this->getSql(), $this->getBindings());
+    }
+
+    /**
+     * Get the bindings for the query.
+     *
+     * @return array
+     */
+    public function getBindings()
+    {
+        return $this->bindings;
     }
 }

--- a/tests/Database/DatabaseQueryExceptionTest.php
+++ b/tests/Database/DatabaseQueryExceptionTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\QueryException;

--- a/tests/Database/DatabaseQueryExceptionTest.php
+++ b/tests/Database/DatabaseQueryExceptionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Mockery as m;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseQueryExceptionTest extends TestCase
+{
+    public function testIfItEmbedsBindingsIntoSql()
+    {
+        $connection = $this->getConnection();
+
+        $sql = 'SELECT * FROM huehue WHERE a = ? and hue = ?';
+        $bindings = [1, 'br'];
+
+        $expectedSql = "SELECT * FROM huehue WHERE a = 1 and hue = 'br'";
+
+        $pdoException = new PDOException('Mock SQL error');
+        $exception = new QueryException($connection->getName(), $sql, $bindings, $pdoException);
+
+        DB::shouldReceive('connection')->andReturn($connection);
+        $result = $exception->getRawSql();
+
+        $this->assertSame($expectedSql, $result);
+    }
+
+    public function testIfItReturnsSameSqlWhenThereAreNoBindings()
+    {
+        $connection = $this->getConnection();
+
+        $sql = "SELECT * FROM huehue WHERE a = 1 and hue = 'br'";
+        $bindings = [];
+
+        $expectedSql = $sql;
+
+        $pdoException = new PDOException('Mock SQL error');
+        $exception = new QueryException($connection->getName(), $sql, $bindings, $pdoException);
+
+        DB::shouldReceive('connection')->andReturn($connection);
+        $result = $exception->getRawSql();
+
+        $this->assertSame($expectedSql, $result);
+    }
+
+    protected function getConnection()
+    {
+        $connection = m::mock(Connection::class);
+
+        $grammar = new Grammar($connection);
+
+        $connection->shouldReceive('getName')->andReturn('default');
+        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+        $connection->shouldReceive('escape')->with(1, false)->andReturn(1);
+        $connection->shouldReceive('escape')->with('br', false)->andReturn("'br'");
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a getRawSql to the QueryExceptionClass.

When error reporting/showing tools want to show "compiled" SQL (with embedded bindings), they resort to simple string substitution (which does not covers all cases), using something like ```Str::replaceArray('?', $bindings, $sql)```

This newly introduce getRawSql methods uses the proper grammar of the connection in which the error occurred in order to generate the raw SQL, just like the query builder does.

### Usage

```php
->withExceptions(function (Exceptions $exceptions) {
    $exceptions->report(function (QueryException $e) {
        // ...
       MyErrorServiceFacade::report('Error executing SQL: ', $e->getRawSql());
    });
})
```

This allows one to send the problematic SQL with context, without having to send SQL and bindings separately or even resort to simple string substitution