### PR TITLE
[12.x] Adds AsFluentObject caster

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsFluentObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsFluentObject.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class AsFluentObject implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Fluent>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            public function __construct(protected array $arguments) {}
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key])) {
+                    return;
+                }
+
+                $data = Json::decode($attributes[$key]);
+
+                if (! is_array($data)) {
+                    return;
+                }
+
+                $fluentClass = $this->arguments[0] ?? null;
+                if (is_subclass_of($fluentClass, \Illuminate\Support\Fluent::class) === false) {
+                    $fluentClass = \Illuminate\Support\Fluent::class;
+                }
+
+                return new $fluentClass($data);
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return [$key => Json::encode($value)];
+            }
+        };
+    }
+
+    public static function using($class)
+    {
+        return static::class.':'.$class;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsFluentObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsFluentObject.php
@@ -16,7 +16,9 @@ class AsFluentObject implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            public function __construct(protected array $arguments) {}
+            public function __construct(protected array $arguments)
+            {
+            }
 
             public function get($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
+use Illuminate\Database\Eloquent\Casts\AsFluentObject;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\InvalidCastException;
@@ -2192,7 +2193,7 @@ trait HasAttributes
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
+        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class, AsFluentObject::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
         } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3162,7 +3162,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('asFluentObjectAttribute'));
     }
 
-
     public function testUnsavedModel()
     {
         $user = new UnsavedModel;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3149,10 +3149,10 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomFluent::class, $model->asFluentObjectAttribute);
         $this->assertFalse($model->isDirty('asFluentObjectAttribute'));
 
-        $model->asFluentObjectAttribute = ["bar" => "foo"];
+        $model->asFluentObjectAttribute = ['bar' => 'foo'];
         $this->assertFalse($model->isDirty('asFluentObjectAttribute'));
 
-        $model->asFluentObjectAttribute = ["bar" => "baz"];
+        $model->asFluentObjectAttribute = ['bar' => 'baz'];
         $this->assertTrue($model->isDirty('asFluentObjectAttribute'));
 
         $model->syncOriginal();


### PR DESCRIPTION
Hello!
### Idea
I would like to suggest the functionality of casting json fields into `Fluent` type objects. In some cases, as a model property, you want to have not just an array, but a typed object.

### Usage
Like `AsCollection`:

Basic usage
```php
protected $casts = [
  'some_prop' => AsFluentObject::class, //cast to basic Fluent object
];
```
Cast to custom Fluent object (main behavior)
```php
/**
 * @property string $object_property
 */
class CustomFluent extends Fluent {}

protected $casts = [
  'some_prop' => AsFluentObject::class.':'. CustomFluent::class //cast to CustomFluent object
];
```
As function
```php
protected function casts(): array
{
  return [
      'some_prop' => AsFluentObject::using(CustomFluent::class) //cast to CustomFluent object
  ];
}
```