### PR TITLE
Ensure queue property is nullable

### DIFF
--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -8,7 +8,7 @@ class JobQueued
      * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
-     * @param  string  $queue  The queue name.
+     * @param  string|null  $queue  The queue name.
      * @param  string|int|null  $id  The job ID.
      * @param  \Closure|string|object  $job  The job instance.
      * @param  string  $payload  The job payload.

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -8,7 +8,7 @@ class JobQueueing
      * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
-     * @param  string  $queue  The queue name.
+     * @param  string|null  $queue  The queue name.
      * @param  \Closure|string|object  $job  The job instance.
      * @param  string  $payload  The job payload.
      * @param  int|null  $delay  The number of seconds the job was delayed.

--- a/types/Queue/Events/JobQueued.php
+++ b/types/Queue/Events/JobQueued.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Queue\Events\JobQueued;
+
+use function PHPStan\Testing\assertType;
+
+$instance = new JobQueued(
+    connectionName: 'connection',
+    queue: null,
+    id: 'id',
+    job: fn () => null,
+    payload: '{}',
+    delay: null,
+);
+
+/**
+ * @see testQueueMayBeNullForJobQueueingAndJobQueuedEvent
+ */
+assertType('string|null', $instance->queue);

--- a/types/Queue/Events/JobQueueing.php
+++ b/types/Queue/Events/JobQueueing.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Queue\Events\JobQueueing;
+
+use function PHPStan\Testing\assertType;
+
+$instance = new JobQueueing(
+    connectionName: 'connection',
+    queue: null,
+    job: fn () => null,
+    payload: '{}',
+    delay: null,
+);
+
+/**
+ * @see testQueueMayBeNullForJobQueueingAndJobQueuedEvent
+ */
+assertType('string|null', $instance->queue);


### PR DESCRIPTION
Type information originally introduced in https://github.com/laravel/framework/pull/51912 and lost in https://github.com/laravel/framework/pull/53855.

Includes **runtime** and **static analysis** tests to ensure we don't revert this again 🧘 