### PR TITLE
Added the missing 'trashed' event to getObservablesEvents()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -134,7 +134,7 @@ trait HasEvents
             [
                 'retrieved', 'creating', 'created', 'updating', 'updated',
                 'saving', 'saved', 'restoring', 'restored', 'replicating',
-                'deleting', 'deleted', 'forceDeleting', 'forceDeleted',
+                'trashed', 'deleting', 'deleted', 'forceDeleting', 'forceDeleted',
             ],
             $this->observables
         );


### PR DESCRIPTION
Fixes #54980

I genuinely think this event was somehow forgot to be added there already.

Added the missing 'trashed' which gets registered with observers, so that observers too can listen to it besides listeners.
As per docs:
> Eloquent models dispatch several events, allowing you to hook into the following moments in a model's lifecycle: retrieved, creating, created, updating, updated, saving, saved, deleting, deleted, **trashed**, forceDeleting, forceDeleted, restoring, restored, and replicating.

No breaking changes.

From the docs developers expect to listen to this event but if one uses observers then by default the observer would not be able catch it because it never was registered. This forced developers to redeclare the `$observables` in the model but this event belongs to the framework so it should not be missing by default from the already hard-coded event names array in `getObservablesEvents()`.

No tests.