### PR TITLE
[12.x] Fix Macroable trait conflicting with class magic methods

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -86,14 +86,14 @@ trait Macroable
     public static function __callStatic($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            $parent = get_parent_class(static::class);
-            if ($parent && method_exists($parent, '__callStatic')) {
+            // Check if we can call parent::__callStatic() - this checks the entire inheritance chain
+            if (is_callable(['parent', '__callStatic'], true)) {
                 return parent::__callStatic($method, $parameters);
-            } else {
-                throw new BadMethodCallException(sprintf(
-                    'Method %s::%s does not exist.', static::class, $method
-                ));
             }
+            
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', static::class, $method
+            ));
         }
 
         $macro = static::$macros[$method];
@@ -117,13 +117,14 @@ trait Macroable
     public function __call($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            if (method_exists(get_parent_class($this), '__call')) {
+            // Check if we can call parent::__call() - this checks the entire inheritance chain
+            if (is_callable(['parent', '__call'], true)) {
                 return parent::__call($method, $parameters);
-            } else {
-                throw new BadMethodCallException(sprintf(
-                    'Method %s::%s does not exist.', static::class, $method
-                ));
             }
+            
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', static::class, $method
+            ));
         }
 
         $macro = static::$macros[$method];

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -90,7 +90,7 @@ trait Macroable
             if (is_callable(['parent', '__callStatic'], true)) {
                 return parent::__callStatic($method, $parameters);
             }
-            
+
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));
@@ -121,7 +121,7 @@ trait Macroable
             if (is_callable(['parent', '__call'], true)) {
                 return parent::__call($method, $parameters);
             }
-            
+
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -86,9 +86,14 @@ trait Macroable
     public static function __callStatic($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $method
-            ));
+            $parent = get_parent_class(static::class);
+            if ($parent && method_exists($parent, '__callStatic')) {
+                return parent::__callStatic($method, $parameters);
+            } else {
+                throw new BadMethodCallException(sprintf(
+                    'Method %s::%s does not exist.', static::class, $method
+                ));
+            }
         }
 
         $macro = static::$macros[$method];
@@ -112,9 +117,13 @@ trait Macroable
     public function __call($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $method
-            ));
+            if (method_exists(get_parent_class($this), '__call')) {
+                return parent::__call($method, $parameters);
+            } else {
+                throw new BadMethodCallException(sprintf(
+                    'Method %s::%s does not exist.', static::class, $method
+                ));
+            }
         }
 
         $macro = static::$macros[$method];

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Traits;
 
 use BadMethodCallException;
 use Closure;
+use Error;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -86,14 +87,13 @@ trait Macroable
     public static function __callStatic($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            // Check if we can call parent::__callStatic() - this checks the entire inheritance chain
-            if (is_callable(['parent', '__callStatic'], true)) {
+            try {
                 return parent::__callStatic($method, $parameters);
+            } catch (Error $e) {
+                throw new BadMethodCallException(sprintf(
+                    'Method %s::%s does not exist.', static::class, $method
+                ));
             }
-
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $method
-            ));
         }
 
         $macro = static::$macros[$method];
@@ -117,14 +117,14 @@ trait Macroable
     public function __call($method, $parameters)
     {
         if (! static::hasMacro($method)) {
-            // Check if we can call parent::__call() - this checks the entire inheritance chain
-            if (is_callable(['parent', '__call'], true)) {
+            try {
                 return parent::__call($method, $parameters);
+            } catch (Error $e) {
+                throw new BadMethodCallException(sprintf(
+                    'Method %s::%s does not exist.', static::class, $method
+                ));
             }
 
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $method
-            ));
         }
 
         $macro = static::$macros[$method];

