### PR TITLE
[12.x] Add `throwWhenEmpty` method to `EnumeratesValues` trait

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,6 +367,22 @@ trait EnumeratesValues
     }
 
     /**
+     * Throw an exception if the collection is empty.
+     *
+     * @template TException of \Throwable
+     *
+     * @param  TException|class-string<TException>|string  $exception
+     * @param  mixed  ...$parameters
+     * @return static<TKey, TValue>
+     *
+     * @throws TException
+     */
+    public function throwWhenEmpty($exception = 'UnexpectedValueException', ...$parameters)
+    {
+        return $this->whenEmpty(fn () => throw_if(true, $exception, ...$parameters));
+    }
+
+    /**
      * Determine if the collection is not empty.
      *
      * @phpstan-assert-if-true TValue $this->first()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5592,6 +5592,32 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testThrowWhenEmpty($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(UnexpectedValueException::class);
+        $data->throwWhenEmpty();
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testThrowWhenEmptyForInstanceThrowable($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Collection should be not empty.');
+        $data->throwWhenEmpty(new InvalidArgumentException('Collection should be not empty.'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testThrowWhenEmptyForStringThrowable($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Collection should be not empty.');
+        $data->throwWhenEmpty('InvalidArgumentException', 'Collection should be not empty.');
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testPercentageWithFlatCollection($collection)
     {
         $collection = new $collection([1, 1, 2, 2, 2, 3]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR introduces the `throwWhenEmpty` method to the EnumeratesValues trait. This method throws an exception if the collection is empty, enhancing the collection's error handling capabilities by allowing custom exceptions to be thrown when a collection is unexpectedly empty.

usage:
```php
use Exception;

collect()->throwWhenEmpty();

collect()->throwWhenEmpty('Exception', 'Collection should be not empty.');

collect()->throwWhenEmpty(new Exception('Collection should be not empty.'));
```