### PR TITLE
Handled Concurrency run() fails when passing an array instead of a cl…

### DIFF
--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -45,7 +45,7 @@ class InvokeSerializedClosureCommand extends Command
                 'successful' => true,
                 'result' => serialize($this->laravel->call(match (true) {
                     ! is_null($this->argument('code')) => unserialize($this->argument('code')),
-                    isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => unserialize($_SERVER['LARAVEL_INVOKABLE_CLOSURE']),
+                    isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => str_starts_with($_SERVER['LARAVEL_INVOKABLE_CLOSURE'], 'O:47:"Laravel\SerializableClosure\SerializableClosure"') ? unserialize($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) : json_decode($_SERVER['LARAVEL_INVOKABLE_CLOSURE'], true),
                     default => fn () => null,
                 })),
             ]));

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -33,8 +33,17 @@ class ProcessDriver implements Driver
 
         $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $key => $task) {
+
+                // Check if the task is a closure
+                if ($task instanceof Closure) {
+                    $serializedTask = serialize(new SerializableClosure($task));
+                } else {
+                    // Serialize arrays or other data as JSON
+                    $serializedTask = json_encode($task);
+                }
+
                 $pool->as($key)->path(base_path())->env([
-                    'LARAVEL_INVOKABLE_CLOSURE' => serialize(new SerializableClosure($task)),
+                    'LARAVEL_INVOKABLE_CLOSURE' => serialize($serializedTask),
                 ])->command($command);
             }
         })->start()->wait();
@@ -67,8 +76,17 @@ class ProcessDriver implements Driver
 
         return defer(function () use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $task) {
+
+                // Check if the task is a closure
+                if ($task instanceof Closure) {
+                    $serializedTask = serialize(new SerializableClosure($task));
+                } else {
+                    // Serialize arrays or other data as JSON
+                    $serializedTask = json_encode($task);
+                }
+
                 $this->processFactory->path(base_path())->env([
-                    'LARAVEL_INVOKABLE_CLOSURE' => serialize(new SerializableClosure($task)),
+                    'LARAVEL_INVOKABLE_CLOSURE' => serialize($serializedTask),
                 ])->run($command.' 2>&1 &');
             }
         });


### PR DESCRIPTION
The original run method only works for closures because it uses SerializableClosure.

To handle both closures and arrays, you need to:

Check the type of each task.

Serialize closures using SerializableClosure.

Serialize arrays or other data using json_encode.

Update the subprocess command to handle both serialized closures and JSON-encoded data.