### PR TITLE
[12.x] `QueueFake::listenersPushed()`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -354,7 +354,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * Get all of the jobs by listener class, passing an optional truth-test callback.
      *
      * @param  class-string  $listenerClass
-     * @param  (\Closure(\Illuminate\Events\CallQueuedListener, string|null, mixed): bool)|null  $callback
+     * @param  (\Closure(mixed, \Illuminate\Events\CallQueuedListener, string|null, mixed): bool)|null  $callback
      * @return \Illuminate\Support\Collection<int, \Illuminate\Events\CallQueuedListener>
      */
     public function listenersPushed($listenerClass, $callback = null)
@@ -367,7 +367,7 @@ class QueueFake extends QueueManager implements Fake, Queue
             ->filter(fn ($data) => $data['job']->class === $listenerClass);
 
         if ($callback) {
-            $collection = $collection->filter(fn ($data) => $callback($data['job'], $data['queue'], $data['data']));
+            $collection = $collection->filter(fn ($data) => $callback($data['job']->data[0] ?? null, $data['job'], $data['queue'], $data['data']));
         }
 
         return $collection->pluck('job');

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Testing\Fakes;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Collection;
@@ -347,6 +348,29 @@ class QueueFake extends QueueManager implements Fake, Queue
         $callback ??= static fn () => true;
 
         return (new Collection($this->rawPushes))->filter(fn ($data) => $callback($data['payload'], $data['queue'], $data['options']));
+    }
+
+    /**
+     * Get all of the jobs by listener class, passing an optional truth-test callback.
+     *
+     * @param  class-string  $listenerClass
+     * @param  (\Closure(CallQueuedListener, string|null, mixed): bool)|null  $callback
+     * @return \Illuminate\Support\Collection<int, object>
+     */
+    public function listenersPushed($listenerClass, $callback = null)
+    {
+        if (! $this->hasPushed(CallQueuedListener::class)) {
+            return new Collection;
+        }
+
+        $collection = (new Collection($this->jobs[CallQueuedListener::class]))
+            ->filter(fn ($data) => $data['job']->class === $listenerClass);
+
+        if ($callback) {
+            $collection = $collection->filter(fn ($data) => $callback($data['job'], $data['queue'], $data['data']));
+        }
+
+        return $collection->pluck('job');
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -354,8 +354,8 @@ class QueueFake extends QueueManager implements Fake, Queue
      * Get all of the jobs by listener class, passing an optional truth-test callback.
      *
      * @param  class-string  $listenerClass
-     * @param  (\Closure(CallQueuedListener, string|null, mixed): bool)|null  $callback
-     * @return \Illuminate\Support\Collection<int, object>
+     * @param  (\Closure(\Illuminate\Events\CallQueuedListener, string|null, mixed): bool)|null  $callback
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Events\CallQueuedListener>
      */
     public function listenersPushed($listenerClass, $callback = null)
     {

--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -25,9 +25,19 @@ class QueuedListenersTest extends TestCase
             return $job->class == QueuedListenersTestListenerShouldQueue::class;
         });
 
+        $this->assertCount(1, Queue::listenersPushed(QueuedListenersTestListenerShouldQueue::class));
+        $this->assertCount(
+            0,
+            Queue::listenersPushed(
+                QueuedListenersTestListenerShouldQueue::class,
+                fn ($handler, $queue, $data) => $queue === 'not-a-real-queue'
+            )
+        );
+
         Queue::assertNotPushed(CallQueuedListener::class, function ($job) {
             return $job->class == QueuedListenersTestListenerShouldNotQueue::class;
         });
+        $this->assertCount(0, Queue::listenersPushed(QueuedListenersTestListenerShouldNotQueue::class));
     }
 }
 

--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -30,7 +30,14 @@ class QueuedListenersTest extends TestCase
             0,
             Queue::listenersPushed(
                 QueuedListenersTestListenerShouldQueue::class,
-                fn ($handler, $queue, $data) => $queue === 'not-a-real-queue'
+                fn ($event, $handler, $queue, $data) => $queue === 'not-a-real-queue'
+            )
+        );
+        $this->assertCount(
+            1,
+            Queue::listenersPushed(
+                QueuedListenersTestListenerShouldQueue::class,
+                fn (QueuedListenersTestEvent $event) => $event->value === 100
             )
         );
 
@@ -43,7 +50,7 @@ class QueuedListenersTest extends TestCase
 
 class QueuedListenersTestEvent
 {
-    //
+    public int $value = 100;
 }
 
 class QueuedListenersTestListenerShouldQueue implements ShouldQueue


### PR DESCRIPTION
It's a bit unwieldy to test queued listeners. I imagine most people went through the process I did today.

1. Try to write a test to check if a listener was queued by checking if the listener was pushed to the queue
2. Test fails... debug code to make sure it's being called
3. `dd(Queue::pushedJobs())`
4. ooooh, it's inside of a CallQueuedListener class.
5. Write another test that fails
6. Inspect the CallQueuedListener class and see that the event is under the `data` property, and that property is an array

The hope here is that this makes it a little bit easier for the next person.

```php
Queue::fake();
event(new SomeEvent(value: 'look, a value!'));

$this->assertCount(
    1,
    Queue::listenersPushed(
        SomeEventListener::class,
        fn (SomeEvent $event) => $event->value === 'look, a value!'
    )
);
```

Note that this is slightly different than the `*pushed` methods in that the first parameter in the callback is the event. Those this is a deviation, I think this is probably what most people want to perform assertions against.

## Other possibilities
Should this be `queuedEvents()` and have it return a Collection of arrays `[$event, $handler]`?