### PR TITLE
[12.x] Changed `whereRelation` to work with only two params

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -421,13 +421,21 @@ trait QueriesRelationships
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $columnOrValue
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
      */
-    public function whereRelation($relation, $column, $operator = null, $value = null)
+    public function whereRelation($relation, $columnOrValue, $operator = null, $value = null)
     {
+        $column = $columnOrValue;
+
+        if (! ($columnOrValue instanceof Closure) && $operator == null && $value == null) {
+            $relationKeys = explode('.', $relation);
+            $column = array_pop($relationKeys);
+            $relation = implode('.', $relationKeys);
+        }
+
         return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);


### PR DESCRIPTION
The Eloquent **whereRelation** accepts 4 parameters in total **_$relation_**, **_$column_**, **_$operator = null_**, **_$value = null_**

So whenever we want to query we have to use the **whereRelation** as follows.

```
$posts = Post::query()
    ->whereRelation('comments', 'user_id', Auth::id())
    ->get()
```

We always have to use atleast **3** parameters.
This pull request allows us to only use **2** parameters for this usecase.

```
$posts = Post::query()
    ->whereRelation('comments.user_id', Auth::id())
    ->get()
```