### PR TITLE
[12.x] Remove Unused `Response` Import from Policy Stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,7 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Auth\Access\Response;
 use {{ namespacedModel }};
 use {{ namespacedUserModel }};
 


### PR DESCRIPTION
**Description:**
The `Illuminate\Auth\Access\Response` class is currently imported in the default policy stub but is not used in the generated policy. Laravel `Pint` automatically removes unused imports, making this unnecessary.

This PR removes the import from the stub to keep the generated code cleaner and aligned with Laravel's coding standards.

This change ensures that newly generated policies do not include unnecessary imports while keeping the option open for developers to use `Illuminate\Auth\Access\Response` if needed.