### PR TITLE
[12.x] Fix visibility of setUp and tearDown in tests

### DIFF
--- a/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+++ b/tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseConcernsPreventsCircularRecursionTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         Carbon::setTestNow('2023-01-01 00:00:00');
     }

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         Carbon::setTestNow('2023-01-01 00:00:00');
     }

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         Carbon::setTestNow('2023-01-01 00:00:00');
     }

--- a/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         Carbon::setTestNow('2023-01-01 00:00:00');
     }

--- a/tests/Foundation/Configuration/ExceptionsTest.php
+++ b/tests/Foundation/Configuration/ExceptionsTest.php
@@ -13,11 +13,6 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ExceptionsTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testStopIgnoring()
     {
         $container = new Container;

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class MiddlewareTest extends TestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Queue/DynamoBatchTest.php
+++ b/tests/Integration/Queue/DynamoBatchTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 #[RequiresEnv('DYNAMODB_ENDPOINT')]
 class DynamoBatchTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {
             BatchRunRecorder::reset();

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -18,7 +18,7 @@ class DatabaseFailedJobProviderTest extends TestCase
 
     protected $provider;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->createDatabaseWithFailedJobTable()


### PR DESCRIPTION
Since setUp and tearDown in \PHPUnit\Framework\TestCase are protected, I have modified the parts that were public to protected.

Also, tests/Foundation/Configuration/ExceptionsTest.php only executes the parent class's tearDown, so I have deleted it this time.