### PR TITLE
[11.x] Revert faulty change to `EnumeratesValues::ensure()` doc block

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -342,7 +342,7 @@ trait EnumeratesValues
      *
      * @template TEnsureOfType
      *
-     * @param  class-string<TEnsureOfType>|array<array-key, class-string<TEnsureOfType>>|scalar|'array'|'null'  $type
+     * @param  class-string<TEnsureOfType>|array<array-key, class-string<TEnsureOfType>>|'string'|'int'|'float'|'bool'|'array'|'null'  $type
      * @return static<TKey, TEnsureOfType>
      *
      * @throws \UnexpectedValueException


### PR DESCRIPTION
This PR partially reverts https://github.com/laravel/framework/pull/54840, specifically one commit which breaks PHPStan type inference.

Explanation:

It seems that there was some confusion and these types were shortened to `scalar` as if the doc blocks said "any string, float, int or bool is allowed" which is a wrong assumption. The doc blocks in fact said "these exact string values are allowed". By changing these constant strings to `scalar` PHPStan will merge the parameter types (after all a `class-string` is also a `scalar`) and the template type becomes unresolvable.

E.g. `$collection->ensure(Foo::class)` no longer works after the change to `scalar` (edit: it still works, but PHPStan can't resolve the type)