### PR TITLE
[12.x] Fix mistake in `asJson` call in `HasAttributes.php` that was recently introduced

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1180,7 +1180,7 @@ trait HasAttributes
 
         $value = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
-        ), $this->hasCast($key, ['json:unicode']));
+        ), $this->getJsonCastFlags($key));
 
         $this->attributes[$key] = $this->isEncryptedCastable($key)
             ? $this->castAttributeAsEncryptedString($key, $value)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
PR #54992 introduced a new `json:unicode` cast.

However, an issue was introduced. In `HasAttributes.php`, in one call to the updated `asJson` method, `hasCast()` is being called instead of `getJsonCastFlags()`.

### Changes
Old
```php
$value = $this->asJson($this->getArrayAttributeWithValue(
    $path, $key, $value
), $this->hasCast($key, ['json:unicode']));
```
New
```php
$value = $this->asJson($this->getArrayAttributeWithValue(
    $path, $key, $value
), $this->getJsonCastFlags($key));
```