### PR TITLE
[12.x] Fixes how the fluent Date rule builder handles `date_format`

### DIFF
--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -13,7 +13,7 @@ class Date implements Stringable
     use Conditionable, Macroable;
 
     /**
-     * The format for the date rule.
+     * The format of the date.
      */
     protected ?string $format = null;
 

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -13,16 +13,23 @@ class Date implements Stringable
     use Conditionable, Macroable;
 
     /**
+     * The format for the date rule.
+     */
+    protected ?string $format = null;
+
+    /**
      * The constraints for the date rule.
      */
-    protected array $constraints = ['date'];
+    protected array $constraints = [];
 
     /**
      * Ensure the date has the given format.
      */
     public function format(string $format): static
     {
-        return $this->addRule('date_format:'.$format);
+        $this->format = $format;
+        
+        return $this;
     }
 
     /**
@@ -121,7 +128,7 @@ class Date implements Stringable
     protected function formatDate(DateTimeInterface|string $date): string
     {
         return $date instanceof DateTimeInterface
-            ? $date->format('Y-m-d')
+            ? $date->format($this->format ?? 'Y-m-d')
             : $date;
     }
 
@@ -130,6 +137,9 @@ class Date implements Stringable
      */
     public function __toString(): string
     {
-        return implode('|', $this->constraints);
+        return implode('|', [
+            $this->format === null ? 'date' : 'date_format:'.$this->format,
+            ...$this->constraints,
+        ]);
     }
 }

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -28,7 +28,7 @@ class Date implements Stringable
     public function format(string $format): static
     {
         $this->format = $format;
-        
+
         return $this;
     }
 

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -49,30 +49,45 @@ class ValidationDateRuleTest extends TestCase
     {
         $rule = Rule::date()->after(Carbon::parse('2024-01-01'));
         $this->assertEquals('date|after:2024-01-01', (string) $rule);
+
+        $rule = Rule::date()->format('d/m/Y')->after(Carbon::parse('2024-01-01'));
+        $this->assertEquals('date_format:d/m/Y|after:01/01/2024', (string) $rule);
     }
 
     public function testBeforeSpecificDateRule()
     {
         $rule = Rule::date()->before(Carbon::parse('2024-01-01'));
         $this->assertEquals('date|before:2024-01-01', (string) $rule);
+
+        $rule = Rule::date()->format('d/m/Y')->before(Carbon::parse('2024-01-01'));
+        $this->assertEquals('date_format:d/m/Y|before:01/01/2024', (string) $rule);
     }
 
     public function testAfterOrEqualSpecificDateRule()
     {
         $rule = Rule::date()->afterOrEqual(Carbon::parse('2024-01-01'));
         $this->assertEquals('date|after_or_equal:2024-01-01', (string) $rule);
+
+        $rule = Rule::date()->format('d/m/Y')->afterOrEqual(Carbon::parse('2024-01-01'));
+        $this->assertEquals('date_format:d/m/Y|after_or_equal:01/01/2024', (string) $rule);
     }
 
     public function testBeforeOrEqualSpecificDateRule()
     {
         $rule = Rule::date()->beforeOrEqual(Carbon::parse('2024-01-01'));
         $this->assertEquals('date|before_or_equal:2024-01-01', (string) $rule);
+
+        $rule = Rule::date()->format('d/m/Y')->beforeOrEqual(Carbon::parse('2024-01-01'));
+        $this->assertEquals('date_format:d/m/Y|before_or_equal:01/01/2024', (string) $rule);
     }
 
     public function testBetweenDatesRule()
     {
         $rule = Rule::date()->between(Carbon::parse('2024-01-01'), Carbon::parse('2024-02-01'));
         $this->assertEquals('date|after:2024-01-01|before:2024-02-01', (string) $rule);
+
+        $rule = Rule::date()->format('d/m/Y')->between(Carbon::parse('2024-01-01'), Carbon::parse('2024-02-01'));
+        $this->assertEquals('date_format:d/m/Y|after:01/01/2024|before:01/02/2024', (string) $rule);
     }
 
     public function testBetweenOrEqualDatesRule()

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -24,7 +24,7 @@ class ValidationDateRuleTest extends TestCase
     public function testDateFormatRule()
     {
         $rule = Rule::date()->format('d/m/Y');
-        $this->assertEquals('date|date_format:d/m/Y', (string) $rule);
+        $this->assertEquals('date_format:d/m/Y', (string) $rule);
     }
 
     public function testAfterTodayRule()
