### PR TITLE
[12.x] Enhance PHPDoc for Manager classes with `@param-closure-this`

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -255,6 +255,7 @@ class AuthManager implements FactoryContract
      * Set the callback to be used to resolve users.
      *
      * @param  \Closure  $userResolver
+     * @param-closure-this  $this  $userResolver
      * @return $this
      */
     public function resolveUsersUsing(Closure $userResolver)
@@ -269,6 +270,7 @@ class AuthManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)
@@ -283,6 +285,7 @@ class AuthManager implements FactoryContract
      *
      * @param  string  $name
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function provider($name, Closure $callback)

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -467,6 +467,7 @@ class BroadcastManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -419,6 +419,7 @@ class CacheManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -425,6 +425,7 @@ class FilesystemManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -587,6 +587,7 @@ class LogManager implements LoggerInterface
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -566,6 +566,7 @@ class MailManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -186,6 +186,7 @@ class QueueManager implements FactoryContract, MonitorContract
      *
      * @param  string  $driver
      * @param  \Closure  $resolver
+     * @param-closure-this  $this  $resolver
      * @return void
      */
     public function extend($driver, Closure $resolver)
@@ -198,6 +199,7 @@ class QueueManager implements FactoryContract, MonitorContract
      *
      * @param  string  $driver
      * @param  \Closure  $resolver
+     * @param-closure-this  $this  $resolver
      * @return void
      */
     public function addConnector($driver, Closure $resolver)

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -255,6 +255,7 @@ class RedisManager implements Factory
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -125,6 +125,7 @@ abstract class Manager
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -192,6 +192,7 @@ abstract class MultipleInstanceManager
      *
      * @param  string  $name
      * @param  \Closure  $callback
+     * @param-closure-this  $this  $callback
      * @return $this
      */
     public function extend($name, Closure $callback)

--- a/types/Managers/AuthManager.php
+++ b/types/Managers/AuthManager.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Auth\AuthManager;
+use function PHPStan\Testing\assertType;
+
+$authManager = resolve(AuthManager::class);
+$authManager->extend('token', function (): void {
+    assertType('Illuminate\Auth\AuthManager',$this);
+});

--- a/types/Managers/BroadcastManager.php
+++ b/types/Managers/BroadcastManager.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use \Illuminate\Broadcasting\BroadcastManager;
+use function PHPStan\Testing\assertType;
+
+$broadcastManager = resolve(BroadcastManager::class);
+$broadcastManager->extend('reverb', function (): void {
+    assertType('Illuminate\Broadcasting\BroadcastManager',$this);
+});

--- a/types/Managers/CacheManager.php
+++ b/types/Managers/CacheManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Cache\CacheManager;
+
+use function PHPStan\Testing\assertType;
+
+$cacheManager = resolve(CacheManager::class);
+$cacheManager->extend('redis', function (): void {
+    assertType('Illuminate\Cache\CacheManager',$this);
+});

--- a/types/Managers/ConcurrencyManager.php
+++ b/types/Managers/ConcurrencyManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+
+use Illuminate\Concurrency\ConcurrencyManager;
+use function PHPStan\Testing\assertType;
+
+$concurrencyManager = resolve(ConcurrencyManager::class);
+$concurrencyManager->extend('custom', function (): void {
+    assertType('Illuminate\Concurrency\ConcurrencyManager', $this);
+});

--- a/types/Managers/FilesystemManager.php
+++ b/types/Managers/FilesystemManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+
+use Illuminate\Filesystem\FilesystemManager;
+use function PHPStan\Testing\assertType;
+
+$filesystemManager = resolve(FilesystemManager::class);
+$filesystemManager->extend('local', function (): void {
+    assertType('Illuminate\Filesystem\FilesystemManager', $this);
+});

--- a/types/Managers/LogManager.php
+++ b/types/Managers/LogManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+
+use Illuminate\Log\LogManager;
+use function PHPStan\Testing\assertType;
+
+$logManager = resolve(LogManager::class);
+$logManager->extend('emergency', function (): void {
+    assertType('Illuminate\Log\LogManager', $this);
+});

--- a/types/Managers/MailManager.php
+++ b/types/Managers/MailManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+
+use Illuminate\Mail\MailManager;
+use function PHPStan\Testing\assertType;
+
+$mailManager = resolve(MailManager::class);
+$mailManager->extend('symfony', function (): void {
+    assertType('Illuminate\Mail\MailManager', $this);
+});

--- a/types/Managers/QueueManager.php
+++ b/types/Managers/QueueManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+
+use Illuminate\Queue\QueueManager;
+use function PHPStan\Testing\assertType;
+
+$queueManager = resolve(QueueManager::class);
+$queueManager->extend('custom', function (): void {
+    assertType('Illuminate\Queue\QueueManager', $this);
+});

--- a/types/Managers/RedisManager.php
+++ b/types/Managers/RedisManager.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+
+use Illuminate\Redis\RedisManager;
+use function PHPStan\Testing\assertType;
+
+$redisManager = resolve(RedisManager::class);
+$redisManager->extend('custom', function (): void {
+    assertType('Illuminate\Redis\RedisManager', $this);
+});


### PR DESCRIPTION
The `@param-closure-this` annotation explicitly specifies the type of the `$this` variable within closures, improving code readability by clarifying the context available inside closure parameters. 