### PR TITLE
[12.x] Introduce `Rule::type()`

### DIFF
--- a/src/Illuminate/Support/NativeType.php
+++ b/src/Illuminate/Support/NativeType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support;
+
+enum NativeType: string
+{
+    case Array = 'array';
+    case Bool = 'bool';
+    case Callable = 'callable';
+    case ClosedResource = 'resource (closed)';
+    case Float = 'float';
+    case Int = 'int';
+    case Iterable = 'iterable';
+    case Null = 'null';
+    case Numeric = 'numeric';
+    case Object = 'object';
+    case Resource = 'resource';
+    case Scalar = 'scalar';
+    case String = 'string';
+}

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -156,6 +156,7 @@ return [
     'starts_with' => 'The :attribute field must start with one of the following: :values.',
     'string' => 'The :attribute field must be a string.',
     'timezone' => 'The :attribute field must be a valid timezone.',
+    'type' => 'The :attribute must be of type :type.',
     'unique' => 'The :attribute has already been taken.',
     'uploaded' => 'The :attribute failed to upload.',
     'uppercase' => 'The :attribute field must be uppercase.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -748,6 +748,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the date_format rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceType($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':type', $parameters[0], $message);
+    }
+
+    /**
      * Replace all place-holders for the before rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2570,7 +2570,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Strictly validate that an attribute is of expected type
+     * Strictly validate that an attribute is of expected type.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\NativeType;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
@@ -2566,6 +2567,32 @@ trait ValidatesAttributes
             constant(DateTimeZone::class.'::'.Str::upper($parameters[0] ?? 'ALL')),
             isset($parameters[1]) ? Str::upper($parameters[1]) : null,
         ), true);
+    }
+
+    /**
+     * Strictly validate that an attribute is of expected type
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<string, null|string>  $parameters
+     * @return bool
+     */
+    public function validateType($attribute, $value, $parameters = [])
+    {
+        $this->requireParameterCount(1, $parameters, 'type');
+
+        $expectedType = NativeType::from($parameters[0]);
+
+        return match ($expectedType) {
+            NativeType::Array => is_array($value),
+            NativeType::Bool => is_bool($value),
+            NativeType::Float => is_float($value),
+            NativeType::Int => is_int($value),
+            NativeType::Numeric => is_numeric($value),
+            NativeType::Scalar => is_scalar($value),
+            NativeType::String => is_string($value),
+            default => false,
+        };
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -20,6 +20,7 @@ use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\TypeRule;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule
@@ -73,6 +74,16 @@ class Rule
     public static function array($keys = null)
     {
         return new ArrayRule(...func_get_args());
+    }
+
+    /**
+     * Get a type rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\TypeRule
+     */
+    public static function type()
+    {
+        return new TypeRule;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/TypeRule.php
+++ b/src/Illuminate/Validation/Rules/TypeRule.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\NativeType;
+
+class TypeRule implements ValidationRule
+{
+    protected ?NativeType $expectedType = null;
+
+    public function array(): static
+    {
+        $this->expectedType = NativeType::Array;
+        
+        return $this;
+    }
+
+    public function bool(): static
+    {
+        $this->expectedType = NativeType::Bool;
+
+        return $this;
+    }
+
+    public function float(): static
+    {
+        $this->expectedType = NativeType::Float;
+
+        return $this;
+    }
+
+    public function int(): static
+    {
+        $this->expectedType = NativeType::Int;
+
+        return $this;
+    }
+
+    public function numeric(): static
+    {
+        $this->expectedType = NativeType::Numeric;
+
+        return $this;
+    }
+
+    public function scalar(): static
+    {
+        $this->expectedType = NativeType::Scalar;
+
+        return $this;
+    }
+
+    public function string(): static
+    {
+        $this->expectedType = NativeType::String;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($this->passes($value)) {
+            return;
+        }
+
+        $fail("The $attribute must be of type {$this->expectedType->value}");
+    }
+
+    protected function passes(mixed $value): bool
+    {
+        if ($this->expectedType === null) {
+            throw new \RuntimeException('Type must be specified');
+        }
+
+        return match (true) {
+            $this->expectedType === NativeType::Array => is_array($value),
+            $this->expectedType === NativeType::Bool => is_bool($value),
+            $this->expectedType === NativeType::Float => is_float($value),
+            $this->expectedType === NativeType::Int => is_int($value),
+            $this->expectedType === NativeType::Numeric => is_numeric($value),
+            $this->expectedType === NativeType::Scalar => is_scalar($value),
+            $this->expectedType === NativeType::String => is_string($value),
+            default => false,
+        };
+    }
+}

--- a/src/Illuminate/Validation/Rules/TypeRule.php
+++ b/src/Illuminate/Validation/Rules/TypeRule.php
@@ -2,18 +2,17 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\NativeType;
+use Stringable;
 
-class TypeRule implements ValidationRule
+class TypeRule implements Stringable
 {
     protected ?NativeType $expectedType = null;
 
     public function array(): static
     {
         $this->expectedType = NativeType::Array;
-        
+
         return $this;
     }
 
@@ -59,30 +58,12 @@ class TypeRule implements ValidationRule
         return $this;
     }
 
-    public function validate(string $attribute, mixed $value, Closure $fail): void
-    {
-        if ($this->passes($value)) {
-            return;
-        }
-
-        $fail("The $attribute must be of type {$this->expectedType->value}");
-    }
-
-    protected function passes(mixed $value): bool
+    public function __toString(): string
     {
         if ($this->expectedType === null) {
-            throw new \RuntimeException('Type must be specified');
+            throw new \RuntimeException('Type rule must have a type specified.');
         }
 
-        return match (true) {
-            $this->expectedType === NativeType::Array => is_array($value),
-            $this->expectedType === NativeType::Bool => is_bool($value),
-            $this->expectedType === NativeType::Float => is_float($value),
-            $this->expectedType === NativeType::Int => is_int($value),
-            $this->expectedType === NativeType::Numeric => is_numeric($value),
-            $this->expectedType === NativeType::Scalar => is_scalar($value),
-            $this->expectedType === NativeType::String => is_string($value),
-            default => false,
-        };
+        return 'type:'.$this->expectedType->value;
     }
 }

--- a/tests/Validation/ValidationTypeRuleTest.php
+++ b/tests/Validation/ValidationTypeRuleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationTypeRuleTest extends TestCase
+{
+    public function testTypeValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        $v = new Validator($trans, ['foo' => 'not an array'], ['foo' => Rule::type()->array()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => ['nullable', Rule::type()->array()]]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'not a bool'], ['foo' => Rule::type()->bool()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => true], ['foo' => Rule::type()->bool()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'not a float'], ['foo' => Rule::type()->float()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => 1.1], ['foo' => Rule::type()->float()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'not an int'], ['foo' => Rule::type()->int()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => 1], ['foo' => Rule::type()->int()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'not numeric'], ['foo' => Rule::type()->numeric()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => 1], ['foo' => Rule::type()->numeric()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => Rule::type()->scalar()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => 1], ['foo' => Rule::type()->scalar()]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => Rule::type()->string()]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => 'string'], ['foo' => Rule::type()->string()]);
+        $this->assertTrue($v->passes());
+    }
+}


