### PR TITLE
[12.x] Added except() method to Model class for excluding attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2015,7 +2015,17 @@ trait HasAttributes
      */
     public function except($attributes)
     {
-        return Arr::except($this->attributesToArray(), is_array($attributes) ? $attributes : func_get_args());
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        $results = [];
+
+        foreach ($this->getAttributes() as $key => $value) {
+            if (!in_array($key, $attributes)) {
+                $results[$key] = $value;
+            }
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2008,6 +2008,23 @@ trait HasAttributes
     }
 
     /**
+     * Get all attributes except the given ones.
+     *
+     * @param  array|mixed  $attributes
+     * @return array
+     */
+    public function except($attributes)
+    {
+        $results = $this->attributesToArray();
+
+        foreach (is_array($attributes) ? $attributes : func_get_args() as $attribute) {
+            unset($results[$attribute]);
+        }
+
+        return $results;
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2015,13 +2015,7 @@ trait HasAttributes
      */
     public function except($attributes)
     {
-        $results = $this->attributesToArray();
-
-        foreach (is_array($attributes) ? $attributes : func_get_args() as $attribute) {
-            unset($results[$attribute]);
-        }
-
-        return $results;
+        return Arr::except($this->attributesToArray(), is_array($attributes) ? $attributes : func_get_args());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2020,7 +2020,7 @@ trait HasAttributes
         $results = [];
 
         foreach ($this->getAttributes() as $key => $value) {
-            if (!in_array($key, $attributes)) {
+            if (! in_array($key, $attributes)) {
                 $results[$key] = $value;
             }
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -585,6 +585,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testExcept()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->except('project'));
+        $this->assertEquals(['project' => 'laravel'], $model->except('first_name', 'last_name'));
+        $this->assertEquals(['project' => 'laravel'], $model->except(['first_name', 'last_name']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
### Overview
This PR introduces a new `except()` method in the Model class, allowing developers to retrieve model attributes excluding specified keys. This method serves as the inverse of the existing `only()` method, improving usability and convenience when working with model data.

Currently, Laravel provides an `only()` method to retrieve a subset of attributes, but there is no built-in way to exclude specific attributes while keeping the rest. This new `except()` method addresses this gap by working as the inverse of `only()`, making it easier to manipulate model data efficiently.

### Example
```php
public function show(User $user)
{
   return response()->json($user->except('id', 'email'));
}
```