### PR TITLE
[12.x] Add test for after method in LazyCollection

### DIFF
--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -286,4 +286,30 @@ class SupportLazyCollectionTest extends TestCase
 
         $this->assertSame([1, 2], $data->all());
     }
+
+    public function testAfter()
+    {
+        $data = new LazyCollection([1, '2', 3, 4]);
+
+        // Test finding item after value with non-strict comparison
+        $result = $data->after(1);
+        $this->assertSame('2', $result);
+
+        // Test with strict comparison
+        $result = $data->after('2', true);
+        $this->assertSame(3, $result);
+
+        $users = new LazyCollection([
+            ['name' => 'Taylor', 'age' => 35],
+            ['name' => 'Jeffrey', 'age' => 45],
+            ['name' => 'Mohamed', 'age' => 35],
+        ]);
+
+        // Test finding item after the one that matches a condition
+        $result = $users->after(function ($user) {
+            return $user['name'] === 'Jeffrey';
+        });
+
+        $this->assertSame(['name' => 'Mohamed', 'age' => 35], $result);
+    }
 }


### PR DESCRIPTION
# Add test for LazyCollection::after method ✅

In this PR, I've added a test for the `after` method in the `LazyCollection` class, There was no test for this method before.

 The test verifies the correct behavior of this method in three key scenarios:

- ▪️ Finding the next item using non-strict comparison
- ▪️ Finding the next item using strict comparison
- ▪️ Finding the next item using a callback function

While reviewing the LazyCollection code, I noticed that the after method lacked test coverage. Adding this test helps improve code reliability and ensures that any future changes to the collection functionality won't inadvertently break the after method's expected behavior. 🧪 