### PR TITLE
Add validation test for forEach with null and empty array values

### DIFF
--- a/tests/Validation/ValidationForEachTest.php
+++ b/tests/Validation/ValidationForEachTest.php
@@ -319,6 +319,37 @@ class ValidationForEachTest extends TestCase
         ], $v->getMessageBag()->toArray());
     }
 
+    public function testForEachWithEmptyAndNullValues()
+    {
+        $data = [
+            'items' => [
+                ['discounts' => null],
+                ['discounts' => []],
+                ['discounts' => [null]],
+            ],
+        ];
+
+        $rules = [
+            'items.*' => Rule::forEach(function () {
+                return [
+                    'discounts' => 'required|array',
+                    'discounts.*' => 'required|array',
+                ];
+            }),
+        ];
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), $data, $rules);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(
+            [
+                'items.0.discounts' => ['validation.required'],
+                'items.1.discounts' => ['validation.required'],
+                'items.2.discounts.0' => ['validation.required'],
+            ],
+            $v->getMessageBag()->toArray()
+        );
+    }
+
     public function getIlluminateArrayTranslator()
     {
         return new Translator(


### PR DESCRIPTION
Ensures the field is required and must be a valid array.

Validates three cases:
- Field being null.
- Field as an empty array ([]).
- Field containing null values.
- Improves validation consistency for missing or empty array inputs.