### PR TITLE
[12.x]Fix PHPDoc return types 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1484,7 +1484,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * This method protects developers from running forceDestroy when the trait is missing.
      *
      * @param  \Illuminate\Support\Collection|array|int|string  $ids
-     * @return bool|null
+     * @return int
      */
     public static function forceDestroy($ids)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1844,7 +1844,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Resolve a connection instance.
      *
      * @param  string|null  $connection
-     * @return \Illuminate\Database\Connection
+     * @return \Illuminate\Database\ConnectionInterface
      */
     public static function resolveConnection($connection = null)
     {


### PR DESCRIPTION
In this PR, I've made three improvements to enhance code clarity and type accuracy without changing any functionality.🧹✨

### 1. Updated `forceDestroy()` return type  to `int`

The `forceDestroy()` method directly returns the result of `destroy()`, which returns an integer (the count of deleted records). Updated the PHPDoc to accurately reflect this relationship for better type consistency.

### 2. Aligned `resolveConnection()` return type with interface definition

Updated the return type from `Connection` to `ConnectionInterface` to match the actual return type from the underlying resolver's `connection()` method. This ensures type consistency and improves IDE support when working with connection objects.


I noticed these issues while refactoring the Model class and thought it would be beneficial to update them for better code quality and developer experience.🔍👨‍💻