### PR TITLE
[12.x] Compilable for Validation Contract

### DIFF
--- a/src/Illuminate/Contracts/Validation/CompilableRules.php
+++ b/src/Illuminate/Contracts/Validation/CompilableRules.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Contracts\Validation;
 
-interface CompiledRules
+interface CompilableRules
 {
     /**
-     * Compile the callback into an array of rules.
+     * Compile the object into usable rules.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/Contracts/Validation/CompiledRules.php
+++ b/src/Illuminate/Contracts/Validation/CompiledRules.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface CompiledRules
+{
+    /**
+     * Compile the callback into an array of rules.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $data
+     * @param  mixed  $context
+     * @return \stdClass
+     */
+    public function compile($attribute, $value, $data = null, $context = null);
+}

--- a/src/Illuminate/Validation/NestedRules.php
+++ b/src/Illuminate/Validation/NestedRules.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Validation;
 
-use Illuminate\Contracts\Validation\CompiledRules;
+use Illuminate\Contracts\Validation\CompilableRules;
 use Illuminate\Support\Arr;
 
-class NestedRules implements CompiledRules
+class NestedRules implements CompilableRules
 {
     /**
      * The callback to execute.
@@ -38,22 +38,6 @@ class NestedRules implements CompiledRules
     {
         $rules = call_user_func($this->callback, $value, $attribute, $data, $context);
 
-        $parser = new ValidationRuleParser(
-            Arr::undot(Arr::wrap($data))
-        );
-
-        if (is_array($rules) && ! array_is_list($rules)) {
-            $nested = [];
-
-            foreach ($rules as $key => $rule) {
-                $nested[$attribute.'.'.$key] = $rule;
-            }
-
-            $rules = $nested;
-        } else {
-            $rules = [$attribute => $rules];
-        }
-
-        return $parser->explode(ValidationRuleParser::filterConditionalRules($rules, $data));
+        return Rule::compile($attribute, $rules, $data);
     }
 }

--- a/src/Illuminate/Validation/NestedRules.php
+++ b/src/Illuminate/Validation/NestedRules.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Validation\CompilableRules;
-use Illuminate\Support\Arr;
 
 class NestedRules implements CompilableRules
 {

--- a/src/Illuminate/Validation/NestedRules.php
+++ b/src/Illuminate/Validation/NestedRules.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Contracts\Validation\CompiledRules;
 use Illuminate\Support\Arr;
 
-class NestedRules
+class NestedRules implements CompiledRules
 {
     /**
      * The callback to execute.

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
@@ -243,5 +244,34 @@ class Rule
     public static function numeric()
     {
         return new Numeric;
+    }
+
+    /**
+     * Compile a set of rules for an attribute.
+     *
+     * @param  string  $attribute
+     * @param  array  $rules
+     * @param  array|null  $data
+     * @return object|\stdClass
+     */
+    public static function compile($attribute, $rules, $data = null)
+    {
+        $parser = new ValidationRuleParser(
+            Arr::undot(Arr::wrap($data))
+        );
+
+        if (is_array($rules) && ! array_is_list($rules)) {
+            $nested = [];
+
+            foreach ($rules as $key => $rule) {
+                $nested[$attribute.'.'.$key] = $rule;
+            }
+
+            $rules = $nested;
+        } else {
+            $rules = [$attribute => $rules];
+        }
+
+        return $parser->explode(ValidationRuleParser::filterConditionalRules($rules, $data));
     }
 }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Validation;
 
 use Closure;
-use Illuminate\Contracts\Validation\CompiledRules;
+use Illuminate\Contracts\Validation\CompilableRules;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -139,7 +139,7 @@ class ValidationRuleParser
             return $rule;
         }
 
