### PR TITLE
[12.x] remove progress bar from PHPStan output

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,4 +40,4 @@ jobs:
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
       - name: Execute type checking
-        run: vendor/bin/phpstan --configuration="phpstan.${{ matrix.directory }}.neon.dist --no-progress"
+        run: vendor/bin/phpstan --configuration="phpstan.${{ matrix.directory }}.neon.dist" --no-progress

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,4 +40,4 @@ jobs:
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
       - name: Execute type checking
-        run: vendor/bin/phpstan --configuration="phpstan.${{ matrix.directory }}.neon.dist"
+        run: vendor/bin/phpstan --configuration="phpstan.${{ matrix.directory }}.neon.dist --no-progress"


### PR DESCRIPTION
the progress bar is unnecessary when running in a pipeline and just clutters things up.

the same as we do for composer installs and updates

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
