### PR TITLE
[12.x] add "single_line_empty_body" rule to Pint

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -184,6 +184,7 @@
         "single_import_per_statement": true,
         "single_line_after_imports": true,
         "single_line_comment_style": true,
+        "single_line_empty_body": true,
         "single_quote": true,
         "space_after_semicolon": true,
         "spaces_inside_parentheses": true,

--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -16,6 +16,5 @@ class Attempting
         public $guard,
         #[\SensitiveParameter] public $credentials,
         public $remember,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -18,6 +18,5 @@ class Authenticated
     public function __construct(
         public $guard,
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -18,6 +18,5 @@ class CurrentDeviceLogout
     public function __construct(
         public $guard,
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -16,6 +16,5 @@ class Failed
         public $guard,
         public $user,
         #[\SensitiveParameter] public $credentials,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -20,6 +20,5 @@ class Login
         public $guard,
         public $user,
         public $remember,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -18,6 +18,5 @@ class Logout
     public function __construct(
         public $guard,
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -18,6 +18,5 @@ class OtherDeviceLogout
     public function __construct(
         public $guard,
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -16,6 +16,5 @@ class PasswordReset
      */
     public function __construct(
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -16,6 +16,5 @@ class PasswordResetLinkSent
      */
     public function __construct(
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -16,6 +16,5 @@ class Registered
      */
     public function __construct(
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -18,6 +18,5 @@ class Validated
     public function __construct(
         public $guard,
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -16,6 +16,5 @@ class Verified
      */
     public function __construct(
         public $user,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -25,8 +25,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
         protected int $expires = 3600,
         protected int $throttle = 60,
         protected string $prefix = '',
-    ) {
-    }
+    ) {}
 
     /**
      * Create a new token.
@@ -122,7 +121,5 @@ class CacheTokenRepository implements TokenRepositoryInterface
      *
      * @return void
      */
-    public function deleteExpired()
-    {
-    }
+    public function deleteExpired() {}
 }

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -23,8 +23,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
         protected string $hashKey,
         protected int $expires = 3600,
         protected int $throttle = 60,
-    ) {
-    }
+    ) {}
 
     /**
      * Create a new token record.

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -390,9 +390,7 @@ class DynamoBatchRepository implements BatchRepository
      *
      * @return void
      */
-    public function rollBack()
-    {
-    }
+    public function rollBack() {}
 
     /**
      * Convert the given raw batch to a Batch object.

--- a/src/Illuminate/Bus/Events/BatchDispatched.php
+++ b/src/Illuminate/Bus/Events/BatchDispatched.php
@@ -14,6 +14,5 @@ class BatchDispatched
      */
     public function __construct(
         public Batch $batch,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Collections/ItemNotFoundException.php
+++ b/src/Illuminate/Collections/ItemNotFoundException.php
@@ -4,6 +4,4 @@ namespace Illuminate\Support;
 
 use RuntimeException;
 
-class ItemNotFoundException extends RuntimeException
-{
-}
+class ItemNotFoundException extends RuntimeException {}

--- a/src/Illuminate/Console/Events/ArtisanStarting.php
+++ b/src/Illuminate/Console/Events/ArtisanStarting.php
@@ -14,6 +14,5 @@ class ArtisanStarting
      */
     public function __construct(
         public Application $artisan,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -21,6 +21,5 @@ class CommandFinished
         public InputInterface $input,
         public OutputInterface $output,
         public int $exitCode,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/CommandStarting.php
+++ b/src/Illuminate/Console/Events/CommandStarting.php
@@ -19,6 +19,5 @@ class CommandStarting
         public string $command,
         public InputInterface $input,
         public OutputInterface $output,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
@@ -14,6 +14,5 @@ class ScheduledBackgroundTaskFinished
      */
     public function __construct(
         public Event $task,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskFailed.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFailed.php
@@ -17,6 +17,5 @@ class ScheduledTaskFailed
     public function __construct(
         public Event $task,
         public Throwable $exception,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -16,6 +16,5 @@ class ScheduledTaskFinished
     public function __construct(
         public Event $task,
         public float $runtime,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
@@ -14,6 +14,5 @@ class ScheduledTaskSkipped
      */
     public function __construct(
         public Event $task,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskStarting.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskStarting.php
@@ -14,6 +14,5 @@ class ScheduledTaskStarting
      */
     public function __construct(
         public Event $task,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Console/PromptValidationException.php
+++ b/src/Illuminate/Console/PromptValidationException.php
@@ -4,6 +4,4 @@ namespace Illuminate\Console;
 
 use RuntimeException;
 
-class PromptValidationException extends RuntimeException
-{
-}
+class PromptValidationException extends RuntimeException {}

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -14,8 +14,7 @@ class PendingEventAttributes
      */
     public function __construct(
         protected Schedule $schedule,
-    ) {
-    }
+    ) {}
 
     /**
      * Do not allow the event to overlap each other.

--- a/src/Illuminate/Container/Attributes/Auth.php
+++ b/src/Illuminate/Container/Attributes/Auth.php
@@ -12,9 +12,7 @@ class Auth implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $guard = null)
-    {
-    }
+    public function __construct(public ?string $guard = null) {}
 
     /**
      * Resolve the authentication guard.

--- a/src/Illuminate/Container/Attributes/Authenticated.php
+++ b/src/Illuminate/Container/Attributes/Authenticated.php
@@ -12,9 +12,7 @@ class Authenticated implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $guard = null)
-    {
-    }
+    public function __construct(public ?string $guard = null) {}
 
     /**
      * Resolve the currently authenticated user.

--- a/src/Illuminate/Container/Attributes/Cache.php
+++ b/src/Illuminate/Container/Attributes/Cache.php
@@ -12,9 +12,7 @@ class Cache implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $store = null)
-    {
-    }
+    public function __construct(public ?string $store = null) {}
 
     /**
      * Resolve the cache store.

--- a/src/Illuminate/Container/Attributes/Config.php
+++ b/src/Illuminate/Container/Attributes/Config.php
@@ -12,9 +12,7 @@ class Config implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public string $key, public mixed $default = null)
-    {
-    }
+    public function __construct(public string $key, public mixed $default = null) {}
 
     /**
      * Resolve the configuration value.

--- a/src/Illuminate/Container/Attributes/Database.php
+++ b/src/Illuminate/Container/Attributes/Database.php
@@ -12,9 +12,7 @@ class Database implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $connection = null)
-    {
-    }
+    public function __construct(public ?string $connection = null) {}
 
     /**
      * Resolve the database connection.

--- a/src/Illuminate/Container/Attributes/Log.php
+++ b/src/Illuminate/Container/Attributes/Log.php
@@ -12,9 +12,7 @@ class Log implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $channel = null)
-    {
-    }
+    public function __construct(public ?string $channel = null) {}
 
     /**
      * Resolve the log channel.

--- a/src/Illuminate/Container/Attributes/RouteParameter.php
+++ b/src/Illuminate/Container/Attributes/RouteParameter.php
@@ -12,9 +12,7 @@ class RouteParameter implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public string $parameter)
-    {
-    }
+    public function __construct(public string $parameter) {}
 
     /**
      * Resolve the route parameter.

--- a/src/Illuminate/Container/Attributes/Storage.php
+++ b/src/Illuminate/Container/Attributes/Storage.php
@@ -12,9 +12,7 @@ class Storage implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $disk = null)
-    {
-    }
+    public function __construct(public ?string $disk = null) {}
 
     /**
      * Resolve the storage disk.

--- a/src/Illuminate/Container/Attributes/Tag.php
+++ b/src/Illuminate/Container/Attributes/Tag.php
@@ -13,8 +13,7 @@ final class Tag implements ContextualAttribute
 {
     public function __construct(
         public string $tag,
-    ) {
-    }
+    ) {}
 
     /**
      * Resolve the tag.

--- a/src/Illuminate/Contracts/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Builder.php
@@ -9,6 +9,4 @@ use Illuminate\Contracts\Database\Query\Builder as BaseContract;
  *
  * @mixin \Illuminate\Database\Eloquent\Builder
  */
-interface Builder extends BaseContract
-{
-}
+interface Builder extends BaseContract {}

--- a/src/Illuminate/Contracts/Database/Query/Builder.php
+++ b/src/Illuminate/Contracts/Database/Query/Builder.php
@@ -7,6 +7,4 @@ namespace Illuminate\Contracts\Database\Query;
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
-interface Builder
-{
-}
+interface Builder {}

--- a/src/Illuminate/Contracts/Database/Query/ConditionExpression.php
+++ b/src/Illuminate/Contracts/Database/Query/ConditionExpression.php
@@ -2,6 +2,4 @@
 
 namespace Illuminate\Contracts\Database\Query;
 
-interface ConditionExpression extends Expression
-{
-}
+interface ConditionExpression extends Expression {}

--- a/src/Illuminate/Contracts/Log/ContextLogProcessor.php
+++ b/src/Illuminate/Contracts/Log/ContextLogProcessor.php
@@ -4,6 +4,4 @@ namespace Illuminate\Contracts\Log;
 
 use Monolog\Processor\ProcessorInterface;
 
-interface ContextLogProcessor extends ProcessorInterface
-{
-}
+interface ContextLogProcessor extends ProcessorInterface {}

--- a/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
@@ -13,7 +13,5 @@ class CollectedBy
      * @param  class-string<\Illuminate\Database\Eloquent\Collection<*, *>>  $collectionClass
      * @return void
      */
-    public function __construct(public string $collectionClass)
-    {
-    }
+    public function __construct(public string $collectionClass) {}
 }

--- a/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
@@ -13,7 +13,5 @@ class ObservedBy
      * @param  array|string  $classes
      * @return void
      */
-    public function __construct(public array|string $classes)
-    {
-    }
+    public function __construct(public array|string $classes) {}
 }

--- a/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
@@ -13,7 +13,5 @@ class ScopedBy
      * @param  array|string  $classes
      * @return void
      */
-    public function __construct(public array|string $classes)
-    {
-    }
+    public function __construct(public array|string $classes) {}
 }

--- a/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
@@ -13,7 +13,5 @@ class UseFactory
      * @param  class-string<\Illuminate\Database\Eloquent\Factories\Factory>  $factoryClass
      * @return void
      */
-    public function __construct(public string $factoryClass)
-    {
-    }
+    public function __construct(public string $factoryClass) {}
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,9 +19,7 @@ class AsCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            public function __construct(protected array $arguments)
-            {
-            }
+            public function __construct(protected array $arguments) {}
 
             public function get($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -20,9 +20,7 @@ class AsEncryptedCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            public function __construct(protected array $arguments)
-            {
-            }
+            public function __construct(protected array $arguments) {}
 
             public function get($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Events/DatabaseBusy.php
+++ b/src/Illuminate/Database/Events/DatabaseBusy.php
@@ -13,6 +13,5 @@ class DatabaseBusy
     public function __construct(
         public $connectionName,
         public $connections,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/DatabaseRefreshed.php
+++ b/src/Illuminate/Database/Events/DatabaseRefreshed.php
@@ -16,6 +16,5 @@ class DatabaseRefreshed implements MigrationEventContract
     public function __construct(
         public ?string $database = null,
         public bool $seeding = false,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -16,6 +16,5 @@ abstract class MigrationsEvent implements MigrationEventContract
     public function __construct(
         public $method,
         public array $options = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/ModelPruningFinished.php
+++ b/src/Illuminate/Database/Events/ModelPruningFinished.php
@@ -12,6 +12,5 @@ class ModelPruningFinished
      */
     public function __construct(
         public $models,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/ModelPruningStarting.php
+++ b/src/Illuminate/Database/Events/ModelPruningStarting.php
@@ -12,6 +12,5 @@ class ModelPruningStarting
      */
     public function __construct(
         public $models
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/ModelsPruned.php
+++ b/src/Illuminate/Database/Events/ModelsPruned.php
@@ -14,6 +14,5 @@ class ModelsPruned
     public function __construct(
         public $model,
         public $count,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/NoPendingMigrations.php
+++ b/src/Illuminate/Database/Events/NoPendingMigrations.php
@@ -14,6 +14,5 @@ class NoPendingMigrations implements MigrationEvent
      */
     public function __construct(
         public $method,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Events/StatementPrepared.php
+++ b/src/Illuminate/Database/Events/StatementPrepared.php
@@ -14,6 +14,5 @@ class StatementPrepared
     public function __construct(
         public $connection,
         public $statement,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -18,8 +18,7 @@ class Expression implements ExpressionContract
      */
     public function __construct(
         protected $value
-    ) {
-    }
+    ) {}
 
     /**
      * Get the value of the expression.

--- a/src/Illuminate/Database/UniqueConstraintViolationException.php
+++ b/src/Illuminate/Database/UniqueConstraintViolationException.php
@@ -2,6 +2,4 @@
 
 namespace Illuminate\Database;
 
-class UniqueConstraintViolationException extends QueryException
-{
-}
+class UniqueConstraintViolationException extends QueryException {}

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -46,9 +46,7 @@ class ApplicationBuilder
     /**
      * Create a new application builder instance.
      */
-    public function __construct(protected Application $app)
-    {
-    }
+    public function __construct(protected Application $app) {}
 
     /**
      * Register the standard kernel classes for the application.

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -15,9 +15,7 @@ class Exceptions
      * @param  \Illuminate\Foundation\Exceptions\Handler  $handler
      * @return void
      */
-    public function __construct(public Handler $handler)
-    {
-    }
+    public function __construct(public Handler $handler) {}
 
     /**
      * Register a reportable callback.

--- a/src/Illuminate/Log/Context/ContextLogProcessor.php
+++ b/src/Illuminate/Log/Context/ContextLogProcessor.php
@@ -15,9 +15,7 @@ class ContextLogProcessor implements ContextLogProcessorContract
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct(protected Application $app)
-    {
-    }
+    public function __construct(protected Application $app) {}
 
     /**
      * Add contextual data to the log's "extra" parameter.

--- a/src/Illuminate/Mail/Events/MessageSending.php
+++ b/src/Illuminate/Mail/Events/MessageSending.php
@@ -16,6 +16,5 @@ class MessageSending
     public function __construct(
         public Email $message,
         public array $data = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -21,8 +21,7 @@ class MessageSent
     public function __construct(
         public SentMessage $sent,
         public array $data = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Get the serializable representation of the object.

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -26,8 +26,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         public $notifiable,
         public $notification,
         public $data = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -23,6 +23,5 @@ class NotificationFailed
         public $notification,
         public $channel,
         public $data = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Notifications/Events/NotificationSending.php
+++ b/src/Illuminate/Notifications/Events/NotificationSending.php
@@ -21,6 +21,5 @@ class NotificationSending
         public $notifiable,
         public $notification,
         public $channel,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Notifications/Events/NotificationSent.php
+++ b/src/Illuminate/Notifications/Events/NotificationSent.php
@@ -23,6 +23,5 @@ class NotificationSent
         public $notification,
         public $channel,
         public $response = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobAttempted.php
+++ b/src/Illuminate/Queue/Events/JobAttempted.php
@@ -16,8 +16,7 @@ class JobAttempted
         public $connectionName,
         public $job,
         public $exceptionOccurred = false,
-    ) {
-    }
+    ) {}
 
     /**
      * Determine if the job completed with failing or an unhandled exception occurring.

--- a/src/Illuminate/Queue/Events/JobExceptionOccurred.php
+++ b/src/Illuminate/Queue/Events/JobExceptionOccurred.php
@@ -16,6 +16,5 @@ class JobExceptionOccurred
         public $connectionName,
         public $job,
         public $exception,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobFailed.php
+++ b/src/Illuminate/Queue/Events/JobFailed.php
@@ -16,6 +16,5 @@ class JobFailed
         public $connectionName,
         public $job,
         public $exception,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobPopped.php
+++ b/src/Illuminate/Queue/Events/JobPopped.php
@@ -14,6 +14,5 @@ class JobPopped
     public function __construct(
         public $connectionName,
         public $job,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobPopping.php
+++ b/src/Illuminate/Queue/Events/JobPopping.php
@@ -12,6 +12,5 @@ class JobPopping
      */
     public function __construct(
         public $connectionName,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobProcessed.php
+++ b/src/Illuminate/Queue/Events/JobProcessed.php
@@ -14,6 +14,5 @@ class JobProcessed
     public function __construct(
         public $connectionName,
         public $job,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobProcessing.php
+++ b/src/Illuminate/Queue/Events/JobProcessing.php
@@ -14,6 +14,5 @@ class JobProcessing
     public function __construct(
         public $connectionName,
         public $job,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -22,8 +22,7 @@ class JobQueued
         public $job,
         public $payload,
         public $delay,
-    ) {
-    }
+    ) {}
 
     /**
      * Get the decoded job payload.

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -20,8 +20,7 @@ class JobQueueing
         public $job,
         public $payload,
         public $delay,
-    ) {
-    }
+    ) {}
 
     /**
      * Get the decoded job payload.

--- a/src/Illuminate/Queue/Events/JobReleasedAfterException.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterException.php
@@ -14,6 +14,5 @@ class JobReleasedAfterException
     public function __construct(
         public $connectionName,
         public $job,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobRetryRequested.php
+++ b/src/Illuminate/Queue/Events/JobRetryRequested.php
@@ -19,8 +19,7 @@ class JobRetryRequested
      */
     public function __construct(
         public $job,
-    ) {
-    }
+    ) {}
 
     /**
      * The job payload.

--- a/src/Illuminate/Queue/Events/JobTimedOut.php
+++ b/src/Illuminate/Queue/Events/JobTimedOut.php
@@ -14,6 +14,5 @@ class JobTimedOut
     public function __construct(
         public $connectionName,
         public $job,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/Looping.php
+++ b/src/Illuminate/Queue/Events/Looping.php
@@ -14,6 +14,5 @@ class Looping
     public function __construct(
         public $connectionName,
         public $queue,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/QueueBusy.php
+++ b/src/Illuminate/Queue/Events/QueueBusy.php
@@ -16,6 +16,5 @@ class QueueBusy
         public $connection,
         public $queue,
         public $size,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -14,6 +14,5 @@ class WorkerStopping
     public function __construct(
         public $status = 0,
         public $workerOptions = null
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Middleware/Skip.php
+++ b/src/Illuminate/Queue/Middleware/Skip.php
@@ -6,9 +6,7 @@ use Closure;
 
 class Skip
 {
-    public function __construct(protected bool $skip = false)
-    {
-    }
+    public function __construct(protected bool $skip = false) {}
 
     /**
      * Apply the middleware if the given condition is truthy.

--- a/src/Illuminate/Routing/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Middleware.php
@@ -13,9 +13,7 @@ class Middleware
      * @param  \Closure|string|array  $middleware
      * @return void
      */
-    public function __construct(public Closure|string|array $middleware, public ?array $only = null, public ?array $except = null)
-    {
-    }
+    public function __construct(public Closure|string|array $middleware, public ?array $only = null, public ?array $except = null) {}
 
     /**
      * Specify the only controller methods the middleware should apply to.

--- a/src/Illuminate/Routing/Events/PreparingResponse.php
+++ b/src/Illuminate/Routing/Events/PreparingResponse.php
@@ -14,6 +14,5 @@ class PreparingResponse
     public function __construct(
         public $request,
         public $response,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Routing/Events/ResponsePrepared.php
+++ b/src/Illuminate/Routing/Events/ResponsePrepared.php
@@ -14,6 +14,5 @@ class ResponsePrepared
     public function __construct(
         public $request,
         public $response,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Routing/Events/RouteMatched.php
+++ b/src/Illuminate/Routing/Events/RouteMatched.php
@@ -14,6 +14,5 @@ class RouteMatched
     public function __construct(
         public $route,
         public $request,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Routing/Events/Routing.php
+++ b/src/Illuminate/Routing/Events/Routing.php
@@ -12,6 +12,5 @@ class Routing
      */
     public function __construct(
         public $request,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -69,8 +69,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
-            };
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {};
         }
 
         return new InvokableValidationRule($invokable);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -97,8 +97,7 @@ class BusBatchTest extends TestCase
             use Batchable;
         };
 
-        $thirdJob = function () {
-        };
+        $thirdJob = function () {};
 
         $queue->shouldReceive('connection')->once()
             ->with('test-connection')

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -250,8 +250,7 @@ class BusPendingBatchTest extends TestCase
         new PendingBatch(
             new Container,
             new Collection([
-                function () {
-                },
+                function () {},
             ])
         );
         $this->expectNotToPerformAssertions();

--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -29,8 +29,7 @@ class ConditionableTest extends TestCase
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when(false));
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when());
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(false, null));
-        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(true, function () {
-        }));
+        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(true, function () {}));
     }
 
     public function testUnless(): void
@@ -39,11 +38,8 @@ class ConditionableTest extends TestCase
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(false));
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless());
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(true, null));
-        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(false, function () {
-        }));
+        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(false, function () {}));
     }
 }
 
-class TestConditionableModel extends Model
-{
-}
+class TestConditionableModel extends Model {}

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -26,9 +26,7 @@ class CommandTest extends TestCase
     {
         $command = new class extends Command
         {
-            public function handle()
-            {
-            }
+            public function handle() {}
         };
 
         $application = m::mock(Application::class);
@@ -60,9 +58,7 @@ class CommandTest extends TestCase
     {
         $command = new class extends Command
         {
-            public function handle()
-            {
-            }
+            public function handle() {}
 
             protected function getArguments()
             {

--- a/tests/Console/Fixtures/JobToTestWithSchedule.php
+++ b/tests/Console/Fixtures/JobToTestWithSchedule.php
@@ -6,6 +6,4 @@ namespace Illuminate\Tests\Console\Fixtures;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-final class JobToTestWithSchedule implements ShouldQueue
-{
-}
+final class JobToTestWithSchedule implements ShouldQueue {}

--- a/tests/Container/AfterResolvingAttributeCallbackTest.php
+++ b/tests/Container/AfterResolvingAttributeCallbackTest.php
@@ -79,8 +79,7 @@ final class ContainerTestOnTenant
 {
     public function __construct(
         public readonly Tenant $tenant
-    ) {
-    }
+    ) {}
 }
 
 enum Tenant
@@ -104,8 +103,7 @@ final class ContainerTestHasTenantImplPropertyWithTenantA
     public function __construct(
         #[ContainerTestOnTenant(Tenant::TenantA)]
         public readonly HasTenantImpl $property
-    ) {
-    }
+    ) {}
 }
 
 final class ContainerTestHasTenantImplPropertyWithTenantB
@@ -113,8 +111,7 @@ final class ContainerTestHasTenantImplPropertyWithTenantB
     public function __construct(
         #[ContainerTestOnTenant(Tenant::TenantB)]
         public readonly HasTenantImpl $property
-    ) {
-    }
+    ) {}
 }
 
 #[Attribute(Attribute::TARGET_CLASS)]
