### PR TITLE
[12.x] Add “Storage Linked” to the `about` command

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -326,6 +326,7 @@ class AboutCommand extends Command
 
     /**
      * Check storage symbolic links status
+     *
      * @param  callable  $formatStorageLinkedStatus  Formatter for link status
      * @return array<string,mixed> Array of paths and their link status
      */
@@ -334,9 +335,9 @@ class AboutCommand extends Command
         return collect(config('filesystems.links', []))
             ->mapWithKeys(function ($target, $link) use ($formatStorageLinkedStatus) {
                 $path = Str::replace(public_path(), '', $link);
+
                 return [public_path($path) => static::format(file_exists($link), console: $formatStorageLinkedStatus)];
             })
             ->toArray();
     }
-
 }

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -325,7 +325,7 @@ class AboutCommand extends Command
     }
 
     /**
-     * Check storage symbolic links status
+     * Check storage symbolic links status.
      *
      * @param  callable  $formatStorageLinkedStatus  Formatter for link status
      * @return array<string,mixed> Array of paths and their link status

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -216,10 +216,27 @@ class AboutCommand extends Command
         ]));
 
         static::addToSection('Storage', fn () => [
-            ...$this->checkStoragePaths($formatStorageLinkedStatus),
+            ...$this->determineStoragePathLinkStatus($formatStorageLinkedStatus),
         ]);
 
         (new Collection(static::$customDataResolvers))->each->__invoke();
+    }
+
+    /**
+     * Determine storage symbolic links status.
+     *
+     * @param  callable  $formatStorageLinkedStatus
+     * @return array<string,mixed>
+     */
+    protected function determineStoragePathLinkStatus(callable $formatStorageLinkedStatus): array
+    {
+        return collect(config('filesystems.links', []))
+            ->mapWithKeys(function ($target, $link) use ($formatStorageLinkedStatus) {
+                $path = Str::replace(public_path(), '', $link);
+
+                return [public_path($path) => static::format(file_exists($link), console: $formatStorageLinkedStatus)];
+            })
+            ->toArray();
     }
 
     /**
@@ -322,22 +339,5 @@ class AboutCommand extends Command
         static::$data = [];
 
         static::$customDataResolvers = [];
-    }
-
-    /**
-     * Check storage symbolic links status.
-     *
-     * @param  callable  $formatStorageLinkedStatus  Formatter for link status
-     * @return array<string,mixed> Array of paths and their link status
-     */
-    protected function checkStoragePaths(callable $formatStorageLinkedStatus): array
-    {
-        return collect(config('filesystems.links', []))
-            ->mapWithKeys(function ($target, $link) use ($formatStorageLinkedStatus) {
-                $path = Str::replace(public_path(), '', $link);
-
-                return [public_path($path) => static::format(file_exists($link), console: $formatStorageLinkedStatus)];
-            })
-            ->toArray();
     }
 }


### PR DESCRIPTION
I've added a section to the `php artisan about` command that shows the status of of the `filesystems` links.

While helping some developers debug why their media isn't displaying correctly, it is often a result of forgetting to link the storage folder. 

```php
// config/filesystem.php
return [
    'links' => [
        public_path('storage') => storage_path('app/public'),
    ],
];
```

`php artisan about`

```
Storage 
public/storage .................................................. LINKED 
```

```php
// config/filesystem.php
return [
    'links' => [
        public_path('storage') => storage_path('app/public'),
        public_path('images') => storage_path('app/images'),
    ],
];

```

Running `php artisan about` will show that the logs link has not been made.

```
Storage 
public/images ................................................... NOT LINKED  
public/storage .................................................. LINKED
```

Running `php artisan storage:link` and then `php artisan about` will show the newly create symbolic link.

```
Storage 
public/images .................................................. LINKED
public/storage ................................................. LINKED
```

ref #53656 
