### PR TITLE
[12.x] Fix collection value() method to properly handle falsy values (issue #54910)

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -330,7 +330,7 @@ trait EnumeratesValues
      */
     public function value($key, $default = null)
     {
-        if ($value = $this->firstWhere($key)) {
+        if ($value = $this->first()) {
             return data_get($value, $key, $default);
         }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -330,7 +330,7 @@ trait EnumeratesValues
      */
     public function value($key, $default = null)
     {
-        if ($value = $this->first()) {
+        if ($value = $this->firstWhere($key, '!==', null)) {
             return data_get($value, $key, $default);
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1144,6 +1144,35 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['value' => 'foo'], $c->value('pivot'));
         $this->assertEquals('foo', $c->value('pivot.value'));
         $this->assertEquals('bar', $c->where('id', 2)->value('pivot.value'));
+
+        // Test falsy values
+        $c = new $collection([
+            ['id' => 1, 'score' => 0],
+            ['id' => 2, 'score' => 100],
+        ]);
+
+        $this->assertSame(0, $c->value('score'));
+
+        $c = new $collection([
+            ['id' => 1, 'active' => false],
+            ['id' => 2, 'active' => true],
+        ]);
+
+        $this->assertSame(false, $c->value('active'));
+
+        $c = new $collection([
+            ['id' => 1, 'code' => '0'],
+            ['id' => 2, 'code' => '123'],
+        ]);
+
+        $this->assertSame('0', $c->value('code'));
+
+        $c = new $collection([
+            ['id' => 1, 'description' => ''],
+            ['id' => 2, 'description' => 'Some description'],
+        ]);
+
+        $this->assertSame('', $c->value('description'));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1173,6 +1173,14 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertSame('', $c->value('description'));
+
+        // Skip values that do not have the key
+        $c = new $collection([
+            ['id' => 1],
+            ['id' => 2, 'description' => ''],
+        ]);
+
+        $this->assertSame('', $c->value('description'));
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
close #54910

This PR fixes issue #54910 where the collection value() method incorrectly skips falsy values (0, false, empty string) in the first element.

The current implementation uses firstWhere() with loose comparison, causing it to skip over the first element when the requested value is 0, false, or an empty string.

This change modifies the value() method to use first() instead, ensuring it always returns the value from the first element regardless of whether that value is "falsy".

I don't think it should be considered a breaking change since it really seems to be a bug in the intended behaviour and that this fix is more in line the documentation.