### PR TITLE
[12.x] Feature: Array Insert At - Array Helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -214,6 +214,29 @@ class Arr
     }
 
     /**
+     * Insert a value at a specific position in an array.
+     *
+     * @param  array  $array
+     * @param  int  $position
+     * @param  mixed  $value
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function insertAt(array $array, int $position, mixed $value)
+    {
+        if ($position < 0 || $position > count($array)) {
+            throw new InvalidArgumentException("Invalid position: {$position}");
+        }
+
+        return array_merge(
+            array_slice($array, 0, $position),
+            [$value],
+            array_slice($array, $position)
+        );
+    }
+
+    /**
      * Return the last element in an array passing a given truth test.
      *
      * @template TKey

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1570,4 +1570,39 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testInsertAt()
+    {
+        // Insert in the middle
+        $array = Arr::insertAt(['a', 'b', 'c'], 1, 'x');
+        $this->assertSame(['a', 'x', 'b', 'c'], $array);
+
+        // Insert at the beginning
+        $array = Arr::insertAt(['b', 'c'], 0, 'a');
+        $this->assertSame(['a', 'b', 'c'], $array);
+
+        // Insert at the end
+        $array = Arr::insertAt(['a', 'b'], 2, 'c');
+        $this->assertSame(['a', 'b', 'c'], $array);
+
+        // Insert into an empty array
+        $array = Arr::insertAt([], 0, 'a');
+        $this->assertSame(['a'], $array);
+
+        // Insert with numeric values
+        $array = Arr::insertAt([1, 2, 4], 2, 3);
+        $this->assertSame([1, 2, 3, 4], $array);
+
+        // Insert with associative array
+        $array = Arr::insertAt(['name' => 'John', 'age' => 30], 1, ['gender' => 'male']);
+        $this->assertSame(['name' => 'John', ['gender' => 'male'], 'age' => 30], $array);
+
+        // Insert at invalid position (negative index)
+        $this->expectException(InvalidArgumentException::class);
+        Arr::insertAt(['a', 'b', 'c'], -1, 'x');
+
+        // Insert at invalid position (out of bounds)
+        $this->expectException(InvalidArgumentException::class);
+        Arr::insertAt(['a', 'b', 'c'], 4, 'x');
+    }
 }


### PR DESCRIPTION
# Add `insertAt` Method to Laravel's `Arr` Helper

## Description
This PR introduces a new helper method, `Arr::insertAt`, which allows inserting a value at a specific position within an array. The method follows Laravel's coding standards and ensures proper validation of insertion positions.

## Changes
- Added `insertAt` method to `Arr` class in `Illuminate\Support`.
- Implemented logic to insert a value at a specified position while handling invalid positions.
- Added unit tests to validate various scenarios including:
  - Inserting at the beginning, middle, and end of an array.
  - Handling empty arrays.
  - Working with numeric and associative arrays.
  - Throwing an exception for invalid positions (negative index or out of bounds).

## Example Usage
```php
$result = Arr::insertAt(['hi', 'otwell', 'thanks'], 1, 'taylor');
// Expected Result: ['hi', 'taylor', 'otwell', 'thanks']
```