### PR TITLE
[12.x] Introduce `ContextLogProcessor`

### DIFF
--- a/src/Illuminate/Contracts/Log/ContextLogProcessor.php
+++ b/src/Illuminate/Contracts/Log/ContextLogProcessor.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Contracts\Log;
+
+use Monolog\Processor\ProcessorInterface;
+
+interface ContextLogProcessor extends ProcessorInterface
+{
+}

--- a/src/Illuminate/Log/Context/ContextLogProcessor.php
+++ b/src/Illuminate/Log/Context/ContextLogProcessor.php
@@ -2,14 +2,13 @@
 
 namespace Illuminate\Log\Context;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\Context\Repository as ContextRepository;
 use Monolog\LogRecord;
-use Illuminate\Contracts\Foundation\Application;
 use Monolog\Processor\ProcessorInterface;
 
 class ContextLogProcessor implements ProcessorInterface
 {
-
     /**
      * Create a new ContextLogProcessor instance.
      *
@@ -21,6 +20,8 @@ class ContextLogProcessor implements ProcessorInterface
     }
 
     /**
+     * Add contextual data to the log's "extra" parameter.
+     *
      * @param  \Monolog\LogRecord  $record
      * @return \Monolog\LogRecord
      */

--- a/src/Illuminate/Log/Context/ContextLogProcessor.php
+++ b/src/Illuminate/Log/Context/ContextLogProcessor.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Log\Context;
+
+use Illuminate\Log\Context\Repository as ContextRepository;
+use Monolog\LogRecord;
+use Illuminate\Contracts\Foundation\Application;
+use Monolog\Processor\ProcessorInterface;
+
+class ContextLogProcessor implements ProcessorInterface
+{
+
+    /**
+     * Create a new ContextLogProcessor instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct(protected Application $app)
+    {
+    }
+
+    /**
+     * @param  \Monolog\LogRecord  $record
+     * @return \Monolog\LogRecord
+     */
+    public function __invoke(LogRecord $record)
+    {
+        if (! $this->app->bound(ContextRepository::class)) {
+            return $record;
+        }
+
+        return $record->with(extra: [
+            ...$record->extra,
+            ...$this->app[ContextRepository::class]->all(),
+        ]);
+    }
+}

--- a/src/Illuminate/Log/Context/ContextLogProcessor.php
+++ b/src/Illuminate/Log/Context/ContextLogProcessor.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Log\Context;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Log\ContextLogProcessor as ContextLogProcessorContract;
 use Illuminate\Log\Context\Repository as ContextRepository;
 use Monolog\LogRecord;
-use Monolog\Processor\ProcessorInterface;
 
-class ContextLogProcessor implements ProcessorInterface
+class ContextLogProcessor implements ContextLogProcessorContract
 {
     /**
      * Create a new ContextLogProcessor instance.

--- a/src/Illuminate/Log/Context/ContextLogProcessor.php
+++ b/src/Illuminate/Log/Context/ContextLogProcessor.php
@@ -25,7 +25,7 @@ class ContextLogProcessor implements ProcessorInterface
      * @param  \Monolog\LogRecord  $record
      * @return \Monolog\LogRecord
      */
-    public function __invoke(LogRecord $record)
+    public function __invoke(LogRecord $record): LogRecord
     {
         if (! $this->app->bound(ContextRepository::class)) {
             return $record;

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Log\Context;
 
+use Illuminate\Contracts\Log\ContextLogProcessor as ContextLogProcessorContract;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Facades\Context;
@@ -17,7 +18,10 @@ class ContextServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->scoped(Repository::class);
-        $this->app->bind(ContextLogProcessor::class, fn ($app) => new ContextLogProcessor($app));
+        $this->app->bind(
+            ContextLogProcessorContract::class,
+            fn ($app) => new ContextLogProcessor($app)
+        );
     }
 
     /**

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -18,6 +18,7 @@ class ContextServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->scoped(Repository::class);
+
         $this->app->bind(ContextLogProcessorContract::class, fn ($app) => new ContextLogProcessor($app));
     }
 

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -17,6 +17,7 @@ class ContextServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->scoped(Repository::class);
+        $this->app->bind(ContextLogProcessor::class, fn ($app) => new ContextLogProcessor($app));
     }
 
     /**

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -18,10 +18,7 @@ class ContextServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->scoped(Repository::class);
-        $this->app->bind(
-            ContextLogProcessorContract::class,
-            fn ($app) => new ContextLogProcessor($app)
-        );
+        $this->app->bind(ContextLogProcessorContract::class, fn ($app) => new ContextLogProcessor($app));
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Log;
 
 use Closure;
-use Illuminate\Log\Context\ContextLogProcessor;
+use Illuminate\Contracts\Log\ContextLogProcessor;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -65,13 +65,12 @@ class LogManager implements LoggerInterface
      */
     protected $dateFormat = 'Y-m-d H:i:s';
 
-
     /**
      * Processor for adding Context variables to the log.
      *
      * @var (\Closure(\Monolog\LogRecord): \Monolog\LogRecord|null)|class-string<\Monolog\Processor\ProcessorInterface>|null
      */
-    protected $contextLogProcessor = null;
+    protected $addContextToLogProcessor = null;
 
     /**
      * Create a new Log manager instance.
@@ -151,10 +150,8 @@ class LogManager implements LoggerInterface
                 )->withContext($this->sharedContext);
 
                 if (method_exists($loggerWithContext->getLogger(), 'pushProcessor')) {
-                    $logProcessor = $this->contextLogProcessor;
-                    if ($logProcessor === null) {
-                        $logProcessor = $this->addContextToLogProcessor(...);
-                    } elseif (is_string($logProcessor) && class_exists($logProcessor)) {
+                    $logProcessor = $this->addContextToLogProcessor ?? $this->defaultAddContextToLogProcessor(...);
+                    if (is_string($logProcessor) && class_exists($logProcessor)) {
                         $logProcessor = $this->app->make($logProcessor);
                     }
 
@@ -600,12 +597,12 @@ class LogManager implements LoggerInterface
     /**
      * Set the log processor to append Context values to the log.
      *
-     * @param (\Closure(\Monolog\LogRecord): \Monolog\LogRecord|null)|class-string<\Monolog\Processor\ProcessorInterface>|null $callback
+     * @param  (\Closure(\Monolog\LogRecord): \Monolog\LogRecord|null)|class-string<\Monolog\Processor\ProcessorInterface>|null  $callback
      * @return $this
      */
-    public function setContextToLogProcessor($callback)
+    public function setAddContextToLogProcessor($callback)
     {
-        $this->contextLogProcessor = $callback;
+        $this->addContextToLogProcessor = $callback;
 
         return $this;
     }
@@ -614,7 +611,7 @@ class LogManager implements LoggerInterface
      * @param  \Monolog\LogRecord  $record
      * @return \Monolog\LogRecord|null
      */
-    protected function addContextToLogProcessor($record)
+    protected function defaultAddContextToLogProcessor($record)
     {
         if (! $this->app->bound(ContextRepository::class)) {
             return $record;

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -4,7 +4,6 @@ namespace Illuminate\Log;
 
 use Closure;
 use Illuminate\Log\Context\ContextLogProcessor;
-use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -559,7 +559,7 @@ class ContextTest extends TestCase
         $path = storage_path('logs/laravel.log');
         file_put_contents($path, '');
 
-        Log::setAddContextToLogProcessor(function(LogRecord $record): LogRecord {
+        Log::setAddContextToLogProcessor(function (LogRecord $record): LogRecord {
             $logChannel = Context::getHidden('log_channel_name');
 
             return $record->with(
@@ -573,7 +573,7 @@ class ContextTest extends TestCase
         Context::addHidden('log_channel_name', 'closure-test');
         Context::add(['value_from_context' => 'hello']);
 
-        Log::info("This is an info log.", ['value_from_log_info_context' => 'foo']);
+        Log::info('This is an info log.', ['value_from_log_info_context' => 'foo']);
 
         $log = Str::after(file_get_contents($path), '] ');
         $this->assertSame('closure-test.INFO: This is an info log. {"value_from_context":"hello","value_from_log_info_context":"foo"}', Str::trim($log));
@@ -595,6 +595,8 @@ class ContextTest extends TestCase
             'testing.INFO: This is an info log. {"value_from_log_info_context":"foo","inside of MyAddContextProcessor":true}',
             Str::trim($log)
         );
+
+        file_put_contents($path, '');
     }
 }
 

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -13,12 +13,21 @@ use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
 use Orchestra\Testbench\TestCase;
 use RuntimeException;
 
 class ContextTest extends TestCase
 {
     use LazilyRefreshDatabase;
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        MyAddContextProcessor::$wasConstructed = false;
+    }
 
     public function test_it_can_set_values()
     {
@@ -544,6 +553,49 @@ class ContextTest extends TestCase
             'hiddenKey2' => 'world',
         ], Context::allHidden());
     }
+
+    public function test_uses_closure_for_context_processor()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        Log::setAddContextToLogProcessor(function(LogRecord $record): LogRecord {
+            $logChannel = Context::getHidden('log_channel_name');
+
+            return $record->with(
+                // allow overriding the context from what's been set on the log
+                context: array_merge(Context::all(), $record->context),
+                // use the log channel we've set in context, or fallback to the current channel
+                channel: $logChannel ?? $record->channel,
+            );
+        });
+
+        Context::addHidden('log_channel_name', 'closure-test');
+        Context::add(['value_from_context' => 'hello']);
+
+        Log::info("This is an info log.", ['value_from_log_info_context' => 'foo']);
+
+        $log = Str::after(file_get_contents($path), '] ');
+        $this->assertSame('closure-test.INFO: This is an info log. {"value_from_context":"hello","value_from_log_info_context":"foo"}', Str::trim($log));
+        file_put_contents($path, '');
+    }
+
+    public function test_from_processor_class_string()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+
+        Log::setAddContextToLogProcessor(MyAddContextProcessor::class);
+
+        Context::add(['this-will-be-included' => false]);
+
+        Log::info('This is an info log.', ['value_from_log_info_context' => 'foo']);
+        $log = Str::after(file_get_contents($path), '] ');
+        $this->assertSame(
+            'testing.INFO: This is an info log. {"value_from_log_info_context":"foo","inside of MyAddContextProcessor":true}',
+            Str::trim($log)
+        );
+    }
 }
 
 enum Suit
@@ -565,4 +617,20 @@ enum StringBackedSuit: string
 class ContextModel extends Model
 {
     //
+}
+
+class MyAddContextProcessor implements ProcessorInterface
+{
+    public static bool $wasConstructed = false;
+
+    public function __construct()
+    {
+        self::$wasConstructed = true;
+    }
+
+    #[\Override]
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        return $record->with(context: array_merge($record->context, ['inside of MyAddContextProcessor' => true]));
+    }
 }

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -4,9 +4,9 @@ namespace Illuminate\Tests\Log;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Log\ContextLogProcessor;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
-use Illuminate\Log\Context\ContextLogProcessor;
 use Illuminate\Log\Context\Events\ContextDehydrating as Dehydrating;
 use Illuminate\Log\Context\Events\ContextHydrated as Hydrated;
 use Illuminate\Log\Context\Repository;
@@ -15,7 +15,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Monolog\LogRecord;
-use Monolog\Processor\ProcessorInterface;
 use Orchestra\Testbench\TestCase;
 use RuntimeException;
 
@@ -626,7 +625,7 @@ class ContextModel extends Model
     //
 }
 
