### PR TITLE
Add dates to allowed PHPDoc types of Builder::having()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2400,8 +2400,8 @@ class Builder implements BuilderContract
      * Add a "having" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
-     * @param  string|int|float|null  $operator
-     * @param  string|int|float|null  $value
+     * @param  \DateTimeInterface|string|int|float|null  $operator
+     * @param  \DateTimeInterface|string|int|float|null  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -2452,8 +2452,8 @@ class Builder implements BuilderContract
      * Add an "or having" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
-     * @param  string|int|float|null  $operator
-     * @param  string|int|float|null  $value
+     * @param  \DateTimeInterface|string|int|float|null  $operator
+     * @param  \DateTimeInterface|string|int|float|null  $value
      * @return $this
      */
     public function orHaving($column, $operator = null, $value = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Dates work fine in a `having()` clause; `Illuminate\Database\Connection::prepareBindings()` is explicitly checking for a `\DateTimeInterface` object so that's what I've used in the comment.

This prevents phpstan from complaining:
```none
Parameter #3 $value of method Illuminate\Database\Query\Builder::having() expects float|int|string|null, Illuminate\Support\Carbon given. 
```

Related, I also noted (but didn't change) that `Builder::havingBetween()` is checking for a `Carbon\CarbonPeriod` instance, but should probably be checking for its ancestor `\DatePeriod` instance instead. This would maintain consistency with other checks later in the code. 
