### PR TITLE
Add remember when/unless methods to cache repository

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -444,7 +444,7 @@ class Repository implements ArrayAccess, CacheContract
     public function rememberWhen($value, $key, $ttl, Closure $callback)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
-        
+
         return $value ? $this->remember($key, $ttl, $callback) : $callback();
     }
 
@@ -461,7 +461,7 @@ class Repository implements ArrayAccess, CacheContract
     public function rememberUnless($value, $key, $ttl, Closure $callback)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
-        
+
         return ! $value ? $this->remember($key, $ttl, $callback) : $callback();
     }
 
@@ -516,7 +516,7 @@ class Repository implements ArrayAccess, CacheContract
     public function rememberForeverWhen($value, $key, Closure $callback)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
-        
+
         return $value ? $this->rememberForever($key, $callback) : $callback();
     }
 
@@ -532,7 +532,7 @@ class Repository implements ArrayAccess, CacheContract
     public function rememberForeverUnless($value, $key, Closure $callback)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
-        
+
         return ! $value ? $this->rememberForever($key, $callback) : $callback();
     }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -432,6 +432,40 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Get an item from the cache, or execute the given Closure and store the result, if the given "value" is (or resolves to) truthy.
+     *
+     * @template TCacheValue
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public function rememberWhen($value, $key, $ttl, Closure $callback)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+        
+        return $value ? $this->remember($key, $ttl, $callback) : $callback();
+    }
+
+    /**
+     * Get an item from the cache, or execute the given Closure and store the result, if the given "value" is (or resolves to) falsy.
+     *
+     * @template TCacheValue
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public function rememberUnless($value, $key, $ttl, Closure $callback)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+        
+        return ! $value ? $this->remember($key, $ttl, $callback) : $callback();
+    }
+
+    /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
      * @template TCacheValue
@@ -468,6 +502,38 @@ class Repository implements ArrayAccess, CacheContract
         $this->forever($key, $value = $callback());
 
         return $value;
+    }
+
+    /**
+     * Get an item from the cache, or execute the given Closure and store the result forever, if the given "value" is (or resolves to) truthy.
+     *
+     * @template TCacheValue
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public function rememberForeverWhen($value, $key, Closure $callback)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+        
+        return $value ? $this->rememberForever($key, $callback) : $callback();
+    }
+
+    /**
+     * Get an item from the cache, or execute the given Closure and store the result forever, if the given "value" is (or resolves to) falsy.
+     *
+     * @template TCacheValue
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null  $value
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public function rememberForeverUnless($value, $key, Closure $callback)
+    {
+        $value = $value instanceof Closure ? $value($this) : $value;
+        
+        return ! $value ? $this->rememberForever($key, $callback) : $callback();
     }
 
     /**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -142,12 +142,82 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
+    public function testRememberWhenUnless()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
+        $result = $repo->rememberWhen(true, 'foo', 10, function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->never();
+        $repo->getStore()->shouldReceive('put')->never();
+        $result = $repo->rememberWhen(false, 'foo', 10, function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
+        $result = $repo->rememberUnless(false, 'foo', 10, function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->never();
+        $repo->getStore()->shouldReceive('put')->never();
+        $result = $repo->rememberUnless(true, 'foo', 10, function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+    }
+
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
         $repo->getStore()->shouldReceive('forever')->once()->with('foo', 'bar');
         $result = $repo->rememberForever('foo', function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+    }
+
+    public function testRememberForeverWhenUnless()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('forever')->once()->with('foo', 'bar');
+        $result = $repo->rememberForeverWhen(true, 'foo', function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->never();
+        $repo->getStore()->shouldReceive('forever')->never();
+        $result = $repo->rememberForeverWhen(false, 'foo', function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('forever')->once()->with('foo', 'bar');
+        $result = $repo->rememberForeverUnless(false, 'foo', function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->never();
+        $repo->getStore()->shouldReceive('forever')->never();
+        $result = $repo->rememberForeverUnless(true, 'foo', function () {
             return 'bar';
         });
         $this->assertSame('bar', $result);


### PR DESCRIPTION
This PR adds remember when/unless methods to the cache repository, which are useful when you only want to cache under certain conditions.

```php
$value = Cache::rememberWhen(app()->isProduction(), 'key', 60, function () {
    // ...
});
```

I don't _think_ the Conditionalable trait can be used for this since you want to call the closure either way, you just want to skip the caching if the condition fails.

The four new methods are:

```php
Cache::rememberWhen($value, $key, $ttl, $callback);
Cache::rememberUnless($value, $key, $ttl, $callback);
Cache::rememberForeverWhen($value, $key, $callback);
Cache::rememberForeverUnless($value, $key, $callback);
```

As discussed here: https://github.com/laravel/framework/discussions/51594 (https://github.com/laravel/framework/discussions/51594#discussioncomment-12412574)

