### PR TITLE
[12.x] Declare Migration Closure as static

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create('{{ table }}', static function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('{{ table }}', static function (Blueprint $table) {
+        Schema::create('{{ table }}', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', static function (Blueprint $table) {
             //
         });
     }
@@ -21,7 +21,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', static function (Blueprint $table) {
             //
         });
     }

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -24,7 +24,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foobar\', function (Blueprint $table) {',
+            'Schema::table(\'foobar\', static function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -36,7 +36,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
+            'Schema::create(\'foos\', static function (Blueprint $table) {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');
     }
@@ -49,7 +49,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foobar\', function (Blueprint $table) {',
+            'Schema::create(\'foobar\', static function (Blueprint $table) {',
             'Schema::dropIfExists(\'foobar\');',
         ], 'foos_table.php');
     }

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -12,7 +12,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foos\', function (Blueprint $table) {',
+            'Schema::table(\'foos\', static function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
 

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -185,7 +185,7 @@ class ModelMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
+            'Schema::create(\'foos\', static function (Blueprint $table) {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');
 


### PR DESCRIPTION
Whenever I create a new model with migration, my IDE(PhpStorm) always recommends making this change, so it would be better if the migration already came with this closure declared as static.

The change is very simple and does not cause any drastic changes, so I see no reason not to include it by default.