### PR TITLE
[12.x] Changed `whereRelation` and related function to work with only two params when the …

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -416,6 +416,33 @@ trait QueriesRelationships
     }
 
     /**
+     * Adds a where like structure functionality to the Eloquent
+     * whereRelation, withWhereRelation, orWhereRelation, whereDoesntHaveRelation
+     * orWhereDoesntHaveRelation, whereMorphRelation, orWhereMorphRelation,
+     * whereMorphDoesntHaveRelation, orWhereMorphDoesntHaveRelation functions.
+     *
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    protected function addDotNotationToWhereRelation(&$relation, &$column, &$operator = null, &$value = null)
+    {
+        if (! $column instanceof Closure && $operator === null && $value === null) {
+            $relationKeys = explode('.', $relation);
+
+            $operator = $column;
+            $column = array_pop($relationKeys);
+            $relation = implode('.', $relationKeys);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a basic where clause to a relationship query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -428,6 +455,8 @@ trait QueriesRelationships
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
@@ -448,6 +477,8 @@ trait QueriesRelationships
      */
     public function withWhereRelation($relation, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->whereRelation($relation, $column, $operator, $value)
             ->with([
                 $relation => fn ($query) => $column instanceof Closure
@@ -469,6 +500,8 @@ trait QueriesRelationships
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
@@ -491,6 +524,8 @@ trait QueriesRelationships
      */
     public function whereDoesntHaveRelation($relation, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->whereDoesntHave($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
@@ -513,6 +548,8 @@ trait QueriesRelationships
      */
     public function orWhereDoesntHaveRelation($relation, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->orWhereDoesntHave($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
@@ -536,6 +573,8 @@ trait QueriesRelationships
      */
     public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->whereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
@@ -555,6 +594,8 @@ trait QueriesRelationships
      */
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
@@ -574,6 +615,8 @@ trait QueriesRelationships
      */
     public function whereMorphDoesntHaveRelation($relation, $types, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->whereDoesntHaveMorph($relation, $types, function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
@@ -593,6 +636,8 @@ trait QueriesRelationships
      */
     public function orWhereMorphDoesntHaveRelation($relation, $types, $column, $operator = null, $value = null)
     {
+        $this->addDotNotationToWhereRelation($relation, $column, $operator, $value);
+
         return $this->orWhereDoesntHaveMorph($relation, $types, function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -160,7 +160,16 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $exists = MorphOneOfManyTestProduct::withWhereRelation('current_state', 'state', 'active')->exists();
         $this->assertTrue($exists);
 
+        $exists = MorphOneOfManyTestProduct::withWhereRelation('current_state.state', 'active')->exists();
+        $this->assertTrue($exists);
+
         $exists = MorphOneOfManyTestProduct::withWhereRelation('current_state', 'state', 'active')->get();
+
+        $this->assertCount(1, $exists);
+        $this->assertTrue($exists->first()->relationLoaded('current_state'));
+        $this->assertSame($exists->first()->current_state->state, $currentState->state);
+
+        $exists = MorphOneOfManyTestProduct::withWhereRelation('current_state.state', 'active')->get();
 
         $this->assertCount(1, $exists);
         $this->assertTrue($exists->first()->relationLoaded('current_state'));

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -155,36 +155,46 @@ class EloquentWhereHasTest extends DatabaseTestCase
     public function testWhereRelation()
     {
         $users = User::whereRelation('posts', 'public', true)->get();
+        $usersTwo = User::whereRelation('posts.public', true)->get();
 
         $this->assertEquals([1], $users->pluck('id')->all());
+        $this->assertEquals([1], $usersTwo->pluck('id')->all());
     }
 
     public function testOrWhereRelation()
     {
         $users = User::whereRelation('posts', 'public', true)->orWhereRelation('posts', 'public', false)->get();
+        $usersTwo = User::whereRelation('posts.public', true)->orWhereRelation('posts.public', false)->get();
 
         $this->assertEquals([1, 2], $users->pluck('id')->all());
+        $this->assertEquals([1, 2], $usersTwo->pluck('id')->all());
     }
 
     public function testNestedWhereRelation()
     {
         $texts = User::whereRelation('posts.texts', 'content', 'test')->get();
+        $textsTwo = User::whereRelation('posts.texts.content', 'test')->get();
 
         $this->assertEquals([1], $texts->pluck('id')->all());
+        $this->assertEquals([1], $textsTwo->pluck('id')->all());
     }
 
     public function testNestedOrWhereRelation()
     {
         $texts = User::whereRelation('posts.texts', 'content', 'test')->orWhereRelation('posts.texts', 'content', 'test2')->get();
+        $textsTwo = User::whereRelation('posts.texts.content', 'test')->orWhereRelation('posts.texts.content', 'test2')->get();
 
         $this->assertEquals([1, 2], $texts->pluck('id')->all());
+        $this->assertEquals([1, 2], $textsTwo->pluck('id')->all());
     }
 
     public function testWhereMorphRelation()
     {
         $comments = Comment::whereMorphRelation('commentable', '*', 'public', true)->get();
+        $commentsTwo = Comment::whereMorphRelation('commentable.public', '*', true)->get();
 
         $this->assertEquals([1], $comments->pluck('id')->all());
+        $this->assertEquals([1], $commentsTwo->pluck('id')->all());
     }
 
     public function testOrWhereMorphRelation()
@@ -193,42 +203,57 @@ class EloquentWhereHasTest extends DatabaseTestCase
             ->orWhereMorphRelation('commentable', '*', 'public', false)
             ->get();
 
+        $commentsTwo = Comment::whereMorphRelation('commentable.public', '*', true)
+            ->orWhereMorphRelation('commentable.public', '*', false)
+            ->get();
+
         $this->assertEquals([1, 2], $comments->pluck('id')->all());
+        $this->assertEquals([1, 2], $commentsTwo->pluck('id')->all());
     }
 
     public function testWhereDoesntHaveRelation()
     {
         $users = User::whereDoesntHaveRelation('posts', 'public', true)->get();
+        $usersTwo = User::whereDoesntHaveRelation('posts.public', true)->get();
 
         $this->assertEquals([2], $users->pluck('id')->all());
+        $this->assertEquals([2], $usersTwo->pluck('id')->all());
     }
 
     public function testOrWhereDoesntHaveRelation()
     {
         $users = User::whereDoesntHaveRelation('posts', 'public', true)->orWhereDoesntHaveRelation('posts', 'public', false)->get();
+        $usersTwo = User::whereDoesntHaveRelation('posts.public', true)->orWhereDoesntHaveRelation('posts.public', false)->get();
 
         $this->assertEquals([1, 2], $users->pluck('id')->all());
+        $this->assertEquals([1, 2], $usersTwo->pluck('id')->all());
     }
 
     public function testNestedWhereDoesntHaveRelation()
     {
         $texts = User::whereDoesntHaveRelation('posts.texts', 'content', 'test')->get();
+        $textsTwo = User::whereDoesntHaveRelation('posts.texts.content', 'test')->get();
 
         $this->assertEquals([2], $texts->pluck('id')->all());
+        $this->assertEquals([2], $textsTwo->pluck('id')->all());
     }
 
     public function testNestedOrWhereDoesntHaveRelation()
     {
         $texts = User::whereDoesntHaveRelation('posts.texts', 'content', 'test')->orWhereDoesntHaveRelation('posts.texts', 'content', 'test2')->get();
+        $textsTwo = User::whereDoesntHaveRelation('posts.texts.content', 'test')->orWhereDoesntHaveRelation('posts.texts.content', 'test2')->get();
 
         $this->assertEquals([1, 2], $texts->pluck('id')->all());
+        $this->assertEquals([1, 2], $textsTwo->pluck('id')->all());
     }
 
     public function testWhereMorphDoesntHaveRelation()
     {
         $comments = Comment::whereMorphDoesntHaveRelation('commentable', '*', 'public', true)->get();
+        $commentsTwo = Comment::whereMorphDoesntHaveRelation('commentable.public', '*', true)->get();
 
         $this->assertEquals([2], $comments->pluck('id')->all());
+        $this->assertEquals([2], $commentsTwo->pluck('id')->all());
     }
 
     public function testOrWhereMorphDoesntHaveRelation()
@@ -237,7 +262,12 @@ class EloquentWhereHasTest extends DatabaseTestCase
             ->orWhereMorphDoesntHaveRelation('commentable', '*', 'public', false)
             ->get();
 
+        $commentsTwo = Comment::whereMorphDoesntHaveRelation('commentable.public', '*', true)
+            ->orWhereMorphDoesntHaveRelation('commentable.public', '*', false)
+            ->get();
+
         $this->assertEquals([1, 2], $comments->pluck('id')->all());
+        $this->assertEquals([1, 2], $commentsTwo->pluck('id')->all());
     }
 
     public function testWithCount()


### PR DESCRIPTION
The Eloquent **whereRelation** accepts 4 parameters in total **_$relation_**, **_$column_**, **_$operator = null_**, **_$value = null_**

If the **$column** parameter is not a **\Closure** we should be able to use a syntax like 
**where** clause.

If either of **$column** and **$operator** value is not null the **addDotNotationToWhereRelation** function
skips everything.

In where clause we can use something like this
```
    $posts = Post::query()
        ->where('user_id', Auth::id());
        ->where('user_id', '!=', $request->user_id);
```

So whenever we want to query we have to use the **whereRelation** as follows.

```
$posts = Post::query()
    ->whereRelation('comments', 'user_id', Auth::id())
    ->get()
```

We always have to use atleast **3** parameters.
This pull request allows us to only use **2** for this usecase.

What i want to do is the **whereRelation** and other related relation function 
to act as the where clause.

```
    $posts = Post::query()
        ->whereRelation('comments', 'user_id', Auth::id());
        ->whereRelation('comments', 'user_id', '!=', $request->user_id);

    $posts = Post::query()
        ->whereRelation('comments.user_id', Auth::id());
        ->whereRelation('comments', 'user_id', '!=', $request->user_id);
```

This commit doesnt break any existing changes because i have written integration testing.
But if we want it to fully replace the previous method we can change the code to accomodate those things.