--- a/tests/Integration/Database/EloquentMacroableTest.php
+++ b/tests/Integration/Database/EloquentMacroableTest.php
@@ -3,11 +3,8 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Traits\Macroable;
@@ -43,9 +40,9 @@ class EloquentMacroableTest extends TestCase
     {
         // This test verifies that static methods like create() continue to work
         // even when the Macroable trait is used
-        
+
         $company = TestCompany::create(['name' => 'Test Company']);
-        
+
         $this->assertInstanceOf(TestCompany::class, $company);
         $this->assertEquals('Test Company', $company->name);
         $this->assertTrue($company->exists);
@@ -55,61 +52,61 @@ class EloquentMacroableTest extends TestCase
     {
         // This test verifies that eloquent methods for retrieving models from the database
         // work correctly even when the Macroable trait is used
-        
+
         // Create a company using the create method
         TestCompany::create(['name' => 'First Company']);
-        
+
         // Retrieve it using first()
         $company = TestCompany::query()->first();
-        
+
         $this->assertInstanceOf(TestCompany::class, $company);
         $this->assertEquals('First Company', $company->name);
     }
-    
+
     public function test_custom_macro_works()
     {
         // This test verifies that custom macros work with model instances
-        
+
         $company = TestCompany::create(['name' => 'Macro Test Company']);
-        
+
         // Use the custom macro
         $result = $company->getCompanyDetails();
-        
+
         $this->assertEquals('Macro Test Company (ID: 1)', $result);
     }
-    
+
     public function test_static_macro_works()
     {
         // This test verifies that static macros work
-        
+
         $result = TestCompany::findByName('Static Macro Company');
-        
+
         $this->assertNull($result); // Should be null since we haven't created this company
-        
+
         // Create the company and try again
         TestCompany::create(['name' => 'Static Macro Company']);
-        
+
         $result = TestCompany::findByName('Static Macro Company');
         $this->assertInstanceOf(TestCompany::class, $result);
         $this->assertEquals('Static Macro Company', $result->name);
     }
-    
+
     public function test_both_eloquent_and_macros_work_together()
     {
         // This test verifies the integration of Eloquent functionality and macros
-        
+
         // Create a company and its team
         $company = TestCompany::create(['name' => 'Integrated Company']);
         $team = $company->teams()->create(['name' => 'Integrated Team']);
-        
+
         // Retrieve the company and use both Eloquent methods and macros
         $retrieved = TestCompany::find($company->id);
         $this->assertEquals('Integrated Company', $retrieved->name);
-        
+
         // Use the custom macro
         $details = $retrieved->getCompanyDetails();
         $this->assertEquals('Integrated Company (ID: 1)', $details);
-        
+
         // Use the relationship
         $this->assertCount(1, $retrieved->teams);
         $this->assertEquals('Integrated Team', $retrieved->teams->first()->name);
@@ -119,10 +116,10 @@ class EloquentMacroableTest extends TestCase
 class TestCompany extends Model
 {
     use Macroable;
-    
+
     protected $table = 'test_companies';
     protected $fillable = ['name'];
-    
+
     public function teams()
     {
         return $this->hasMany(TestTeam::class, 'company_id');
@@ -133,7 +130,7 @@ class TestTeam extends Model
 {
     protected $table = 'test_teams';
     protected $fillable = ['company_id', 'name'];
-    
+
     public function company()
     {
         return $this->belongsTo(TestCompany::class, 'company_id');
@@ -146,20 +143,21 @@ class TestMacroServiceProvider extends ServiceProvider
     {
         // Nothing to register
     }
-    
+
     public function boot()
     {
         // Instance macro
         TestCompany::macro('getCompanyDetails', function () {
             /** @var TestCompany $this */
-            return $this->name . ' (ID: ' . $this->id . ')';
+            return $this->name.' (ID: '.$this->id.')';
         });
-        
+
         // Static macro
         TestCompany::macro('findByName', function ($name) {
             /** @var \Illuminate\Database\Eloquent\Builder $query */
             $query = TestCompany::query();
+
             return $query->where('name', $name)->first();
         });
     }
-} 
+}

--- a/tests/Integration/Database/EloquentMacroableTest.php
+++ b/tests/Integration/Database/EloquentMacroableTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Traits\Macroable;
+use Orchestra\Testbench\TestCase;
+
+class EloquentMacroableTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create tables
+        Schema::create('test_companies', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        // Register the service provider to define the macro
+        $this->app->register(TestMacroServiceProvider::class);
+    }
+
+    public function test_create_static_method_fails_with_macroable()
+    {
+        // This test demonstrates the conflict between Macroable and Eloquent
+        // We expect BadMethodCallException because the Macroable trait intercepts
+        // the create call and doesn't find it as a defined macro
+        
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method Illuminate\Tests\Integration\Database\TestCompany::create does not exist');
+        
+        // This should throw the exception because create isn't defined as a macro
+        TestCompany::create(['name' => 'Test Company']);
+    }
+
+    public function test_query_first_fails_with_macroable()
+    {
+        // Even if we manually insert data, attempting to retrieve it will fail
+        // because of the hydrate method conflict
+        
+        // Insert a record directly to bypass the create method
+        $id = DB::table('test_companies')->insertGetId([
+            'name' => 'Direct Insert Company',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        
+        $this->expectException(\BadMethodCallException::class);
+        
+        // This fails with: Method TestCompany::hydrate does not exist
+        TestCompany::query()->first();
+    }
+}
+
+class TestCompany extends Model
+{
+    use Macroable;
+    
+    protected $table = 'test_companies';
+    protected $fillable = ['name'];
+}
+
+class TestMacroServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        // Nothing to register
+    }
+    
+    public function boot()
+    {
+        TestCompany::macro('customMethod', function () {
+            /** @var Model $this */
+            return $this->getKey();
+        });
+    }
+} 

--- a/tests/Integration/Database/EloquentMacroableTest.php
+++ b/tests/Integration/Database/EloquentMacroableTest.php
@@ -28,39 +28,91 @@ class EloquentMacroableTest extends TestCase
             $table->timestamps();
         });
 
+        Schema::create('test_teams', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained('test_companies');
+            $table->string('name');
+            $table->timestamps();
+        });
+
         // Register the service provider to define the macro
         $this->app->register(TestMacroServiceProvider::class);
     }
 
