### PR TITLE
Add an optional `shouldRun` method to migrations.

### DIFF
--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -54,7 +54,7 @@ class Task extends Component
             $this->output->write("<fg=gray>$runTime</>", false, $verbosity);
 
             $this->output->writeln(
-                match($result) {
+                match ($result) {
                     MigrationResult::Failure => ' <fg=red;options=bold>FAIL</>',
                     MigrationResult::Skipped => ' <fg=yellow;options=bold>SKIPPED</>',
                     default => ' <fg=green;options=bold>DONE</>'

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\View\Components;
 
+use Illuminate\Database\Migrations\MigrationResult;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
@@ -34,10 +35,10 @@ class Task extends Component
 
         $startTime = microtime(true);
 
-        $result = false;
+        $result = MigrationResult::Failure;
 
         try {
-            $result = ($task ?: fn () => true)();
+            $result = ($task ?: fn () => MigrationResult::Success)();
         } catch (Throwable $e) {
             throw $e;
         } finally {
@@ -53,7 +54,11 @@ class Task extends Component
             $this->output->write("<fg=gray>$runTime</>", false, $verbosity);
 
             $this->output->writeln(
-                $result !== false ? ' <fg=green;options=bold>DONE</>' : ' <fg=red;options=bold>FAIL</>',
+                match($result) {
+                    MigrationResult::Failure => ' <fg=red;options=bold>FAIL</>',
+                    MigrationResult::Skipped => ' <fg=yellow;options=bold>SKIPPED</>',
+                    default => ' <fg=green;options=bold>DONE</>'
+                },
                 $verbosity,
             );
         }

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -29,7 +29,7 @@ abstract class Migration
     }
 
     /**
-     * Should this migration run or not.
+     * Determine if this migration should run.
      *
      * @return bool
      */

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -27,4 +27,14 @@ abstract class Migration
     {
         return $this->connection;
     }
+
+    /**
+     * Should this migration run or not.
+     *
+     * @return bool
+     */
+    public function shouldRun(): bool
+    {
+        return true;
+    }
 }

--- a/src/Illuminate/Database/Migrations/MigrationResult.php
+++ b/src/Illuminate/Database/Migrations/MigrationResult.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database\Migrations;
+
+enum MigrationResult: int
+{
+    case Success = 1;
+    case Failure = 2;
+    case Skipped = 3;
+}

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -141,19 +141,6 @@ class Migrator
     }
 
     /**
-     * Determine if the migration should be ran.
-     *
-     * @param  string  $file
-     * @return bool
-     */
-    public function shouldMigrationBeRan($file)
-    {
-        $instance = $this->resolvePath($file);
-
-        return $instance instanceof Migration ? $instance->shouldRun() : false;
-    }
-
-    /**
      * Get the migration files that have not yet run.
      *
      * @param  string[]  $files
@@ -171,6 +158,19 @@ class Migrator
             ->filter(fn ($file) => $this->shouldMigrationBeRan($file))
             ->values()
             ->all();
+    }
+
+    /**
+     * Determine if the migration should be ran.
+     *
+     * @param  string  $file
+     * @return bool
+     */
+    protected function shouldMigrationBeRan($file)
+    {
+        $instance = $this->resolvePath($file);
+
+        return $instance instanceof Migration ? $instance->shouldRun() : false;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -140,7 +140,7 @@ class Migrator
         return $migrations;
     }
 
