### PR TITLE
[12.x] Types: Collection chunk without preserving keys 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1442,7 +1442,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $size
      * @param  bool  $preserveKeys
-     * @return static<int, static>
+     * @return ($preserveKeys is true ? static<int, static> : static<int, static<int, TValue>>)
      */
     public function chunk($size, $preserveKeys = true)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1377,7 +1377,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $size
      * @param  bool  $preserveKeys
-     * @return static<int, static>
+     * @return ($preserveKeys is true ? static<int, static> : static<int, static<int, TValue>>)
      */
     public function chunk($size, $preserveKeys = true)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2148,18 +2148,18 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testChunkPreservingKeys($collection)
     {
-        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = new $collection(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]);
 
         $this->assertEquals(
-            [[0 => 1, 1 => 2, 2 => 3], [3 => 4, 4 => 5, 5 => 6], [6 => 7, 7 => 8, 8 => 9], [9 => 10]],
-            $data->chunk(3)->toArray()
+            [['a' => 1, 'b' => 2], ['c' => 3, 'd' => 4], ['e' => 5]],
+            $data->chunk(2)->toArray()
         );
 
-        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = new $collection([1, 2, 3, 4, 5]);
 
         $this->assertEquals(
-            [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]],
-            $data->chunk(3, false)->toArray()
+            [[0 => 1, 1 => 2], [0 => 3, 1 => 4], [0 => 5]],
+            $data->chunk(2, false)->toArray()
         );
     }
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -10,7 +10,7 @@ class Users implements Arrayable
 {
     public function toArray(): array
     {
-        return [new User()];
+        return [new User];
     }
 }
 
@@ -20,6 +20,8 @@ $arrayable = new Users;
 $iterable = [1];
 /** @var Traversable<int, string> $traversable */
 $traversable = new ArrayIterator(['string']);
+
+$associativeCollection = collect(['John' => new User]);
 
 class Invokable
 {
@@ -806,6 +808,8 @@ assertType('User', $collection->firstOrFail(function ($user, $int) {
 
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->chunk(1));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->chunk(2));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, User>>', $associativeCollection->chunk(2));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $associativeCollection->chunk(2, false));
 
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->chunkWhile(function ($user, $int, $collection) {
     assertType('User', $user);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -30,7 +30,7 @@ class Invokable
         return 'Taylor';
     }
 }
-$invokable = new Invokable();
+$invokable = new Invokable;
 
 assertType('Illuminate\Support\Collection<int, User>', $collection);
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -11,19 +11,21 @@ class Users implements Arrayable
 {
     public function toArray(): array
     {
-        return [new User()];
+        return [new User];
     }
 }
 
 $collection = new LazyCollection([new User]);
-$arrayable = new Users();
+$arrayable = new Users;
 /** @var iterable<int, int> $iterable */
 $iterable = [1];
 /** @var Traversable<int, string> $traversable */
 $traversable = new ArrayIterator(['string']);
 $generator = function () {
-    yield new User();
+    yield new User;
 };
+
+$associativeCollection = new LazyCollection(['Sam' => new User]);
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection);
 
@@ -665,6 +667,8 @@ assertType('User', $collection->firstOrFail(function ($user, $int) {
 
 assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, string>>', $collection::make(['string'])->chunk(1));
 assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>', $collection->chunk(2));
+assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<string, User>>', $associativeCollection->chunk(2));
+assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>', $associativeCollection->chunk(2, false));
 
 assertType('Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>', $collection->chunkWhile(function ($user, $int, $collection) {
     assertType('User', $user);


### PR DESCRIPTION
Hey, realised [#54916](https://github.com/laravel/framework/pull/54916/files) needs some slight type tweaks - added type tests accordingly.

I understand it to still adhere to the `Enumerable` interface, as `static<int, static<int, TValue>>` is a subtype of `static<int, static>` (which is implicitly `static<int, static<TKey, TValue>>`) as `TKey` is covariant.