### PR TITLE
[12.x] Reset PHP’s peak memory usage when resetting scope for queue worker

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -216,6 +216,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 $app->forgetScopedInstances();
 
                 Facade::clearResolvedInstances();
+
+                memory_reset_peak_usage();
             };
 
             return new Worker(


### PR DESCRIPTION
This is similar to the reset of the total query duration that is already happening. PHP’s peak memory usage is another bit of global state is not useful to keep in a long-running process handling individual self-contained jobs.

By resetting the peak memory usage for each executed job it becomes possible to measure a given job’s maximum memory usage accurately, allowing to optimize hardware resources, for example by placing individual jobs with a high-memory usage into their own queue that is executed on a larger worker instance.
