### PR TITLE
[12.x] Add cache:list command for listing configured cache stores

### DIFF
--- a/src/Illuminate/Foundation/Console/CacheListCommand.php
+++ b/src/Illuminate/Foundation/Console/CacheListCommand.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Terminal;
+
+#[AsCommand(name: 'cache:list')]
+class CacheListCommand extends Command
+{
+    protected $name = 'cache:list';
+
+    protected $description = 'List all configured cache stores and their status';
+
+    protected $headers = ['Store', 'Driver', 'Status', 'Error'];
+
+    protected static $terminalWidthResolver;
+
+    protected $statusColors = [
+        'OK' => 'green',
+        'ERROR' => 'red',
+    ];
+
+    public function handle()
+    {
+        $stores = config('cache.stores');
+
+        if (empty($stores)) {
+            return $this->components->error("Your application doesn't have any cache stores configured.");
+        }
+
+        $items = $this->getCacheStores();
+
+        if (empty($items)) {
+            return $this->components->error("Your application doesn't have any cache stores matching the given criteria.");
+        }
+
+        $this->displayStores($items);
+    }
+
+    protected function getCacheStores()
+    {
+        $stores = collect(config('cache.stores'))->map(function ($config, $store) {
+            return $this->getCacheStoreInformation($store, $config);
+        })->filter()->all();
+
+        if (($sort = $this->option('sort')) !== null) {
+            $stores = $this->sortStores($sort, $stores);
+        }
+
+        if ($this->option('reverse')) {
+            $stores = array_reverse($stores);
+        }
+
+        return $this->pluckColumns($stores);
+    }
+
+    protected function getCacheStoreInformation($store, $config)
+    {
+        $status = 'OK';
+        $error = null;
+
+        try {
+            Cache::store($store)->has('test');
+        } catch (\Throwable $th) {
+            $status = 'ERROR';
+            $error = $th->getMessage() . ' in ' . $th->getFile() . ' on line ' . $th->getLine();
+        }
+
+        return $this->filterStore([
+            'store' => $store,
+            'driver' => $config['driver'],
+            'status' => $status,
+            'error' => $error,
+        ]);
+    }
+
+    protected function sortStores($sort, array $stores)
+    {
+        return Arr::sort($stores, function ($store) use ($sort) {
+            return $store[$sort];
+        });
+    }
+
+    protected function pluckColumns(array $stores)
+    {
+        return array_map(function ($store) {
+            return Arr::only($store, $this->getColumns());
+        }, $stores);
+    }
+
+    protected function displayStores($stores)
+    {
+        $stores = collect($stores);
+
+        $this->output->writeln(
+            $this->option('json') ? $this->asJson($stores) : $this->forCli($stores)
+        );
+    }
+
+    protected function filterStore(array $store)
+    {
+        if (($this->option('store') && ! Str::contains($store['store'], $this->option('store'))) ||
+            ($this->option('driver') && ! Str::contains($store['driver'], $this->option('driver'))) ||
+            ($this->option('status') && ! Str::contains($store['status'], strtoupper($this->option('status'))))
+        ) {
+            return;
+        }
+
+        return $store;
+    }
+
+    protected function getColumns()
+    {
+        return array_map('strtolower', $this->headers);
+    }
+
+    protected function asJson($stores)
+    {
+        return $stores->values()->toJson();
+    }
+
+    protected function forCli($stores)
+    {
+        $terminalWidth = $this->getTerminalWidth();
+
+        $maxStore = mb_strlen($stores->max('store'));
+
+        $storeCount = $this->determineStoreCountOutput($stores, $terminalWidth);
+
+        return $stores->map(function ($store) use ($maxStore, $terminalWidth) {
+            $spaces = str_repeat(' ', max($maxStore + 2 - mb_strlen($store['store']), 0));
+
+            $dots = str_repeat('.', max(
+                $terminalWidth - mb_strlen($store['store'] . $spaces . $store['driver']) - 30,
+                0
+            ));
+
+            $status = sprintf(
+                '<fg=%s>%s</>',
+                $this->statusColors[$store['status']] ?? 'default',
+                $store['status']
+            );
+
+            $line = sprintf(
+                "  <fg=white;options=bold>%s</> %s<fg=#6C7280>%s</> <fg=#6C7280>%s</> ⇂ %s",
+                $store['store'],
+                $spaces,
+                $dots,
+                $store['driver'],
+                $status
+            );
+
+            if ($store['error']) {
+                $line .= sprintf("\n    ⇂ <fg=red>%s</>", $store['error']);
+            }
+
+            return $line;
+        })
+            ->prepend('')
+            ->push('')
+            ->push($storeCount)
+            ->push('')
+            ->toArray();
+    }
+
+    protected function determineStoreCountOutput($stores, $terminalWidth)
+    {
+        $storeCountText = 'Showing [' . $stores->count() . '] cache stores';
+
+        $offset = $terminalWidth - mb_strlen($storeCountText) - 2;
+
+        $spaces = str_repeat(' ', $offset);
+
+        return $spaces . '<fg=blue;options=bold>' . $storeCountText . '</>';
+    }
+
+    public static function getTerminalWidth()
+    {
+        return is_null(static::$terminalWidthResolver)
+            ? (new Terminal)->getWidth()
+            : call_user_func(static::$terminalWidthResolver);
+    }
+
+    public static function resolveTerminalWidthUsing($resolver)
+    {
+        static::$terminalWidthResolver = $resolver;
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['json', null, InputOption::VALUE_NONE, 'Output the cache store list as JSON'],
+            ['store', null, InputOption::VALUE_OPTIONAL, 'Filter the stores by name'],
+            ['driver', null, InputOption::VALUE_OPTIONAL, 'Filter the stores by driver'],
+            ['status', null, InputOption::VALUE_OPTIONAL, 'Filter the stores by status (OK or ERROR)'],
+            ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the stores'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (store, driver, status) to sort by', 'store'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/CacheListCommand.php
+++ b/src/Illuminate/Foundation/Console/CacheListCommand.php
@@ -69,7 +69,7 @@ class CacheListCommand extends Command
             Cache::store($store)->has('test');
         } catch (\Throwable $th) {
             $status = 'ERROR';
-            $error = $th->getMessage() . ' in ' . $th->getFile() . ' on line ' . $th->getLine();
+            $error = $th->getMessage().' in '.$th->getFile().' on line '.$th->getLine();
         }
 
         return $this->filterStore([
@@ -137,7 +137,7 @@ class CacheListCommand extends Command
             $spaces = str_repeat(' ', max($maxStore + 2 - mb_strlen($store['store']), 0));
 
             $dots = str_repeat('.', max(
-                $terminalWidth - mb_strlen($store['store'] . $spaces . $store['driver']) - 30,
+                $terminalWidth - mb_strlen($store['store'].$spaces.$store['driver']) - 30,
                 0
             ));
 
@@ -148,7 +148,7 @@ class CacheListCommand extends Command
             );
 
             $line = sprintf(
-                "  <fg=white;options=bold>%s</> %s<fg=#6C7280>%s</> <fg=#6C7280>%s</> ⇂ %s",
+                '  <fg=white;options=bold>%s</> %s<fg=#6C7280>%s</> <fg=#6C7280>%s</> ⇂ %s',
                 $store['store'],
                 $spaces,
                 $dots,
@@ -171,13 +171,13 @@ class CacheListCommand extends Command
 
     protected function determineStoreCountOutput($stores, $terminalWidth)
     {
-        $storeCountText = 'Showing [' . $stores->count() . '] cache stores';
+        $storeCountText = 'Showing ['.$stores->count().'] cache stores';
 
         $offset = $terminalWidth - mb_strlen($storeCountText) - 2;
 
         $spaces = str_repeat(' ', $offset);
 
-        return $spaces . '<fg=blue;options=bold>' . $storeCountText . '</>';
+        return $spaces.'<fg=blue;options=bold>'.$storeCountText.'</>';
     }
 
     public static function getTerminalWidth()

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
+use Illuminate\Foundation\Console\CacheListCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
@@ -119,6 +120,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'About' => AboutCommand::class,
         'CacheClear' => CacheClearCommand::class,
         'CacheForget' => CacheForgetCommand::class,
+        'CacheList' => CacheListCommand::class,
         'ClearCompiled' => ClearCompiledCommand::class,
         'ClearResets' => ClearResetsCommand::class,
         'ConfigCache' => ConfigCacheCommand::class,


### PR DESCRIPTION
---

# 🔥 New Artisan Command: `cache:list`

Some cache stores may have been added dynamically by third-party packages, and there hasn't been a centralized way to view them. This feature provides the ability to list all configured cache stores in one place, helping you manage and troubleshoot your cache configuration more easily.

This PR introduces a new Artisan command:

```bash
php artisan cache:list
```

This command provides a comprehensive overview of all configured cache stores, their drivers, and real-time statuses, making debugging and configuration management much easier.

## ✨ Features
- 📌 **Lists all cache stores** along with their drivers  
- 🟢 **Displays real-time status** for each store (OK/ERROR)  
- ⚠️ **Provides detailed error messages** when stores are misconfigured  
- 🔍 **Supports filtering** by store name, driver, or status  
- 📊 **Sorting and reverse ordering** options  
- ⚡ **JSON output for automation & monitoring**  

## 🛠️ Command Options
```bash
--json            # Output as JSON  
--store=         # Filter by store name  
--driver=        # Filter by driver type  
--status=        # Filter by status (OK or ERROR)  
--reverse, -r    # Reverse the order  
--sort=          # Sort by column (store, driver, status)  
```

## 🔮 Future Scope
If this approach is accepted, I can introduce similar `list` commands for other Laravel subsystems:
- 🗄️ **`database:list`** – Show configured database connections  
- 📂 **`filesystem:list`** – Display filesystem disks  
- 📜 **`logging:list`** – List logging channels  
- … and other configurable subsystems  

Each command would follow the same structure, providing better visibility and easier debugging.

## 🚀 Benefits
✅ **Better visibility** into application configuration  
🐛 **Easier debugging** of misconfigured stores  
🔄 **Quick status checks** for all stores  
🏗 **Useful for multi-store environments**  
⚡ **Ideal for automated monitoring & health checks**  

### 📷 Preview
![image](https://github.com/user-attachments/assets/3f3a9430-2874-4fa0-80d4-c47a2ea44d18)

Let me know if you have any suggestions or if you'd like any modifications! 🚀
