### PR TITLE
Add element type to return array in Filesystem

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -173,7 +173,7 @@ interface Filesystem
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
-     * @return array
+     * @return array<string>
      */
     public function files($directory = null, $recursive = false);
 
@@ -181,7 +181,7 @@ interface Filesystem
      * Get all of the files from the given directory (recursive).
      *
      * @param  string|null  $directory
-     * @return array
+     * @return array<string>
      */
     public function allFiles($directory = null);
 
@@ -190,7 +190,7 @@ interface Filesystem
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
-     * @return array
+     * @return array<string>
      */
     public function directories($directory = null, $recursive = false);
 
@@ -198,7 +198,7 @@ interface Filesystem
      * Get all (recursive) of the directories within a given directory.
      *
      * @param  string|null  $directory
-     * @return array
+     * @return array<string>
      */
     public function allDirectories($directory = null);
 


### PR DESCRIPTION
This adds documentation to the types returned by the file and dir listing functions, this helps IDEs and static analyzers reason about the values returned.