@@ -122,8 +119,7 @@ final class ContainerTestConfiguresClass
 {
     public function __construct(
         public readonly string $value
-    ) {
-    }
+    ) {}
 }
 
 #[ContainerTestConfiguresClass(value: 'the-right-value')]
@@ -131,14 +127,11 @@ final class ContainerTestHasSelfConfiguringAttributeAndConstructor
 {
     public function __construct(
         public string $value
-    ) {
-    }
+    ) {}
 }
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class ContainerTestBootable
-{
-}
+final class ContainerTestBootable {}
 
 #[ContainerTestBootable]
 final class ContainerTestHasBootable

--- a/tests/Container/ContainerExtendTest.php
+++ b/tests/Container/ContainerExtendTest.php
@@ -236,22 +236,18 @@ class ContainerLazyExtendStub
     }
 }
 
-interface ContainerExtendInterfaceStub
-{
-}
+interface ContainerExtendInterfaceStub {}
 
 class ContainerExtendInterfaceImplementationStub implements ContainerExtendInterfaceStub
 {
     public function __construct(
         public string $value,
-    ) {
-    }
+    ) {}
 }
 
 class ContainerExtendConsumesInterfaceStub
 {
     public function __construct(
         public ContainerExtendInterfaceStub $stub,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Container/ContainerResolveNonInstantiableTest.php
+++ b/tests/Container/ContainerResolveNonInstantiableTest.php
@@ -33,9 +33,7 @@ class ContainerResolveNonInstantiableTest extends TestCase
     }
 }
 
