### PR TITLE
[12.x] Update `Illuminate\Concurrency` composer.json

### DIFF
--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "11.x-dev"
+            "dev-master": "12.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Update `branch-alias` -> `dev-master` value to use 12.x instead of 11.x version in `Illuminate\Concurrency` composer.json file