### PR TITLE
Allow Http requests to be recorded without requests being faked

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -322,7 +322,7 @@ class Factory
      *
      * @return $this
      */
-    protected function record()
+    public function record()
     {
         $this->recording = true;
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\ResponseSequence sequence(array $responses = [])
  * @method static bool preventingStrayRequests()
  * @method static \Illuminate\Http\Client\Factory allowStrayRequests()
+ * @method static \Illuminate\Http\Client\Factory record()
  * @method static void recordRequestResponsePair(\Illuminate\Http\Client\Request $request, \Illuminate\Http\Client\Response|null $response)
  * @method static void assertSent(callable $callback)
  * @method static void assertSentInOrder(array $callbacks)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a simple PR which allows users to call `Http::record()`. `record` has already existed in the framework and is used for faking requests, but I believe it may be useful for testing without also faking the requests.

Usage:

```
use Illuminate\Support\Facades\Http;

Http::record();

Http::get('https://example.com');

Http::recorded(function (\Illuminate\Http\Client\Request $request, \Illuminate\Http\Client\Response $response) {
    // Do something with the request, response pair
});
```
