### PR TITLE
[11.x] Check if the running Symfony process has timed out

### DIFF
--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -66,9 +66,17 @@ class InvokedProcess implements InvokedProcessContract
      * Determine if the process is still running.
      *
      * @return bool
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
      */
     public function running()
     {
+        try {
+            $this->process->checkTimeout();
+        } catch (SymfonyTimeoutException $e) {
+            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+        }
+
         return $this->process->isRunning();
     }
 


### PR DESCRIPTION
This fix checks for timeouts when a process is running.

Consider the following example from the documentation: 
```
$process = Process::timeout(120)->start('bash import.sh');
 
// ...
 
$result = $process->wait();
```

This uses the `wait` method from Symfony's `Process` which includes a call to `checkTimeout` that throws `ProcessTimedOutException` which the framework catches and reports back.

Compared to this example from the documentation:
```
$process = Process::timeout(120)->start('bash import.sh');
 
while ($process->running()) {
    // ...
}
 
$result = $process->wait();
```

This uses the `isRunning` method from Symfony's `Process` which doesn't ever call `checkTimeout`. The loop will never catch any timeouts.

If this change is too breaking, maybe instead exposing the `checkTimeout` method and adding a note to the docs so developers know to make this check themselves in their `while` loop ?