### PR TITLE
[12.x] feat: Ensure correct state of wasRecentlyCreated after Eloquent model refresh

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1739,6 +1739,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->syncOriginal();
 
+        $this->wasRecentlyCreated = false;
+
         return $this;
     }
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -71,6 +71,17 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $post->children->first()->refresh();
     }
+
+    public function testItResetsWasRecentlyCreatedProperty()
+    {
+        $post = Post::create(['title' => 'laravel']);
+
+        $this->assertTrue($post->wasRecentlyCreated);
+
+        $post->refresh();
+
+        $this->assertFalse($post->wasRecentlyCreated);
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
# Ensure correct state of wasRecentlyCreated after Eloquent model refresh

In this PR, I fixed an issue with Laravel Eloquent's `refresh()` method where the `wasRecentlyCreated` property wasn't being reset properly. 🐛

**Issue Description:**
When creating a new model and then calling `refresh()`, the `wasRecentlyCreated` property remained `true` instead of being set to `false`. This could lead to incorrect logic in applications that rely on this property.

for Example:
![carbon (8)](https://github.com/user-attachments/assets/b70aa3ac-36d3-4f23-8e14-a78a6baa04d4)

Added a line in the `refresh()` method to explicitly set `wasRecentlyCreated` to `false`:
```php
$this->wasRecentlyCreated = false;
```
This ensures that if a model was recently saved in any way and then refreshed, the wasRecentlyCreated property will be set to false if it was previously true, maintaining the correct state of the model.

**Test Coverage:** ✅
Added a test case to ensure the property is correctly reset

This fix ensures that the model's state is properly maintained after a refresh operation, providing more reliable behavior for applications.