### PR TITLE
[12.x] DocBlock: Changed typehint for `Arr::partition` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -949,7 +949,7 @@ class Arr
      * @template TValue of mixed
      *
      * @param  iterable<TKey, TValue>  $array
-     * @param  callable  $callback
+     * @param  callable(TValue, TKey): bool  $callback
      * @return array<int<0, 1>, array<TKey, TValue>>
      */
     public static function partition($array, callable $callback)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### DocBlock Change
Changed the docblock for the newly introduced `Arr::partition` (#54859). The typehint for the `$callback` parameter now communicates what the callable will be receiving and should be returning (`callable(TValue, TKey): bool`)

### Example
```php
/**
 * @var array<string, bool>
 */
$names = [
    'taylor' => true,
    'francis' => true,
    'primeagen' => false,
];

// Before
[$realNames, $aliasNames] = Arr::partition(
    $names,
    fn (/** @param mixed */ $value, /** @param mixed */ $key) => /** @return mixed */ $value,
);

// After
[$realNames, $aliasNames] = Arr::partition(
    $names,
    fn (/** @param bool */ $value, /** @param string */ $key) => /** @return bool */ $value,
);
```

### Why
`Arr::partition` was recently added and does not have a generic typehint for the `$callback` parameter. I matched the typehint to be similar to the typehints for the preexisting `Arr::first` and `Arr::last` callbacks.