-interface TestInterface
-{
-}
+interface TestInterface {}
 
 class ParentClass
 {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -800,8 +800,7 @@ class ContainerClassWithDefaultValueStub
     public function __construct(
         public ?ContainerConcreteStub $noDefault,
         public ?ContainerConcreteStub $default = null,
-    ) {
-    }
+    ) {}
 }
 
 class ContainerMixedPrimitiveStub
@@ -840,9 +839,7 @@ class ContainerInjectVariableStubWithInterfaceImplementation implements IContain
 
 class ContainerContextualBindingCallTarget
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function work(IContainerContractStub $stub)
     {

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -306,29 +306,21 @@ class ContainerTestAttributeThatResolvesContractImpl implements ContextualAttrib
 {
     public function __construct(
         public readonly string $name
-    ) {
-    }
+    ) {}
 }
 
-interface ContainerTestContract
-{
-}
+interface ContainerTestContract {}
 
-final class ContainerTestImplA implements ContainerTestContract
-{
-}
+final class ContainerTestImplA implements ContainerTestContract {}
 
-final class ContainerTestImplB implements ContainerTestContract
-{
-}
+final class ContainerTestImplB implements ContainerTestContract {}
 
 final class ContainerTestHasAttributeThatResolvesToImplA
 {
     public function __construct(
         #[ContainerTestAttributeThatResolvesContractImpl('A')]
         public readonly ContainerTestContract $property
-    ) {
-    }
+    ) {}
 }
 
 final class ContainerTestHasAttributeThatResolvesToImplB