-    public function test_create_static_method_fails_with_macroable()
+    public function test_create_static_method_works_with_macroable()
     {
-        // This test demonstrates the conflict between Macroable and Eloquent
-        // We expect BadMethodCallException because the Macroable trait intercepts
-        // the create call and doesn't find it as a defined macro
+        // This test verifies that static methods like create() continue to work
+        // even when the Macroable trait is used
         
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\Tests\Integration\Database\TestCompany::create does not exist');
+        $company = TestCompany::create(['name' => 'Test Company']);
         
-        // This should throw the exception because create isn't defined as a macro
-        TestCompany::create(['name' => 'Test Company']);
+        $this->assertInstanceOf(TestCompany::class, $company);
+        $this->assertEquals('Test Company', $company->name);
+        $this->assertTrue($company->exists);
     }
 
-    public function test_query_first_fails_with_macroable()
+    public function test_query_first_works_with_macroable()
     {
-        // Even if we manually insert data, attempting to retrieve it will fail
-        // because of the hydrate method conflict
+        // This test verifies that eloquent methods for retrieving models from the database
+        // work correctly even when the Macroable trait is used
         
-        // Insert a record directly to bypass the create method
-        $id = DB::table('test_companies')->insertGetId([
-            'name' => 'Direct Insert Company',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        // Create a company using the create method
+        TestCompany::create(['name' => 'First Company']);
         
-        $this->expectException(\BadMethodCallException::class);
+        // Retrieve it using first()
+        $company = TestCompany::query()->first();
         
-        // This fails with: Method TestCompany::hydrate does not exist
-        TestCompany::query()->first();
+        $this->assertInstanceOf(TestCompany::class, $company);
+        $this->assertEquals('First Company', $company->name);
+    }
+    
+    public function test_custom_macro_works()
+    {
+        // This test verifies that custom macros work with model instances
+        
+        $company = TestCompany::create(['name' => 'Macro Test Company']);
+        
+        // Use the custom macro
+        $result = $company->getCompanyDetails();
+        
+        $this->assertEquals('Macro Test Company (ID: 1)', $result);
+    }
+    
+    public function test_static_macro_works()
+    {
+        // This test verifies that static macros work
+        
+        $result = TestCompany::findByName('Static Macro Company');
+        
+        $this->assertNull($result); // Should be null since we haven't created this company
+        
+        // Create the company and try again
+        TestCompany::create(['name' => 'Static Macro Company']);
+        
+        $result = TestCompany::findByName('Static Macro Company');
+        $this->assertInstanceOf(TestCompany::class, $result);
+        $this->assertEquals('Static Macro Company', $result->name);
+    }
+    
+    public function test_both_eloquent_and_macros_work_together()
+    {
+        // This test verifies the integration of Eloquent functionality and macros
+        
+        // Create a company and its team
+        $company = TestCompany::create(['name' => 'Integrated Company']);
+        $team = $company->teams()->create(['name' => 'Integrated Team']);
+        
+        // Retrieve the company and use both Eloquent methods and macros
+        $retrieved = TestCompany::find($company->id);
+        $this->assertEquals('Integrated Company', $retrieved->name);
+        
+        // Use the custom macro
+        $details = $retrieved->getCompanyDetails();
+        $this->assertEquals('Integrated Company (ID: 1)', $details);
+        
+        // Use the relationship
+        $this->assertCount(1, $retrieved->teams);
+        $this->assertEquals('Integrated Team', $retrieved->teams->first()->name);
     }
 }
 
@@ -70,6 +122,22 @@ class TestCompany extends Model
     
     protected $table = 'test_companies';
     protected $fillable = ['name'];
+    
+    public function teams()
+    {
+        return $this->hasMany(TestTeam::class, 'company_id');
+    }
+}
+
+class TestTeam extends Model
+{
+    protected $table = 'test_teams';
+    protected $fillable = ['company_id', 'name'];
+    
+    public function company()
+    {
+        return $this->belongsTo(TestCompany::class, 'company_id');
+    }
 }
 
 class TestMacroServiceProvider extends ServiceProvider
