### PR TITLE
[12.x] standardize multiline ternaries

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -75,7 +75,8 @@ class BroadcastEvent implements ShouldQueue
     public function handle(BroadcastingFactory $manager)
     {
         $name = method_exists($this->event, 'broadcastAs')
-            ? $this->event->broadcastAs() : get_class($this->event);
+            ? $this->event->broadcastAs()
+            : get_class($this->event);
 
         $channels = Arr::wrap($this->event->broadcastOn());
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -821,8 +821,9 @@ trait HasRelationships
         // sorted alphabetically and concatenated with an underscore, so we can
         // just sort the models and join them together to get the table name.
         $segments = [
-            $instance ? $instance->joiningTableSegment()
-                      : Str::snake(class_basename($related)),
+            $instance
+                ? $instance->joiningTableSegment()
+                : Str::snake(class_basename($related)),
             $this->joiningTableSegment(),
         ];
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1095,7 +1095,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             // us to recurse into all of these nested relations for the model instance.
             foreach ($this->relations as $models) {
                 $models = $models instanceof Collection
-                    ? $models->all() : [$models];
+                    ? $models->all()
+                    : [$models];
 
                 foreach (array_filter($models) as $model) {
                     if (! $model->push()) {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -157,8 +157,9 @@ class MorphToMany extends BelongsToMany
 
         $attributes = array_merge([$this->morphType => $this->morphClass], $attributes);
 
-        $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
-                        : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
+        $pivot = $using
+            ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
+            : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
 
         $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
             ->setRelatedModel($this->related)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3306,7 +3306,8 @@ class Builder implements BuilderContract
     {
         return array_map(function ($column) {
             return is_string($column) && ($aliasPosition = stripos($column, ' as ')) !== false
-                ? substr($column, 0, $aliasPosition) : $column;
+                ? substr($column, 0, $aliasPosition)
+                : $column;
         }, $columns);
     }
 
@@ -3634,7 +3635,8 @@ class Builder implements BuilderContract
         // cast it to one. When it does we will cast it to a float since it needs to be
         // cast to the expected data type for the developers out of pure convenience.
         return ! str_contains((string) $result, '.')
-            ? (int) $result : (float) $result;
+            ? (int) $result
+            : (float) $result;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/BlueprintState.php
+++ b/src/Illuminate/Database/Schema/BlueprintState.php
@@ -77,9 +77,11 @@ class BlueprintState
             'collation' => $column['collation'],
             'comment' => $column['comment'],
             'virtualAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'virtual'
-                ? $column['generation']['expression'] : null,
+                ? $column['generation']['expression']
+                : null,
             'storedAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'stored'
-                ? $column['generation']['expression'] : null,
+                ? $column['generation']['expression']
+                : null,
         ]))->all();
 
         [$primary, $indexes] = (new Collection($schema->getIndexes($table)))->map(fn ($index) => new IndexDefinition([

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -381,9 +381,11 @@ class MySqlGrammar extends Grammar
             'collation' => $column['collation'],
             'comment' => $column['comment'],
             'virtualAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'virtual'
-                ? $column['generation']['expression'] : null,
+                ? $column['generation']['expression']
+                : null,
             'storedAs' => ! is_null($column['generation']) && $column['generation']['type'] === 'stored'
-                ? $column['generation']['expression'] : null,
+                ? $column['generation']['expression']
+                : null,
         ]));
 
         return sprintf('alter table %s change %s %s %s',

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -344,7 +344,8 @@ class Dispatcher implements DispatcherContract
     protected function broadcastWhen($event)
     {
         return method_exists($event, 'broadcastWhen')
-            ? $event->broadcastWhen() : true;
+            ? $event->broadcastWhen()
+            : true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -141,7 +141,8 @@ trait DatabaseTruncation
     protected function connectionsToTruncate(): array
     {
         return property_exists($this, 'connectionsToTruncate')
-            ? $this->connectionsToTruncate : [null];
+            ? $this->connectionsToTruncate
+            : [null];
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -792,7 +792,8 @@ class Route
     public function getDomain()
     {
         return isset($this->action['domain'])
-            ? str_replace(['http://', 'https://'], '', $this->action['domain']) : null;
+            ? str_replace(['http://', 'https://'], '', $this->action['domain'])
+            : null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -164,7 +164,8 @@ class RouteUrlGenerator
         $port = (int) $this->request->getPort();
 
         return ($secure && $port === 443) || (! $secure && $port === 80)
-            ? $domain : $domain.':'.$port;
+            ? $domain
+            : $domain.':'.$port;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -630,7 +630,8 @@ class Router implements BindingRegistrar, RegistrarContract
         $group = end($this->groupStack);
 
         return isset($group['namespace']) && ! str_starts_with($class, '\\') && ! str_starts_with($class, $group['namespace'])
-            ? $group['namespace'].'\\'.$class : $class;
+            ? $group['namespace'].'\\'.$class
+            : $class;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -267,7 +267,8 @@ trait FormatsMessages
         $primaryAttribute = $this->getPrimaryAttribute($attribute);
 
         $expectedAttributes = $attribute != $primaryAttribute
-            ? [$attribute, $primaryAttribute] : [$attribute];
+            ? [$attribute, $primaryAttribute]
+            : [$attribute];
 
         foreach ($expectedAttributes as $name) {
             // The developer may dynamically specify the array of custom attributes on this

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1119,7 +1119,8 @@ trait ValidatesAttributes
     public function getQueryColumn($parameters, $attribute)
     {
         return isset($parameters[1]) && $parameters[1] !== 'NULL'
-            ? $parameters[1] : $this->guessColumnForQuery($attribute);
+            ? $parameters[1]
+            : $this->guessColumnForQuery($attribute);
     }
 
     /**


### PR DESCRIPTION
if either the truthy or falsy expression is on a newline, make them both on a new line, and indent exactly once.

I don't think we have to go so far as to say ALL ternaries need to be multi-line, but I would say if one expression is, they both should be.

will make for easy readability and better diffs.

unable to found an automation rule for this yet, but will keep looking.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
