### PR TITLE
Write Blade templates cache atomically

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -193,7 +193,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 $compiledPath = $this->getCompiledPath($this->getPath())
             );
 
-            $this->files->put($compiledPath, $contents);
+            $this->files->replace($compiledPath, $contents);
         }
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -66,7 +66,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
     }
 
@@ -76,7 +76,7 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(false);
         $files->shouldReceive('makeDirectory')->once()->with(__DIR__, 0777, true, true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
     }
 
@@ -85,7 +85,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
         $this->assertSame('foo', $compiler->getPath());
     }
@@ -102,7 +102,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
         // set path before compilation
         $compiler->setPath('foo');
         // trigger compilation with $path
@@ -132,7 +132,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn($content);
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', $compiled);
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php', $compiled);
 
         $compiler->compile('foo');
     }
@@ -187,7 +187,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', 'Hello World');
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', 'Hello World');
         $compiler->setPath('');
         $compiler->compile();
     }
@@ -197,7 +197,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with(null)->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', 'Hello World');
+        $files->shouldReceive('replace')->once()->with(__DIR__.'/'.hash('xxh128', 'v2').'.php', 'Hello World');
         $compiler->setPath(null);
         $compiler->compile();
     }


### PR DESCRIPTION
This change ensures that the blade cache file is written atomically. Without atomic writing, there is a brief period during which the file is created but empty. By ensuring the file is written atomically, we can guarantee that it always has a consistent state.

Reproducing this bug is quite difficult because it requires sending two requests that compile the same blade component. The second request must access the blade component before the content is written but after the file is created. To reproduce the bug, I slowed down the filesystem's write speed using the following package: https://github.com/bandwidth-throttle/bandwidth-throttle, and patched the filesystem ([Patch file to reproduce](https://github.com/user-attachments/files/19209638/josh.patch); requires the Composer package bandwidth-throttle/bandwidth-throttle, which is not installed with the attached patch). Afterward, we can easily trigger the bug with PHPUnit and Parallel Testing using various tests that send the same mailable (in different tests):

```
ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty

[…]/vendor/tijsverkoyen/css-to-inline-styles/src/CssToInlineStyles.php:117
[…]/vendor/tijsverkoyen/css-to-inline-styles/src/CssToInlineStyles.php:37
[…]/vendor/laravel/framework/src/Illuminate/Mail/Markdown.php:75
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailable.php:379
[…]/vendor/laravel/framework/src/Illuminate/Collections/helpers.php:236
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailer.php:441
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailer.php:420
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailer.php:313
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailable.php:206
[…]/vendor/laravel/framework/src/Illuminate/Support/Traits/Localizable.php:29
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailable.php:199
[…]/vendor/laravel/framework/src/Illuminate/Mail/SendOrderReceivedMailable.php:83
[…]/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36
[…]/vendor/laravel/framework/src/Illuminate/Container/Util.php:43
[…]/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:95
[…]/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:35
[…]/vendor/laravel/framework/src/Illuminate/Container/Container.php:696
[…]/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php:126
[…]/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:170
[…]/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:127
[…]/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php:130
[…]/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php:126
[…]/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:170
[…]/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:127
[…]/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php:121
[…]/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php:69
[…]/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php:102
[…]/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php:76
[…]/vendor/laravel/framework/src/Illuminate/Queue/SyncQueue.php:56
[…]/vendor/laravel/framework/src/Illuminate/Queue/Queue.php:59
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailable.php:234
[…]/vendor/laravel/framework/src/Illuminate/Mail/Mailer.php:483
[…]/vendor/laravel/framework/src/Illuminate/Mail/PendingMail.php:146
[…]/app/Helpers/Order/Create.php:532
[…]/tests/SimpleOrderTest.php:17
```

