### PR TITLE
[12.x] Allowing merging model attributes before insert via `Model::fillAndInsert()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -61,13 +61,6 @@ class Builder implements BuilderContract
     public $pendingAttributes = [];
 
     /**
-     * Indicates if attributes, timestamps, and unique IDs should be merged before insert.
-     *
-     * @var bool
-     */
-    public $mergeAttributesBeforeInsert = false;
-
-    /**
      * The relationships that should be eager loaded.
      *
      * @var array
@@ -596,56 +589,51 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Insert new records into the database.
+     * Merge in Model's default attributes, set timestamps,
+     * cast any values, and then insert into the database.
      *
+     * @param  array<int, array<string, mixed>>  $values
      * @return bool
      */
-    public function insert(array $values)
+    public function hydrateAndInsert(array $values)
     {
-        if ($this->mergeAttributesBeforeInsert) {
-            $values = $this->castBeforeInsert($values);
-        }
-
-        return $this->forwardCallTo($this->query, 'insert', [$values]);
+        return $this->insert($this->hydrateForInsert($values));
     }
 
     /**
-     * Insert a new record and get the value of the primary key.
+     * Merge in Model's default attributes, set timestamps,
+     * cast any values, and then insert into the database,
+     * ignoring errors.
      *
-     * @param  string|null  $sequence
+     * @param  array<int, array<string, mixed>>  $values
      * @return int
      */
-    public function insertGetId(array $values, $sequence = null)
+    public function hydrateAndInsertOrIgnore(array $values)
     {
-        if ($this->mergeAttributesBeforeInsert) {
-            $values = $this->castBeforeInsert([$values])[0];
-        }
-
-        return $this->forwardCallTo($this->query, 'insertGetId', [$values, $sequence]);
+        return $this->insertOrIgnore($this->hydrateForInsert($values));
     }
 
     /**
-     * Insert new records into the database while ignoring errors.
+     * Merge in Model's default attributes, set timestamps,
+     * cast any values, and then insert into the database,
+     * returning the ID of the new record.
      *
+     * @param  array<string, mixed>  $values
      * @return int
      */
-    public function insertOrIgnore(array $values)
+    public function hydrateAndInsertGetId(array $values)
     {
-        if ($this->mergeAttributesBeforeInsert) {
-            $values = $this->castBeforeInsert($values);
-        }
-
-        return $this->forwardCallTo($this->query, 'insertOrIgnore', [$values]);
+        return $this->insertGetId($this->hydrateForInsert([$values])[0]);
     }
 
     /**
-     * Insert a number of records, merging in default attributes,
+     * Enrich values by merging in the Model's default attributes,
      * adding timestamps, and converting casts to raw values.
      *
      * @param  array<int, array<string, mixed>>  $values
      * @return array<int, array<string, mixed>>
      */
-    public function castBeforeInsert(array $values)
+    public function hydrateForInsert(array $values)
     {
         if (empty($values)) {
             return [];
@@ -1911,20 +1899,6 @@ class Builder implements BuilderContract
         }
 
         $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
-
-        return $this;
-    }
-
-    /**
-     * Indicate if insert methods should merge in default attributes,
-     * add timestamps, and converting casts to raw values.
-     *
-     * @param  bool  $mergeBeforeInsert
-     * @return $this
-     */
-    public function mergeAttributesBeforeInsert($mergeBeforeInsert = true)
-    {
-        $this->mergeAttributesBeforeInsert = $mergeBeforeInsert;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -144,19 +144,6 @@ class Builder implements BuilderContract
     ];
 
     /**
-     * The pass-thru methods that can have attributes merged before insert.
-     *
-     * @var string[]
-     */
-    protected $mergeBeforeInsertPassThru = [
-        'insert',
-        'insertgetid',
-        'insertorignore',
-        'insertusing',
-        'insertorignoreusing',
-    ];
-
-    /**
      * Applied global scopes.
      *
      * @var array

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -647,6 +647,7 @@ class Builder implements BuilderContract
      */
     public function castBeforeInsert(array $values)
     {
+        /*
         if (empty($values)) {
             return [];
         }
@@ -679,7 +680,25 @@ class Builder implements BuilderContract
             }
         });
 
+        dd($values);
         return $values;
+        */
+
+        if (empty($values)) {
+            return [];
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        $this->model->unguard(function () use (&$values) {
+            foreach($values as $key => $rowValues) {
+                $values[$key] = $this->newModelInstance($rowValues)->getAttributes();
+            }
+        });
+
+        return dd($this->addTimestampsToUpsertValues($this->addUniqueIdsToUpsertValues($values)));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -608,13 +608,6 @@ class Builder implements BuilderContract
         return $callback();
     }
 
-    /*
-     * 'insert',
-        'insertgetid',
-        'insertorignore',
-        'insertusing',
-        'insertorignoreusing',
-     */
     /**
      * Insert new records into the database.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,7 +648,7 @@ class Builder implements BuilderContract
             $values = $this->castBeforeInsert($values);
         }
 
-        return $this->forwardCallTo($this->query, 'insertGetId', [$values]);
+        return $this->forwardCallTo($this->query, 'insertOrIgnore', [$values]);
     }
 
     /**
@@ -1947,12 +1947,12 @@ class Builder implements BuilderContract
      * Indicate if insert methods should merge in default attributes,
      * add timestamps, and converting casts to raw values.
      *
-     * @param  bool  $merge
-     * @return $this|Builder
+     * @param  bool  $mergeBeforeInsert
+     * @return $this
      */
-    public function mergeAttributesBeforeInsert($merge = true)
+    public function mergeAttributesBeforeInsert($mergeBeforeInsert = true)
     {
-        $this->mergeAttributesBeforeInsert = $merge;
+        $this->mergeAttributesBeforeInsert = $mergeBeforeInsert;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -595,9 +595,9 @@ class Builder implements BuilderContract
      * @param  array<int, array<string, mixed>>  $values
      * @return bool
      */
-    public function hydrateAndInsert(array $values)
+    public function fillAndInsert(array $values)
     {
-        return $this->insert($this->hydrateForInsert($values));
+        return $this->insert($this->fillForInsert($values));
     }
 
     /**
@@ -608,9 +608,9 @@ class Builder implements BuilderContract
      * @param  array<int, array<string, mixed>>  $values
      * @return int
      */
-    public function hydrateAndInsertOrIgnore(array $values)
+    public function fillAndInsertOrIgnore(array $values)
     {
-        return $this->insertOrIgnore($this->hydrateForInsert($values));
+        return $this->insertOrIgnore($this->fillForInsert($values));
     }
 
     /**
@@ -621,9 +621,9 @@ class Builder implements BuilderContract
      * @param  array<string, mixed>  $values
      * @return int
      */
-    public function hydrateAndInsertGetId(array $values)
+    public function fillAndInsertGetId(array $values)
     {
-        return $this->insertGetId($this->hydrateForInsert([$values])[0]);
+        return $this->insertGetId($this->fillForInsert([$values])[0]);
     }
 
     /**
@@ -633,7 +633,7 @@ class Builder implements BuilderContract
      * @param  array<int, array<string, mixed>>  $values
      * @return array<int, array<string, mixed>>
      */
-    public function hydrateForInsert(array $values)
+    public function fillForInsert(array $values)
     {
         if (empty($values)) {
             return [];
@@ -644,7 +644,7 @@ class Builder implements BuilderContract
         }
 
         $this->model->unguarded(function () use (&$values) {
-            foreach($values as $key => $rowValues) {
+            foreach ($values as $key => $rowValues) {
                 $values[$key] = tap(
                     $this->newModelInstance($rowValues),
                     fn ($model) => $model->setUniqueIds()

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2257,6 +2257,10 @@ class Builder implements BuilderContract
             return $this->callNamedScope($method, $parameters);
         }
 
+        if (in_array(strtolower($method), $this->passthru)) {
+            return $this->toBase()->{$method}(...$parameters);
+        }
+
         $this->forwardCallTo($this->query, $method, $parameters);
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -642,12 +642,11 @@ class Builder implements BuilderContract
      * Insert a number of records, merging in default attributes,
      * adding timestamps, and converting casts to raw values.
      *
-     * @param  array<int, <array<string, mixed>>  $values
-     * @return array
+     * @param  array<int, array<string, mixed>>  $values
+     * @return array<int, array<string, mixed>>
      */
     public function castBeforeInsert(array $values)
     {
-        /*
         if (empty($values)) {
             return [];
         }
@@ -656,49 +655,16 @@ class Builder implements BuilderContract
             $values = [$values];
         }
 
-        $modelInstance = $this->newModelInstance();
-        $timestampColumns = [];
-
-        if ($modelInstance->usesTimestamps()) {
-            $now = $modelInstance->freshTimestamp();
-
-            if ($createdAtColumn = $modelInstance->getCreatedAtColumn()) {
-                $timestampColumns[$createdAtColumn] ??= $now;
-            }
-            if ($updatedAtColumn = $modelInstance->getUpdatedAtColumn()) {
-                $timestampColumns[$updatedAtColumn] ??= $now;
-            }
-        }
-
-        $this->model->unguarded(function () use (&$values, $timestampColumns) {
-            foreach ($values as $key => $value) {
-                $newModelInstance = tap(
-                    $this->newModelInstance(array_merge($timestampColumns, $value)),
-                    fn (Model $model) => $model->setUniqueIds()
-                );
-                $values[$key] = $newModelInstance->getAttributes();
-            }
-        });
-
-        dd($values);
-        return $values;
-        */
-
-        if (empty($values)) {
-            return [];
-        }
-
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-
-        $this->model->unguard(function () use (&$values) {
+        $this->model->unguarded(function () use (&$values) {
             foreach($values as $key => $rowValues) {
-                $values[$key] = $this->newModelInstance($rowValues)->getAttributes();
+                $values[$key] = tap(
+                    $this->newModelInstance($rowValues),
+                    fn ($model) => $model->setUniqueIds()
+                )->getAttributes();
             }
         });
 
-        return dd($this->addTimestampsToUpsertValues($this->addUniqueIdsToUpsertValues($values)));
+        return $this->addTimestampsToUpsertValues($values);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -588,7 +588,14 @@ class Builder implements BuilderContract
         return $callback();
     }
 
-    public function insertWithCasts(array $values)
+    /**
+     * Insert a number of records, merging in default attributes,
+     * adding timestamps, and converting casts to raw values.
+     *
+     * @param  list<array<string, mixed>>  $values
+     * @return bool
+     */
+    public function insertWithCasts($values)
     {
         if (empty($values)) {
             return true;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -658,7 +658,7 @@ class Builder implements BuilderContract
      * @param  array<int, <array<string, mixed>>  $values
      * @return array
      */
-    public function castBeforeInsert($values)
+    public function castBeforeInsert(array $values)
     {
         if (empty($values)) {
             return [];

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -615,6 +615,11 @@ class Builder implements BuilderContract
         'insertusing',
         'insertorignoreusing',
      */
+    /**
+     * Insert new records into the database.
+     *
+     * @return bool
+     */
     public function insert(array $values)
     {
         if ($this->mergeAttributesBeforeInsert) {
@@ -625,9 +630,10 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param  array  $values
-     * @param $sequence
-     * @return int|mixed
+     * Insert a new record and get the value of the primary key.
+     *
+     * @param  string|null  $sequence
+     * @return int
      */
     public function insertGetId(array $values, $sequence = null)
     {
@@ -639,16 +645,30 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Insert new records into the database while ignoring errors.
+     *
+     * @return int
+     */
+    public function insertOrIgnore(array $values)
+    {
+        if ($this->mergeAttributesBeforeInsert) {
+            $values = $this->castBeforeInsert($values);
+        }
+
+        return $this->forwardCallTo($this->query, 'insertGetId', [$values]);
+    }
+
+    /**
      * Insert a number of records, merging in default attributes,
      * adding timestamps, and converting casts to raw values.
      *
-     * @param  list<array<string, mixed>>  $values
+     * @param  array<int, <array<string, mixed>>  $values
      * @return array
      */
     public function castBeforeInsert($values)
     {
         if (empty($values)) {
-            [];
+            return [];
         }
 
         if (! is_array(reset($values))) {
@@ -2242,13 +2262,6 @@ class Builder implements BuilderContract
 
         if ($this->hasNamedScope($method)) {
             return $this->callNamedScope($method, $parameters);
-        }
-
-        if (in_array($lowerCaseMethod = strtolower($method), $this->passthru)) {
-            if ($this->mergeAttributesBeforeInsert && in_array($lowerCaseMethod, $this->mergeBeforeInsertPassThru)) {
-                $parameters[0] = $this->castBeforeInsert($parameters[0])[0];
-            }
-            return $this->toBase()->{$method}(...$parameters);
         }
 
         $this->forwardCallTo($this->query, $method, $parameters);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -995,7 +995,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertSame('foo', $builder->insertOrIgnore(['bar']));
 
-
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insertOrIgnoreUsing')->once()->with(['bar'], 'baz')->andReturn('foo');
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -995,13 +995,14 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertSame('foo', $builder->insertOrIgnore(['bar']));
 
+
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insertOrIgnoreUsing')->once()->with(['bar'], 'baz')->andReturn('foo');
 
         $this->assertSame('foo', $builder->insertOrIgnoreUsing(['bar'], 'baz'));
 
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('insertGetId')->once()->with(['bar'])->andReturn('foo');
+        $builder->getQuery()->shouldReceive('insertGetId')->once()->with(['bar'], null)->andReturn('foo');
 
         $this->assertSame('foo', $builder->insertGetId(['bar']));
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1001,7 +1001,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('foo', $builder->insertOrIgnoreUsing(['bar'], 'baz'));
 
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('insertGetId')->once()->with(['bar'], null)->andReturn('foo');
+        $builder->getQuery()->shouldReceive('insertGetId')->once()->with(['bar'])->andReturn('foo');
 
         $this->assertSame('foo', $builder->insertGetId(['bar']));
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -198,6 +198,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         Eloquent::unsetConnectionResolver();
 
         Carbon::setTestNow(null);
+        Str::createUuidsNormally();
+        DB::flushQueryLog();
     }
 
     /**
@@ -2573,11 +2575,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         DB::enableQueryLog();
 
-        $newId = ModelWithUniqueStringIds::mergeAttributesBeforeInsert()->insertGetId([
+        $this->assertIsInt($newId = ModelWithUniqueStringIds::mergeAttributesBeforeInsert()->insertGetId([
             'name' => 'Taylor',
             'role' => IntBackedRole::Admin,
             'role_string' => StringBackedRole::Admin,
-        ]);
+        ]));
         $this->assertCount(1, DB::getRawQueryLog());
         $this->assertSame($newId, ModelWithUniqueStringIds::sole()->id);
     }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2572,17 +2572,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         DB::enableQueryLog();
-        try {
-            $this->assertSame(1, ModelWithUniqueStringIds::mergeAttributesBeforeInsert()->insertGetId([
-                'name' => 'Taylor',
-                'role' => IntBackedRole::Admin,
-                'role_string' => StringBackedRole::Admin,
-            ]));
-        } catch (\Throwable $t) {
-            dd($t);
-            echo "error";
-        }
-        //dd(DB::getRawQueryLog());
+
+        $newId = ModelWithUniqueStringIds::mergeAttributesBeforeInsert()->insertGetId([
+            'name' => 'Taylor',
+            'role' => IntBackedRole::Admin,
+            'role_string' => StringBackedRole::Admin,
+        ]);
+        $this->assertCount(1, DB::getRawQueryLog());
+        $this->assertSame($newId, ModelWithUniqueStringIds::sole()->id);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2474,12 +2474,12 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
     }
 
-    public function testCanEnrichAndInsert()
+    public function testCanFillAndInsert()
     {
         DB::enableQueryLog();
         Carbon::setTestNow('2025-03-15T07:32:00Z');
 
-        $this->assertTrue(EloquentTestUser::hydrateAndInsert([
+        $this->assertTrue(EloquentTestUser::fillAndInsert([
             ['email' => 'taylor@laravel.com', 'birthday' => null],
             ['email' => 'nuno@laravel.com', 'birthday' => new Carbon('1980-01-01')],
             ['email' => 'tim@laravel.com', 'birthday' => '1987-11-01', 'created_at' => '2025-01-02T02:00:55', 'updated_at' => Carbon::parse('2025-02-19T11:41:13')],
@@ -2505,7 +2505,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         DB::flushQueryLog();
 
-        $this->assertTrue(EloquentTestWithJSON::hydrateAndInsert([
+        $this->assertTrue(EloquentTestWithJSON::fillAndInsert([
             ['id' => 1, 'json' => ['album' => 'Keep It Like a Secret', 'release_date' => '1999-02-02']],
             ['id' => 2, 'json' => (object) ['album' => 'You In Reverse', 'release_date' => '2006-04-11']],
         ]));
@@ -2520,7 +2520,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
-    public function testCanHydrateAndInsertWithUniqueStringIds()
+    public function testCanFillAndInsertWithUniqueStringIds()
     {
         Str::createUuidsUsingSequence([
             '00000000-0000-7000-0000-000000000000',
@@ -2528,7 +2528,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             '22222222-0000-7000-0000-000000000000',
         ]);
 
-        $this->assertTrue(ModelWithUniqueStringIds::hydrateAndInsert([
+        $this->assertTrue(ModelWithUniqueStringIds::fillAndInsert([
             [
                 'name' => 'Taylor', 'role' => IntBackedRole::Admin, 'role_string' => StringBackedRole::Admin,
             ],
@@ -2567,7 +2567,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('22222222-0000-7000-0000-000000000000', $chris->uuid);
     }
 
-    public function testHydrateAndInsertOrIgnore()
+    public function testFillAndInsertOrIgnore()
     {
         Str::createUuidsUsingSequence([
             '00000000-0000-7000-0000-000000000000',
@@ -2575,13 +2575,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
             '22222222-0000-7000-0000-000000000000',
         ]);
 
-        $this->assertEquals(1, ModelWithUniqueStringIds::hydrateAndInsertOrIgnore([
+        $this->assertEquals(1, ModelWithUniqueStringIds::fillAndInsertOrIgnore([
             [
                 'id' => 1, 'name' => 'Taylor', 'role' => IntBackedRole::Admin, 'role_string' => StringBackedRole::Admin,
             ],
         ]));
 
-        $this->assertSame(1, ModelWithUniqueStringIds::hydrateAndInsertOrIgnore([
+        $this->assertSame(1, ModelWithUniqueStringIds::fillAndInsertOrIgnore([
             [
                 'id' => 1, 'name' => 'Taylor', 'role' => IntBackedRole::Admin, 'role_string' => StringBackedRole::Admin,
             ],
@@ -2598,7 +2598,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
     }
 
-    public function testMergeBeforeInsertGetId()
+    public function testFillAndInsertGetId()
     {
         Str::createUuidsUsingSequence([
             '00000000-0000-7000-0000-000000000000',
@@ -2606,7 +2606,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         DB::enableQueryLog();
 
-        $this->assertIsInt($newId = ModelWithUniqueStringIds::hydrateAndinsertGetId([
+        $this->assertIsInt($newId = ModelWithUniqueStringIds::fillAndInsertGetId([
             'name' => 'Taylor',
             'role' => IntBackedRole::Admin,
             'role_string' => StringBackedRole::Admin,

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2476,7 +2476,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testCanInsertWithCasts()
     {
-
         DB::enableQueryLog();
         Carbon::setTestNow('2025-03-15T07:32:00Z');
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2476,6 +2476,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testCanInsertWithCasts()
     {
+
         DB::enableQueryLog();
         Carbon::setTestNow('2025-03-15T07:32:00Z');
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/38d4bbdd-5b05-4997-aa59-507c9180d7a1)


I [submitted a PR](https://github.com/laravel/framework/pull/46798) for this about two years ago, but I wanted to take a second shot at it.

---
## The Goal
Be able to perform a bulk insert of records without having to manually cast values to primitives, set timestamps, or set UUIDs in an array_map(). Why is this important?

Inserting models one-by-one is terribly inefficient. The `upsert()` functionality already does quite a bit of the heavy lifting (setting timestamps and unique string IDs), but doesn't play nice with casts. 

### Current Way of Doing This
**Write a custom macro**. Since the last PR, I have added this to three separate projects, and will probably always add it to new projects where I need to be able to bulk insert records. 

**Loop through all of your records and add the casts/timestamps yourself**. This works, but isn't easy to reach for.

Due to this headache, I believe it nudges users into performing inserts one-by-one, which will lead to increased DB load and performance degradations at scale. (We don't want people mistakenly thinking Laravel is slow)

## How to use this functionality

```php
ModelWithUniqueStringIds::fillAndInsert([
    [
        'name' => 'Taylor', 'role' => IntBackedRole::Admin, 'role_string' => StringBackedRole::Admin,
    ],
    [
        'name' => 'Nuno', 'role' => 3, 'role_string' => 'admin',
    ],
    [
        'name' => 'Dries', 'uuid' => 'bbbb0000-0000-7000-0000-000000000000',
    ],
    [
        'name' => 'Chris',
    ],
]);
```

This will convert the enums to their raw values, cast any objects/arrays to their DB representation, add created_at/updated_at timestamps, and set unique string IDs.