-class MyAddContextProcessor implements ProcessorInterface
+class MyAddContextProcessor implements ContextLogProcessor
 {
     public static bool $wasConstructed = false;
 

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -584,7 +584,7 @@ class ContextTest extends TestCase
         file_put_contents($path, '');
     }
 
-    public function test_can_rebind_()
+    public function test_can_rebind_to_separate_class()
     {
         $path = storage_path('logs/laravel.log');
         file_put_contents($path, '');

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -595,6 +595,7 @@ class ContextTest extends TestCase
             'testing.INFO: This is an info log. {"value_from_log_info_context":"foo","inside of MyAddContextProcessor":true}',
             Str::trim($log)
         );
+        $this->assertTrue(MyAddContextProcessor::$wasConstructed);
 
         file_put_contents($path, '');
     }


### PR DESCRIPTION
## Why
There are two particular things I would like to be able to do with how context is used with logs.

1. I do not want the Context data set on `extra`, but instead, want it merged into the existing log `context`. This makes querying DataDog easier, since it doesn't require me to know if it's a value set in Context **versus** added via `Log::withContext()` or added to the log context via `Log::info('some important log', ['a-value-i-care-about' => true])`.
2. I want to be able to set a consistent log channel for my actions. For a fuller example, see https://github.com/laravel/framework/pull/54692

