### PR TITLE
[12.x] Add support for PostgreSQL "unique nulls not distinct"

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -333,9 +333,16 @@ class PostgresGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        $sql = sprintf('alter table %s add constraint %s unique (%s)',
+        $uniqueStatement = 'unique';
+
+        if (! is_null($command->nullsNotDistinct)) {
+            $uniqueStatement .= ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct');
+        }
+
+        $sql = sprintf('alter table %s add constraint %s %s (%s)',
             $this->wrapTable($blueprint),
             $this->wrap($command->index),
+            $uniqueStatement,
             $this->columnize($command->columns)
         );
 

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Fluent;
  * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
+ * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  */
 class IndexDefinition extends Fluent
 {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -286,6 +286,26 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyWithNullsNotDistinct()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->nullsNotDistinct();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "bar" unique nulls not distinct ("foo")', $statements[0]);
+    }
+
+    public function testAddingUniqueKeyWithNullsDistinct()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->nullsNotDistinct(false);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "bar" unique nulls distinct ("foo")', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');


### PR DESCRIPTION
# What

This adds support for PostgreSQL (`>= 15`)  `unique nulls [not] distinct` when building unique indexes.

# Why

The only way to execute such a statement inside a migration at the moment is to wait after the table creation (outside the `Schema::create()` statement, as AFAIK there's no way to inform the blueprint of a custom command to be executed) or by extending the Postgres schema grammar ([idea thread](https://github.com/laravel/framework/discussions/55023))

# How

By adding support for a new `nullsNotDistinct()` fluent index definition method (see the unit tests for some examples) when using the `postgres` database driver (or more precisely when using the Postgres schema grammar).

# Benefits

Developers will now be able to use this native PostgreSQL feature, which could reduce the scope of work when building a feature requiring unique database record combinations, including null values.