@@ -336,8 +328,7 @@ final class ContainerTestHasAttributeThatResolvesToImplB
     public function __construct(
         #[ContainerTestAttributeThatResolvesContractImpl('B')]
         public readonly ContainerTestContract $property
-    ) {
-    }
+    ) {}
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
@@ -345,8 +336,7 @@ final class ContainerTestConfigValue implements ContextualAttribute
 {
     public function __construct(
         public readonly string $key
-    ) {
-    }
+    ) {}
 }
 
 final class ContainerTestHasConfigValueProperty
@@ -354,8 +344,7 @@ final class ContainerTestHasConfigValueProperty
     public function __construct(
         #[ContainerTestConfigValue('app.timezone')]
         public string $timezone
-    ) {
-    }
+    ) {}
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
@@ -363,8 +352,7 @@ final class ContainerTestConfigValueWithResolve implements ContextualAttribute
 {
     public function __construct(
         public readonly string $key
-    ) {
-    }
+    ) {}
 
     public function resolve(self $attribute, Container $container): string
     {
@@ -377,8 +365,7 @@ final class ContainerTestHasConfigValueWithResolveProperty
     public function __construct(
         #[ContainerTestConfigValueWithResolve('app.env')]
         public string $env
-    ) {
-    }
+    ) {}
 }
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
@@ -400,64 +387,47 @@ final class ContainerTestHasConfigValueWithResolvePropertyAndAfterCallback
     public function __construct(
         #[ContainerTestConfigValueWithResolveAndAfter]
         public object $person
-    ) {
-    }
+    ) {}
 }
 
 final class AuthedTest
 {
-    public function __construct(#[Authenticated('foo')] AuthenticatableContract $foo, #[CurrentUser('bar')] AuthenticatableContract $bar)
-    {
-    }
+    public function __construct(#[Authenticated('foo')] AuthenticatableContract $foo, #[CurrentUser('bar')] AuthenticatableContract $bar) {}
 }
 
 final class CacheTest
 {
-    public function __construct(#[Cache('foo')] CacheRepository $foo, #[Cache('bar')] CacheRepository $bar)
-    {
-    }
+    public function __construct(#[Cache('foo')] CacheRepository $foo, #[Cache('bar')] CacheRepository $bar) {}
 }
 
 final class ConfigTest
 {
-    public function __construct(#[Config('foo')] string $foo, #[Config('bar')] string $bar)
-    {
-    }
+    public function __construct(#[Config('foo')] string $foo, #[Config('bar')] string $bar) {}
 }
 
 final class DatabaseTest
 {
-    public function __construct(#[Database('foo')] Connection $foo, #[Database('bar')] Connection $bar)
-    {
-    }
+    public function __construct(#[Database('foo')] Connection $foo, #[Database('bar')] Connection $bar) {}
 }
 
 final class GuardTest
 {
-    public function __construct(#[Auth('foo')] GuardContract $foo, #[Auth('bar')] GuardContract $bar)
-    {
-    }
+    public function __construct(#[Auth('foo')] GuardContract $foo, #[Auth('bar')] GuardContract $bar) {}
 }
 
 final class LogTest
 {
-    public function __construct(#[Log('foo')] LoggerInterface $foo, #[Log('bar')] LoggerInterface $bar)
-    {
-    }
+    public function __construct(#[Log('foo')] LoggerInterface $foo, #[Log('bar')] LoggerInterface $bar) {}
 }
 
 final class RouteParameterTest
 {
-    public function __construct(#[RouteParameter('foo')] Model $foo, #[RouteParameter('bar')] string $bar)
-    {
-    }
+    public function __construct(#[RouteParameter('foo')] Model $foo, #[RouteParameter('bar')] string $bar) {}
 }
 
 final class StorageTest
 {
-    public function __construct(#[Storage('foo')] Filesystem $foo, #[Storage('bar')] Filesystem $bar)
-    {
-    }
+    public function __construct(#[Storage('foo')] Filesystem $foo, #[Storage('bar')] Filesystem $bar) {}
 }
 
 final class TimezoneObject

--- a/tests/Container/UtilTest.php
+++ b/tests/Container/UtilTest.php
@@ -44,12 +44,10 @@ class UtilTest extends TestCase
 
     public function testGetParameterClassName()
     {
-        $parameter = new ReflectionParameter(function (stdClass $foo) {
-        }, 0);
+        $parameter = new ReflectionParameter(function (stdClass $foo) {}, 0);
         $this->assertSame('stdClass', Util::getParameterClassName($parameter));
 
-        $parameter = new ReflectionParameter(function (string $foo) {
-        }, 0);
+        $parameter = new ReflectionParameter(function (string $foo) {}, 0);
         $this->assertNull(Util::getParameterClassName($parameter));
     }
 }

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -69,16 +69,13 @@ class HasAttributesWithoutConstructor
 
     public function someAttribute(): Attribute
     {
-        return new Attribute(function () {
-        });
+        return new Attribute(function () {});
     }
 }
 
 class HasAttributesWithConstructorArguments extends HasAttributesWithoutConstructor
 {
-    public function __construct($someValue)
-    {
-    }
+    public function __construct($someValue) {}
 }
 
 class HasAttributesWithArrayCast

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -332,8 +332,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->expects($this->exactly(3))->method('commit')->will($this->throwException(new DatabaseConnectionTestMockPDOException('Serialization failure', '40001')));
         $pdo->expects($this->exactly(3))->method('beginTransaction');
         $pdo->expects($this->never())->method('rollBack');
-        $mock->transaction(function () {
-        }, 3);
+        $mock->transaction(function () {}, 3);
     }
 
     public function testTransactionMethodRetriesOnDeadlock()

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -808,9 +808,7 @@ class EloquentTestCommentModel extends Model
 
 class EloquentTestKey
 {
-    public function __construct(private readonly string $key)
-    {
-    }
+    public function __construct(private readonly string $key) {}
 
     public function __toString()
     {

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -118,8 +118,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $relation->addEagerConstraints([$user]);
         $this->assertSame('select "logins".* from "logins" inner join (select MAX("logins"."id") as "id_aggregate", "logins"."user_id" from "logins" where "logins"."user_id" in (1) group by "logins"."user_id") as "latestOfMany" on "latestOfMany"."id_aggregate" = "logins"."id" and "latestOfMany"."user_id" = "logins"."user_id" where "logins"."user_id" = ? and "logins"."user_id" is not null', $relation->getQuery()->toSql());
 
-        HasOneOfManyTestLogin::addGlobalScope('test', function ($query) {
-        });
+        HasOneOfManyTestLogin::addGlobalScope('test', function ($query) {});
     }
 
     public function testGlobalScopeIsNotAppliedWhenRelationIsDefinedWithoutGlobalScopeWithComplexQuery()
@@ -132,8 +131,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $relation = $user->price_without_global_scope();
         $this->assertSame('select "prices".* from "prices" inner join (select max("prices"."id") as "id_aggregate", min("prices"."published_at") as "published_at_aggregate", "prices"."user_id" from "prices" inner join (select max("prices"."published_at") as "published_at_aggregate", "prices"."user_id" from "prices" where "published_at" < ? group by "prices"."user_id") as "price_without_global_scope" on "price_without_global_scope"."published_at_aggregate" = "prices"."published_at" and "price_without_global_scope"."user_id" = "prices"."user_id" where "published_at" < ? group by "prices"."user_id") as "price_without_global_scope" on "price_without_global_scope"."id_aggregate" = "prices"."id" and "price_without_global_scope"."published_at_aggregate" = "prices"."published_at" and "price_without_global_scope"."user_id" = "prices"."user_id" where "prices"."user_id" = ? and "prices"."user_id" is not null', $relation->getQuery()->toSql());
 
-        HasOneOfManyTestPrice::addGlobalScope('test', function ($query) {
-        });
+        HasOneOfManyTestPrice::addGlobalScope('test', function ($query) {});
     }
 
     public function testQualifyingSubSelectColumn()

--- a/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughOfManyTest.php
@@ -128,8 +128,7 @@ class DatabaseEloquentHasOneThroughOfManyTest extends TestCase
         $relation->addEagerConstraints([$user]);
         $this->assertSame('select "logins".* from "logins" inner join "intermediates" on "intermediates"."id" = "logins"."intermediate_id" inner join (select MAX("logins"."id") as "id_aggregate", "intermediates"."user_id" from "logins" inner join "intermediates" on "intermediates"."id" = "logins"."intermediate_id" where "intermediates"."user_id" in (1) group by "intermediates"."user_id") as "latestOfMany" on "latestOfMany"."id_aggregate" = "logins"."id" and "latestOfMany"."user_id" = "intermediates"."user_id" where "intermediates"."user_id" = ?', $relation->getQuery()->toSql());
 
-        HasOneThroughOfManyTestLogin::addGlobalScope('test', function ($query) {
-        });
+        HasOneThroughOfManyTestLogin::addGlobalScope('test', function ($query) {});
     }
 
     public function testGlobalScopeIsNotAppliedWhenRelationIsDefinedWithoutGlobalScopeWithComplexQuery(): void
@@ -142,8 +141,7 @@ class DatabaseEloquentHasOneThroughOfManyTest extends TestCase
         $relation = $user->price_without_global_scope();
         $this->assertSame('select "prices".* from "prices" inner join "intermediates" on "intermediates"."id" = "prices"."intermediate_id" inner join (select max("prices"."id") as "id_aggregate", min("prices"."published_at") as "published_at_aggregate", "intermediates"."user_id" from "prices" inner join "intermediates" on "intermediates"."id" = "prices"."intermediate_id" inner join (select max("prices"."published_at") as "published_at_aggregate", "intermediates"."user_id" from "prices" inner join "intermediates" on "intermediates"."id" = "prices"."intermediate_id" where "published_at" < ? group by "intermediates"."user_id") as "price_without_global_scope" on "price_without_global_scope"."published_at_aggregate" = "prices"."published_at" and "price_without_global_scope"."user_id" = "intermediates"."user_id" where "published_at" < ? group by "intermediates"."user_id") as "price_without_global_scope" on "price_without_global_scope"."id_aggregate" = "prices"."id" and "price_without_global_scope"."published_at_aggregate" = "prices"."published_at" and "price_without_global_scope"."user_id" = "intermediates"."user_id" where "intermediates"."user_id" = ?', $relation->getQuery()->toSql());
 
-        HasOneThroughOfManyTestPrice::addGlobalScope('test', function ($query) {
-        });
+        HasOneThroughOfManyTestPrice::addGlobalScope('test', function ($query) {});
     }
 
     public function testQualifyingSubSelectColumn(): void

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -4009,13 +4009,9 @@ class EloquentModelWithMutators extends Model
 }
 
 #[CollectedBy(CustomEloquentCollection::class)]
-class EloquentModelWithCollectedByAttribute extends Model
-{
-}
+class EloquentModelWithCollectedByAttribute extends Model {}
 
-class CustomEloquentCollection extends Collection
-{
-}
+class CustomEloquentCollection extends Collection {}
 
 class EloquentModelWithUseFactoryAttributeFactory extends Factory
 {

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -77,10 +77,6 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
     }
 }
 
-class TestModel extends Model
-{
-}
+class TestModel extends Model {}
 
-class TestPivotModel extends Pivot
-{
-}
+class TestPivotModel extends Pivot {}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4401,8 +4401,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPreserveAddsClosureToArray()
     {
         $builder = $this->getBuilder();
-        $builder->beforeQuery(function () {
-        });
+        $builder->beforeQuery(function () {});
         $this->assertCount(1, $builder->beforeQueryCallbacks);
         $this->assertInstanceOf(Closure::class, $builder->beforeQueryCallbacks[0]);
     }
@@ -4410,8 +4409,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testApplyPreserveCleansArray()
     {
         $builder = $this->getBuilder();
-        $builder->beforeQuery(function () {
-        });
+        $builder->beforeQuery(function () {});
         $this->assertCount(1, $builder->beforeQueryCallbacks);
         $builder->applyBeforeQueryCallbacks();
         $this->assertCount(0, $builder->beforeQueryCallbacks);

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -94,15 +94,13 @@ class DatabaseTransactionsManagerTest extends TestCase
 
         $manager->begin('default', 1);
 
-        $manager->addCallback(function () use (&$callbacks) {
-        });
+        $manager->addCallback(function () use (&$callbacks) {});
 
         $manager->begin('default', 2);
 
         $manager->begin('admin', 1);
 
-        $manager->addCallback(function () use (&$callbacks) {
-        });
+        $manager->addCallback(function () use (&$callbacks) {});
 
         $this->assertCount(1, $manager->getPendingTransactions()[0]->getCallbacks());
         $this->assertCount(0, $manager->getPendingTransactions()[1]->getCallbacks());

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -105,8 +105,7 @@ class EventsDispatcherTest extends TestCase
         $d->listen('foo', function () {
             return '';
         });
-        $d->listen('foo', function () {
-        });
+        $d->listen('foo', function () {});
 
         $response = $d->dispatch('foo', ['bar']);
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -415,6 +415,4 @@ class HandleExceptionsTest extends TestCase
     }
 }
 
-class CustomNullHandler extends NullHandler
-{
-}
+class CustomNullHandler extends NullHandler {}

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -458,9 +458,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $handler = new class($this->container) extends Handler
         {
-            protected function registerErrorViewPaths()
-            {
-            }
+            protected function registerErrorViewPaths() {}
 
             public function getErrorView($e)
             {
@@ -879,9 +877,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     }
 }
 
-class CustomException extends Exception
-{
-}
+class CustomException extends Exception {}
 
 class ResponsableException extends Exception implements Responsable
 {

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -460,9 +460,7 @@ class FoundationTestFormRequestPassesWithResponseStub extends FormRequest
 
 class InvokableAfterValidationRule
 {
-    public function __construct(private $value)
-    {
-    }
+    public function __construct(private $value) {}
 
     public function __invoke($validator)
     {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3488,6 +3488,4 @@ class CustomFactory extends Factory
     }
 }
 
-class TestResponse extends Response
-{
-}
+class TestResponse extends Response {}

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -121,9 +121,7 @@ PHP);
     }
 }
 
-class ExceptionWithoutParam extends Exception
-{
-}
+class ExceptionWithoutParam extends Exception {}
 
 class ExceptionWithParam extends Exception
 {

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -78,18 +78,12 @@ class ExampleSubscriber
         ];
     }
 
-    public function a()
-    {
-    }
+    public function a() {}
 
-    public function b()
-    {
-    }
+    public function b() {}
 }
 
-class ExampleEvent
-{
-}
+class ExampleEvent {}
 
 class ExampleBroadcastEvent implements ShouldBroadcast
 {
@@ -101,16 +95,12 @@ class ExampleBroadcastEvent implements ShouldBroadcast
 
 class ExampleListener
 {
-    public function handle()
-    {
-    }
+    public function handle() {}
 }
 
 class ExampleQueueListener implements ShouldQueue
 {
-    public function handle()
-    {
-    }
+    public function handle() {}
 }
 
 class ExampleBroadcastListener

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -14,8 +14,7 @@ class CallbackEventTest extends TestCase
     {
         $success = null;
 
-        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
-        }))->onSuccess(function () use (&$success) {
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {}))->onSuccess(function () use (&$success) {
             $success = true;
         })->onFailure(function () use (&$success) {
             $success = false;

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -132,8 +132,7 @@ class ScheduleListCommandTest extends TestCase
 
     public function testClosureCommandsMayBeScheduled()
     {
-        $closure = function () {
-        };
+        $closure = function () {};
 
         Artisan::command('one', $closure)->weekly()->everySecond();
         Artisan::command('two', $closure)->everyTwoSeconds();
@@ -169,24 +168,16 @@ class FooCommand extends Command
     protected $description = 'This is the description of the command.';
 }
 
-class FooJob
-{
-}
+class FooJob {}
 
 class FooParamJob
 {
-    public function __construct($param)
-    {
-    }
+    public function __construct($param) {}
 }
 
 class FooCall
 {
-    public function __invoke(): void
-    {
-    }
+    public function __invoke(): void {}
 
-    public function fooFunction(): void
-    {
-    }
+    public function fooFunction(): void {}
 }

--- a/tests/Integration/Console/UniqueJobSchedulingTest.php
+++ b/tests/Integration/Console/UniqueJobSchedulingTest.php
@@ -58,6 +58,4 @@ class TestJob implements ShouldQueue
     use InteractsWithQueue, Queueable, Dispatchable;
 }
 
-class UniqueTestJob extends TestJob implements ShouldBeUnique
-{
-}
+class UniqueTestJob extends TestJob implements ShouldBeUnique {}

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -606,9 +606,7 @@ class DateObjectCaster implements CastsAttributes
 
 class DateTimezoneCasterWithObjectCaching implements CastsAttributes
 {
-    public function __construct(private string $timezone = 'UTC')
-    {
-    }
+    public function __construct(private string $timezone = 'UTC') {}
 
     public function get($model, $key, $value, $attributes)
     {

--- a/tests/Integration/Database/ModelInspectorTest.php
+++ b/tests/Integration/Database/ModelInspectorTest.php
@@ -204,15 +204,9 @@ class ParentTestModel extends Model
 
 class ModelInspectorTestModelObserver
 {
-    public function created()
-    {
-    }
+    public function created() {}
 }
 
-class ModelInspectorTestModelEloquentCollection extends Collection
-{
-}
+class ModelInspectorTestModelEloquentCollection extends Collection {}
 
-class ModelInspectorTestModelBuilder extends Builder
-{
-}
+class ModelInspectorTestModelBuilder extends Builder {}

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -257,13 +257,9 @@ class NonImportantEvent
 
 class PostEventSubscriber
 {
-    public function handlePostCreated($event)
-    {
-    }
+    public function handlePostCreated($event) {}
 
-    public function handlePostDeleted($event)
-    {
-    }
+    public function handlePostDeleted($event) {}
 
     public function subscribe($events)
     {

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -135,8 +135,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
 
         DB::transaction(function () {
-            DB::transaction(function () {
-            });
+            DB::transaction(function () {});
 
             Event::dispatch(new ShouldDispatchAfterCommitTestEvent);
 

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -94,8 +94,7 @@ class MarkdownNotification extends Notification
 {
     public function __construct(
         protected $theme = null
-    ) {
-    }
+    ) {}
 
     public function via($notifiable): array
     {

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -68,9 +68,7 @@ class DeleteMissingModelJob implements ShouldQueue
 
     public $deleteWhenMissingModels = true;
 
-    public function __construct(public MyTestModel $model)
-    {
-    }
+    public function __construct(public MyTestModel $model) {}
 
     public function displayName(): string
     {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -387,8 +387,7 @@ trait TraitBootsAndInitializersTest
 
     public static function bootTraitBootsAndInitializersTest()
     {
-        static::addGlobalScope('foo_bar', function () {
-        });
+        static::addGlobalScope('foo_bar', function () {});
     }
 }
 
@@ -562,9 +561,7 @@ class ModelSerializationAttributeTargetsClassTestClass
 {
     use SerializesModels;
 
-    public function __construct(public User $user, public DataValueObject $value)
-    {
-    }
+    public function __construct(public User $user, public DataValueObject $value) {}
 }
 
 class ModelRelationSerializationTestClass
@@ -593,7 +590,5 @@ class CollectionSerializationTestClass
 
 class DataValueObject
 {
-    public function __construct(public $value = 1)
-    {
-    }
+    public function __construct(public $value = 1) {}
 }

--- a/tests/Integration/Queue/SkipMiddlewareTest.php
+++ b/tests/Integration/Queue/SkipMiddlewareTest.php
@@ -109,8 +109,7 @@ class SkipTestJob
     public function __construct(
         protected bool|SerializableClosure $skip,
         protected bool $useUnless = false,
-    ) {
-    }
+    ) {}
 
     public function handle(): void
     {

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -227,9 +227,7 @@ class UniqueTestSerializesModelsJob extends UniqueTestJob
 
     public $deleteWhenMissingModels = true;
 
-    public function __construct(public User $user)
-    {
-    }
+    public function __construct(public User $user) {}
 }
 
 class UniqueViaJob extends UniqueTestJob

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -35,7 +35,5 @@ class HasMiddlewareTestController implements HasMiddleware
         //
     }
 
-    public function show()
-    {
-    }
+    public function show() {}
 }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -263,8 +263,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedMiddlewareIgnoringParameter()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
-        })->name('foo')->middleware('signed:relative');
+        Route::get('/foo/{id}', function (Request $request, $id) {})->name('foo')->middleware('signed:relative');
 
         $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]).'&ignore=me');
         $request = Request::create($url);
@@ -281,8 +280,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedMiddlewareIgnoringParameterViaArgumentsWithRelative()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
-        })->name('foo')->middleware('signed:relative,ignore');
+        Route::get('/foo/{id}', function (Request $request, $id) {})->name('foo')->middleware('signed:relative,ignore');
 
         $this->assertIsString('https://fake.test'.URL::signedRoute('foo', ['id' => 1, 'ignore' => 'me'], null, false));
 
@@ -294,8 +292,7 @@ class UrlSigningTest extends TestCase
     {
         ValidateSignature::except(['globally_ignore']);
 
-        Route::get('/foo/{id}', function (Request $request, $id) {
-        })->name('foo')->middleware('signed:relative');
+        Route::get('/foo/{id}', function (Request $request, $id) {})->name('foo')->middleware('signed:relative');
 
         $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]).'&globally_ignore=me');
         $request = Request::create($url);
