### PR TITLE
[11.x] Fix callOnce in Seeder so it handles arrays properly

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -110,11 +110,15 @@ abstract class Seeder
      */
     public function callOnce($class, $silent = false, array $parameters = [])
     {
-        if (in_array($class, static::$called)) {
-            return;
-        }
+        $classes = Arr::wrap($class);
 
-        $this->call($class, $silent, $parameters);
+        foreach ($classes as $class) {
+            if (in_array($class, static::$called)) {
+                continue;
+            }
+
+            $this->call($class, $silent, $parameters);
+        }
     }
 
     /**


### PR DESCRIPTION
The PHP doc indicates that the `callOnce` method allows an `array` or `string` for the `$class` parameter which is not the case. This PR adds `array` support for the `$class` parameter.