### PR TITLE
[13.x] Removed unneeded default argument

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -545,7 +545,7 @@ class Str
             return false;
         }
 
-        return json_validate($value, 512);
+        return json_validate($value);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### Why
This is a very minor change. Recently https://github.com/laravel/framework/pull/54876 removed unneeded function existence checks. Two of the calls were for `json_validate`, but only one of them passed in a depth value (`512`, which is the php default). This PR is removes the passing of a default value, normalizes the code to be the same in both cases of `json_validate`, and is based on this comment: https://github.com/laravel/framework/pull/54876#discussion_r1979895328.

### What
```diff php
-return json_validate($value, 512);
+return json_validate($value);
```