Number two is solvable by storing the log channel in the Context's hidden data and pushing an additional processor to the set the log channel based on that.

What is proposed in this PR is that we move the context log processor into a separate class. I can achieve both of my goals with minimal impact to the framework's code. Now in userland, I can easily override the bound processor class. For 99.99% of users, they won't ever use this. For those who want control over how context is merged into the log record, they have an idiomatic way of configuring that.

<details>
<summary>An example of how I might use this</summary>

```php
// inside AppServiceProvider::boot()
$this->app->bind(ContextLogProcessor::class, fn () => new class implements ProcessorInterface {
    public function __invoke(LogRecord $record): LogRecord
    {
        $logChannel = Context::getHidden('log_channel_name');

        return $record->with(
            // allow overriding the context from what's been set on the log
            context: array_merge(Context::all(), $record->context),
            // use the log channel we've set in context, or fallback to the current channel
            channel: $logChannel ?? $record->channel,
        );
    }
});
```

</details>

## Other Possible Approaches
* Create a `setContextToLogProcessor` on either the LogManager or the Context\Repository. This was the initial approach I took, but it seemed kinda wonky/unwieldy for something so few people might ever use. Binding a concrete class and allowing override makes this much more seamless.
* Ignore this approach, and let user-land just `Log::popProcessor()`, `Log::pushProcessor()` themselves. It's workable, but might not be reliable, since it's possible another processor got pushed by a third-party package
  * A user could also just push another processor to the end and then remove the `extra` but.... eh.... I find that to be annoying.
* Allow setting a property that determines whether Context values get merged into `extra` or `context` on the `Monolog\LogRecord`. This feels considerably less robust.

## Also...
While playing around with this, I realized you cannot add processors to the `single` driver via the config. Wouldn't solve the problem, but it seems weird that it doesn't allow for this.