### PR TITLE
[12.x] apply Pint rule "single_line_comment_style"

### DIFF
--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -61,9 +61,7 @@ class BroadcasterTest extends TestCase
         $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
         $this->assertEquals([], $parameters);
 
-        /*
-         * Test Explicit Binding...
-         */
+        // Test Explicit Binding...
         $container = new Container;
         Container::setInstance($container);
         $binder = m::mock(BindingRegistrar::class);

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -128,9 +128,7 @@ class CacheRepositoryTest extends TestCase
         });
         $this->assertSame('qux', $result);
 
-        /*
-         * Use a callable...
-         */
+        // Use a callable...
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
         $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -10,9 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class FrequencyTest extends TestCase
 {
-    /*
-     * @var \Illuminate\Console\Scheduling\Event
-     */
+    /** @var \Illuminate\Console\Scheduling\Event */
     protected $event;
 
     protected function setUp(): void

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -146,9 +146,7 @@ class ContainerCallTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertSame($stub, $result[1]);
 
-        /*
-         * Wrap a function...
-         */
+        // Wrap a function...
         $result = $container->wrap(function (stdClass $foo, $bar = []) {
             return func_get_args();
         }, ['bar' => 'taylor']);

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -23,9 +23,7 @@ class ContextualBindingTest extends TestCase
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $one->impl);
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $two->impl);
 
-        /*
-         * Test With Closures
-         */
+        // Test With Closures
         $container = new Container;
 
         $container->bind(IContainerContextContractStub::class, ContainerContextImplementationStub::class);
@@ -41,9 +39,7 @@ class ContextualBindingTest extends TestCase
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $one->impl);
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $two->impl);
 
