### PR TITLE
[12.x] Add support for native JSON/JSONB column types in SQLite Schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -893,7 +893,6 @@ class SQLiteGrammar extends Grammar
     {
         $useNativeJson = $this->connection->getConfig('schema.use_native_json');
 
-        var_dump($useNativeJson);
         if ($useNativeJson) {
             return 'json';
         }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -891,13 +891,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
-        $useNativeJson = $this->connection->getConfig('schema.use_native_json');
-
-        if ($useNativeJson) {
-            return 'json';
-        }
-
-        return 'text';
+        return $this->connection->getConfig('use_native_json') ? 'json' : 'text';
     }
 
     /**
@@ -908,13 +902,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeJsonb(Fluent $column)
     {
-        $useNativeJson = $this->connection->getConfig('schema.use_native_jsonb');
-
-        if ($useNativeJson) {
-            return 'jsonb';
-        }
-
-        return 'text';
+        return $this->connection->getConfig('use_native_jsonb') ? 'jsonb' : 'text';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -891,6 +891,13 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
+        $useNativeJson = $this->connection->getConfig('schema.use_native_json');
+
+        var_dump($useNativeJson);
+        if ($useNativeJson) {
+            return 'json';
+        }
+
         return 'text';
     }
 
@@ -902,6 +909,12 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeJsonb(Fluent $column)
     {
+        $useNativeJson = $this->connection->getConfig('schema.use_native_jsonb');
+
+        if ($useNativeJson) {
+            return 'jsonb';
+        }
+
         return 'text';
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -582,6 +582,25 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
+    public function testAddingNativeJson()
+    {
+        $connection = m::mock(Connection::class);
+        $connection
+            ->shouldReceive('getTablePrefix')->andReturn('')
+            ->shouldReceive('getConfig')->once()->with('schema.use_native_json')->andReturn(true)
+            ->shouldReceive('getSchemaGrammar')->andReturn($this->getGrammar($connection))
+            ->shouldReceive('getSchemaBuilder')->andReturn($this->getBuilder())
+            ->shouldReceive('getServerVersion')->andReturn('3.35')
+            ->getMock();
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->json('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" json not null', $statements[0]);
+    }
+
     public function testAddingJsonb()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -590,6 +609,25 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
+    }
+
+    public function testAddingNativeJsonb()
+    {
+        $connection = m::mock(Connection::class);
+        $connection
+            ->shouldReceive('getTablePrefix')->andReturn('')
+            ->shouldReceive('getConfig')->once()->with('schema.use_native_jsonb')->andReturn(true)
+            ->shouldReceive('getSchemaGrammar')->andReturn($this->getGrammar($connection))
+            ->shouldReceive('getSchemaBuilder')->andReturn($this->getBuilder())
+            ->shouldReceive('getServerVersion')->andReturn('3.35')
+            ->getMock();
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->jsonb('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" jsonb not null', $statements[0]);
     }
 
     public function testAddingDate()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -587,7 +587,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $connection = m::mock(Connection::class);
         $connection
             ->shouldReceive('getTablePrefix')->andReturn('')
-            ->shouldReceive('getConfig')->once()->with('schema.use_native_json')->andReturn(true)
+            ->shouldReceive('getConfig')->once()->with('use_native_json')->andReturn(true)
             ->shouldReceive('getSchemaGrammar')->andReturn($this->getGrammar($connection))
             ->shouldReceive('getSchemaBuilder')->andReturn($this->getBuilder())
             ->shouldReceive('getServerVersion')->andReturn('3.35')
@@ -616,7 +616,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $connection = m::mock(Connection::class);
         $connection
             ->shouldReceive('getTablePrefix')->andReturn('')
-            ->shouldReceive('getConfig')->once()->with('schema.use_native_jsonb')->andReturn(true)
+            ->shouldReceive('getConfig')->once()->with('use_native_jsonb')->andReturn(true)
             ->shouldReceive('getSchemaGrammar')->andReturn($this->getGrammar($connection))
             ->shouldReceive('getSchemaBuilder')->andReturn($this->getBuilder())
             ->shouldReceive('getServerVersion')->andReturn('3.35')


### PR DESCRIPTION
redo of #54984

# Overview

SQLite has supported JSON data type as a built-in feature since version 3.38.0, but prior to that, users needed to opt-in by installing an extension.
Additionally, native support for JSONB type began with version 3.45.
Since Laravel 12 supports SQLite 3.26.0 and above, it should not be designed with the assumption that JSON/JSONB support is always available.
While Query\Grammars\SQLiteGrammar::class includes support for JSON functions, Schema\Grammars\SQLiteGrammar::class does not offer this option.
This PullRequest allows injecting configuration from the database connection config to enable the use of native JSON columns when defining Schema.

# Details

This feature allows the following configuration in config/database.php:

```php
'sqlite' => [
    'driver' => 'sqlite',
    'url' => env('DATABASE_URL'),
    ...,
    'use_native_json' => true,
    'use_native_jsonb' => true,
],
```

## JSON 

By setting use_native_json in a connection with sqlite driver, the following DDL changes will occur:

### use_native_json = false (default)

```php
Schema::create('sample', function (Blueprint $table) {
    $table->json('column_1');
});
```

```sql
create table sample
(
    column_1 text not null
);
```

### use_native_json = true

```php
Schema::create('sample', function (Blueprint $table) {
    $table->json('column_1');
});
```

```sql
create table sample
(
    column_1 json not null
);
```

## JSONB

The same applies to JSONB:

### use_native_jsonb = false (default)

```php
Schema::create('sample', function (Blueprint $table) {
    $table->jsonb('column_1');
});
```

```sql
create table sample
(
    column_1 text not null
);
```

### use_native_jsonb = true

```php
Schema::create('sample', function (Blueprint $table) {
    $table->jsonb('column_1');
});
```

```sql
create table sample
(
    column_1 jsonb not null
);
```