### PR TITLE
[12.x] Add `AsHtmlString` cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsHtmlString.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsHtmlString.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Stringable;
 
 class AsHtmlString implements Castable
 {

--- a/src/Illuminate/Database/Eloquent/Casts/AsHtmlString.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsHtmlString.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Stringable;
+
+class AsHtmlString implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\HtmlString, string|HtmlString>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes
+        {
+            public function get($model, $key, $value, $attributes)
+            {
+                return isset($value) ? new HtmlString($value) : null;
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return isset($value) ? (string) $value : null;
+            }
+        };
+    }
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -265,7 +265,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->asStringableAttribute = new Stringable('foo baz');
         $this->assertTrue($model->isDirty('asStringableAttribute'));
     }
-	
+
     public function testDirtyOnCastedHtmlString()
     {
         $model = new EloquentModelCastingStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -26,6 +26,7 @@ use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
+use Illuminate\Database\Eloquent\Casts\AsHtmlString;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
@@ -45,6 +46,7 @@ use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
@@ -262,6 +264,24 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->asStringableAttribute = new Stringable('foo baz');
         $this->assertTrue($model->isDirty('asStringableAttribute'));
+    }
+	
+    public function testDirtyOnCastedHtmlString()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setRawAttributes([
+            'asHtmlStringAttribute' => '<div>foo bar</div>',
+        ]);
+        $model->syncOriginal();
+
+        $this->assertInstanceOf(HtmlString::class, $model->asHtmlStringAttribute);
+        $this->assertFalse($model->isDirty('asHtmlStringAttribute'));
+
+        $model->asHtmlStringAttribute = new HtmlString('<div>foo bar</div>');
+        $this->assertFalse($model->isDirty('asHtmlStringAttribute'));
+
+        $model->asHtmlStringAttribute = new Stringable('<div>foo baz</div>');
+        $this->assertTrue($model->isDirty('asHtmlStringAttribute'));
     }
 
     // public function testDirtyOnCastedEncryptedCollection()
@@ -3670,6 +3690,7 @@ class EloquentModelCastingStub extends Model
             'datetimeAttribute' => 'datetime',
             'asarrayobjectAttribute' => AsArrayObject::class,
             'asStringableAttribute' => AsStringable::class,
+            'asHtmlStringAttribute' => AsHtmlString::class,
             'asCustomCollectionAttribute' => AsCollection::using(CustomCollection::class),
             'asEncryptedArrayObjectAttribute' => AsEncryptedArrayObject::class,
             'asEncryptedCustomCollectionAttribute' => AsEncryptedCollection::using(CustomCollection::class),


### PR DESCRIPTION
Sometimes it can be useful to store user-provided HTML in the database, for example for snippets or templates. As `HtmlString` is Illuminate-provided, I was missing an Eloquent cast to automatically cast an attribute to an `HtmlString`.

```php
protected function casts(): array
{
   return [
      'html' => AsHtmlString::class,
   ];
}
```

Thanks!