### PR TITLE
[12.x] return `$this` for chaining

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -994,6 +994,8 @@ class TestResponse implements ArrayAccess
         $unexpectedErrorKeys = Arr::except($jsonErrors, $expectedErrorKeys);
 
         PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: '.collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
looks like a small oversight from #54678 of which part of it was caught in #54941

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
