### PR TITLE
feat: autoconfigure interfaces

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -177,6 +177,13 @@ class Container implements ArrayAccess, ContainerContract
     protected $afterResolvingAttributeCallbacks = [];
 
     /**
+     * An array of the interfaces to AutoConfigure
+     *
+     * @var class-string[]
+     */
+    protected $autoconfigure = [];
+
+    /**
      * Define a contextual binding.
      *
      * @param  array|string  $concrete
@@ -1692,5 +1699,13 @@ class Container implements ArrayAccess, ContainerContract
     public function __set($key, $value)
     {
         $this[$key] = $value;
+    }
+
+    /**
+     * @param class-string $interface
+     */
+    public function autoconfigure(string $interface): void
+    {
+        $this->autoconfigure[] = $interface;
     }
 }


### PR DESCRIPTION
The idea of auto-configurable services is that you setup some interfaces for auto configuration and they get automatically tagged by the Laravel container. For example, let's take this interface:

```php
interface ProviderInterface {}
```

We want this interface to be automatically tagged in the container, a Laravel component would have something like this:

```php
$app->make(LibraryProvider::class, function(Application $app) { 
    return new Provider($app->tagged(ProviderInterface::class)); 
});

$app->autoconfigure(ProviderInterface::class);
```

With this feature, in userland developers don't need to do anything as these services are automatically discovered and tagged. 
We implemented this into API Platform and @tomasvotruba suggested I propose this to the Laravel framework. 

Do you think that this is something we'd like to see inside the Laravel framework? 