### PR TITLE
Feat: Add `getIf` method to handle conditional input retrieval

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -413,6 +413,34 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Retrieve an input value conditionally from the request.
+     *
+     * If the provided condition evaluates to true, the value associated with the
+     * specified key will be returned from the request. Otherwise, the default value is returned.
+     *
+     * @param bool|Closure $condition Condition or a callback returning a boolean value determining if the input should be retrieved.
+     * @param string $key The key of the input parameter to retrieve.
+     * @param mixed $default The default value returned if condition is false or key is not present.
+     *
+     * @return mixed
+     *
+     * @see \Illuminate\Http\Request::get()
+     */
+    #[\Override]
+    public function getIf(bool|Closure $condition, string $key, mixed $default = null): mixed
+    {
+        if ($condition instanceof Closure) {
+            $condition = $condition();
+        }
+
+        if (! $condition) {
+            return $default;
+        }
+
+        return parent::get($key, $default);
+    }
+
+    /**
      * Get the JSON payload for the request.
      *
      * @param  string|null  $key

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -418,15 +418,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * If the provided condition evaluates to true, the value associated with the
      * specified key will be returned from the request. Otherwise, the default value is returned.
      *
-     * @param bool|Closure $condition Condition or a callback returning a boolean value determining if the input should be retrieved.
-     * @param string $key The key of the input parameter to retrieve.
-     * @param mixed $default The default value returned if condition is false or key is not present.
-     *
+     * @param  bool|Closure  $condition  Condition or a callback returning a boolean value determining if the input should be retrieved.
+     * @param  string  $key  The key of the input parameter to retrieve.
+     * @param  mixed  $default  The default value returned if condition is false or key is not present.
      * @return mixed
      *
      * @see \Illuminate\Http\Request::get()
      */
-    #[\Override]
     public function getIf(bool|Closure $condition, string $key, mixed $default = null): mixed
     {
         if ($condition instanceof Closure) {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -987,13 +987,13 @@ class HttpRequestTest extends TestCase
     public function testGetIfMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Test']);
-        $this->assertEquals('Test', $request->getIf(true,'name'));
-        $this->assertNull($request->getIf(false,'name'));
-        $this->assertEquals('default', $request->getIf(false,'name', 'default'));
+        $this->assertEquals('Test', $request->getIf(true, 'name'));
+        $this->assertNull($request->getIf(false, 'name'));
+        $this->assertEquals('default', $request->getIf(false, 'name', 'default'));
 
-        $this->assertEquals('Test', $request->getIf(fn() => true,'name'));
-        $this->assertNull($request->getIf(fn() => false,'name'));
-        $this->assertEquals('default', $request->getIf(fn() => false,'name', 'default'));
+        $this->assertEquals('Test', $request->getIf(fn () => true, 'name'));
+        $this->assertNull($request->getIf(fn () => false, 'name'));
+        $this->assertEquals('default', $request->getIf(fn () => false, 'name', 'default'));
     }
 
     public function testCookieMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -984,6 +984,18 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Taylor', $all['name']);
     }
 
+    public function testGetIfMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Test']);
+        $this->assertEquals('Test', $request->getIf(true,'name'));
+        $this->assertNull($request->getIf(false,'name'));
+        $this->assertEquals('default', $request->getIf(false,'name', 'default'));
+
+        $this->assertEquals('Test', $request->getIf(fn() => true,'name'));
+        $this->assertNull($request->getIf(fn() => false,'name'));
+        $this->assertEquals('default', $request->getIf(fn() => false,'name', 'default'));
+    }
+
     public function testCookieMethod()
     {
         $request = Request::create('/', 'GET', [], ['name' => 'Taylor']);


### PR DESCRIPTION
This Pull Request introduces the `getIf` method to the `Illuminate\Http\Request` class, providing a convenient way to conditionally retrieve input values from the request.

**Key Features:**
- Retrieves input values based on a provided boolean condition or a closure.
- Returns a specified default value if the condition evaluates to false.

**Method Signature:**
```php
public function getIf(bool|Closure $condition, string $key, mixed $default = null): mixed
```

### Included Changes:
- Implemented the `getIf` method in `Request.php`.
- Added comprehensive tests for the new method in `HttpRequestTest.php`.

### Tests Coverage:
- Condition explicitly set to `true` and `false`.
- Condition as a closure returning `true` or `false`.
- Proper handling of default values.

These tests ensure robust behavior and confirm the method handles different scenarios as expected.

I'm open to feedback and would appreciate any recommendations 🙂
