### PR TITLE
[11.x] Expose process checkTimeout method

### DIFF
--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -113,13 +113,13 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
-     * Check if the process has timed out.
+     * Ensure that the process has not timed out.
      *
      * @return void
      *
      * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
      */
-    public function checkTimeout()
+    public function ensureNotTimedOut()
     {
         try {
             $this->process->checkTimeout();

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -113,6 +113,22 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Check if the process has timed out.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
+     */
+    public function checkTimeout()
+    {
+        try {
+            $this->process->checkTimeout();
+        } catch (SymfonyTimeoutException $e) {
+            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+        }
+    }
+
+    /**
      * Wait for the process to finish.
      *
      * @param  callable|null  $output


### PR DESCRIPTION
This PR targets the same issue as this https://github.com/laravel/framework/pull/54903 but without any breaking changes.

It just exposes the `checkTimeout` method and throws the same exception as `wait` would if the process has timed out.

This would update ensure the example use of `Process::timeout()` actually does something.

```
$process = Process::timeout(120)->start('bash import.sh');
 
while ($process->running()) {
    $process->checkTimeout()

    // ... 
}
 
$result = $process->wait();
```

As of right now, setting `Process::timeout(x)` and using `$process->running` as documented is pointless as the timeout will never happen.