### PR TITLE
[12.x] Refactor: Concise way to call a method dynamically

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -306,6 +306,6 @@ class Logger implements LoggerInterface
      */
     public function __call($method, $parameters)
     {
-        return $this->logger->{$method}(...$parameters);
+        return $this->logger->$method(...$parameters);
     }
 }


### PR DESCRIPTION
## Simplify dynamic method calls by removing unnecessary curly braces

**Description:**
This PR updates the `__call` method to use a more concise syntax for dynamic method calls. The curly braces were unnecessary, as PHP allows method calls directly without curly braces.

This change improves readability while maintaining the same functionality.