### PR TITLE
Handle case when migrate:install command is called and table exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "framework",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "framework",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -53,7 +53,9 @@ class InstallCommand extends Command
     {
         $this->repository->setSource($this->input->getOption('database'));
 
-        $this->repository->createRepository();
+        if (!$this->repository->repositoryExists()) {
+            $this->repository->createRepository();
+        }
 
         $this->components->info('Migration table created successfully.');
     }

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -53,7 +53,7 @@ class InstallCommand extends Command
     {
         $this->repository->setSource($this->input->getOption('database'));
 
-        if (!$this->repository->repositoryExists()) {
+        if (! $this->repository->repositoryExists()) {
             $this->repository->createRepository();
         }
 

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -23,6 +23,17 @@ class DatabaseMigrationInstallCommandTest extends TestCase
         $command->setLaravel(new Application);
         $repo->shouldReceive('setSource')->once()->with('foo');
         $repo->shouldReceive('createRepository')->once();
+        $repo->shouldReceive('repositoryExists')->once()->andReturn(false);
+
+        $this->runCommand($command, ['--database' => 'foo']);
+    }
+
+    public function testFireCallsRepositoryToInstallExists()
+    {
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setLaravel(new Application);
+        $repo->shouldReceive('setSource')->once()->with('foo');
+        $repo->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
     }


### PR DESCRIPTION
The migrate:install command is frequently used in application install scripts. 

To ensure smooth deployments in containerized environments where install scripts are called on every deployment, Laravel should handle the case where this table already exists and not cause deployment failure.