### PR TITLE
[12.x] Adds a new "Alias" contextual attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Alias.php
+++ b/src/Illuminate/Container/Attributes/Alias.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class Alias implements ContextualAttribute
+{
+    public function __construct(
+        public string $alias,
+    ) {
+    }
+
+    /**
+     * Resolve the tag.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->get($attribute->alias);
+    }
+}

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -7,6 +7,7 @@ use Illuminate\Auth\AuthManager;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Config\Repository;
+use Illuminate\Container\Attributes\Alias;
 use Illuminate\Container\Attributes\Auth;
 use Illuminate\Container\Attributes\Authenticated;
 use Illuminate\Container\Attributes\Cache;
@@ -299,6 +300,27 @@ class ContextualAttributeBindingTest extends TestCase
 
         $this->assertEquals([1, 2], iterator_to_array($value));
     }
+
+    public function testAliasAttribute()
+    {
+        $container = new Container;
+
+        $container->bind(ContainerTestAliasAttribute::class, fn () => new ContainerTestAliasAttribute('default'));
+        $container->bind('one', fn () => new ContainerTestAliasAttribute('one'));
+        $container->bind('two', fn () => new ContainerTestAliasAttribute('two'));
+
+        $default = $container->call(fn (ContainerTestAliasAttribute $object) => $object->name);
+
+        $this->assertEquals('default', $default);
+
+        $one = $container->call(fn (#[Alias('one')] ContainerTestAliasAttribute $object) => $object->name);
+
+        $this->assertEquals('one', $one);
+
+        $two = $container->call(fn (#[Alias('two')] ContainerTestAliasAttribute $object) => $object->name);
+
+        $this->assertEquals('two', $two);
+    }
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
@@ -400,6 +422,14 @@ final class ContainerTestHasConfigValueWithResolvePropertyAndAfterCallback
     public function __construct(
         #[ContainerTestConfigValueWithResolveAndAfter]
         public object $person
+    ) {
+    }
+}
+
+final class ContainerTestAliasAttribute
+{
+    public function __construct(
+        public string $name
     ) {
     }
 }


### PR DESCRIPTION
# Motivation
Laravel provides a way to define an alias when registering a service in the container, which is convenient when initializing a subset of the service and using it in different parts of the application.

```
// Service
class State
{
    public function __construct(private string $storageKey) {}
}

// AppServiceProvider
$this->app->bind('module1.state', fn () => new State('module1'));
$this->app->bind('module2.state', fn () => new State('module2'));
```

However, there is no straightforward way to inject these instances into multiple services without manually binding them in the service provider.

# Solution
A new `Alias` contextual attribute allows dependencies to be resolved by their alias.

```
class Service
{
    public function __construct(private #[Alias('module1.state')] State $state) {}
}
```

This ensures that the correct instance of State is resolved based on the specified alias.