### PR TITLE
Add test for Arr::reject method in Illuminate Support

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1533,4 +1533,32 @@ class SupportArrTest extends TestCase
             [],
         ], Arr::select($array, null));
     }
+
+    public function testReject()
+    {
+        $array = [1, 2, 3, 4, 5, 6];
+
+        // Test rejection behavior (removing even numbers)
+        $result = Arr::reject($array, function ($value) {
+            return $value % 2 === 0;
+        });
+
+        $this->assertEquals([
+            0 => 1,
+            2 => 3,
+            4 => 5,
+        ], $result);
+
+        // Test key preservation with associative array
+        $assocArray = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
+
+        $result = Arr::reject($assocArray, function ($value) {
+            return $value > 2;
+        });
+
+        $this->assertEquals([
+            'a' => 1,
+            'b' => 2,
+        ], $result);
+    }
 }


### PR DESCRIPTION
In this PR, test have been added for the reject method in Arr and Illuminate Support, and there was no test for this method before. It tests the correct functionality of the method.
