### PR TITLE
[12.x] Refactor get method to use data_get for query payload retrieval

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -398,18 +398,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * This method belongs to Symfony HttpFoundation and is not usually needed when using Laravel.
+     * Retrieve a query payload item from the request.
      *
-     * Instead, you may use the "input" method.
-     *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  mixed  $default
      * @return mixed
      */
     #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
-        return parent::get($key, $default);
+        return data_get($this->getInputSource()->all(), $key, $default);
     }
 
     /**


### PR DESCRIPTION
Refactored the get method to replace the parent class method call with data_get, which retrieves the query payload item from the request using the input source. This improves flexibility in handling the request data.

Wanted something like:
```php
  $request->get('user.name');
```

**Found that get method does not support dot syntax to access data.**

Changes:
```php
    public function get(string $key, mixed $default = null): mixed
    {
        return data_get($this->getInputSource()->all(), $key, $default);
    }
```