### PR TITLE
[12.x] Add `ensureNotEmpty` to `EnumeratesValues`

### DIFF
--- a/src/Illuminate/Collections/CollectionIsEmptyException.php
+++ b/src/Illuminate/Collections/CollectionIsEmptyException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Collections;
+
+use RuntimeException;
+
+class CollectionIsEmptyException extends RuntimeException
+{
+}

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -367,6 +367,28 @@ trait EnumeratesValues
     }
 
     /**
+     * Throw an exception if the collection is empty.
+     *
+     * @template TException of \Throwable
+     *
+     * @param  TException|class-string<TException>|string  $exception
+     * @param  mixed  ...$parameters
+     * @return static<TKey, TValue>
+     *
+     * @throws TException
+     */
+    public function throwIfEmpty($exception = 'UnexpectedValueException', ...$parameters)
+    {
+        return $this->whenEmpty(function () use ($exception, $parameters): never {
+            if (is_string($exception) && class_exists($exception)) {
+                $exception = new $exception(...$parameters);
+            }
+
+            throw is_string($exception) ? new UnexpectedValueException($exception) : $exception;
+        });
+    }
+
+    /**
      * Determine if the collection is not empty.
      *
      * @phpstan-assert-if-true TValue $this->first()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use ArrayObject;
 use CachingIterator;
 use Exception;
+use Illuminate\Collections\CollectionIsEmptyException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\Model;
@@ -5592,38 +5593,38 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
-    public function testThrowIfEmpty($collection)
+    public function testEnsureNotEmpty($collection)
     {
         $data = $collection::empty();
-        $this->expectException(UnexpectedValueException::class);
-        $data->throwIfEmpty();
+        $this->expectException(CollectionIsEmptyException::class);
+        $data->ensureNotEmpty();
     }
 
     #[DataProvider('collectionClassProvider')]
-    public function testThrowIfEmptyForInstanceThrowable($collection)
+    public function testEnsureNotEmptyForInstanceThrowable($collection)
     {
         $data = $collection::empty();
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Collection should be not empty.');
-        $data->throwIfEmpty(new InvalidArgumentException('Collection should be not empty.'));
+        $data->ensureNotEmpty(new InvalidArgumentException('Collection should be not empty.'));
     }
 
     #[DataProvider('collectionClassProvider')]
-    public function testThrowIfEmptyForStringThrowable($collection)
+    public function testEnsureNotEmptyForStringThrowable($collection)
     {
         $data = $collection::empty();
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Collection should be not empty.');
-        $data->throwIfEmpty('InvalidArgumentException', 'Collection should be not empty.');
+        $data->ensureNotEmpty('InvalidArgumentException', 'Collection should be not empty.');
     }
 
     #[DataProvider('collectionClassProvider')]
-    public function testThrowIfEmptyForString($collection)
+    public function testEnsureNotEmptyForString($collection)
     {
         $data = $collection::empty();
-        $this->expectException(UnexpectedValueException::class);
+        $this->expectException(CollectionIsEmptyException::class);
         $this->expectExceptionMessage('Collection should be not empty.');
-        $data->throwIfEmpty('Collection should be not empty.');
+        $data->ensureNotEmpty('Collection should be not empty.');
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5592,6 +5592,41 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testThrowIfEmpty($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(UnexpectedValueException::class);
+        $data->throwIfEmpty();
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testThrowIfEmptyForInstanceThrowable($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Collection should be not empty.');
+        $data->throwIfEmpty(new InvalidArgumentException('Collection should be not empty.'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testThrowIfEmptyForStringThrowable($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Collection should be not empty.');
+        $data->throwIfEmpty('InvalidArgumentException', 'Collection should be not empty.');
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testThrowIfEmptyForString($collection)
+    {
+        $data = $collection::empty();
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Collection should be not empty.');
+        $data->throwIfEmpty('Collection should be not empty.');
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testPercentageWithFlatCollection($collection)
     {
         $collection = new $collection([1, 1, 2, 2, 2, 3]);


### PR DESCRIPTION
This PR introduces the `ensureNotEmpty` method to `Illuminate\Support\Traits\EnumeratesValues`, allowing collections to throw an exception when empty.

Example usage:
```php
use RuntimeException;

collect($data)->ensureNotEmpty(); // this will throw CollectionIsEmptyException

collect($data)->ensureNotEmpty(new RuntimeException('Collection cannot be empty.')); // this will throw RuntimeException

collect($data)->ensureNotEmpty('RuntimeException', 'Collection cannot be empty.') // this will throw RuntimeException

collect($data)->ensureNotEmpty('Collection cannot be empty.') // this will throw CollectionIsEmptyException
```