### PR TITLE
Cast type hint

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -787,7 +787,7 @@ trait HasAttributes
 
                     return $cast.':'.implode(',', $arguments);
                 }),
-                default => $cast,
+                default => (string) $cast,
             };
         }
 


### PR DESCRIPTION
This small improvement makes us truly ensured that casts are string values.

And allows us to make fluent cast builders (as Rules does).