### PR TITLE
[12.x] Add `Arr::sole()` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -820,6 +820,34 @@ class Arr
     }
 
     /**
+     * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
+     *
+     * @param array $array
+     * @param callable  $callback
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     * @throws \Illuminate\Support\MultipleItemsFoundException
+     */
+    public static function sole($array, callable $callback = null)
+    {
+		if ($callback) {
+			$array = static::where($array, $callback);
+		}
+		
+	    $count = count($array);
+	    
+	    if ($count === 0) {
+		    throw new ItemNotFoundException;
+	    }
+	    
+	    if ($count > 1) {
+		    throw new MultipleItemsFoundException($count);
+	    }
+	    
+	    return static::first($array);
+    }
+
+    /**
      * Sort the array in descending order using the given callback or "dot" notation.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -808,18 +808,6 @@ class Arr
     }
 
     /**
-     * Sort the array using the given callback or "dot" notation.
-     *
-     * @param  array  $array
-     * @param  callable|array|string|null  $callback
-     * @return array
-     */
-    public static function sort($array, $callback = null)
-    {
-        return (new Collection($array))->sortBy($callback)->all();
-    }
-
-    /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  array  $array
@@ -845,6 +833,18 @@ class Arr
         }
 
         return static::first($array);
+    }
+
+    /**
+     * Sort the array using the given callback or "dot" notation.
+     *
+     * @param  array  $array
+     * @param  callable|array|string|null  $callback
+     * @return array
+     */
+    public static function sort($array, $callback = null)
+    {
+        return (new Collection($array))->sortBy($callback)->all();
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -822,29 +822,29 @@ class Arr
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param array $array
-     * @param callable  $callback
+     * @param  array  $array
+     * @param  callable  $callback
      *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException
      */
-    public static function sole($array, callable $callback = null)
+    public static function sole($array, ?callable $callback = null)
     {
-		if ($callback) {
-			$array = static::where($array, $callback);
-		}
-		
-	    $count = count($array);
-	    
-	    if ($count === 0) {
-		    throw new ItemNotFoundException;
-	    }
-	    
-	    if ($count > 1) {
-		    throw new MultipleItemsFoundException($count);
-	    }
-	    
-	    return static::first($array);
+        if ($callback) {
+            $array = static::where($array, $callback);
+        }
+
+        $count = count($array);
+
+        if ($count === 0) {
+            throw new ItemNotFoundException;
+        }
+
+        if ($count > 1) {
+            throw new MultipleItemsFoundException($count);
+        }
+
+        return static::first($array);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1391,7 +1391,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function sole($key = null, $operator = null, $value = null)
     {
-        $filter = (func_num_args() > 1 && $key && $operator && $value)
+        $filter = func_num_args() > 1
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1391,7 +1391,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function sole($key = null, $operator = null, $value = null)
     {
-        $filter = func_num_args() > 1
+        $filter = (func_num_args() > 1 && $key && $operator && $value)
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -1069,36 +1068,36 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals($input, $shuffled);
     }
-	
-	public function testSoleReturnsFirstItemInCollectionIfOnlyOneExists()
-	{
-		$this->assertSame('foo', Arr::sole(['foo']));
-		
-		$array = [
-			['name' => 'foo'],
-			['name' => 'bar'],
-		];
-		
-		$this->assertSame(
-			['name' => 'foo'],
-			Arr::sole($array, fn (array $value) => $value['name'] === 'foo')
-		);
-	}
-	
-	public function testSoleThrowsExceptionIfNoItemsExist()
-	{
-		$this->expectException(ItemNotFoundException::class);
-		
-		Arr::sole(['foo'], fn (string $value) => $value === 'baz');
-	}
-	
-	public function testSoleThrowsExceptionIfMoreThanOneItemExists()
-	{
-		$this->expectExceptionObject(new MultipleItemsFoundException(2));
-		
-		Arr::sole(['baz', 'foo', 'baz'], fn (string $value) => $value === 'baz');
-	}
-	
+
+    public function testSoleReturnsFirstItemInCollectionIfOnlyOneExists()
+    {
+        $this->assertSame('foo', Arr::sole(['foo']));
+
+        $array = [
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ];
+
+        $this->assertSame(
+            ['name' => 'foo'],
+            Arr::sole($array, fn (array $value) => $value['name'] === 'foo')
+        );
+    }
+
+    public function testSoleThrowsExceptionIfNoItemsExist()
+    {
+        $this->expectException(ItemNotFoundException::class);
+
+        Arr::sole(['foo'], fn (string $value) => $value === 'baz');
+    }
+
+    public function testSoleThrowsExceptionIfMoreThanOneItemExists()
+    {
+        $this->expectExceptionObject(new MultipleItemsFoundException(2));
+
+        Arr::sole(['baz', 'foo', 'baz'], fn (string $value) => $value === 'baz');
+    }
+
     public function testEmptyShuffle()
     {
         $this->assertEquals([], Arr::shuffle([]));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -6,7 +6,10 @@ use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\ItemNotFoundException;
+use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -1066,7 +1069,36 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals($input, $shuffled);
     }
-
+	
+	public function testSoleReturnsFirstItemInCollectionIfOnlyOneExists()
+	{
+		$this->assertSame('foo', Arr::sole(['foo']));
+		
+		$array = [
+			['name' => 'foo'],
+			['name' => 'bar'],
+		];
+		
+		$this->assertSame(
+			['name' => 'foo'],
+			Arr::sole($array, fn (array $value) => $value['name'] === 'foo')
+		);
+	}
+	
+	public function testSoleThrowsExceptionIfNoItemsExist()
+	{
+		$this->expectException(ItemNotFoundException::class);
+		
+		Arr::sole(['foo'], fn (string $value) => $value === 'baz');
+	}
+	
+	public function testSoleThrowsExceptionIfMoreThanOneItemExists()
+	{
+		$this->expectExceptionObject(new MultipleItemsFoundException(2));
+		
+		Arr::sole(['baz', 'foo', 'baz'], fn (string $value) => $value === 'baz');
+	}
+	
     public function testEmptyShuffle()
     {
         $this->assertEquals([], Arr::shuffle([]));


### PR DESCRIPTION
I was missing an `Arr::sole()` method when I was working with a simple array for which wrapping in a collection is quite overkill. This PR adds the method, both a simple version without parameters and a version with a callback support same as the other `Arr::where()` method.

```php
$foo = Arr::sole(['foo']);

$bar = Arr::sole(['bar', 'baz'], fn (string $value) => $value === 'bar');
```

Thanks!