### PR TITLE
✅ Ensure Enum validation is case-sensitive by adding a new test case.

### DIFF
--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -249,6 +249,22 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
     }
 
+    public function testValidationFailsWhenUsingDifferentCase()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'DONE',
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
     public static function conditionalCasesDataProvider(): array
     {
         return [


### PR DESCRIPTION
This pull request adds a new test case to verify that the Laravel Enum validation rule is case-sensitive. The test ensures that values with different letter casing (e.g., DONE instead of done) fail validation, preventing unintended matches.