@@ -87,7 +87,7 @@ class ValidationDateRuleTest extends TestCase
             ->format('Y-m-d')
             ->after('2024-01-01 00:00:00')
             ->before('2025-01-01 00:00:00');
-        $this->assertEquals('date|date_format:Y-m-d|after:2024-01-01 00:00:00|before:2025-01-01 00:00:00', (string) $rule);
+        $this->assertEquals('date_format:Y-m-d|after:2024-01-01 00:00:00|before:2025-01-01 00:00:00', (string) $rule);
 
         $rule = Rule::date()
             ->format('Y-m-d')
@@ -97,7 +97,7 @@ class ValidationDateRuleTest extends TestCase
             ->unless(true, function ($rule) {
                 $rule->before('2025-01-01');
             });
-        $this->assertSame('date|date_format:Y-m-d|after:2024-01-01', (string) $rule);
+        $this->assertSame('date_format:Y-m-d|after:2024-01-01', (string) $rule);
     }
 
     public function testDateValidation()

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -398,7 +398,7 @@ class ValidationRuleParserTest extends TestCase
         ]));
 
         $rules = [
-            'date' => Rule::date()->format('Y-m-d'),
+            'date' => Rule::date()->after('today'),
         ];
 
         $results = $parser->explode($rules);
@@ -406,7 +406,7 @@ class ValidationRuleParserTest extends TestCase
         $this->assertEquals([
             'date' => [
                 'date',
-                'date_format:Y-m-d',
+                'after:today',
             ],
         ], $results->rules);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Why
As brought up and potentially fixed in draft PR #55033, calling `Rule::date()->format('"d F, Y"')` makes the following rule: `date|date_format:"d F, Y"`, which fails due to the conflict between `date` and `date_format`:
```php
$validator = Validator::make([
    'start' => now()->format('d F, Y'),
], [
    'start' => Rule::date()->format('"d F, Y"')
]);

$validator->passes(); // false
```
The Laravel documentation for [`date_format`](https://laravel.com/docs/12.x/validation#rule-date-format) says not to use both `date` and `date_format`, but the fluent rule builder always includes the initial `date` rule.

## What
This PR is different from #55033 in that it does not use `array_shift` to remove `date` from the `$constraints` property, but uses a new property to store the format and determines whether to use `date` or `date_format` depending on the state of this property (`$this->format === null ? 'date' : 'date_format:'.$this->format`).

This PR also takes the solution a bit further and allows for this format property to be used in the `formatDate` method of the rule builder. This will allow fluent methods like `after` and `before` to use this format instead of the hard-coded `Y-m-d` format.

Example:
```php
// Normal
$validator = Validator::make([
    'start' => now()->format('Y-m-d\TH:i:s'),
], [
    'start' => 'date_format:"Y-m-d\TH:i:s"|before:'.now()->addHour()->format('Y-m-d\TH:i:s'),
]);

$validator->passes(); // true

// Rule::date() without this PR
$validator = Validator::make([
    'start' => now()->format('Y-m-d\TH:i:s'),
], [
    'start' => Rule::date()->format('"Y-m-d\TH:i:s"')->before(now()->addHour()),
    // Assuming the issue with `date` is resolved,
    // this would be: date_format:"Y-m-d\TH:i:s"|before:2025-03-17
]);

$validator->passes(); // false
```

By using the date format passed in from `format` for `formatDate`, it would resolve this issue.

Now:
```php
(string) Rule::date()->format('"Y-m-d\TH:i:s"')->before(now()->addHour())
// date|date_format:"Y-m-d\TH:i:s"|before:2025-03-17
```

PR #55033 or this PR without the fix to `formatDate`:
```php
(string) Rule::date()->format('"Y-m-d\TH:i:s"')->before(now()->addHour())
// date_format:"Y-m-d\TH:i:s"|before:2025-03-17
```

This PR:
```php
(string) Rule::date()->format('"Y-m-d\TH:i:s"')->before(now()->addHour())
// date_format:"Y-m-d\TH:i:s"|before:"2025-03-17T16:58:15"
```

I proposed these changes in the original PR, but since it was drafted due to `array_shift`, I decided to make a new PR.

Thanks to @oli-laban for the initial PR and the work on the tests.