### PR TITLE
Improve `toKilobytes` to handle spaces and case-insensitive units

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -218,6 +218,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
         }
 
         $size = strtolower(trim($size));
+
         $value = floatval($size);
 
         return round(match (true) {

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -217,6 +217,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
             return $size;
         }
 
+        $size = strtolower(trim($size));
         $value = floatval($size);
 
         return round(match (true) {

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -418,6 +418,27 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testFileSizeConversionWithDifferentUnits()
+    {
+        $this->passes(
+            File::image()->size('5MB'),
+            UploadedFile::fake()->create('foo.png', 5000)
+        );
+
+        $this->passes(
+            File::image()->size(' 2gb '),
+            UploadedFile::fake()->create('foo.png', 2 * 1000000)
+        );
+
+        $this->passes(
+            File::image()->size('1Tb'),
+            UploadedFile::fake()->create('foo.png', 1000000000)
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        File::image()->size('10xyz');
+    }
+
     protected function setUp(): void
     {
         $container = Container::getInstance();


### PR DESCRIPTION
**Changes:**

- Trimmed input (`trim($size)`) to remove extra spaces.
- Converted input to lowercase (`strtolower($size)`) for case-insensitive unit matching.
- Updated tests to cover inputs like "5MB", " 2gb ", and "1Tb".

🔹 Why?
Previously, `toKilobytes` only worked with strictly formatted units (1mb, 5gb, etc.). This update improves flexibility, ensuring better user experience and avoiding unnecessary validation failures.

🔹 Benefits:
✅ More flexible and user-friendly input handling.
✅ Fully backward-compatible with existing validation rules.
✅ Ensures size(), min(), max(), and between() work reliably with various input formats.

🚀 Ready for review & merge!