-     /**
+    /**
      * Determine if the migration should be ran.
      *
      * @param  string  $file
@@ -149,7 +149,7 @@ class Migrator
     public function shouldMigrationBeRan($file)
     {
         $instance = $this->resolvePath($file);
-        
+
         return $instance instanceof Migration ? $instance->shouldRun() : false;
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -549,7 +549,7 @@ class Migrator
     protected function resolvePath(string $path)
     {
         $class = $this->getMigrationClass($this->getMigrationName($path));
-//        dd($class, $this->getMigrationName($path));
+
         if (class_exists($class) && realpath($path) == (new ReflectionClass($class))->getFileName()) {
             return new $class;
         }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -140,6 +140,18 @@ class Migrator
         return $migrations;
     }
 
+     /**
+     * Determine if the migration should be ran.
+     *
+     * @param  string  $file
+     * @return bool
+     */
+    public function shouldMigrationBeRan($file)
+    {
+        $instance = $this->resolvePath($file);
+        return $instance instanceof Migration ? $instance->shouldRun() : false;
+    }
+
     /**
      * Get the migration files that have not yet run.
      *
@@ -155,6 +167,7 @@ class Migrator
             ->reject(fn ($file) => in_array($migrationName = $this->getMigrationName($file), $ran) ||
                 in_array($migrationName, $migrationsToSkip)
             )
+            ->filter(fn ($file) => $this->shouldMigrationBeRan($file))
             ->values()
             ->all();
     }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -160,19 +160,6 @@ class Migrator
     }
 
     /**
-     * Determine if the migration should be ran.
-     *
-     * @param  object  $migration
-     * @return bool
-     */
-    public function shouldSkipMigration($migration)
-    {
-        return $migration instanceof Migration
-            ? ! $migration->shouldRun()
-            : false;
-    }
-
-    /**
      * Get list of pending migrations to skip.
      *
      * @return list<string>
@@ -254,7 +241,11 @@ class Migrator
             return $this->pretendToRun($migration, 'up');
         }
 
-        if ($this->shouldSkipMigration($migration)) {
+        $shouldRunMigration = $migration instanceof Migration
+            ? $migration->shouldRun()
+            : true;
+
+        if (! $shouldRunMigration) {
             $this->write(Task::class, $name, fn () => MigrationResult::Skipped);
         } else {
             $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -149,6 +149,7 @@ class Migrator
     public function shouldMigrationBeRan($file)
     {
         $instance = $this->resolvePath($file);
+        
         return $instance instanceof Migration ? $instance->shouldRun() : false;
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -159,6 +159,19 @@ class Migrator
             ->all();
     }
 
+     /**
+     * Determine if the migration should be ran.
+     *
+     * @param  object  $migration
+     * @return bool
+     */
+    public function shouldSkipMigration($migration)
+    {
+        return $migration instanceof Migration
+            ? ! $migration->shouldRun()
+            : false;
+    }
+
     /**
      * Determine if the migration should be ran.
      *

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -173,19 +173,6 @@ class Migrator
     }
 
     /**
-     * Determine if the migration should be ran.
-     *
-     * @param  string  $file
-     * @return bool
-     */
-    protected function shouldMigrationBeRan($file)
-    {
-        $instance = $this->resolvePath($file);
-
-        return $instance instanceof Migration ? $instance->shouldRun() : false;
-    }
-
-    /**
      * Get list of pending migrations to skip.
      *
      * @return list<string>

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -159,7 +159,7 @@ class Migrator
             ->all();
     }
 
-     /**
+    /**
      * Determine if the migration should be ran.
      *
      * @param  object  $migration
@@ -264,9 +264,6 @@ class Migrator
             // in the application. A migration repository keeps the migrate order.
             $this->repository->log($name, $batch);
         }
-
-
-
     }
 
     /**
@@ -441,15 +438,12 @@ class Migrator
      */
     protected function runMigration($migration, $method)
     {
-
         $connection = $this->resolveConnection(
             $migration->getConnection()
         );
 
         $callback = function () use ($connection, $migration, $method) {
-
             if (method_exists($migration, $method)) {
-
                 $this->fireMigrationEvent(new MigrationStarted($migration, $method));
 
                 $this->runMethod($connection, $migration, $method);
@@ -557,7 +551,6 @@ class Migrator
         $class = $this->getMigrationClass($this->getMigrationName($path));
 //        dd($class, $this->getMigrationName($path));
         if (class_exists($class) && realpath($path) == (new ReflectionClass($class))->getFileName()) {
-
             return new $class;
         }
 
@@ -568,6 +561,7 @@ class Migrator
                 ? $this->files->getRequire($path)
                 : clone $migration;
         }
+
         return new $class;
     }
 

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Console\View;
 
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components;
+use Illuminate\Database\Migrations\MigrationResult;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -108,15 +109,20 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Task($output))->render('My task', fn () => true);
+        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Success);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('DONE', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => false);
+        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Failure);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('FAIL', $result);
+
+        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped);
+        $result = $output->fetch();
+        $this->assertStringContainsString('My task', $result);
+        $this->assertStringContainsString('SKIPPED', $result);
     }
 
     public function testTwoColumnDetail()

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -33,7 +33,6 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('shouldMigrationBeRan')->andReturn(true);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -33,6 +33,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('shouldMigrationBeRan')->andReturn(true);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);

