### PR TITLE
[12.x] Changed `whereRelation` to work with only two params when the `$column` variable is not instance of `\Closure`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -428,6 +428,14 @@ trait QueriesRelationships
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
+        if (! ($column instanceof Closure) && $operator == null && $value == null) {
+            $relationKeys = explode('.', $relation);
+            
+            $value = $column;
+            $column = array_pop($relationKeys);
+            $relation = implode('.', $relationKeys);
+        }
+
         return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);


### PR DESCRIPTION
The Eloquent **whereRelation** accepts 4 parameters in total **_$relation_**, **_$column_**, **_$operator = null_**, **_$value = null_**

So whenever we want to query we have to use the **whereRelation** as follows.

```
$posts = Post::query()
    ->whereRelation('comments', 'user_id', Auth::id())
    ->get()
```

We always have to use atleast **3** parameters if the **_$column_** is not instance of \Closure.
This pull request allows us to only use **2** parameters for this usecase.

```
$posts = Post::query()
    ->whereRelation('comments.user_id', Auth::id())
    ->get()
```