### PR TITLE
[12.x] Add comprehensive test coverage for LazyCollection diff methods

### DIFF
--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -456,14 +456,14 @@ class SupportLazyCollectionTest extends TestCase
                 'Jeffrey Way',
                 'Adam Wathan',
                 'Caleb Porzio',
-                'Mohamed Said'
+                'Mohamed Said',
             ]);
 
         $diff = $collection->diff(
             [
                 'Jeffrey Way',
                 'Caleb Porzio',
-                'Nuno Maduro'
+                'Nuno Maduro',
             ]);
 
         $this->assertEquals([0 => 'Taylor Otwell', 2 => 'Adam Wathan', 4 => 'Mohamed Said'], $diff->all());
@@ -483,5 +483,83 @@ class SupportLazyCollectionTest extends TestCase
         });
 
         $this->assertEquals([1 => 20, 2 => 30, 3 => 40], $diff2->all());
+    }
+
+    public function testDiffAssoc()
+    {
+        $collection = new LazyCollection([
+            'name' => 'Laravel',
+            'version' => '10.0',
+            'type' => 'framework',
+            'license' => 'MIT',
+            'features' => 'Eloquent',
+        ]);
+
+        $diff = $collection->diffAssoc([
+            'name' => 'Laravel',
+            'version' => '9.0',
+            'type' => 'framework',
+            'author' => 'Taylor Otwell',
+            'features' => 'Blade',
+        ]);
+
+        $this->assertEquals(
+            [
+                'version' => '10.0',
+                'license' => 'MIT',
+                'features' => 'Eloquent',
+            ],
+            $diff->all()
+        );
+
+        $this->assertInstanceOf(LazyCollection::class, $diff);
+    }
+
+    public function testDiffKeys()
+    {
+        $collection = new LazyCollection([
+            'one' => 'Laravel',
+            'two' => 'Livewire',
+            'three' => 'Blade',
+            'four' => 'Eloquent',
+            'five' => 'Forge',
+        ]);
+
+        $diff = $collection->diffKeys([
+            'two' => 'Something else',
+            'four' => 'Completely different value',
+            'six' => 'Nova',
+        ]);
+
+        $this->assertEquals(
+            [
+                'one' => 'Laravel',
+                'three' => 'Blade',
+                'five' => 'Forge',
+            ],
+            $diff->all()
+        );
+        $this->assertInstanceOf(LazyCollection::class, $diff);
+    }
+
+    public function testDiffKeysUsing()
+    {
+        $collection = new LazyCollection([
+            100 => 'Route definition',
+            200 => 'Middleware',
+            300 => 'Controller',
+            400 => 'Model',
+        ]);
+
+        $diff = $collection->diffKeysUsing([
+            150 => 'Something',
+            250 => 'Something else',
+            350 => 'Another thing',
+        ], function ($a, $b) {
+            return (int) ($a / 100) - (int) ($b / 100);
+        });
+
+        $this->assertEquals([400 => 'Model'], $diff->all());
+        $this->assertInstanceOf(LazyCollection::class, $diff);
     }
 }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -447,4 +447,41 @@ class SupportLazyCollectionTest extends TestCase
 
         $this->assertEquals($expected, $dotted->all());
     }
+
+    public function testDiff()
+    {
+        $collection = new LazyCollection(
+            [
+                'Taylor Otwell',
+                'Jeffrey Way',
+                'Adam Wathan',
+                'Caleb Porzio',
+                'Mohamed Said'
+            ]);
+
+        $diff = $collection->diff(
+            [
+                'Jeffrey Way',
+                'Caleb Porzio',
+                'Nuno Maduro'
+            ]);
+
+        $this->assertEquals([0 => 'Taylor Otwell', 2 => 'Adam Wathan', 4 => 'Mohamed Said'], $diff->all());
+        $this->assertInstanceOf(LazyCollection::class, $diff);
+    }
+
+    public function testDiffUsing()
+    {
+        $collection = new LazyCollection(['Taylor', 'Jeffrey', 'Adam']);
+
+        $diff1 = $collection->diffUsing(['TAYLOR', 'JEFFREY'], 'strcasecmp');
+        $this->assertEquals([2 => 'Adam'], $diff1->all());
+
+        $numbers = new LazyCollection([10, 20, 30, 40]);
+        $diff2 = $numbers->diffUsing([5, 10, 15], function ($a, $b) {
+            return ($a / 10) <=> ($b / 10);
+        });
+
+        $this->assertEquals([1 => 20, 2 => 30, 3 => 40], $diff2->all());
+    }
 }


### PR DESCRIPTION
# Add comprehensive test coverage for LazyCollection comparison methods

In this PR, I've added thorough test coverage for several LazyCollection comparison methods that previously lacked tests to verify their behavior across different scenarios. 🧪

## Methods covered in this PR:

- **diff**: Tests how the method identifies values present in the original collection but absent in the compared collection ✅
- **diffUsing**: Tests custom value comparison with a callback function, enabling more flexible difference detection 🔄
- **diffAssoc**: Tests associative comparison that considers both keys and values, returning items with unique key-value combinations 📊
- **diffKeys**: Tests key-only comparison, ensuring items with keys not present in the compared collection are properly returned 🔑
- **diffKeysUsing**: Tests custom key comparison logic with a callback function, demonstrating advanced use cases like numeric grouping 🧩

## Test scenarios included:

- Standard collection comparisons with mixed matching/non-matching elements
- Edge cases with identical keys but different values
- Custom comparison logic for specialized filtering needs
- Numeric key grouping and custom string comparison scenarios
- Verification that each method properly returns a new LazyCollection instance

These tests ensure that the comparison methods work correctly under various conditions and handle all scenarios according to their intended functionality, providing greater confidence in the LazyCollection implementation's correctness and reliability.

## Related work

This PR builds upon my [previous contribution](https://github.com/laravel/framework/pull/55022) where I added tests for other LazyCollection methods (collapseWithKeys, containsOneItem, doesntContain, dot, hasAny). Together, these PRs significantly improve the test coverage of the LazyCollection class, helping maintain code quality and prevent regressions. 🚀