### PR TITLE
[12.x] Enhance PHPDoc for Manager classes with `@param-closure-this`

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -419,6 +419,9 @@ class CacheManager implements FactoryContract
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     *
+     * @param-closure-this  $this  $callback
+     *
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -587,6 +587,9 @@ class LogManager implements LoggerInterface
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     *
+     * @param-closure-this  $this  $callback
+     *
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -255,6 +255,9 @@ class RedisManager implements Factory
      *
      * @param  string  $driver
      * @param  \Closure  $callback
+     *
+     * @param-closure-this  $this  $callback
+     *
      * @return $this
      */
     public function extend($driver, Closure $callback)

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -192,6 +192,9 @@ abstract class MultipleInstanceManager
      *
      * @param  string  $name
      * @param  \Closure  $callback
+     *
+     * @param-closure-this  $this  $callback
+     *
      * @return $this
      */
     public function extend($name, Closure $callback)

--- a/types/Managers/CacheManager.php
+++ b/types/Managers/CacheManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Cache\CacheManager;
+
+use function PHPStan\Testing\assertType;
+
+$cacheManager = resolve(CacheManager::class);
+
+$cacheManager->extend('redis', function (): void {
+    assertType('Illuminate\Cache\CacheManager', $this);
+});

--- a/types/Managers/ConcurrencyManager.php
+++ b/types/Managers/ConcurrencyManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Concurrency\ConcurrencyManager;
+
+use function PHPStan\Testing\assertType;
+
+$concurrencyManager = resolve(ConcurrencyManager::class);
+
+$concurrencyManager->extend('custom', function (): void {
+    assertType('Illuminate\Concurrency\ConcurrencyManager', $this);
+});

--- a/types/Managers/LogManager.php
+++ b/types/Managers/LogManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Log\LogManager;
+
+use function PHPStan\Testing\assertType;
+
+$logManager = resolve(LogManager::class);
+
+$logManager->extend('emergency', function (): void {
+    assertType('Illuminate\Log\LogManager', $this);
+});

--- a/types/Managers/RedisManager.php
+++ b/types/Managers/RedisManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Redis\RedisManager;
+
+use function PHPStan\Testing\assertType;
+
+$redisManager = resolve(RedisManager::class);
+
+$redisManager->extend('custom', function (): void {
+    assertType('Illuminate\Redis\RedisManager', $this);
+});


### PR DESCRIPTION
The `@param-closure-this` annotation explicitly specifies the type of the `$this` variable within closures that use `bindTo()`, improving code readability by clarifying which object context is available inside these rebound closure parameters.