### PR TITLE
Add Tests for Str::pluralPascal Method

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1790,6 +1790,16 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('foo baZ baz bar', $result);
     }
+
+    public function testPluralPascal(): void
+    {
+        // Test basic functionality with default count
+        $this->assertSame('UserGroups', Str::pluralPascal('UserGroup'));
+        $this->assertSame('ProductCategories', Str::pluralPascal('ProductCategory'));
+
+
+
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1797,8 +1797,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup'));
         $this->assertSame('ProductCategories', Str::pluralPascal('ProductCategory'));
 
+        // Test with different count values and array
+        $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', 0)); // plural
+        $this->assertSame('UserGroup', Str::pluralPascal('UserGroup', 1));  // singular
+        $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', 2)); // plural
+        $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', []));   // plural (empty array count is 0)
 
+        // Test with Countable
+        $countable = new class implements \Countable
+        {
+            public function count(): int
+            {
+                return 3;
+            }
+        };
 
+        $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
 }
 


### PR DESCRIPTION
# Add Tests for Str::pluralPascal Method

This PR adds comprehensive tests for the Str::pluralPascal method which previously had no test coverage. The tests validate the method’s behavior across several scenarios to ensure it functions correctly.

## Test Coverage 🔍
The tests verify three key aspects of the `pluralPascal` method:
1. ✅ Basic functionality with default count parameter (converting Pascal case singular words to plural)
2. ✅ Behavior with different numeric count values (0, 1, 2) to ensure proper singular/plural handling
3. ✅ Support for complex types like empty arrays and Countable objects

## 🎯 Test Coverage Achievement

I've thoroughly reviewed the entire `Str` class and with the merging of previous PR (https://github.com/laravel/framework/pull/54930), and this one, every single method in the class now has test coverage. This PR completes our testing journey by adding coverage for the last untested method. 🎉