### PR TITLE
Add "trashed" event to $observables in SoftDeletes Trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -15,17 +15,6 @@ use Illuminate\Support\Collection as BaseCollection;
 trait SoftDeletes
 {
     /**
-     * User exposed observable events.
-     *
-     * These are extra user-defined events observers may subscribe to.
-     *
-     * @var array
-     */
-    protected $observables = [
-        'trashed',
-    ];
-    
-    /**
      * Indicates if the model is currently force deleting.
      *
      * @var bool
@@ -52,6 +41,9 @@ trait SoftDeletes
         if (! isset($this->casts[$this->getDeletedAtColumn()])) {
             $this->casts[$this->getDeletedAtColumn()] = 'datetime';
         }
+
+        // Include Soft Delete Event in $observables array
+        $this->addObservableEvents('trashed');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -15,6 +15,17 @@ use Illuminate\Support\Collection as BaseCollection;
 trait SoftDeletes
 {
     /**
+     * User exposed observable events.
+     *
+     * These are extra user-defined events observers may subscribe to.
+     *
+     * @var array
+     */
+    protected $observables = [
+        'trashed',
+    ];
+    
+    /**
      * Indicates if the model is currently force deleting.
      *
      * @var bool


### PR DESCRIPTION
Added "trashed" event to $observables array so that subscribed Observers can catch the event as Expected!

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
