### PR TITLE
[12.x] Feature: Array partition

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -7,7 +7,6 @@ use ArrayAccess;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
-use Traversable;
 
 class Arr
 {
@@ -949,7 +948,7 @@ class Arr
      * @template TKey of array-key
      * @template TValue of mixed
      *
-     * @param  array<TKey, TValue>|Traversable<TKey, TValue>  $array
+     * @param  array<TKey, TValue>|\Traversable<TKey, TValue>  $array
      * @param  callable  $callback
      * @return array<int<0, 1>, array<TKey, TValue>>
      */

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -943,6 +943,32 @@ class Arr
     }
 
     /**
+     * Partition the array into two arrays using the given callback.
+     *
+     * @template TKey of array-key
+     * @template TValue of mixed
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  callable  $callback
+     * @return array<int<0, 1>, array<TKey, TValue>>
+     */
+    public static function partition($array, callable $callback)
+    {
+        $passed = [];
+        $failed = [];
+
+        foreach ($array as $key => $item) {
+            if ($callback($item, $key)) {
+                $passed[$key] = $item;
+            } else {
+                $failed[$key] = $item;
+            }
+        }
+
+        return [$passed, $failed];
+    }
+
+    /**
      * Filter items where the value is not null.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
+use Traversable;
 
 class Arr
 {
@@ -948,7 +949,7 @@ class Arr
      * @template TKey of array-key
      * @template TValue of mixed
      *
-     * @param  array<TKey, TValue>  $array
+     * @param  array<TKey, TValue>|Traversable<TKey, TValue>  $array
      * @param  callable  $callback
      * @return array<int<0, 1>, array<TKey, TValue>>
      */

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -948,7 +948,7 @@ class Arr
      * @template TKey of array-key
      * @template TValue of mixed
      *
-     * @param  array<TKey, TValue>|\Traversable<TKey, TValue>  $array
+     * @param  iterable<TKey, TValue>  $array
      * @param  callable  $callback
      * @return array<int<0, 1>, array<TKey, TValue>>
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -504,20 +504,11 @@ trait EnumeratesValues
      */
     public function partition($key, $operator = null, $value = null)
     {
-        $passed = [];
-        $failed = [];
-
         $callback = func_num_args() === 1
                 ? $this->valueRetriever($key)
                 : $this->operatorForWhere(...func_get_args());
 
-        foreach ($this as $key => $item) {
-            if ($callback($item, $key)) {
-                $passed[$key] = $item;
-            } else {
-                $failed[$key] = $item;
-            }
-        }
+        [$passed, $failed] = Arr::partition($this->getIterator(), $callback);
 
         return new static([new static($passed), new static($failed)]);
     }


### PR DESCRIPTION
Hey, this PR adds a `partition` method to the Array helper.

This allows using the existing partition logic, without needing to reach for collections.

```php
// Pre code:
$numbers = [0, 1, 2, 3, 4, 5];

// Before:
[$evens, $odds] = collect($numbers)->partition(fn(int $number) => $number % 2 === 0);

// After:
[$evens, $odds] = Arr::partition($numbers, fn(int $number) => $number % 2 === 0);
```

I also converted the existing `Collection::partition` to use the `Arr::partition` method, to prevent duplication. Happy to revert this bit if preferable.