### PR TITLE
Add a utility function which runs a callback with a locale

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -231,6 +231,13 @@ interface Application extends Container
     public function setLocale($locale);
 
     /**
+     * Execute the callback with the given locale.
+     *
+     * @param callable(string): void $callback  The function that will be executed. Will receive the current locale.
+     */
+    public function withLocale(string $locale, callable $callback): void;
+
+    /**
      * Determine if middleware has been disabled for the application.
      *
      * @return bool

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1589,6 +1589,25 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Execute the callback with the given locale.
+     *
+     * @param callable(string): void $callback  The function that will be executed. Will receive the current locale.
+     */
+    public function withLocale(string $locale, callable $callback): void
+    {
+        $currentLocale = $this->getLocale();
+
+        try {
+            $this['config']->set('app.locale', $locale);
+            $this['translator']->setLocale($locale);
+            $callback($currentLocale);
+        } finally {
+            $this['config']->set('app.locale', $currentLocale);
+            $this['translator']->setLocale($currentLocale);
+        }
+    }
+
+    /**
      * Set the current application fallback locale.
      *
      * @param  string  $fallbackLocale


### PR DESCRIPTION
It happens frequently to me where I have to change the locale to do some quick work and a utility function like this would be quite useful.

There are lots of translations libraries that use the App's locale in order to select the correct translation.

For most use cases, setting the locale once somewhere in the request is enough, but there are cases where I have objects that dictate what translation to use (for example when syncing data).