@@ -81,9 +149,17 @@ class TestMacroServiceProvider extends ServiceProvider
     
     public function boot()
     {
-        TestCompany::macro('customMethod', function () {
-            /** @var Model $this */
-            return $this->getKey();
+        // Instance macro
+        TestCompany::macro('getCompanyDetails', function () {
+            /** @var TestCompany $this */
+            return $this->name . ' (ID: ' . $this->id . ')';
+        });
+        
+        // Static macro
+        TestCompany::macro('findByName', function ($name) {
+            /** @var \Illuminate\Database\Eloquent\Builder $query */
+            $query = TestCompany::query();
+            return $query->where('name', $name)->first();
         });
     }
 } 


### PR DESCRIPTION

## Problem  
Adding the `Macroable` trait to a class that already implements `__call` and  
`__callStatic` breaks core functionality. This is especially problematic for  
**Eloquent models**, where methods like `create()` and `hydrate()` fail, but  
it affects **any class** using these magic methods.  

**Reproduction:** A full demonstration of this issue can be found at  
[https://github.com/rsd/macroable-test](https://github.com/rsd/macroable-test).  

### Root Cause  
- Both the base class and `Macroable` implement `__call` and `__callStatic`.  
- PHP gives **precedence** to the trait's implementation.  
- `Macroable` does not attempt to **delegate** to the parent class.  

## Solution  
Updated `Macroable`'s magic methods to **check if the parent class can handle  
the method** before throwing an exception. This ensures:  
- **Macro functionality is preserved.**  
- **Original class methods continue to work.**  

## Testing  
- **Added tests** using **Eloquent models** as a real-world example.  
- **Verified** that both **standard Eloquent methods** and **custom macros**  
  work together correctly.  

## Impact  
This fix is critical for:  
- **Eloquent models** that use `Macroable`.  
- Other Laravel components relying on magic methods (**Collections, Query Builder, etc.**).  
- Any class using `Macroable` **alongside magic methods**.  
- **Modular Laravel applications**, where modules extend core models dynamically.  

Without this fix, developers **must choose** between using `Macroable` or keeping  
the class’s original magic method functionality. This is especially problematic  
for **modular Laravel systems**, where extending models dynamically is essential.  
