### PR TITLE
Add additional validation tests for MIME type and file extension mismatches

### DIFF
--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -90,6 +90,21 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testValidMimeTypeButInvalidExtension()
+    {
+        $this->fails(
+            File::types(['image/png']),
+            UploadedFile::fake()->createWithContent('foo.txt', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.mimetypes']
+        );
+
+        $this->fails(
+            File::types(['image/svg']),
+            UploadedFile::fake()->createWithContent('foo.jpeg', file_get_contents(__DIR__.'/fixtures/image.svg')),
+            ['validation.mimetypes']
+        );
+    }
+
     public function testSingleMime()
     {
         $this->fails(
@@ -118,6 +133,21 @@ class ValidationFileRuleTest extends TestCase
                 UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
                 UploadedFile::fake()->createWithContent('foo.svg', file_get_contents(__DIR__.'/fixtures/image.svg')),
             ]
+        );
+    }
+
+    public function testValidMimeButInvalidExtension()
+    {
+        $this->fails(
+            File::types('png'),
+            UploadedFile::fake()->createWithContent('foo.txt', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.mimes']
+        );
+
+        $this->fails(
+            File::types('svg'),
+            UploadedFile::fake()->createWithContent('foo.jpeg', file_get_contents(__DIR__.'/fixtures/image.svg')),
+            ['validation.mimes']
         );
     }
 
@@ -178,6 +208,21 @@ class ValidationFileRuleTest extends TestCase
         $this->passes(
             File::default()->extensions(['png', 'jpeg', 'jpg']),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testFileWithValidExtensionButInvalidMimeType()
+    {
+        $this->fails(
+            File::types(['image/png'])->extensions(['png']),
+            UploadedFile::fake()->create('foo.png', 100)->mimeType('text/plain'),
+            ['validation.mimetypes']
+        );
+
+        $this->fails(
+            File::types(['application/pdf'])->extensions(['pdf']),
+            UploadedFile::fake()->create('document.pdf', 200)->mimeType('image/jpeg'),
+            ['validation.mimetypes']
         );
     }
 


### PR DESCRIPTION
Added three new test methods in `ValidationFileRuleTest` to improve coverage of MIME type and file extension validation:

`testValidMimeTypeButInvalidExtension():` Ensures files with a correct MIME type but an incorrect extension are rejected.

`testValidMimeButInvalidExtension():` Verifies that files with a valid MIME-based type rule but an incorrect extension fail validation.

`testFileWithValidExtensionButInvalidMimeType():` Ensures that files with a valid extension but an incorrect MIME type are properly rejected.

🔹 Why?
These tests enhance Laravel’s validation rules by ensuring strict enforcement of both MIME types and file extensions, preventing security risks such as MIME spoofing and incorrect file validation.

🔹 Benefits:
✅ Improved test coverage for File validation.
✅ Better protection against file type spoofing attacks.
✅ Ensures Laravel handles edge cases in file validation correctly.

🚀 Ready for review & merge! 🔥