### PR TITLE
[12.x] Date validation rule: remove 'date' when 'date_format' is present

### DIFF
--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -22,6 +22,8 @@ class Date implements Stringable
      */
     public function format(string $format): static
     {
+        array_shift($this->constraints);
+
         return $this->addRule('date_format:'.$format);
     }
 

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -24,7 +24,7 @@ class ValidationDateRuleTest extends TestCase
     public function testDateFormatRule()
     {
         $rule = Rule::date()->format('d/m/Y');
-        $this->assertEquals('date|date_format:d/m/Y', (string) $rule);
+        $this->assertEquals('date_format:d/m/Y', (string) $rule);
     }
 
     public function testAfterTodayRule()
@@ -87,7 +87,7 @@ class ValidationDateRuleTest extends TestCase
             ->format('Y-m-d')
             ->after('2024-01-01 00:00:00')
             ->before('2025-01-01 00:00:00');
-        $this->assertEquals('date|date_format:Y-m-d|after:2024-01-01 00:00:00|before:2025-01-01 00:00:00', (string) $rule);
+        $this->assertEquals('date_format:Y-m-d|after:2024-01-01 00:00:00|before:2025-01-01 00:00:00', (string) $rule);
 
         $rule = Rule::date()
             ->format('Y-m-d')
@@ -97,7 +97,7 @@ class ValidationDateRuleTest extends TestCase
             ->unless(true, function ($rule) {
                 $rule->before('2025-01-01');
             });
-        $this->assertSame('date|date_format:Y-m-d|after:2024-01-01', (string) $rule);
+        $this->assertSame('date_format:Y-m-d|after:2024-01-01', (string) $rule);
     }
 
     public function testDateValidation()

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -398,7 +398,7 @@ class ValidationRuleParserTest extends TestCase
         ]));
 
         $rules = [
-            'date' => Rule::date()->format('Y-m-d'),
+            'date' => Rule::date()->after('today'),
         ];
 
         $results = $parser->explode($rules);
@@ -406,7 +406,7 @@ class ValidationRuleParserTest extends TestCase
         $this->assertEquals([
             'date' => [
                 'date',
-                'date_format:Y-m-d',
+                'after:today',
             ],
         ], $results->rules);
     }


### PR DESCRIPTION
Currently, when using using `Rule::date()->format(...)`, the `date_format` rule gets appended to the rule's `$constraints` array which is already instantiated with the `date` rule. As such, the following:

```php
Rule::date()->format('"d F, Y"')
```

... would end up with the following rules:

```php
['date', 'date_format:"d F, Y"']
```

A date of say "12 March, 2025" fails the `date` rule, yet is a valid date of the format `d F, Y`, so would incorrectly throw a validation error under the aforementioned `Rule` usage.

Cases like this are why the `date_format` [documentation](https://laravel.com/docs/12.x/validation#rule-date-format) already states:

>You should use either `date` or `date_format` when validating a field, not both.

This PR simply removes the existing `date` rule from `$constraints` when adding the `date_format` rule.

