### PR TITLE
[12.x] Fix `LogManager::configurationFor()` typehint

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -554,7 +554,7 @@ class LogManager implements LoggerInterface
      * Get the log connection configuration.
      *
      * @param  string  $name
-     * @return array
+     * @return array|null
      */
     protected function configurationFor($name)
     {


### PR DESCRIPTION
Though I'm bummed the LogFake PR did not get merged, I can at least extract this docblock change 😆 