### PR TITLE
[12.x] Add json:unicode cast to support JSON_UNESCAPED_UNICODE encoding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -21,9 +21,9 @@ class Json
     /**
      * Encode the given value.
      */
-    public static function encode(mixed $value): mixed
+    public static function encode(mixed $value, int $flags = 0): mixed
     {
-        return isset(static::$encoder) ? (static::$encoder)($value) : json_encode($value);
+        return isset(static::$encoder) ? (static::$encoder)($value) : json_encode($value, $flags);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1327,7 +1327,7 @@ trait HasAttributes
     }
 
     /**
-     * Get JSON casting flags for the specified attribute.
+     * Get the JSON casting flags for the given attribute.
      *
      * @param  string  $key
      * @return int

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -117,6 +117,7 @@ trait HasAttributes
         'int',
         'integer',
         'json',
+        'json:unicode',
         'object',
         'real',
         'string',
@@ -837,6 +838,7 @@ trait HasAttributes
                 return $this->fromJson($value, true);
             case 'array':
             case 'json':
+            case 'json:unicode':
                 return $this->fromJson($value);
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
@@ -1178,7 +1180,7 @@ trait HasAttributes
 
         $value = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
-        ));
+        ), $this->hasCast($key, ['json:unicode']));
 
         $this->attributes[$key] = $this->isEncryptedCastable($key)
             ? $this->castAttributeAsEncryptedString($key, $value)
@@ -1313,7 +1315,7 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
-        $value = $this->asJson($value);
+        $value = $this->asJson($value, $this->hasCast($key, ['json:unicode']));
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
@@ -1328,10 +1330,15 @@ trait HasAttributes
      * Encode the given value as JSON.
      *
      * @param  mixed  $value
+     * @param  bool  $isUnicode
      * @return string
      */
-    protected function asJson($value)
+    protected function asJson($value, $isUnicode = false)
     {
+        if ($isUnicode) {
+            return Json::encode($value, JSON_UNESCAPED_UNICODE);
+        }
+
         return Json::encode($value);
     }
 
@@ -1669,7 +1676,7 @@ trait HasAttributes
      */
     protected function isJsonCastable($key)
     {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
+        return $this->hasCast($key, ['array', 'json', 'json:unicode', 'object', 'collection', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1315,7 +1315,7 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
-        $value = $this->asJson($value, $this->hasCast($key, ['json:unicode']));
+        $value = $this->asJson($value, $this->getJsonCastFlags($key));
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
@@ -1327,19 +1327,32 @@ trait HasAttributes
     }
 
     /**
+     * Get JSON casting flags for the specified attribute.
+     *
+     * @param  string  $key
+     * @return int
+     */
+    protected function getJsonCastFlags($key)
+    {
+        $flags = 0;
+
+        if ($this->hasCast($key, ['json:unicode'])) {
+            $flags |= JSON_UNESCAPED_UNICODE;
+        }
+
+        return $flags;
+    }
+
+    /**
      * Encode the given value as JSON.
      *
      * @param  mixed  $value
-     * @param  bool  $isUnicode
+     * @param  int  $flags
      * @return string
      */
-    protected function asJson($value, $isUnicode = false)
+    protected function asJson($value, $flags = 0)
     {
-        if ($isUnicode) {
-            return Json::encode($value, JSON_UNESCAPED_UNICODE);
-        }
-
-        return Json::encode($value);
+        return Json::encode($value, $flags);
     }
 
     /**


### PR DESCRIPTION
# Description

This PR introduces a new `json:unicode` cast type for Eloquent attributes, allowing JSON encoding with `JSON_UNESCAPED_UNICODE`. This makes it easier to store and retrieve JSON data without Unicode escaping (`\uXXXX`), which is particularly useful for applications that handle non-ASCII characters like Japanese, Chinese, or emojis.

# Why?

Currently, Eloquent's `json` cast escapes Unicode characters by default, making JSON-encoded attributes harder to read for humans and increasing the need for manual decoding. Developers often work around this by overriding accessors/mutators or manually using `json_encode($value, JSON_UNESCAPED_UNICODE)`, which is cumbersome.

By introducing `json:unicode`, developers can simply specify it in the `$casts` array:

```php
protected $casts = [
    'data' => 'json:unicode',
];
```

This automatically applies `JSON_UNESCAPED_UNICODE` when encoding the attribute.

# Changes

## Core Modifications

- Updated `Illuminate\Database\Eloquent\Casts\Json`:
  - Added an optional `$flags` parameter to `Json::encode()`, allowing different encoding options.
- Updated `Illuminate\Database\Eloquent\Concerns\HasAttributes`:
  - Added `json:unicode` to the list of castable types.
  - Modified `asJson()` to check if `json:unicode` is used and apply `JSON_UNESCAPED_UNICODE`.

## Tests

- Added `testJsonCastingRespectsUnicodeOption()`
  - Ensures that `json:unicode` encodes JSON without escaping Unicode characters.
- Added `testModelJsonUnicodeCastingFailsOnUnencodableData()`
  - Verifies that `JsonEncodingException` is thrown when `json:unicode` encounters malformed UTF-8 characters.

# Before & After Example

## Before (using default json cast)

```php
protected $casts = ['data' => 'json'];

$model = new SomeModel();
$model->data = ['こんにちは' => '世界'];
$model->save();

echo $model->toJson();
// {"data":{"\u3053\u3093\u306b\u3061\u306f":"\u4e16\u754c"}}
```

## After (using json:unicode cast)

```php
protected $casts = ['data' => 'json:unicode'];

$model = new SomeModel();
$model->data = ['こんにちは' => '世界'];
$model->save();

echo $model->toJson();
// {"data":{"こんにちは":"世界"}}
```

# Backward Compatibility

- The default `json` cast remains unchanged, ensuring full backward compatibility.
- Developers can opt-in to `json:unicode` when needed.

# Potential Edge Cases Considered

- Malformed UTF-8 data: Ensured `json:unicode` still throws `JsonEncodingException` when encoding fails.
- Null handling: Verified that `null` values are properly handled.
- Attribute retrieval: Ensured both `json` and `json:unicode` return arrays when accessed.