### PR TITLE
Ensure ValidationEmailRuleTest skips tests requiring the intl extension when unavailable

### DIFF
--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -11,6 +11,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
@@ -143,6 +144,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testValidateMxRecord()
     {
         $this->fails(
@@ -674,6 +676,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testCombiningRules()
     {
         $this->passes(


### PR DESCRIPTION
This PR adds the `#[RequiresPhpExtension('intl')]` attribute to the `testValidateMxRecord` and `testCombiningRules` methods in the `ValidationEmailRuleTest` class.

These methods rely on the intl PHP extension because the Email class `validateMxRecord` method depends on it. The attribute ensures the tests are only executed if the required extension is available, preventing potential test failures in environments without the extension.
