### PR TITLE
[12.x] Add support for native JSON/JSONB column types in SQLite Schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -891,6 +891,13 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
+        $useNativeJson = $this->connection->getConfig('schema.use_native_json');
+
+        var_dump($useNativeJson);
+        if ($useNativeJson) {
+            return 'json';
+        }
+
         return 'text';
     }
 
@@ -902,6 +909,12 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeJsonb(Fluent $column)
     {
+        $useNativeJson = $this->connection->getConfig('schema.use_native_jsonb');
+
+        if ($useNativeJson) {
+            return 'jsonb';
+        }
+
         return 'text';
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -582,6 +582,25 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
+    public function testAddingNativeJson()
+    {
+        $connection = m::mock(Connection::class);
+        $connection
+            ->shouldReceive('getTablePrefix')->andReturn('')
+            ->shouldReceive('getConfig')->once()->with('schema.use_native_json')->andReturn(true)
+            ->shouldReceive('getSchemaGrammar')->andReturn($this->getGrammar($connection))
+            ->shouldReceive('getSchemaBuilder')->andReturn($this->getBuilder())
+            ->shouldReceive('getServerVersion')->andReturn('3.35')
+            ->getMock();
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->json('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" json not null', $statements[0]);
+    }
+
     public function testAddingJsonb()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -590,6 +609,25 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
+    }
+
+    public function testAddingNativeJsonb()
+    {
+        $connection = m::mock(Connection::class);
+        $connection
+            ->shouldReceive('getTablePrefix')->andReturn('')
+            ->shouldReceive('getConfig')->once()->with('schema.use_native_jsonb')->andReturn(true)
+            ->shouldReceive('getSchemaGrammar')->andReturn($this->getGrammar($connection))
+            ->shouldReceive('getSchemaBuilder')->andReturn($this->getBuilder())
+            ->shouldReceive('getServerVersion')->andReturn('3.35')
+            ->getMock();
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->jsonb('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" jsonb not null', $statements[0]);
     }
 
     public function testAddingDate()


### PR DESCRIPTION
# Overview

SQLite has supported JSON data type as a built-in feature since version 3.38.0, but prior to that, users needed to opt-in by installing an extension.
Additionally, native support for JSONB type began with version 3.45.
Since Laravel 12 supports SQLite 3.26.0 and above, it should not be designed with the assumption that JSON/JSONB support is always available.
While Query\Grammars\SQLiteGrammar::class includes support for JSON functions, Schema\Grammars\SQLiteGrammar::class does not offer this option.
This PullRequest allows injecting configuration from the database connection config to enable the use of native JSON columns when defining Schema.

# Details

This feature allows the following configuration in config/database.php:

```php
'sqlite' => [
    'driver' => 'sqlite',
    'url' => env('DATABASE_URL'),
    ...,
    'schema' => [
    	'use_native_json' => true,
    	'use_native_jsonb' => true,
    ],
],
```

## JSON 

By setting schema.use_native_json in a connection with sqlite driver, the following DDL changes will occur:

### schema.use_native_json = false (default)

```php
Schema::create('sample', function (Blueprint $table) {
    $table->json('column_1');
});
```

```sql
create table sample
(
    column_1 text not null
);
```

### schema.use_native_json = true

```php
Schema::create('sample', function (Blueprint $table) {
    $table->json('column_1');
});
```

```sql
create table sample
(
    column_1 json not null
);
```

## JSONB

The same applies to JSONB:

### schema.use_native_jsonb = false (default)

```php
Schema::create('sample', function (Blueprint $table) {
    $table->jsonb('column_1');
});
```

```sql
create table sample
(
    column_1 text not null
);
```

### schema.use_native_jsonb = true

```php
Schema::create('sample', function (Blueprint $table) {
    $table->jsonb('column_1');
});
```

```sql
create table sample
(
    column_1 jsonb not null
);
```