### PR TITLE
[12.x] use already determined `related` property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -172,7 +172,7 @@ abstract class Relation implements BuilderContract
     public function getEager()
     {
         return $this->eagerKeysWereEmpty
-            ? $this->query->getModel()->newCollection()
+            ? $this->related->newCollection()
             : $this->get();
     }
 


### PR DESCRIPTION
we already pull the related model off of the `$query` in the constructor, so we can use it directly.

introduced in #43724

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
