### PR TITLE
[12.x] Add `increment` and `decrement` methods to `Context`

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -370,6 +370,35 @@ class Repository
     }
 
     /**
+     * Increment a context counter.
+     *
+     * @param  string  $key
+     * @param  int  $amount
+     * @return $this
+     */
+    public function increment(string $key, int $amount = 1)
+    {
+        $this->add(
+            $key,
+            (int) $this->get($key, 0) + $amount,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Decrement a context counter.
+     *
+     * @param  string  $key
+     * @param  int  $amount
+     * @return $this
+     */
+    public function decrement(string $key, int $amount = 1)
+    {
+        return $this->increment($key, $amount * -1);
+    }
+
+    /**
      * Determine if the given value is in the given stack.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -25,6 +25,8 @@ namespace Illuminate\Support\Facades;
  * @method static mixed pop(string $key)
  * @method static \Illuminate\Log\Context\Repository pushHidden(string $key, mixed ...$values)
  * @method static mixed popHidden(string $key)
+ * @method static mixed increment(string $key, int $amount)
+ * @method static mixed decrement(string $key, int $amount)
  * @method static bool stackContains(string $key, mixed $value, bool $strict = false)
  * @method static bool hiddenStackContains(string $key, mixed $value, bool $strict = false)
  * @method static mixed scope(callable $callback, array $data = [], array $hidden = [])

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -602,6 +602,38 @@ class ContextTest extends TestCase
 
         file_put_contents($path, '');
     }
+
+    public function test_it_increments_a_counter()
+    {
+        Context::increment('foo');
+        $this->assertSame(1, Context::get('foo'));
+
+        Context::increment('foo');
+        $this->assertSame(2, Context::get('foo'));
+    }
+
+    public function test_it_custom_increments_a_counter()
+    {
+        Context::increment('foo', 2);
+        $this->assertSame(2, Context::get('foo'));
+
+        Context::increment('foo', 3);
+        $this->assertSame(5, Context::get('foo'));
+    }
+
+    public function test_it_decrements_a_counter()
+    {
+        Context::increment('foo');
+        Context::decrement('foo');
+        $this->assertSame(0, Context::get('foo'));
+    }
+
+    public function test_it_custom_decrements_a_counter()
+    {
+        Context::increment('foo', 2);
+        Context::decrement('foo', 2);
+        $this->assertSame(0, Context::get('foo'));
+    }
 }
 
 enum Suit


### PR DESCRIPTION
This PR proposes adding `increment` and `decrement` methods to `Context`.

This simplifies keeping track of a counter, e.g. number of records added, number of requests made, etc.