### PR TITLE
[12.x] Add `morphWithExists` method to `MorphTo` relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -68,6 +68,13 @@ class MorphTo extends BelongsTo
     protected $morphableEagerLoadCounts = [];
 
     /**
+     * A map of exists queries to run for each individual morph type.
+     *
+     * @var array
+     */
+    protected $morphableEagerLoadExists = [];
+
+    /**
      * A map of constraints to apply for each individual morph type.
      *
      * @var array
@@ -153,6 +160,9 @@ class MorphTo extends BelongsTo
             ))
             ->withCount(
                 (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
+            )
+            ->withExists(
+                (array) ($this->morphableEagerLoadExists[get_class($instance)] ?? [])
             );
 
         if ($callback = ($this->morphableConstraints[get_class($instance)] ?? null)) {
@@ -328,6 +338,21 @@ class MorphTo extends BelongsTo
     {
         $this->morphableEagerLoadCounts = array_merge(
             $this->morphableEagerLoadCounts, $withCount
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify which exists queries to load for a given morph type.
+     *
+     * @param  array  $withExists
+     * @return $this
+     */
+    public function morphWithExists(array $withExists)
+    {
+        $this->morphableEagerLoadExists = array_merge(
+            $this->morphableEagerLoadExists, $withExists
         );
 
         return $this;

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -391,17 +391,17 @@ class DatabaseEloquentMorphToTest extends TestCase
     public function testMorphWithExists()
     {
         $relation = $this->getRelation();
-        
+
         $relation->morphWithExists([
             'Post' => ['comments'],
             'Video' => ['tags'],
         ]);
-        
+
         // Create a reflection to access the protected property
         $reflection = new \ReflectionObject($relation);
         $property = $reflection->getProperty('morphableEagerLoadExists');
         $property->setAccessible(true);
-        
+
         $this->assertEquals([
             'Post' => ['comments'],
             'Video' => ['tags'],

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -387,6 +387,26 @@ class DatabaseEloquentMorphToTest extends TestCase
 
         return m::mock(MorphTo::class.'[createModelByType]', [$this->builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation']);
     }
+
+    public function testMorphWithExists()
+    {
+        $relation = $this->getRelation();
+        
+        $relation->morphWithExists([
+            'Post' => ['comments'],
+            'Video' => ['tags'],
+        ]);
+        
+        // Create a reflection to access the protected property
+        $reflection = new \ReflectionObject($relation);
+        $property = $reflection->getProperty('morphableEagerLoadExists');
+        $property->setAccessible(true);
+        
+        $this->assertEquals([
+            'Post' => ['comments'],
+            'Video' => ['tags'],
+        ], $property->getValue($relation));
+    }
 }
 
 class EloquentMorphToModelStub extends Model


### PR DESCRIPTION
# Add morphWithExists method to eloquent MorphTo relationship

This PR adds a new `morphWithExists` method to the `MorphTo` relationship, which allows specifying which exists queries to load for a given morph type.

## Use Case
When eager loading morph relationships, developers may want to check for the existence of related models without loading them. This method complements the existing `morphWith` and `morphWithCount` methods, providing a consistent API for all types of eager loading.

## Changes
- Added `morphWithExists` method to `MorphTo` class
- Added tests to verify functionality
- Implemented usage in the `getResultsByType` method

## Testing
Added unit test for the new method to ensure it properly stores the exists queries to be loaded.