### PR TITLE
[12.x] Add a creation callback when building the application

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -427,7 +427,7 @@ class ApplicationBuilder
     /**
      * Register a callback to be invoked before the application is returned by the create method.
      *
-     * @param  \Closure $callback
+     * @param  \Closure  $callback
      * @return $this
      */
     public function with(Closure $callback)
@@ -484,7 +484,7 @@ class ApplicationBuilder
     public function create()
     {
         if ($this->createCallback !== null) {
-            call_user_func($this->createCallback,  $this->app);
+            call_user_func($this->createCallback, $this->app);
         }
 
         return $this->app;

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -44,6 +44,13 @@ class ApplicationBuilder
     protected array $pageMiddleware = [];
 
     /**
+     * An optional callback that is invoked right before the app is returned by the create method.
+     *
+     * @var \Closure|null
+     */
+    protected ?Closure $createCallback = null;
+
+    /**
      * Create a new application builder instance.
      */
     public function __construct(protected Application $app)
@@ -418,6 +425,19 @@ class ApplicationBuilder
     }
 
     /**
+     * Register a callback to be invoked before the application is returned by the create method.
+     *
+     * @param  \Closure $callback
+     * @return $this
+     */
+    public function with(Closure $callback)
+    {
+        $this->createCallback = $callback;
+
+        return $this;
+    }
+
+    /**
      * Register a callback to be invoked when the application's service providers are registered.
      *
      * @param  callable  $callback
@@ -463,6 +483,10 @@ class ApplicationBuilder
      */
     public function create()
     {
+        if ($this->createCallback !== null) {
+            call_user_func($this->createCallback,  $this->app);
+        }
+
         return $this->app;
     }
 }


### PR DESCRIPTION
The `ApplicationBuilder` class is supposed to simplify the process of configuring and customising Laravel, but there are a number of features within the Laravel `Application` class that you can't currently make use of, without modifying the `public/index.php` file.

Here are a few of them:

- `\Illuminate\Foundation\Application::afterLoadingEnvironment`
- `\Illuminate\Foundation\Application::beforeBootstrapping`
- `\Illuminate\Foundation\Application::afterBootstrapping`
- `\Illuminate\Foundation\Application::useConfigPath`

There's nowhere outside `public/index.php` where you can make use of these methods, as the values they set are already used by the time any of you code is hit. I'm aware that _you can technically do it_, but it requires some complexity and heavy lifting.

So, I added a `with()` method to the `ApplicationBuilder` that lets you provide a final `Closure` which is called right before the `Application` is returned by `\Illuminate\Foundation\Configuration\ApplicationBuilder::create`.

```php
use Illuminate\Foundation\Application;
use Illuminate\Foundation\Configuration\Exceptions;
use Illuminate\Foundation\Configuration\Middleware;

return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )
    ->withMiddleware(function (Middleware $middleware) {
        //
    })
    ->withExceptions(function (Exceptions $exceptions) {
        //
    })
	->with(function (Application $app) {
		$app->useConfigPath(realpath(__DIR__.'/../core/config'));
	})->create();
```

It's intentionally called right before the instance is returned so that all the other things that this class needs to do have been done.