-        if ($rule instanceof CompiledRules) {
+        if ($rule instanceof CompilableRules) {
             return $rule->compile(
                 $attribute, $this->data[$attribute] ?? null, Arr::dot($this->data), $this->data
             )->rules[$attribute];
@@ -165,7 +165,7 @@ class ValidationRuleParser
         foreach ($data as $key => $value) {
             if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $rule) {
-                    if ($rule instanceof CompiledRules) {
+                    if ($rule instanceof CompilableRules) {
                         $context = Arr::get($this->data, Str::beforeLast($key, '.'));
 
                         $compiled = $rule->compile($key, $value, $data, $context);
@@ -239,7 +239,7 @@ class ValidationRuleParser
      */
     public static function parse($rule)
     {
-        if ($rule instanceof RuleContract || $rule instanceof CompiledRules) {
+        if ($rule instanceof RuleContract || $rule instanceof CompilableRules) {
             return [$rule, []];
         }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Closure;
+use Illuminate\Contracts\Validation\CompiledRules;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -138,7 +139,7 @@ class ValidationRuleParser
             return $rule;
         }
 
-        if ($rule instanceof NestedRules) {
+        if ($rule instanceof CompiledRules) {
             return $rule->compile(
                 $attribute, $this->data[$attribute] ?? null, Arr::dot($this->data), $this->data
             )->rules[$attribute];
@@ -164,7 +165,7 @@ class ValidationRuleParser
         foreach ($data as $key => $value) {
             if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $rule) {
-                    if ($rule instanceof NestedRules) {
+                    if ($rule instanceof CompiledRules) {
                         $context = Arr::get($this->data, Str::beforeLast($key, '.'));
 
                         $compiled = $rule->compile($key, $value, $data, $context);
@@ -238,7 +239,7 @@ class ValidationRuleParser
      */
     public static function parse($rule)
     {
-        if ($rule instanceof RuleContract || $rule instanceof NestedRules) {
+        if ($rule instanceof RuleContract || $rule instanceof CompiledRules) {
             return [$rule, []];
         }
 


### PR DESCRIPTION
# Changes

- Adds a new validation contract called Compilable.
- Updates the ValidationRuleParser to use the Compilable contract instead of the NestedRules class for type checks.
- Moves some of the code from NestedRules into a static `Rule::compile()` method so it's easier to reuse.
- Applies Compilable contract to the original NestedRules class.

No tests added because there's no new logic added. Just refactoring. I don't believe any of the code would be breaking in this situation. The NestedRules class just behaves the same even if someone extended it. I wouldn't expect the RulesParser to be extended but no method signatures have been changed.

# Why

NestedRules are great but can't be extended as a class easily without fiddling with the constructor and overloading the compile method while duplicating that logic. This PR seeks to make NestedRules use a contract that developers can use themselves to determine nested rule logic instead of being forced to use a closure.

for instance:

```php
class FooNestedRules extends NestedRules
{
    public function __construct()
    {
        // callable property has to be set with empty closure
        parent::__construct(function() {});
    }

    public function compile($attribute, $value, $data = null, $context = null)
    {
       $rules = // do some logic to make the rules.

        $parser = new ValidationRuleParser(
            Arr::undot(Arr::wrap($data))
        );

        if (is_array($rules) && ! array_is_list($rules)) {
            $nested = [];

            foreach ($rules as $key => $rule) {
                $nested[$attribute.'.'.$key] = $rule;
            }

            $rules = $nested;
        } else {
            $rules = [$attribute => $rules];
        }

        return $parser->explode(ValidationRuleParser::filterConditionalRules($rules, $data));
    }
}
```

Could become a class like:

```php
class FooNestedRules implements CompilableRules
{
    public function compile($attribute, $value, $data = null, $context = null)
    {
       $rules = // do some logic to make the rules.

       return Rule::compile($attribute, $rules, $data);
    }
}
```

This will make it possible for people to implement classes to manage their own nested rules.

```php
Validation::make([
    'form' => [
        'fields' => [
           [
               'type' => 'text',
               'text'  => 'foobar',
           ],
           [
               'type'  => 'image',
               'path'  => 'foobar.jpg',
               'alt'     => 'photo of foobar',
           ]
        ]
    ]
], [
    'form.fields.*' => new FormFields();
]);