### PR DESCRIPTION
This PR introduces a new validation rule called `type`.

Currently, as PHP is allowing us to declare types more strictly, we're yet to introduce a way of strictly validating types in the framework through our validator, ensuring the initial data that enter the application are safe to use.

### Imagine a scenario, where:
We're developing an entrypoint to our strict application utilizing the `declare(strict_types=1);` execution directive across the entire codebase. 

Most likely, we'd create a FormRequest, which requests `id` as an integer.

We'd define the rule as `['id' => ['integer', 'numeric']]`, and later in the application, pass the value to some strict method, expecting an `integer`.
The validation would pass, even if we used `"1"` as a value for the `id` parameter, which would cause our application to crash due to a `TypeError` thrown by PHP.

This would happen due to the way `integer` & `numeric` validation is intended in Laravel - we'd only check whether the variable passes via `filter_var` combined with the `is_numeric` check, however, this would still allow the entrypoint to receive `"1"` as a value.


## Solution
This PR solves this issue by introducing a new `type` validation rule, which *strictly* checks for the type of a variable which we're validating.
The validation rule supports strictly checking the following types:
```php
array
bool
float
int
numeric
scalar
string
```

This would now allow us to do the following:
```php
use \Illuminate\Validation\Rule;

['id' => [Rule::type()->integer()]]
```
Or the following:
```php
use \Illuminate\Validation\Rule;

['id' => ['type:integer']]
```


## Notes
I've decided to introduce a `NativeType` enum into the `Support` namespace, which holds more types than the validation rule allows, as validating a `callback` simply would not make sense, yet we could, in the future, utilize this enum when e.g. casting native types in Eloquent models.
All credits for this enum go to `PHPUnit` which I've copied it from - perhaps this needs some sort of note added.

This will not work for GET/standard HTML forms, but that should be clear due to the nature of the problem. Most of the applications I've dealt with in the past years used Laravel as an API, therefore utilizing JSON, which is what this is intended for, mostly.

## Discussion
This rule is, in a way, duplicate of `array` & `string` rule, perhaps these could utilize this new rule instead. I'm not a fan of removing these from the new `type`. On the other hand, perhaps, this rule could be renamed to `strict`, or `strictType` to be more clear of it's usage.

## References
https://github.com/laravel/ideas/issues/1719
https://github.com/laravel/ideas/issues/2145