### PR TITLE
[10.x] Fix attribute name used on `Validator` instance within certain rule classes

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -302,11 +302,11 @@ class Validator implements ValidatorContract
     protected $defaultNumericRules = ['Numeric', 'Integer', 'Decimal'];
 
     /**
-     * The current placeholder for dots in rule keys.
+     * The current random hash for the validator.
      *
      * @var string
      */
-    protected $dotPlaceholder;
+    protected static $placeholderHash;
 
     /**
      * The exception to throw upon failure.
@@ -335,7 +335,9 @@ class Validator implements ValidatorContract
     public function __construct(Translator $translator, array $data, array $rules,
                                 array $messages = [], array $attributes = [])
     {
-        $this->dotPlaceholder = Str::random();
+        if (! isset(static::$placeholderHash)) {
+            static::$placeholderHash = Str::random();
+        }
 
         $this->initialRules = $rules;
         $this->translator = $translator;
@@ -363,7 +365,7 @@ class Validator implements ValidatorContract
 
             $key = str_replace(
                 ['.', '*'],
-                [$this->dotPlaceholder, '__asterisk__'],
+                ['__dot__'.static::$placeholderHash, '__asterisk__'.static::$placeholderHash],
                 $key
             );
 
@@ -401,7 +403,7 @@ class Validator implements ValidatorContract
     protected function replacePlaceholderInString(string $value)
     {
         return str_replace(
-            [$this->dotPlaceholder, '__asterisk__'],
+            ['__dot__'.static::$placeholderHash, '__asterisk__'.static::$placeholderHash],
             ['.', '*'],
             $value
         );
@@ -720,7 +722,7 @@ class Validator implements ValidatorContract
     protected function replaceDotInParameters(array $parameters)
     {
         return array_map(function ($field) {
-            return str_replace('\.', $this->dotPlaceholder, $field);
+            return str_replace('\.', '__dot__'.static::$placeholderHash, $field);
         }, $parameters);
     }
 
@@ -846,11 +848,23 @@ class Validator implements ValidatorContract
      */
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
-        $attribute = $this->replacePlaceholderInString($attribute);
+        $originalAttribute = $this->replacePlaceholderInString($attribute);
+
+        $attribute = match (true) {
+            $rule instanceof Rules\File => $attribute,
+            $rule instanceof Rules\Password => $attribute,
+            default => $originalAttribute,
+        };
 
         $value = is_array($value) ? $this->replacePlaceholders($value) : $value;
 
         if ($rule instanceof ValidatorAwareRule) {
+            if ($attribute !== $originalAttribute) {
+                $this->addCustomAttributes([
+                    $attribute => $this->customAttributes[$originalAttribute] ?? $originalAttribute,
+                ]);
+            }
+
             $rule->setValidator($this);
         }
 
@@ -863,14 +877,14 @@ class Validator implements ValidatorContract
                 get_class($rule->invokable()) :
                 get_class($rule);
 
-            $this->failedRules[$attribute][$ruleClass] = [];
+            $this->failedRules[$originalAttribute][$ruleClass] = [];
 
-            $messages = $this->getFromLocalArray($attribute, $ruleClass) ?? $rule->message();
+            $messages = $this->getFromLocalArray($originalAttribute, $ruleClass) ?? $rule->message();
 
             $messages = $messages ? (array) $messages : [$ruleClass];
 
             foreach ($messages as $key => $message) {
-                $key = is_string($key) ? $key : $attribute;
+                $key = is_string($key) ? $key : $originalAttribute;
 
                 $this->messages->add($key, $this->makeReplacements(
                     $message, $key, $ruleClass, []
@@ -1159,7 +1173,7 @@ class Validator implements ValidatorContract
     {
         return collect($this->rules)
             ->mapWithKeys(fn ($value, $key) => [
-                str_replace($this->dotPlaceholder, '\\.', $key) => $value,
+                str_replace('__dot__'.static::$placeholderHash, '\\.', $key) => $value,
             ])
             ->all();
     }
@@ -1173,7 +1187,7 @@ class Validator implements ValidatorContract
     public function setRules(array $rules)
     {
         $rules = collect($rules)->mapWithKeys(function ($value, $key) {
-            return [str_replace('\.', $this->dotPlaceholder, $key) => $value];
+            return [str_replace('\.', '__dot__'.static::$placeholderHash, $key) => $value];
         })->toArray();
 
         $this->initialRules = $rules;

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Validation\Rules;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\File;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
+
+class FileValidationTest extends TestCase
+{
+    #[TestWith(['0'])]
+    #[TestWith(['.'])]
+    #[TestWith(['*'])]
+    #[TestWith(['__asterisk__'])]
+    public function test_it_can_validate_attribute_as_array(string $attribute)
+    {
+        $file = UploadedFile::fake()->create('laravel.png', 1, 'image/png');
+
+        $validator = Validator::make([
+            'files' => [
+                $attribute => $file,
+            ],
+        ], [
+            'files.*' => ['required', File::types(['image/png', 'image/jpeg'])],
+        ]);
+
+        $this->assertTrue($validator->passes());
+    }
+
+    #[TestWith(['0'])]
+    #[TestWith(['.'])]
+    #[TestWith(['*'])]
+    #[TestWith(['__asterisk__'])]
+    public function test_it_can_validate_attribute_as_array_when_validation_should_fails(string $attribute)
+    {
+        $file = UploadedFile::fake()->create('laravel.php', 1, 'image/php');
+
+        $validator = Validator::make([
+            'files' => [
+                $attribute => $file,
+            ],
+        ], [
+            'files.*' => ['required', File::types($mimes = ['image/png', 'image/jpeg'])],
+        ]);
+
+        $this->assertFalse($validator->passes());
+
+        $this->assertSame([
+            0 => __('validation.mimetypes', ['attribute' => sprintf('files.%s', str_replace('_', ' ', $attribute)), 'values' => implode(', ', $mimes)]),
+        ], $validator->messages()->all());
+    }
+}

--- a/tests/Integration/Validation/Rules/PasswordValidationTest.php
+++ b/tests/Integration/Validation/Rules/PasswordValidationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Validation\Rules;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
+
+class PasswordValidationTest extends TestCase
+{
+    #[TestWith(['0'])]
+    #[TestWith(['.'])]
+    #[TestWith(['*'])]
+    #[TestWith(['__asterisk__'])]
+    public function test_it_can_validate_attribute_as_array(string $attribute)
+    {
+        $validator = Validator::make([
+            'passwords' => [
+                $attribute => 'secret',
+            ],
+        ], [
+            'passwords.*' => ['required', Password::default()->min(6)],
+        ]);
+
+        $this->assertTrue($validator->passes());
+    }
+
+    #[TestWith(['0'])]
+    #[TestWith(['.'])]
+    #[TestWith(['*'])]
+    #[TestWith(['__asterisk__'])]
+    public function test_it_can_validate_attribute_as_array_when_validation_should_fails(string $attribute)
+    {
+        $validator = Validator::make([
+            'passwords' => [
+                $attribute => 'secret',
+            ],
+        ], [
+            'passwords.*' => ['required', Password::default()->min(8)],
+        ]);
+
+        $this->assertFalse($validator->passes());
+
+        $this->assertSame([
+            0 => sprintf('The passwords.%s field must be at least 8 characters.', str_replace('_', ' ', $attribute)),
+        ], $validator->messages()->all());
+    }
+}


### PR DESCRIPTION


Backport PR #54845 to Laravel 10

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