--- a/tests/Database/migrations/should_run/2016_01_01_200000_create_flights_table.php
+++ b/tests/Database/migrations/should_run/2016_01_01_200000_create_flights_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFlightsTable extends Migration
+{
+
+    public function shouldRun(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('flights', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('flights');
+    }
+}

--- a/tests/Database/migrations/should_run/2016_01_01_200000_create_flights_table.php
+++ b/tests/Database/migrations/should_run/2016_01_01_200000_create_flights_table.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateFlightsTable extends Migration
 {
-
     public function shouldRun(): bool
     {
         return false;

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -44,6 +44,7 @@ class MigratorTest extends TestCase
         $this->expectTask('2014_10_12_000000_create_people_table', 'DONE');
         $this->expectTask('2015_10_04_000000_modify_people_table', 'DONE');
         $this->expectTask('2016_10_04_000000_modify_people_table', 'DONE');
+        $this->expectTask('2017_10_04_000000_add_age_to_people', 'SKIPPED');
 
         $this->output->shouldReceive('writeln')->once();
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -52,6 +52,7 @@ class MigratorTest extends TestCase
         $this->assertTrue(DB::getSchemaBuilder()->hasTable('people'));
         $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'first_name'));
         $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'last_name'));
+        $this->assertFalse(DB::getSchemaBuilder()->hasColumn('people', 'age'));
     }
 
     public function testMigrateWithoutOutput()
@@ -64,6 +65,7 @@ class MigratorTest extends TestCase
         $this->assertTrue(DB::getSchemaBuilder()->hasTable('people'));
         $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'first_name'));
         $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'last_name'));
+        $this->assertFalse(DB::getSchemaBuilder()->hasColumn('people', 'age'));
     }
 
     public function testWithSkippedMigrations()

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -123,7 +123,7 @@ class MigratorTest extends TestCase
         $this->expectTwoColumnDetail('2016_10_04_000000_modify_people_table');
         $this->expectBulletList(['alter table "people" add column "last_name" varchar']);
 
-        $this->output->shouldReceive('writeln')->once();
+        $this->output->shouldReceive('writeln')->times(3);
 
         $this->subject->run([__DIR__.'/fixtures'], ['pretend' => true]);
 

--- a/tests/Integration/Migration/fixtures/2017_10_04_000000_add_age_to_people.php
+++ b/tests/Integration/Migration/fixtures/2017_10_04_000000_add_age_to_people.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function shouldRun(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->unsignedInteger('age')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropColumn('age');
+        });
+    }
+};


### PR DESCRIPTION
## What's this?

I've added the ability to declare a `shouldRun` function in your migration files to determine wether or not a migration should run when `php artisan migrate` or `php artisan rollback` is called.


```php
<?php

return new class extends Migration
{
   public function shouldRun()
   {
        return Feature::active(Flights::class);
   }

    /**
     * Run the migrations.
     */
    public function up(): void
    {
        Schema::create('flights', function (Blueprint $table) {
            $table->id();
            $table->string('name');
            $table->string('airline');
            $table->timestamps();
        });
    }
 
    /**
     * Reverse the migrations.
     */
    public function down(): void
    {
        Schema::drop('flights');
    }
};

```

## Why?

This adds the ability to selectively run migrations that you may have shipped to various environments based on:

- Feature flags
- Environment checks
- Config values
- Database adapter configured / other config values.]

etc.

This allows you to ship code to environments without running potentially damaging migrations before you're ready.

## Backwards compatibility.

The `shouldRun` function is added as an implemented function on the abstract `Migration` class and returns true by default, so ALL migration classes should work as usual, with no need to adjust the `stub` file either.

