### PR TITLE
[12.x] multiline chaining on Collections

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -141,11 +141,11 @@ abstract class Broadcaster implements BroadcasterContract
     {
         $callbackParameters = $this->extractParameters($callback);
 
-        return (new Collection($this->extractChannelKeys($pattern, $channel)))->reject(function ($value, $key) {
-            return is_numeric($key);
-        })->map(function ($value, $key) use ($callbackParameters) {
-            return $this->resolveBinding($key, $value, $callbackParameters);
-        })->values()->all();
+        return (new Collection($this->extractChannelKeys($pattern, $channel)))
+            ->reject(fn ($value, $key) => is_numeric($key))
+            ->map(fn ($value, $key) => $this->resolveBinding($key, $value, $callbackParameters))
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -142,9 +142,11 @@ class Repository implements ArrayAccess, CacheContract
     {
         $this->event(new RetrievingManyKeys($this->getName(), $keys));
 
-        $values = $this->store->many((new Collection($keys))->map(function ($value, $key) {
-            return is_string($key) ? $key : $value;
-        })->values()->all());
+        $values = $this->store->many((new Collection($keys))
+            ->map(fn ($value, $key) => is_string($key) ? $key : $value)
+            ->values()
+            ->all()
+        );
 
         return (new Collection($values))
             ->map(fn ($value, $key) => $this->handleManyResult($keys, $key, $value))

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -138,15 +138,11 @@ class PruneCommand extends Command
                     ['\\', ''],
                     Str::after($model->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
                 );
-            })->when(! empty($except), function ($models) use ($except) {
-                return $models->reject(function ($model) use ($except) {
-                    return in_array($model, $except);
-                });
-            })->filter(function ($model) {
-                return class_exists($model);
-            })->filter(function ($model) {
-                return $this->isPrunable($model);
-            })->values();
+            })
+            ->when(! empty($except), fn ($models) => $models->reject(fn ($model) => in_array($model, $except)))
+            ->filter(fn ($model) => class_exists($model))
+            ->filter(fn ($model) => $this->isPrunable($model))
+            ->values();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2850,11 +2850,9 @@ class Builder implements BuilderContract
     protected function removeExistingOrdersFor($column)
     {
         return (new Collection($this->orders))
-            ->reject(function ($order) use ($column) {
-                return isset($order['column'])
-                    ? $order['column'] === $column
-                    : false;
-            })->values()->all();
+            ->reject(fn ($order) => isset($order['column']) && $order['column'] === $column)
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -114,9 +114,10 @@ class RouteListCommand extends Command
      */
     protected function getRoutes()
     {
-        $routes = (new Collection($this->router->getRoutes()))->map(function ($route) {
-            return $this->getRouteInformation($route);
-        })->filter()->all();
+        $routes = (new Collection($this->router->getRoutes()))
+            ->map(fn ($route) => $this->getRouteInformation($route))
+            ->filter()
+            ->all();
 
         if (($sort = $this->option('sort')) !== null) {
             $routes = $this->sortRoutes($sort, $routes);
@@ -208,9 +209,9 @@ class RouteListCommand extends Command
      */
     protected function getMiddleware($route)
     {
-        return (new Collection($this->router->gatherRouteMiddleware($route)))->map(function ($middleware) {
-            return $middleware instanceof Closure ? 'Closure' : $middleware;
-        })->implode("\n");
+        return (new Collection($this->router->gatherRouteMiddleware($route)))
+            ->map(fn ($middleware) => $middleware instanceof Closure ? 'Closure' : $middleware)
+            ->implode("\n");
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -483,10 +483,14 @@ class Handler implements ExceptionHandlerContract
         $exceptions = Arr::wrap($exceptions);
 
         $this->dontReport = (new Collection($this->dontReport))
-            ->reject(fn ($ignored) => in_array($ignored, $exceptions))->values()->all();
+            ->reject(fn ($ignored) => in_array($ignored, $exceptions))
+            ->values()
+            ->all();
 
         $this->internalDontReport = (new Collection($this->internalDontReport))
-            ->reject(fn ($ignored) => in_array($ignored, $exceptions))->values()->all();
+            ->reject(fn ($ignored) => in_array($ignored, $exceptions))
+            ->values()
+            ->all();
 
         return $this;
     }

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -88,9 +88,10 @@ class PackageManifest
      */
     public function config($key)
     {
-        return (new Collection($this->getManifest()))->flatMap(function ($configuration) use ($key) {
-            return (array) ($configuration[$key] ?? []);
-        })->filter()->all();
+        return (new Collection($this->getManifest()))
+            ->flatMap(fn ($configuration) => (array) ($configuration[$key] ?? []))
+            ->filter()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -991,13 +991,15 @@ class PendingRequest
             $options[$this->bodyFormat] = $this->pendingBody;
         }
 
-        return (new Collection($options))->map(function ($value, $key) {
-            if ($key === 'json' && $value instanceof JsonSerializable) {
-                return $value;
-            }
+        return (new Collection($options))
+            ->map(function ($value, $key) {
+                if ($key === 'json' && $value instanceof JsonSerializable) {
+                    return $value;
+                }
 
-            return $value instanceof Arrayable ? $value->toArray() : $value;
-        })->all();
+                return $value instanceof Arrayable ? $value->toArray() : $value;
+            })
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -263,11 +263,13 @@ class MailChannel
             $recipients = [$recipients];
         }
 
-        return (new Collection($recipients))->mapWithKeys(function ($recipient, $email) {
-            return is_numeric($email)
-                ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
-                : [$email => $recipient];
-        })->all();
+        return (new Collection($recipients))
+            ->mapWithKeys(function ($recipient, $email) {
+                return is_numeric($email)
+                    ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
+                    : [$email => $recipient];
+            })
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -372,9 +372,10 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     protected function parseAddresses($value)
     {
-        return (new Collection($value))->map(function ($address, $name) {
-            return [$address, is_numeric($name) ? null : $name];
-        })->values()->all();
+        return (new Collection($value))
+            ->map(fn ($address, $name) => [$address, is_numeric($name) ? null : $name])
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Process/FakeProcessDescription.php
@@ -94,9 +94,10 @@ class FakeProcessDescription
      */
     public function replaceOutput(string $output)
     {
-        $this->output = (new Collection($this->output))->reject(function ($output) {
-            return $output['type'] === 'out';
-        })->values()->all();
+        $this->output = (new Collection($this->output))
+            ->reject(fn ($output) => $output['type'] === 'out')
+            ->values()
+            ->all();
 
         if (strlen($output) > 0) {
             $this->output[] = [
@@ -116,9 +117,10 @@ class FakeProcessDescription
      */
     public function replaceErrorOutput(string $output)
     {
-        $this->output = (new Collection($this->output))->reject(function ($output) {
-            return $output['type'] === 'err';
-        })->values()->all();
+        $this->output = (new Collection($this->output))
+            ->reject(fn ($output) => $output['type'] === 'err')
+            ->values()
+            ->all();
 
         if (strlen($output) > 0) {
             $this->output[] = [

--- a/src/Illuminate/Process/Pool.php
+++ b/src/Illuminate/Process/Pool.php
@@ -74,7 +74,8 @@ class Pool
                     if (! $pendingProcess instanceof PendingProcess) {
                         throw new InvalidArgumentException('Process pool must only contain pending processes.');
                     }
-                })->mapWithKeys(function ($pendingProcess, $key) use ($output) {
+                })
+                ->mapWithKeys(function ($pendingProcess, $key) use ($output) {
                     return [$key => $pendingProcess->start(output: $output ? function ($type, $buffer) use ($key, $output) {
                         $output($type, $buffer, $key);
                     } : null)];

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -155,9 +155,11 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
         return $this->lock(function () use ($before) {
             $jobs = $this->read();
 
-            $this->write($prunedJobs = (new Collection($jobs))->reject(function ($job) use ($before) {
-                return $job->failed_at_timestamp <= $before->getTimestamp();
-            })->values()->all());
+            $this->write($prunedJobs = (new Collection($jobs))
+                ->reject(fn ($job) => $job->failed_at_timestamp <= $before->getTimestamp())
+                ->values()
+                ->all()
+            );
 
             return count($jobs) - count($prunedJobs);
         });

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1139,15 +1139,22 @@ class Route
      */
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
     {
-        return (new Collection($class::middleware()))->map(function ($middleware) {
-            return $middleware instanceof Middleware
-                ? $middleware
-                : new Middleware($middleware);
-        })->reject(function ($middleware) use ($method) {
-            return static::methodExcludedByOptions(
-                $method, ['only' => $middleware->only, 'except' => $middleware->except]
-            );
-        })->map->middleware->flatten()->values()->all();
+        return (new Collection($class::middleware()))
+            ->map(function ($middleware) {
+                return $middleware instanceof Middleware
+                    ? $middleware
+                    : new Middleware($middleware);
+            })
+            ->reject(function ($middleware) use ($method) {
+                return static::methodExcludedByOptions(
+                    $method, ['only' => $middleware->only, 'except' => $middleware->except],
+                );
+            })
+            ->map
+            ->middleware
+            ->flatten()
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -830,9 +830,13 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function resolveMiddleware(array $middleware, array $excluded = [])
     {
-        $excluded = $excluded === [] ? $excluded : (new Collection($excluded))->map(function ($name) {
-            return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
-        })->flatten()->values()->all();
+        $excluded = $excluded === []
+            ? $excluded
+            : (new Collection($excluded))
+                ->map(fn ($name) => (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups))
+                ->flatten()
+                ->values()
+                ->all();
 
         $middleware = (new Collection($middleware))->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1051,8 +1051,10 @@ class Str
                 ']', '|', ':', ';',
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
-        ]))->filter()->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
-        )->flatten();
+        ]))
+            ->filter()
+            ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
+            ->flatten();
 
         $length = $length - $password->count();
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -379,9 +379,10 @@ class QueueFake extends QueueManager implements Fake, Queue
      */
     public function size($queue = null)
     {
-        return (new Collection($this->jobs))->flatten(1)->filter(
-            fn ($job) => $job['queue'] === $queue
-        )->count();
+        return (new Collection($this->jobs))
+            ->flatten(1)
+            ->filter(fn ($job) => $job['queue'] === $queue)
+            ->count();
     }
 
     /**

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -338,9 +338,10 @@ trait InteractsWithData
             return [];
         }
 
-        return $this->collect($key)->map(function ($value) use ($enumClass) {
-            return $enumClass::tryFrom($value);
-        })->filter()->all();
+        return $this->collect($key)
+            ->map(fn ($value) => $enumClass::tryFrom($value))
+            ->filter()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Support/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Support/Traits/ReflectsClosures.php
@@ -47,13 +47,17 @@ trait ReflectsClosures
     {
         $reflection = new ReflectionFunction($closure);
 
-        $types = (new Collection($reflection->getParameters()))->mapWithKeys(function ($parameter) {
-            if ($parameter->isVariadic()) {
-                return [$parameter->getName() => null];
-            }
+        $types = (new Collection($reflection->getParameters()))
+            ->mapWithKeys(function ($parameter) {
+                if ($parameter->isVariadic()) {
+                    return [$parameter->getName() => null];
+                }
 
-            return [$parameter->getName() => Reflector::getParameterClassNames($parameter)];
-        })->filter()->values()->all();
+                return [$parameter->getName() => Reflector::getParameterClassNames($parameter)];
+            })
+            ->filter()
+            ->values()
+            ->all();
 
         if (empty($types)) {
             throw new RuntimeException('The given Closure has no parameters.');
@@ -78,12 +82,14 @@ trait ReflectsClosures
     {
         $reflection = new ReflectionFunction($closure);
 
-        return (new Collection($reflection->getParameters()))->mapWithKeys(function ($parameter) {
-            if ($parameter->isVariadic()) {
-                return [$parameter->getName() => null];
-            }
+        return (new Collection($reflection->getParameters()))
+            ->mapWithKeys(function ($parameter) {
+                if ($parameter->isVariadic()) {
+                    return [$parameter->getName() => null];
+                }
 
-            return [$parameter->getName() => Reflector::getParameterClassName($parameter)];
-        })->all();
+                return [$parameter->getName() => Reflector::getParameterClassName($parameter)];
+            })
+            ->all();
     }
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1042,9 +1042,11 @@ class Validator implements ValidatorContract
      */
     protected function attributesThatHaveMessages()
     {
-        return (new Collection($this->messages()->toArray()))->map(function ($message, $key) {
-            return explode('.', $key)[0];
-        })->unique()->flip()->all();
+        return (new Collection($this->messages()->toArray()))
+            ->map(fn ($message, $key) => explode('.', $key)[0])
+            ->unique()
+            ->flip()
+            ->all();
     }
 
     /**
@@ -1217,9 +1219,11 @@ class Validator implements ValidatorContract
      */
     public function setRules(array $rules)
     {
-        $rules = (new Collection($rules))->mapWithKeys(function ($value, $key) {
-            return [str_replace('\.', '__dot__'.static::$placeholderHash, $key) => $value];
-        })->toArray();
+        $rules = (new Collection($rules))
+            ->mapWithKeys(function ($value, $key) {
+                return [str_replace('\.', '__dot__' . static::$placeholderHash, $key) => $value];
+            })
+            ->toArray();
 
         $this->initialRules = $rules;
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1221,7 +1221,7 @@ class Validator implements ValidatorContract
     {
         $rules = (new Collection($rules))
             ->mapWithKeys(function ($value, $key) {
-                return [str_replace('\.', '__dot__' . static::$placeholderHash, $key) => $value];
+                return [str_replace('\.', '__dot__'.static::$placeholderHash, $key) => $value];
             })
             ->toArray();
 


### PR DESCRIPTION
when chaining methods or properties on a `Collection`, place them on a newline for easier readability and clearer diffs. also use short closures for simple bodies.

this is a continuation of some of my previous formatting commits.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
