### PR TITLE
[12.x] Allow brick/math ^0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.11|^0.12",
+        "brick/math": "^0.11|^0.12|^0.13",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^3.2.1|^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.2",
         "ext-pdo": "*",
-        "brick/math": "^0.11|^0.12",
+        "brick/math": "^0.11|^0.12|^0.13",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",
         "illuminate/contracts": "^12.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-mbstring": "*",
-        "brick/math": "^0.11|^0.12",
+        "brick/math": "^0.11|^0.12|^0.13",
         "egulias/email-validator": "^3.2.5|^4.0",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

See https://github.com/brick/math/releases/tag/0.13.0.

Note this first requires https://github.com/ramsey/uuid/pull/589 and subsequent release to be effective.

```
> composer why-not brick/math ^0.13
ramsey/uuid 4.7.6 requires brick/math (^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12)
Not finding what you were looking for? Try calling `composer require "brick/math:^0.13" --dry-run` to get another view on the problem.
```