### PR TITLE
[12.x] Add `ddBody` method to TestResponse for dumping various response payloads

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1646,17 +1646,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Dump the JSON payload from the response and end the script.
-     *
-     * @param  string|null  $key
-     */
-    public function ddJson($key = null)
-    {
-        dd($this->json($key));
-    }
-
-    /**
-     * Dump the payload from the response and end the script.
+     * Dump the body of the response and end the script.
      *
      * @param  string|null  $key
      * @return never
@@ -1670,6 +1660,16 @@ class TestResponse implements ArrayAccess
         }
 
         dd($content);
+    }
+
+    /**
+     * Dump the JSON payload from the response and end the script.
+     *
+     * @param  string|null  $key
+     */
+    public function ddJson($key = null)
+    {
+        dd($this->json($key));
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1656,6 +1656,23 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the payload from the response and end the script.
+     *
+     * @param  string|null  $key
+     * @return never
+     */
+    public function ddBody($key = null)
+    {
+        $content = $this->content();
+
+        if (json_validate($content)) {
+            $this->ddJson($key);
+        }
+
+        dd($content);
+    }
+
+    /**
      * Dump the session from the response and end the script.
      *
      * @param  string|array  $keys


### PR DESCRIPTION
This PR implements a more generic `ddBody` method to the `Illuminate/Testing/TestResponse` class which is useful for dumping out any HTTP response body. 

The `ddJson` method was added previously and this code will use that if `json_validate` passes. Otherwise it will dump out the content of the response.

I noticed there weren't any tests for the other methods so I didn't write a test for this, however happy to write tests for this if needed.

----

Q: Do we need to do anything with streamed content? I noticed the following code in the codebase, perhaps we should use `getStreamedContent()` when the response is streamed?

```php
if ($this->baseResponse instanceof StreamedResponse ||
    $this->baseResponse instanceof StreamedJsonResponse) {
    // $this->streamedContent();
} else {
    // $this->getContent();
}
```