### PR TITLE
[12.x] Refactor: Remove unnecessary variables in Str class methods

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -623,7 +623,7 @@ class Str
 
         try {
             $factoryUuid = $factory->fromString($value);
-        } catch (InvalidUuidStringException $ex) {
+        } catch (InvalidUuidStringException) {
             return false;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -454,7 +454,7 @@ class Str
      */
     public static function wrap($value, $before, $after = null)
     {
-        return $before.$value.($after ??= $before);
+        return $before.$value.($after ?? $before);
     }
 
     /**


### PR DESCRIPTION
# Refactor: Remove unnecessary variables in Str class methods 🧹

In this PR, I've made two small refactoring improvements to remove unnecessary variables: ✨

1. Replaced the null coalescing assignment operator (`??=`) with the standard null coalescing operator (`??`) in the `Str::wrap` method, as the variable is not used after the operation. 🔄

2. Removed the unused exception variable in the `isUuid` method's try-catch block by using PHP 8.0's variable-less catch syntax. 🪄

These changes eliminate unused variables and improve code readability while maintaining the exact same functionality. Removing unnecessary variables contributes to better code maintenance and reduces potential confusion for developers reading the code. 📝

The modifications are minimal and focused on code quality improvements only. 🚀