-        /*
-         * Test nesting to make the same 'abstract' in different context
-         */
+        // Test nesting to make the same 'abstract' in different context
         $container = new Container;
 
         $container->bind(IContainerContextContractStub::class, ContainerContextImplementationStub::class);

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -957,9 +957,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
     public function testSelfReferencingRelationshipWithSoftDeletes()
     {
-        /*
-         * https://github.com/laravel/framework/issues/42075
-         */
+        // https://github.com/laravel/framework/issues/42075
         [$taylor, $abigail] = $this->createUsers();
 
         $this->assertCount(1, $abigail->self_referencing);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2475,9 +2475,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereWithArrayConditions()
     {
-        /*
-         * where(key, value)
-         */
+        // where(key, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where([['foo', 1], ['bar', 2]]);
@@ -2509,9 +2507,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
-        /*
-         * where(key, <, value)
-         */
+        // where(key, <, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where([['foo', 1], ['bar', '<', 2]]);
@@ -2528,9 +2524,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where ("foo" = ? and "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
-        /*
-         * whereNot(key, value)
-         */
+        // whereNot(key, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot([['foo', 1], ['bar', 2]]);
@@ -2562,9 +2556,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where not (("foo" = ? and "bar" = ?))', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
-        /*
-         * whereNot(key, <, value)
-         */
+        // whereNot(key, <, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot([['foo', 1], ['bar', '<', 2]]);
@@ -2581,9 +2573,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where not (("foo" = ? and "bar" < ?))', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
-        /*
-         * whereColumn(col1, col2)
-         */
+        // whereColumn(col1, col2)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '_bar']]);
@@ -2615,9 +2605,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" = "_bar")', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
-        /*
-         * whereColumn(col1, <, col2)
-         */
+        // whereColumn(col1, <, col2)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn([['foo', '_foo'], ['bar', '<', '_bar']]);
@@ -2634,9 +2622,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where ("foo" = "_foo" and "bar" < "_bar")', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
-        /*
-         * whereAll([...keys], value)
-         */
+        // whereAll([...keys], value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereAll(['foo', 'bar'], 2);
@@ -2648,9 +2634,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 2], $builder->getBindings());
 
-        /*
-         * whereAny([...keys], value)
-         */
+        // whereAny([...keys], value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereAny(['foo', 'bar'], 2);
@@ -2662,9 +2646,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where ("foo" = ? or "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 2], $builder->getBindings());
 
-        /*
-         * whereNone([...keys], value)
-         */
+        // whereNone([...keys], value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNone(['foo', 'bar'], 2);
@@ -2676,9 +2658,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where not ("foo" = ? or "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhere(key, value)
-         */
+        // where()->orWhere(key, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhere([['foo', 1], ['bar', 2]]);
@@ -2690,18 +2670,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhere(key, <, value)
-         */
+        // where()->orWhere(key, <, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhere([['foo', 1], ['bar', '<', 2]]);
         $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhereColumn(col1, col2)
-         */
+        // where()->orWhereColumn(col1, col2)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhereColumn([['foo', '_foo'], ['bar', '_bar']]);
@@ -2713,18 +2689,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = "_foo" or "bar" = "_bar")', $builder->toSql());
         $this->assertEquals([0 => 'xxxx'], $builder->getBindings());
 
-        /*
-         * where()->orWhere(key, <, value)
-         */
+        // where()->orWhere(key, <, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhere([['foo', 1], ['bar', '<', 2]]);
         $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhereNot(key, value)
-         */
+        // where()->orWhereNot(key, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhereNot([['foo', 1], ['bar', 2]]);
@@ -2736,18 +2708,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "xxxx" = ? or not (("foo" = ? or "bar" = ?))', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhereNot(key, <, value)
-         */
+        // where()->orWhereNot(key, <, value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhereNot([['foo', 1], ['bar', '<', 2]]);
         $this->assertSame('select * from "users" where "xxxx" = ? or not (("foo" = ? or "bar" < ?))', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 1, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhereAll([...keys], value)
-         */
+        // where()->orWhereAll([...keys], value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhereAll(['foo', 'bar'], 2);
@@ -2759,9 +2727,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 2, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhereAny([...keys], value)
-         */
+        // where()->orWhereAny([...keys], value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhereAny(['foo', 'bar'], 2);
@@ -2773,9 +2739,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "xxxx" = ? or ("foo" = ? or "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'xxxx', 1 => 2, 2 => 2], $builder->getBindings());
 
-        /*
-         * where()->orWhereNone([...keys], value)
-         */
+        // where()->orWhereNone([...keys], value)
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('xxxx', 'xxxx')->orWhereNone(['foo', 'bar'], 2);

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -37,9 +37,7 @@ class UrlWindowTest extends TestCase
 
         $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [19 => '/?page=19', 20 => '/?page=20']], $window->get());
 
-        /*
-         * Test Being Near The End Of The List
-         */
+        // Test Being Near The End Of The List
         $array = [];
         for ($i = 1; $i <= 20; $i++) {
             $array[$i] = 'item'.$i;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -781,9 +781,7 @@ class RoutingRouteTest extends TestCase
 
     public function testMatchesMethodAgainstRequests()
     {
-        /*
-         * Basic
-         */
+        // Basic
         $request = Request::create('foo/bar', 'GET');
         $route = new Route('GET', 'foo/{bar}', function () {
             //
@@ -796,9 +794,7 @@ class RoutingRouteTest extends TestCase
         });
         $this->assertFalse($route->matches($request));
 
-        /*
-         * Method checks
-         */
+        // Method checks
         $request = Request::create('foo/bar', 'GET');
         $route = new Route('GET', 'foo/{bar}', function () {
             //
@@ -811,9 +807,7 @@ class RoutingRouteTest extends TestCase
         });
         $this->assertFalse($route->matches($request));
 
-        /*
-         * Domain checks
-         */
+        // Domain checks
         $request = Request::create('http://something.foo.com/foo/bar', 'GET');
         $route = new Route('GET', 'foo/{bar}', ['domain' => '{foo}.foo.com', function () {
             //
@@ -826,9 +820,7 @@ class RoutingRouteTest extends TestCase
         }]);
         $this->assertFalse($route->matches($request));
 
-        /*
-         * HTTPS checks
-         */
+        // HTTPS checks
         $request = Request::create('https://foo.com/foo/bar', 'GET');
         $route = new Route('GET', 'foo/{bar}', ['https', function () {
             //
@@ -847,9 +839,7 @@ class RoutingRouteTest extends TestCase
         }]);
         $this->assertFalse($route->matches($request));
 
-        /*
-         * HTTP checks
-         */
+        // HTTP checks
         $request = Request::create('https://foo.com/foo/bar', 'GET');
         $route = new Route('GET', 'foo/{bar}', ['http', function () {
             //
@@ -906,9 +896,7 @@ class RoutingRouteTest extends TestCase
         $route->where('bar', '123|456');
         $this->assertFalse($route->matches($request));
 
-        /*
-         * Optional
-         */
+        // Optional
         $request = Request::create('foo/123', 'GET');
         $route = new Route('GET', 'foo/{bar?}', function () {
             //
@@ -944,9 +932,7 @@ class RoutingRouteTest extends TestCase
         $route->where('bar', '[0-9]+');
         $this->assertFalse($route->matches($request));
 
-        /*
-         * Conditional
-         */
+        // Conditional
         $route = new Route('GET', '{subdomain}.awesome.test', function () {
             //
         });
@@ -1196,9 +1182,7 @@ class RoutingRouteTest extends TestCase
 
     public function testRouteGrouping()
     {
-        /*
-         * getPrefix() method
-         */
+        // getPrefix() method
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo'], function () use ($router) {
             $router->get('bar', function () {
@@ -1275,9 +1259,7 @@ class RoutingRouteTest extends TestCase
 
     public function testNestedRouteGroupingWithAs()
     {
-        /*
-         * nested with all layers present
-         */
+        // nested with all layers present
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->group(['prefix' => 'bar', 'as' => 'Bar::'], function () use ($router) {
@@ -1290,9 +1272,7 @@ class RoutingRouteTest extends TestCase
         $route = $routes->getByName('Foo::Bar::baz');
         $this->assertSame('foo/bar/baz', $route->uri());
 
-        /*
-         * nested with layer skipped
-         */
+        // nested with layer skipped
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->group(['prefix' => 'bar'], function () use ($router) {
@@ -1308,9 +1288,7 @@ class RoutingRouteTest extends TestCase
 
     public function testNestedRouteGroupingPrefixing()
     {
-        /*
-         * nested with layer skipped
-         */
+        // nested with layer skipped
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->prefix('bar')->get('baz', ['as' => 'baz', function () {
@@ -1340,9 +1318,7 @@ class RoutingRouteTest extends TestCase
 
     public function testRoutePrefixing()
     {
-        /*
-         * Prefix route
-         */
+        // Prefix route
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
             return 'hello';
@@ -1352,9 +1328,7 @@ class RoutingRouteTest extends TestCase
         $routes[0]->prefix('prefix');
         $this->assertSame('prefix/foo/bar', $routes[0]->uri());
 
-        /*
-         * Use empty prefix
-         */
+        // Use empty prefix
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
             return 'hello';
@@ -1364,9 +1338,7 @@ class RoutingRouteTest extends TestCase
         $routes[0]->prefix('/');
         $this->assertSame('foo/bar', $routes[0]->uri());
 
-        /*
-         * Prefix homepage
-         */
+        // Prefix homepage
         $router = $this->getRouter();
         $router->get('/', function () {
             return 'hello';
@@ -1376,9 +1348,7 @@ class RoutingRouteTest extends TestCase
         $routes[0]->prefix('prefix');
         $this->assertSame('prefix', $routes[0]->uri());
 
-        /*
-         * Prefix homepage with empty prefix
-         */
+        // Prefix homepage with empty prefix
         $router = $this->getRouter();
         $router->get('/', function () {
             return 'hello';

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -31,9 +31,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.foo.com/foo/bar/baz/boom', $url->to('foo/bar', ['baz', 'boom'], true));
         $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar', $url->to('foo/bar?foo=bar', ['baz'], true));
 
-        /*
-         * Test HTTPS request URL generation...
-         */
+        // Test HTTPS request URL generation...
         $url = new UrlGenerator(
             new RouteCollection,
             Request::create('https://www.foo.com/')
@@ -204,78 +202,54 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/')
         );
 
-        /*
-         * Empty Named Route
-         */
+        // Empty Named Route
         $route = new Route(['GET'], '/', ['as' => 'plain']);
         $routes->add($route);
 
-        /*
-         * Named Routes
-         */
+        // Named Routes
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo']);
         $routes->add($route);
 
-        /*
-         * Parameters...
-         */
+        // Parameters...
         $route = new Route(['GET'], 'foo/bar/{baz}/breeze/{boom}', ['as' => 'bar']);
         $routes->add($route);
 
-        /*
-         * Single Parameter...
-         */
+        // Single Parameter...
         $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'foobar']);
         $routes->add($route);
 
-        /*
-         * Optional parameter
-         */
+        // Optional parameter
         $route = new Route(['GET'], 'foo/bar/{baz?}', ['as' => 'optional']);
         $routes->add($route);
 
-        /*
-         * HTTPS...
-         */
+        // HTTPS...
         $route = new Route(['GET'], 'foo/baz', ['as' => 'baz', 'https']);
         $routes->add($route);
 
-        /*
-         * Controller Route Route
-         */
+        // Controller Route Route
         $route = new Route(['GET'], 'foo/bam', ['controller' => 'foo@bar']);
         $routes->add($route);
 
-        /*
-         * Non ASCII routes
-         */
+        // Non ASCII routes
         $route = new Route(['GET'], 'foo/bar/åαф/{baz}', ['as' => 'foobarbaz']);
         $routes->add($route);
 
-        /*
-         * Fragments
-         */
+        // Fragments
         $route = new Route(['GET'], 'foo/bar#derp', ['as' => 'fragment']);
         $routes->add($route);
 
-        /*
-         * Invoke action
-         */
+        // Invoke action
         $route = new Route(['GET'], 'foo/invoke', ['controller' => 'InvokableActionStub']);
         $routes->add($route);
 
-        /*
-         * With Default Parameter
-         */
+        // With Default Parameter
         $url->defaults(['locale' => 'en']);
         $route = new Route(['GET'], 'foo', ['as' => 'defaults', 'domain' => '{locale}.example.com', function () {
             //
         }]);
         $routes->add($route);
 
-        /*
-         * With backed enum name and domain
-         */
+        // With backed enum name and domain
         $route = (new Route(['GET'], 'backed-enum', ['as' => 'prefixed.']))->name(RouteNameEnum::UserIndex)->domain(RouteDomainEnum::DashboardDomain);
         $routes->add($route);
 
@@ -321,9 +295,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/')
         );
 
-        /*
-         * Named Routes
-         */
+        // Named Routes
         $route = new Route(['GET'], 'foo/bar', []);
         $route->name('foo');
         $routes->add($route);
@@ -341,9 +313,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $url->setRootControllerNamespace('namespace');
 
-        /*
-         * Controller Route Route
-         */
+        // Controller Route Route
         $route = new Route(['GET'], 'foo/bar', ['controller' => 'namespace\foo@bar']);
         $routes->add($route);
 
@@ -478,9 +448,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('https://www.foo.com/')
         );
 
-        /*
-         * Named Routes
-         */
+        // Named Routes
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo']);
         $routes->add($route);
 
@@ -494,9 +462,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('https://www.foo.com/')
         );
 
-        /*
-         * Named Routes
-         */
+        // Named Routes
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'http']);
         $routes->add($route);
 
@@ -513,9 +479,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com']);
         $routes->add($route);
 
-        /*
-         * Wildcards & Domains...
-         */
+        // Wildcards & Domains...
         $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com']);
         $routes->add($route);
 
@@ -534,9 +498,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com']);
         $routes->add($route);
 
-        /*
-         * Wildcards & Domains...
-         */
+        // Wildcards & Domains...
         $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com']);
         $routes->add($route);
 
@@ -546,9 +508,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
     public function testRoutesWithDomainsStripsProtocols()
     {
-        /*
-         * http:// Route
-         */
+        // http:// Route
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             Request::create('http://www.foo.com/')
@@ -559,9 +519,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
 
-        /*
-         * https:// Route
-         */
+        // https:// Route
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             Request::create('https://www.foo.com/')
@@ -580,9 +538,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('https://foo.com/')
         );
 
-        /*
-         * When on HTTPS, no need to specify 443
-         */
+        // When on HTTPS, no need to specify 443
         $route = new Route(['GET'], 'foo/bar', ['as' => 'baz', 'domain' => 'sub.foo.com']);
         $routes->add($route);
 
@@ -716,9 +672,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $url->useOrigin('http://www.foo.com/');
         $this->assertSame('http://www.foo.com/bar', $url->to('/bar'));
 
-        /*
-         * Route Based...
-         */
+        // Route Based...
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             Request::create('http://www.foo.com/')


### PR DESCRIPTION
`FrequencyTest` is the outlier here, as it retains the `/**` syntax so the docbloc is picked up. This maintains consistency with other similar uses in the framework, such as in https://github.com/laravel/framework/blob/12.x/src/Illuminate/Collections/LazyCollection.php#L233

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/comment/single_line_comment_style.rst

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
