### PR TITLE
[11.x] Backport "Fix issue with using `RedisCluster` with compression or serialization"

### DIFF
--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -95,26 +95,26 @@ trait PacksPhpRedisValues
         $oldSerializer = null;
 
         if ($this->serialized()) {
-            $oldSerializer = $client->getOption($client::OPT_SERIALIZER);
-            $client->setOption($client::OPT_SERIALIZER, $client::SERIALIZER_NONE);
+            $oldSerializer = $client->getOption(Redis::OPT_SERIALIZER);
+            $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
         }
 
         $oldCompressor = null;
 
         if ($this->compressed()) {
-            $oldCompressor = $client->getOption($client::OPT_COMPRESSION);
-            $client->setOption($client::OPT_COMPRESSION, $client::COMPRESSION_NONE);
+            $oldCompressor = $client->getOption(Redis::OPT_COMPRESSION);
+            $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_NONE);
         }
 
         try {
             return $callback();
         } finally {
             if ($oldSerializer !== null) {
-                $client->setOption($client::OPT_SERIALIZER, $oldSerializer);
+                $client->setOption(Redis::OPT_SERIALIZER, $oldSerializer);
             }
 
             if ($oldCompressor !== null) {
-                $client->setOption($client::OPT_COMPRESSION, $oldCompressor);
+                $client->setOption(Redis::OPT_COMPRESSION, $oldCompressor);
             }
         }
     }


### PR DESCRIPTION
This is just a backport of the #54934 bugfix from `12.x` to `11.x` branch. 

> Using RedisCluster (Laravel Vapor) with compression or serialization doesn't work, because the OPT_SERIALIZER and OPT_COMPRESSION don't exist on the RedisCluster class.
> 
> The error: Undefined constant RedisCluster::OPT_SERIALIZER
> 
> I replaced $client:: with Redis::.
> 
> Even in the PhpRedis extension tests they are using Redis::OPT_SERIALIZER and not RedisCluster::OPT_SERIALIZER https://github.com/phpredis/phpredis/blob/d342e4ac18723607b001deb593c8d45e40bbc4c8/tests/RedisClusterTest.php#L281-L295