### PR TITLE
[12.x] Test Improvements

### DIFF
--- a/tests/Integration/Filesystem/ServeFileTest.php
+++ b/tests/Integration/Filesystem/ServeFileTest.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Tests\Integration\Filesystem;
 
 use Illuminate\Support\Facades\Storage;
+use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
+#[WithConfig('filesystems.disks.local.serve', true)]
 class ServeFileTest extends TestCase
 {
     protected function setUp(): void
@@ -47,12 +49,5 @@ class ServeFileTest extends TestCase
         $response = $this->get($url);
 
         $response->assertForbidden();
-    }
-
-    protected function getEnvironmentSetup($app)
-    {
-        tap($app['config'], function ($config) {
-            $config->set('filesystems.disks.local.serve', true);
-        });
     }
 }


### PR DESCRIPTION
Remove `getEnvironmentSetup()` usage as it has been marked as deprecated.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
