### PR TITLE
[12.x] Feature: Array partition without preserving keys

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -950,18 +950,24 @@ class Arr
      *
      * @param  iterable<TKey, TValue>  $array
      * @param  callable(TValue, TKey): bool  $callback
+     * @param  bool  $preserveKeys
      * @return array<int<0, 1>, array<TKey, TValue>>
      */
-    public static function partition($array, callable $callback)
+    public static function partition($array, callable $callback, bool $preserveKeys = true)
     {
         $passed = [];
         $failed = [];
 
+        $add = match ($preserveKeys) {
+            true => fn (array &$array, mixed $value, int|string $key) => $array[$key] = $value,
+            false => fn (array &$array, mixed $value, int|string $key) => $array[] = $value,
+        };
+
         foreach ($array as $key => $item) {
             if ($callback($item, $key)) {
-                $passed[$key] = $item;
+                $add($passed, $item, $key);
             } else {
-                $failed[$key] = $item;
+                $add($failed, $item, $key);
             }
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -951,7 +951,7 @@ class Arr
      * @param  iterable<TKey, TValue>  $array
      * @param  callable(TValue, TKey): bool  $callback
      * @param  bool  $preserveKeys
-     * @return array<int<0, 1>, array<TKey, TValue>>
+     * @return ($preserveKeys is true ? array<int<0, 1>, array<TKey, TValue>> : array<int<0, 1>, list<TValue>>)
      */
     public static function partition($array, callable $callback, bool $preserveKeys = true)
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1565,9 +1565,11 @@ class SupportArrTest extends TestCase
     public function testPartition()
     {
         $array = ['John', 'Jane', 'Greg'];
-
         $result = Arr::partition($array, fn (string $value) => str_contains($value, 'J'));
-
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
+
+        $assocArray = ['John', 'Jane', 'Greg'];
+        $result = Arr::partition($assocArray, fn (string $value) => str_contains($value, 'J'), false);
+        $this->assertEquals([[0 => 'John', 1 => 'Jane'], [0 => 'Greg']], $result);
     }
 }

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -4,11 +4,14 @@ use Illuminate\Support\Arr;
 
 use function PHPStan\Testing\assertType;
 
+/** @var array<int, User> $array */
 $array = [new User];
 /** @var iterable<int, User> $iterable */
 $iterable = [];
 /** @var Traversable<int, User> $traversable */
 $traversable = new ArrayIterator([new User]);
+/** @var array<string, User> $associativeArray */
+$associativeArray = ['John' => new User];
 
 assertType('User|null', Arr::first($array));
 assertType('User|null', Arr::first($array, function ($user) {
@@ -99,3 +102,6 @@ assertType("'string'|User", Arr::last($traversable, function ($user) {
 assertType("'string'|User", Arr::last($traversable, null, function () {
     return 'string';
 }));
+
+assertType('array<int<0, 1>, array<string, User>>', Arr::partition($associativeArray, fn($user) => true));
+assertType('array<int<0, 1>, array<int, User>>', Arr::partition($associativeArray, fn($user) => true, false));

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -104,4 +104,4 @@ assertType("'string'|User", Arr::last($traversable, null, function () {
 }));
 
 assertType('array<int<0, 1>, array<string, User>>', Arr::partition($associativeArray, fn($user) => true));
-assertType('array<int<0, 1>, array<int, User>>', Arr::partition($associativeArray, fn($user) => true, false));
+assertType('array<int<0, 1>, list<User>>', Arr::partition($associativeArray, fn($user) => true, false));

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -103,5 +103,5 @@ assertType("'string'|User", Arr::last($traversable, null, function () {
     return 'string';
 }));
 
-assertType('array<int<0, 1>, array<string, User>>', Arr::partition($associativeArray, fn($user) => true));
-assertType('array<int<0, 1>, list<User>>', Arr::partition($associativeArray, fn($user) => true, false));
+assertType('array<int<0, 1>, array<string, User>>', Arr::partition($associativeArray, fn ($user) => true));
+assertType('array<int<0, 1>, list<User>>', Arr::partition($associativeArray, fn ($user) => true, false));


### PR DESCRIPTION
Hey, this PR allows using the existing `Arr::partition` method, without preserving keys.

I haven't added this to the `EnumeratesValue` trait (which `Collection` and `LazyCollection` make use of), due to it's additional complexity of `operatorForWhere`. This is not a problem (despite it's reliance on `Arr::partition` due to the new parameter being optional.
