### PR TITLE
Enhance validation tests: Add test for connection name detection in Unique rule

### DIFF
--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -80,6 +80,10 @@ class ValidationUniqueRuleTest extends TestCase
         $rule = new Unique('table');
         $rule->where('foo', '"bar"');
         $this->assertSame('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
+
+        $rule = new Unique(EloquentModelWithConnection::class, 'column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:mysql.table,column,NULL,id,foo,"bar"', (string) $rule);
     }
 
     public function testItIgnoresSoftDeletes()
@@ -169,4 +173,9 @@ class ClassWithNonEmptyConstructor
         $this->bar = $bar;
         $this->baz = $baz;
     }
+}
+
+class EloquentModelWithConnection extends EloquentModelStub
+{
+    protected $connection = 'mysql';
 }


### PR DESCRIPTION
This PR adds a test to verify that the Unique validation rule correctly detects the database connection name. This ensures proper handling of multi-database setups in Laravel validation.