### PR TITLE
[12.x] Types: EnumeratesValues Sum

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -535,8 +535,10 @@ trait EnumeratesValues
     /**
      * Get the sum of the given values.
      *
-     * @param  (callable(TValue): mixed)|string|null  $callback
-     * @return mixed
+     * @template TReturnType
+     *
+     * @param  (callable(TValue): TReturnType)|string|null  $callback
+     * @return ($callback is callable ? TReturnType : mixed)
      */
     public function sum($callback = null)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -873,10 +873,10 @@ assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->so
 assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
 
 assertType('mixed', $collection->make([1])->sum('string'));
-assertType('int', $collection->make(['string'])->sum(function ($string) {
+assertType('int<1, 2>', $collection->make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
-    return 1;
+    return rand(1, 2);
 }));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->take(1));

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -873,7 +873,7 @@ assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->so
 assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
 
 assertType('mixed', $collection->make([1])->sum('string'));
-assertType('mixed', $collection->make(['string'])->sum(function ($string) {
+assertType('int', $collection->make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
     return 1;

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -732,7 +732,7 @@ assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
 
 assertType('mixed', $collection->make([1])->sum('string'));
-assertType('mixed', $collection->make(['string'])->sum(function ($string) {
+assertType('int', $collection->make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
     return 1;

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -732,10 +732,10 @@ assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
 
 assertType('mixed', $collection->make([1])->sum('string'));
-assertType('int', $collection->make(['string'])->sum(function ($string) {
+assertType('int<1, 2>', $collection->make(['string'])->sum(function ($string) {
     assertType('string', $string);
 
-    return 1;
+    return rand(1, 2);
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->take(1));


### PR DESCRIPTION
Hey, this PR adds a more specific typehint to the return value of `EnumeratesValues::sum`.

```php
$amount = $transactions->sum(fn (Transaction $transaction) => $transaction->amount);

// Currently: mixed
// After PR:  float
```

After implementing, I discovered that this doesn't work when the return type is literal. For example:

```php
$amount = $transactions->sum(fn (Transaction $transaction) => 5);

// Currently: mixed
// After PR:  5
// Actual:    int
```

I don't believe this is a big deal for two reasons:
1. Passing a callable with a literal return type to `sum` doesn't feel realistic.
2. This issue already exists in `EnumeratesValues::reduce` (see below snippet)

```php
$collection->reduce(fn(int $int, Transaction $transaction, int $key) => 5, 3)

// Currently: 5
// Actual:    3|5
```

Open to other ideas, that would fix my use case without breaking this (albeit seemingly strange) other one!