@@ -312,8 +309,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedMiddlewareIgnoringParameterViaArgumentsWithoutRelative()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
-        })->name('foo')->middleware('signed:ignore');
+        Route::get('/foo/{id}', function (Request $request, $id) {})->name('foo')->middleware('signed:ignore');
 
         $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', ['id' => 1, 'ignore' => 'me'], null, false));
 
@@ -323,8 +319,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedMiddlewareIgnoringParameterViaClassAndArguments()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
-        })->name('foo')->middleware(IgnoreParameterMiddleware::relative('test'));
+        Route::get('/foo/{id}', function (Request $request, $id) {})->name('foo')->middleware(IgnoreParameterMiddleware::relative('test'));
 
         $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', ['id' => 1, 'ignore' => 'me', 'test' => 'bar'], null, false));
 

--- a/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
+++ b/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
@@ -38,9 +38,7 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
     {
         return new class($config)
         {
-            public function __construct(public $config)
-            {
-            }
+            public function __construct(public $config) {}
         };
     }
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -169,16 +169,12 @@ class SyncQueueAfterCommitJob
 
     public $afterCommit = true;
 
-    public function handle()
-    {
-    }
+    public function handle() {}
 }
 
 class SyncQueueAfterCommitInterfaceJob implements ShouldQueueAfterCommit
 {
     use InteractsWithQueue;
 
-    public function handle()
-    {
-    }
+    public function handle() {}
 }

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -16,8 +16,7 @@ class RouteBindingTest extends TestCase
     {
         $container = Container::getInstance();
 
-        $route = new Route('GET', '/users/{user}', function () {
-        });
+        $route = new Route('GET', '/users/{user}', function () {});
 
         $callback = RouteBinding::forModel($container, ExplicitRouteBindingUser::class);
         $this->assertInstanceOf(ExplicitRouteBindingUser::class, $callback(1, $route));
@@ -27,8 +26,7 @@ class RouteBindingTest extends TestCase
     {
         $container = Container::getInstance();
 
-        $route = new Route('GET', '/users/{user}', function () {
-        });
+        $route = new Route('GET', '/users/{user}', function () {});
 
         $callback = RouteBinding::forModel($container, ExplicitRouteBindingSoftDeletableUser::class);
 
@@ -40,8 +38,7 @@ class RouteBindingTest extends TestCase
     {
         $container = Container::getInstance();
 
-        $route = (new Route('GET', '/users/{user}', function () {
-        }))->withTrashed();
+        $route = (new Route('GET', '/users/{user}', function () {}))->withTrashed();
 
         $callback = RouteBinding::forModel($container, ExplicitRouteBindingSoftDeletableUser::class);
         $this->assertInstanceOf(ExplicitRouteBindingSoftDeletableUser::class, $callback(1, $route));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -497,8 +497,7 @@ class RoutingRouteTest extends TestCase
         $router = new Router(new Dispatcher, $container);
         $container->instance(Registrar::class, $router);
 
-        $container->bind(RoutingTestUserModel::class, function () {
-        });
+        $container->bind(RoutingTestUserModel::class, function () {});
         $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
 
         $router->get('foo/{team}/{post}', [
@@ -2358,9 +2357,7 @@ class RouteTestResourceControllerWithModelParameter extends Controller
 
 class RouteTestNestedResourceControllerWithMissingUser extends Controller
 {
-    public function show(RoutingTestTeamWithoutUserModel $team, RoutingTestUserModel $user)
-    {
-    }
+    public function show(RoutingTestTeamWithoutUserModel $team, RoutingTestUserModel $user) {}
 }
 
 class RouteTestClosureMiddlewareController extends Controller
@@ -2680,8 +2677,7 @@ final class RoutingTestOnTenant
 {
     public function __construct(
         public readonly RoutingTestTenant $tenant
-    ) {
-    }
+    ) {}
 }
 
 enum RoutingTestTenant

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -144,9 +144,7 @@ class OnceTest extends TestCase
 
         $instance = new class($invokable)
         {
-            public function __construct(protected $invokable)
-            {
-            }
+            public function __construct(protected $invokable) {}
 
             public function call()
             {
@@ -401,6 +399,4 @@ class MyClass
     }
 }
 
-class MyExtendedClass extends MyClass
-{
-}
+class MyExtendedClass extends MyClass {}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1300,9 +1300,7 @@ class SupportTestClassThree extends SupportTestClassTwo
 
 trait SupportTestTraitArrayAccess
 {
-    public function __construct(protected array $items = [])
-    {
-    }
+    public function __construct(protected array $items = []) {}
 
     public function offsetExists($offset): bool
     {
@@ -1327,9 +1325,7 @@ trait SupportTestTraitArrayAccess
 
 trait SupportTestTraitArrayIterable
 {
-    public function __construct(protected array $items = [])
-    {
-    }
+    public function __construct(protected array $items = []) {}
 
     public function getIterator(): Traversable
     {

--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -64,8 +64,7 @@ class SupportReflectorTest extends TestCase
 
     public function testIsCallable()
     {
-        $this->assertTrue(Reflector::isCallable(function () {
-        }));
+        $this->assertTrue(Reflector::isCallable(function () {}));
         $this->assertTrue(Reflector::isCallable([B::class, 'f']));
         $this->assertFalse(Reflector::isCallable([TestClassWithCall::class, 'f']));
         $this->assertTrue(Reflector::isCallable([new TestClassWithCall, 'f']));
@@ -77,9 +76,7 @@ class SupportReflectorTest extends TestCase
     }
 }
 
-class A
-{
-}
+class A {}
 
 class B extends A
 {
@@ -113,13 +110,9 @@ class TestClassWithCallStatic
     }
 }
 
-interface IA
-{
-}
+interface IA {}
 
-interface IB extends IA
-{
-}
+interface IB extends IA {}
 
 class TestClassWithInterfaceSubclassParameter
 {

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -877,9 +877,7 @@ class BusFakeJobWithSerialization
 {
     use Queueable;
 
-    public function __construct(public $value)
-    {
-    }
+    public function __construct(public $value) {}
 
     public function __serialize(): array
     {

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -273,9 +273,7 @@ class NotificationWithSerialization extends NotificationStub implements ShouldQu
 {
     use Queueable;
 
-    public function __construct(public $value)
-    {
-    }
+    public function __construct(public $value) {}
 
     public function __serialize(): array
     {

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -580,9 +580,7 @@ class JobWithSerialization
 {
     use Queueable;
 
-    public function __construct(public $value)
-    {
-    }
+    public function __construct(public $value) {}
 
     public function __serialize(): array
     {

--- a/tests/Support/SupportTimeboxTest.php
+++ b/tests/Support/SupportTimeboxTest.php
@@ -23,8 +23,7 @@ class SupportTimeboxTest extends TestCase
         $mock = m::spy(Timebox::class)->shouldAllowMockingProtectedMethods()->makePartial();
         $mock->shouldReceive('usleep')->once();
 
-        $mock->call(function () {
-        }, 10000);
+        $mock->call(function () {}, 10000);
 
         $mock->shouldHaveReceived('usleep')->once();
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -9734,6 +9734,4 @@ class ExplicitTableAndConnectionModel extends Model
     public $timestamps = false;
 }
 
-class NonEloquentModel
-{
-}
+class NonEloquentModel {}

--- a/tests/View/Blade/BladeBoolTest.php
+++ b/tests/View/Blade/BladeBoolTest.php
@@ -61,7 +61,5 @@ class BladeBoolTest extends AbstractBladeTestCase
 
 class SomeClass
 {
-    public function someMethod()
-    {
-    }
+    public function someMethod() {}
 }

--- a/types/Autoload.php
+++ b/types/Autoload.php
@@ -30,10 +30,6 @@ class UserFactory extends Factory
     }
 }
 
-class Post extends Model
-{
-}
+class Post extends Model {}
 
-enum UserType
-{
-}
+enum UserType {}

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -253,9 +253,7 @@ class Post extends Model
     }
 }
 
-class ChildPost extends Post
-{
-}
+class ChildPost extends Post {}
 
 class Comment extends Model
 {
@@ -280,6 +278,4 @@ class CommonBuilder extends Builder
 }
 
 /** @extends CommonBuilder<Comment> */
-class CommentBuilder extends CommonBuilder
-{
-}
+class CommentBuilder extends CommonBuilder {}

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -62,9 +62,7 @@ class Post extends Model
  * @template TModel of Post
  *
  * @extends Collection<TKey, TModel> */
-class Posts extends Collection
-{
-}
+class Posts extends Collection {}
 
 final class Comment extends Model
 {
@@ -79,9 +77,7 @@ final class Comment extends Model
 }
 
 /** @extends Collection<array-key, Comment> */
-final class Comments extends Collection
-{
-}
+final class Comments extends Collection {}
 
 #[CollectedBy(Articles::class)]
 class Article extends Model
@@ -95,6 +91,4 @@ class Article extends Model
  * @template TModel of Article
  *
  * @extends Collection<TKey, TModel> */
-class Articles extends Collection
-{
-}
+class Articles extends Collection {}

--- a/types/Database/Eloquent/Relations.php
+++ b/types/Database/Eloquent/Relations.php
@@ -343,21 +343,9 @@ class Mechanic extends Model
     }
 }
 
-class ChildUser extends User
-{
-}
-class Address extends Model
-{
-}
-class Role extends Model
-{
-}
-class Car extends Model
-{
-}
-class Part extends Model
-{
-}
-class Image extends Model
-{
-}
+class ChildUser extends User {}
+class Address extends Model {}
+class Role extends Model {}
+class Car extends Model {}
+class Part extends Model {}
+class Image extends Model {}

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1064,9 +1064,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->add(new User
  *
  * @extends \Illuminate\Support\Collection<TKey, TValue>
  */
-class CustomCollection extends Collection
-{
-}
+class CustomCollection extends Collection {}
 
 // assertType('CustomCollection<int, User>', CustomCollection::make([new User]));
 assertType('Illuminate\Support\Collection<int, User>', CustomCollection::make([new User])->toBase());
@@ -1091,18 +1089,10 @@ foreach ($collection as $int => $user) {
     assertType('User', $user);
 }
 
-class Animal
-{
-}
-class Tiger extends Animal
-{
-}
-class Lion extends Animal
-{
-}
-class Zebra extends Animal
-{
-}
+class Animal {}
+class Tiger extends Animal {}
+class Lion extends Animal {}
+class Zebra extends Animal {}
 
 class Zoo
 {

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -875,9 +875,7 @@ assertType(
  *
  * @extends \Illuminate\Support\LazyCollection<TKey, TValue>
  */
-class CustomLazyCollection extends LazyCollection
-{
-}
+class CustomLazyCollection extends LazyCollection {}
 
 // assertType('CustomLazyCollection<int, User>', CustomLazyCollection::make([new User]));
 
@@ -891,18 +889,10 @@ foreach ($collection as $int => $user) {
     assertType('User', $user);
 }
 
-class LazyAnimal
-{
-}
-class LazyTiger extends LazyAnimal
-{
-}
-class LazyLion extends LazyAnimal
-{
-}
-class LazyZebra extends LazyAnimal
-{
-}
+class LazyAnimal {}
+class LazyTiger extends LazyAnimal {}
+class LazyLion extends LazyAnimal {}
+class LazyZebra extends LazyAnimal {}
 
 class LazyZoo
 {


### PR DESCRIPTION
the PHPCS Fixer Laravel preset had the "single_line_empty_body" rule added here:

https://github.com/laravel/pint/pull/277

I think this is a good option, as it removes a lot of unnecessary line breaks, and brings more consistency to our code.

I believe this PR, along with #54995, gets us passing all Pint rules.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
