### PR TITLE
[12.x] reapply Pint style changes

### DIFF
--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -69,7 +69,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule
+            {
             };
         }
 

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -71,7 +71,8 @@ class BusPendingBatchTest extends TestCase
 
         $container = new Container;
 
-        $job = new class {
+        $job = new class
+        {
         };
 
         $pendingBatch = new PendingBatch($container, new Collection([$job]));
@@ -226,7 +227,8 @@ class BusPendingBatchTest extends TestCase
 
     public function test_it_throws_exception_if_batched_job_is_not_batchable(): void
     {
-        $nonBatchableJob = new class {
+        $nonBatchableJob = new class
+        {
         };
 
         $this->expectException(RuntimeException::class);
@@ -242,7 +244,8 @@ class BusPendingBatchTest extends TestCase
         new PendingBatch(
             $container,
             new Collection(
-                [new PendingBatch($container, new Collection([new BatchableJob, new class {
+                [new PendingBatch($container, new Collection([new BatchableJob, new class
+                {
                 }]))]
             )
         );

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -17,7 +17,8 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
     public function testCreateDatabase()
     {
         $connection = m::mock(Connection::class);
-        $grammar = new class($connection) extends Grammar {
+        $grammar = new class($connection) extends Grammar
+        {
         };
 
         $this->assertSame('create database "foo"', $grammar->compileCreateDatabase('foo'));
@@ -26,7 +27,8 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
     public function testDropDatabaseIfExists()
     {
         $connection = m::mock(Connection::class);
-        $grammar = new class($connection) extends Grammar {
+        $grammar = new class($connection) extends Grammar
+        {
         };
 
         $this->assertSame('drop database if exists "foo"', $grammar->compileDropDatabaseIfExists('foo'));

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -288,7 +288,8 @@ class DatabaseEloquentInverseRelationTest extends TestCase
             [],
             new HasInverseRelationRelatedStub(),
             'foo',
-            new class() {
+            new class()
+            {
             },
             new HasInverseRelationRelatedStub(),
         ]);

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -248,10 +248,12 @@ class EncrypterTest extends TestCase
 
         return [
             [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
-            [['iv' => new class() {
+            [['iv' => new class()
+            {
             }, 'value' => '', 'mac' => '']],
             [['iv' => $validIv, 'value' => ['value_in_array'], 'mac' => '']],
-            [['iv' => $validIv, 'value' => new class() {
+            [['iv' => $validIv, 'value' => new class()
+            {
             }, 'mac' => '']],
             [['iv' => $validIv, 'value' => '', 'mac' => ['value_in_array']]],
             [['iv' => $validIv, 'value' => '', 'mac' => null]],

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -12,7 +12,8 @@ class JsonResourceTest extends TestCase
 {
     public function testJsonResourceNullAttributes()
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
         $model->setAttribute('relation_sum_column', null);
@@ -32,7 +33,8 @@ class JsonResourceTest extends TestCase
 
     public function testJsonResourceToJsonSucceedsWithPriorErrors(): void
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
         $resource = m::mock(JsonResource::class, ['resource' => $model])

--- a/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
@@ -19,7 +19,8 @@ class CursorPaginatorLoadMorphCountTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractCursorPaginator {
+        $p = (new class extends AbstractCursorPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorphCount('parentable', $relations));

--- a/tests/Pagination/CursorPaginatorLoadMorphTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphTest.php
@@ -19,7 +19,8 @@ class CursorPaginatorLoadMorphTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractCursorPaginator {
+        $p = (new class extends AbstractCursorPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorph('parentable', $relations));

--- a/tests/Pagination/PaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/PaginatorLoadMorphCountTest.php
@@ -19,7 +19,8 @@ class PaginatorLoadMorphCountTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractPaginator {
+        $p = (new class extends AbstractPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorphCount('parentable', $relations));

--- a/tests/Pagination/PaginatorLoadMorphTest.php
+++ b/tests/Pagination/PaginatorLoadMorphTest.php
@@ -19,7 +19,8 @@ class PaginatorLoadMorphTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractPaginator {
+        $p = (new class extends AbstractPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorph('parentable', $relations));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2371,10 +2371,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model {
+        $modelTwo = new class extends Model
+        {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -925,7 +925,8 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class($v) extends ValidationException {
+        $exception = new class($v) extends ValidationException
+        {
         };
         $v->setException($exception);
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -796,7 +796,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
             }
         };
 
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute('<hi>'));


### PR DESCRIPTION
@taylorotwell please do not merge right away.  in this final Pint fix, we have a conflict with StyleCI, and I'm not sure if there's a way to adjust the rules to get them to play nice, without StyleCI immediately reverting the changes.

we're in a little bit of a chicken/egg situation due to StyleCIs rules, which seems to have some inconsistencies on if it wants opening braces for an anonymous class on a newline or the same line.

I think we've reached to point where we need to decide if we're dropping StyleCI in favor of Pint, which would be my vote.

However, prior to doing that, we would need to setup Pint in the Github Actions pipeline, which I believe would probably need to be handled by the Laravel team.  As discussed in a previous PR, we have 2 options for using Pint in our CI.

- we can use `pint --test` to either pass or fail the PR, and force the contributor to ensure style rules are followed. they can do this manually, or run `pint` to automatically apply fixes. (my vote)
- we could also use regular `pint` in CI and have it auto-commit changes

below is a simple Github Action job I've used for projects before:

```yaml
style:
    name: 'Coding Style'
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - name: Setup PHP
        uses: shivammathur/setup-php@v2
        with:
          php-version: ${{ matrix.php }}
      - name: Install Composer Dependencies
        run: composer install --no-progress --prefer-dist --optimize-autoloader
      - name: Run Laravel Pint
        run: ./vendor/bin/pint --test -v
```



<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
