### PR TITLE
Ensure ExcludeIf correctly rejects a null value as an invalid condition

### DIFF
--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -42,7 +42,7 @@ class ValidationExcludeIfTest extends TestCase
         new ExcludeIf(true);
         new ExcludeIf(fn () => true);
 
-        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
+        foreach ([1, 1.1, 'phpinfo', new stdClass, null] as $condition) {
             try {
                 new ExcludeIf($condition);
                 $this->fail('The ExcludeIf constructor must not accept '.gettype($condition));


### PR DESCRIPTION
This update adds a null value to test cases to verify that the ExcludeIf functionality properly rejects it as an invalid condition. This ensures more robust validation and prevents unintended behavior when a null value is used.