### PR TITLE
[12.x] Fix serve command ignoring `PHP_CLI_WORKER_SERVERS` env

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -9,9 +9,7 @@ use Illuminate\Support\Env;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Stringable;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 use function Illuminate\Support\php_binary;
@@ -210,7 +208,6 @@ class ServeCommand extends Command
     protected function port()
     {
         $port = $this->input->getOption('port');
-
 
         if (is_null($port)) {
             [, $port] = $this->getHostAndPort();


### PR DESCRIPTION
### Changed

- In https://github.com/laravel/framework/pull/54606, the `artisan serve` command was changed to require a `--no-reload` flag when using the `PHP_CLI_WORKER_SERVERS`. Instead of ignoring the config (which is the default in [Laravel's scaffold](https://github.com/laravel/laravel/blob/12.x/.env.example#L14)), we can wait for the port to become available (for a few seconds) and throw an exception if it doesn't (clearly something went wrong and we can't recover)

---

Related PRs:
- https://github.com/laravel/framework/pull/54606

**Context:**

As I was working on the [Hotreload package](https://github.com/hotwired-laravel/hotreload), I noticed the processes were getting stuck by the SSE endpoint. Turns out there was only 1 process, even though we set the `PHP_CLI_WORKER_SERVERS` in the [default Laravel env](https://github.com/laravel/laravel/blob/12.x/.env.example#L14).

The current way it's working right now, we're ignoring the desired number of processes configured. With the changes here, we'd respect that but disable the auto-reload behavior. This is important for the Hotreload package, but also for [Sail](https://github.com/laravel/sail/blob/1.x/runtimes/8.4/Dockerfile#L14), since the `--no-reload` flag is not being used in the default command there.