### PR TITLE
[12.x] Add test coverage for Str::replaceMatches method 

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1763,11 +1763,32 @@ class SupportStrTest extends TestCase
     {
         // Test basic string replacement
         $this->assertSame('foo bar bar', Str::replaceMatches('/baz/', 'bar', 'foo baz bar'));
-        $this->assertSame('foo BBB baz', Str::replaceMatches('/bar/', 'BBB', 'foo bar baz'));
         $this->assertSame('foo baz baz', Str::replaceMatches('/404/', 'found', 'foo baz baz'));
 
         // Test with array of patterns
         $this->assertSame('foo XXX YYY', Str::replaceMatches(['/bar/', '/baz/'], ['XXX', 'YYY'], 'foo bar baz'));
+
+        // Test with callback
+        $result = Str::replaceMatches('/ba(.)/', function ($match) {
+            return 'ba'.strtoupper($match[1]);
+        }, 'foo baz bar');
+
+        $this->assertSame('foo baZ baR', $result);
+
+        $result = Str::replaceMatches('/(\d+)/', function ($match) {
+            return $match[1] * 2;
+        }, 'foo 123 bar 456');
+
+        $this->assertSame('foo 246 bar 912', $result);
+
+        // Test with limit parameter
+        $this->assertSame('foo baz baz', Str::replaceMatches('/ba(.)/', 'ba$1', 'foo baz baz', 1));
+
+        $result = Str::replaceMatches('/ba(.)/', function ($match) {
+            return 'ba'.strtoupper($match[1]);
+        }, 'foo baz baz bar', 1);
+
+        $this->assertSame('foo baZ baz bar', $result);
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1758,6 +1758,17 @@ class SupportStrTest extends TestCase
             $this->assertSame($expected, Str::chopEnd($subject, $needle));
         }
     }
+
+    public function testReplaceMatches()
+    {
+        // Test basic string replacement
+        $this->assertSame('foo bar bar', Str::replaceMatches('/baz/', 'bar', 'foo baz bar'));
+        $this->assertSame('foo BBB baz', Str::replaceMatches('/bar/', 'BBB', 'foo bar baz'));
+        $this->assertSame('foo baz baz', Str::replaceMatches('/404/', 'found', 'foo baz baz'));
+
+        // Test with array of patterns
+        $this->assertSame('foo XXX YYY', Str::replaceMatches(['/bar/', '/baz/'], ['XXX', 'YYY'], 'foo bar baz'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
# Add test coverage for Str::replaceMatches method ✨

This PR adds comprehensive test coverage for the Str::replaceMatches method to ensure it correctly handles string replacements, array patterns, callback functions, and limit parameters.

## The test cases cover three main aspects of the method's functionality:

1. **Basic string replacement** ✅
   - Simple pattern replacement with static strings
   - Handling non-matching patterns correctly

2. **Array-based pattern replacement** 
   - Testing multiple patterns and replacements in a single call

3. **Callback-based replacement** 
   - Testing dynamic replacements using callback functions
   - Verifying capture group access within callbacks
   - Ensuring proper handling of complex transformations (like numeric operations)

4. **Limit parameter functionality** 
   - Testing the behavior when limiting the number of replacements

The implementation follows the established testing patterns in the Laravel codebase, making it consistent with the existing test suite. I discovered while reviewing the code that the Str::replaceMatches method lacked any test coverage.🔍