### PR TITLE
[12.x] remove `@return` docblocks on constructors

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -27,7 +27,6 @@ class AuthorizationException extends Exception
      * @param  string|null  $message
      * @param  mixed  $code
      * @param  \Throwable|null  $previous
-     * @return void
      */
     public function __construct($message = null, $code = null, ?Throwable $previous = null)
     {

--- a/src/Illuminate/Auth/Access/Events/GateEvaluated.php
+++ b/src/Illuminate/Auth/Access/Events/GateEvaluated.php
@@ -39,7 +39,6 @@ class GateEvaluated
      * @param  string  $ability
      * @param  bool|null  $result
      * @param  array  $arguments
-     * @return void
      */
     public function __construct($user, $ability, $result, $arguments)
     {

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -94,7 +94,6 @@ class Gate implements GateContract
      * @param  array  $beforeCallbacks
      * @param  array  $afterCallbacks
      * @param  callable|null  $guessPolicyNamesUsingCallback
-     * @return void
      */
     public function __construct(
         Container $container,

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -41,7 +41,6 @@ class Response implements Arrayable, Stringable
      * @param  bool  $allowed
      * @param  string|null  $message
      * @param  mixed  $code
-     * @return void
      */
     public function __construct($allowed, $message = '', $code = null)
     {

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -48,7 +48,6 @@ class AuthManager implements FactoryContract
      * Create a new Auth manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -34,7 +34,6 @@ class AuthenticationException extends Exception
      * @param  string  $message
      * @param  array  $guards
      * @param  string|null  $redirectTo
-     * @return void
      */
     public function __construct($message = 'Unauthenticated.', array $guards = [], $redirectTo = null)
     {

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -38,7 +38,6 @@ class DatabaseUserProvider implements UserProvider
      * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
      * @param  string  $table
-     * @return void
      */
     public function __construct(ConnectionInterface $connection, HasherContract $hasher, $table)
     {

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -36,7 +36,6 @@ class EloquentUserProvider implements UserProvider
      *
      * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
      * @param  string  $model
-     * @return void
      */
     public function __construct(HasherContract $hasher, $model)
     {

--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -10,7 +10,6 @@ class Attempting
      * @param  string  $guard  The authentication guard name.
      * @param  array  $credentials  The credentials for the user.
      * @param  bool  $remember  Indicates if the user should be "remembered".
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -13,7 +13,6 @@ class Authenticated
      *
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -13,7 +13,6 @@ class CurrentDeviceLogout
      *
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -10,7 +10,6 @@ class Failed
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user  The user the attempter was trying to authenticate as.
      * @param  array  $credentials  The credentials provided by the attempter.
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/Lockout.php
+++ b/src/Illuminate/Auth/Events/Lockout.php
@@ -17,7 +17,6 @@ class Lockout
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return void
      */
     public function __construct(Request $request)
     {

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -14,7 +14,6 @@ class Login
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
      * @param  bool  $remember  Indicates if the user should be "remembered".
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -13,7 +13,6 @@ class Logout
      *
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -13,7 +13,6 @@ class OtherDeviceLogout
      *
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  \Illuminate\Contracts\Auth\Authenticatable
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -12,7 +12,6 @@ class PasswordReset
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The user.
-     * @return void
      */
     public function __construct(
         public $user,

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -12,7 +12,6 @@ class PasswordResetLinkSent
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user  The user instance.
-     * @return void
      */
     public function __construct(
         public $user,

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -12,7 +12,6 @@ class Registered
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The authenticated user.
-     * @return void
      */
     public function __construct(
         public $user,

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -13,7 +13,6 @@ class Validated
      *
      * @param  string  $guard  The authentication guard name.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user  The user retrieved and validated from the User Provider.
-     * @return void
      */
     public function __construct(
         public $guard,

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -12,7 +12,6 @@ class Verified
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\MustVerifyEmail  $user  The verified user.
-     * @return void
      */
     public function __construct(
         public $user,

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -17,7 +17,6 @@ class GenericUser implements UserContract
      * Create a new generic User object.
      *
      * @param  array  $attributes
-     * @return void
      */
     public function __construct(array $attributes)
     {

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -28,7 +28,6 @@ class Authenticate implements AuthenticatesRequests
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
-     * @return void
      */
     public function __construct(Auth $auth)
     {

--- a/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
+++ b/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
@@ -18,7 +18,6 @@ class AuthenticateWithBasicAuth
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
-     * @return void
      */
     public function __construct(AuthFactory $auth)
     {

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -22,7 +22,6 @@ class Authorize
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
-     * @return void
      */
     public function __construct(Gate $gate)
     {

--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -35,7 +35,6 @@ class RequirePassword
      * @param  \Illuminate\Contracts\Routing\ResponseFactory  $responseFactory
      * @param  \Illuminate\Contracts\Routing\UrlGenerator  $urlGenerator
      * @param  int|null  $passwordTimeout
-     * @return void
      */
     public function __construct(ResponseFactory $responseFactory, UrlGenerator $urlGenerator, $passwordTimeout = null)
     {

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -33,7 +33,6 @@ class ResetPassword extends Notification
      * Create a notification instance.
      *
      * @param  string  $token
-     * @return void
      */
     public function __construct(#[\SensitiveParameter] $token)
     {

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -40,7 +40,6 @@ class PasswordBroker implements PasswordBrokerContract
      * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
      * @param  \Illuminate\Contracts\Auth\UserProvider  $users
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
-     * @return void
      */
     public function __construct(#[\SensitiveParameter] TokenRepositoryInterface $tokens, UserProvider $users, ?Dispatcher $dispatcher = null)
     {

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -28,7 +28,6 @@ class PasswordBrokerManager implements FactoryContract
      * Create a new PasswordBroker manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -15,7 +15,6 @@ class Recaller
      * Create a new recaller instance.
      *
      * @param  string  $recaller
-     * @return void
      */
     public function __construct($recaller)
     {

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -31,7 +31,6 @@ class RequestGuard implements Guard
      * @param  callable  $callback
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Contracts\Auth\UserProvider|null  $provider
-     * @return void
      */
     public function __construct(callable $callback, Request $request, ?UserProvider $provider = null)
     {

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -126,7 +126,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Symfony\Component\HttpFoundation\Request|null  $request
      * @param  \Illuminate\Support\Timebox|null  $timebox
      * @param  bool  $rehashOnLogin
-     * @return void
      */
     public function __construct(
         $name,

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -47,7 +47,6 @@ class TokenGuard implements Guard
      * @param  string  $inputKey
      * @param  string  $storageKey
      * @param  bool  $hash
-     * @return void
      */
     public function __construct(
         UserProvider $provider,

--- a/src/Illuminate/Broadcasting/AnonymousEvent.php
+++ b/src/Illuminate/Broadcasting/AnonymousEvent.php
@@ -40,7 +40,6 @@ class AnonymousEvent implements ShouldBroadcast
     /**
      * Create a new anonymous broadcastable event instance.
      *
-     * @return void
      */
     public function __construct(protected Channel|array|string $channels)
     {

--- a/src/Illuminate/Broadcasting/AnonymousEvent.php
+++ b/src/Illuminate/Broadcasting/AnonymousEvent.php
@@ -39,7 +39,6 @@ class AnonymousEvent implements ShouldBroadcast
 
     /**
      * Create a new anonymous broadcastable event instance.
-     *
      */
     public function __construct(protected Channel|array|string $channels)
     {

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -54,7 +54,6 @@ class BroadcastEvent implements ShouldQueue
      * Create a new job handler instance.
      *
      * @param  mixed  $event
-     * @return void
      */
     public function __construct($event)
     {

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -51,7 +51,6 @@ class BroadcastManager implements FactoryContract
      * Create a new manager instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -26,7 +26,6 @@ class AblyBroadcaster extends Broadcaster
      * Create a new broadcaster instance.
      *
      * @param  \Ably\AblyRest  $ably
-     * @return void
      */
     public function __construct(AblyRest $ably)
     {

--- a/src/Illuminate/Broadcasting/Broadcasters/LogBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/LogBroadcaster.php
@@ -17,7 +17,6 @@ class LogBroadcaster extends Broadcaster
      * Create a new broadcaster instance.
      *
      * @param  \Psr\Log\LoggerInterface  $logger
-     * @return void
      */
     public function __construct(LoggerInterface $logger)
     {

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -24,7 +24,6 @@ class PusherBroadcaster extends Broadcaster
      * Create a new broadcaster instance.
      *
      * @param  \Pusher\Pusher  $pusher
-     * @return void
      */
     public function __construct(Pusher $pusher)
     {

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -40,7 +40,6 @@ class RedisBroadcaster extends Broadcaster
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
      * @param  string|null  $connection
      * @param  string  $prefix
-     * @return void
      */
     public function __construct(Redis $redis, $connection = null, $prefix = '')
     {

--- a/src/Illuminate/Broadcasting/Channel.php
+++ b/src/Illuminate/Broadcasting/Channel.php
@@ -18,7 +18,6 @@ class Channel implements Stringable
      * Create a new channel instance.
      *
      * @param  \Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string  $name
-     * @return void
      */
     public function __construct($name)
     {

--- a/src/Illuminate/Broadcasting/EncryptedPrivateChannel.php
+++ b/src/Illuminate/Broadcasting/EncryptedPrivateChannel.php
@@ -8,7 +8,6 @@ class EncryptedPrivateChannel extends Channel
      * Create a new channel instance.
      *
      * @param  string  $name
-     * @return void
      */
     public function __construct($name)
     {

--- a/src/Illuminate/Broadcasting/PendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/PendingBroadcast.php
@@ -25,7 +25,6 @@ class PendingBroadcast
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  mixed  $event
-     * @return void
      */
     public function __construct(Dispatcher $events, $event)
     {

--- a/src/Illuminate/Broadcasting/PresenceChannel.php
+++ b/src/Illuminate/Broadcasting/PresenceChannel.php
@@ -8,7 +8,6 @@ class PresenceChannel extends Channel
      * Create a new channel instance.
      *
      * @param  string  $name
-     * @return void
      */
     public function __construct($name)
     {

--- a/src/Illuminate/Broadcasting/PrivateChannel.php
+++ b/src/Illuminate/Broadcasting/PrivateChannel.php
@@ -10,7 +10,6 @@ class PrivateChannel extends Channel
      * Create a new channel instance.
      *
      * @param  \Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string  $name
-     * @return void
      */
     public function __construct($name)
     {

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -26,7 +26,6 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
      * Create a new event instance.
      *
      * @param  mixed  $event
-     * @return void
      */
     public function __construct($event)
     {

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -113,7 +113,6 @@ class Batch implements Arrayable, JsonSerializable
      * @param  \Carbon\CarbonImmutable  $createdAt
      * @param  \Carbon\CarbonImmutable|null  $cancelledAt
      * @param  \Carbon\CarbonImmutable|null  $finishedAt
-     * @return void
      */
     public function __construct(
         QueueFactory $queue,

--- a/src/Illuminate/Bus/BatchFactory.php
+++ b/src/Illuminate/Bus/BatchFactory.php
@@ -18,7 +18,6 @@ class BatchFactory
      * Create a new batch factory instance.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $queue
-     * @return void
      */
     public function __construct(QueueFactory $queue)
     {

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -39,7 +39,6 @@ class ChainedBatch implements ShouldQueue
      * Create a new chained batch instance.
      *
      * @param  \Illuminate\Bus\PendingBatch  $batch
-     * @return void
      */
     public function __construct(PendingBatch $batch)
     {

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -56,7 +56,6 @@ class Dispatcher implements QueueingDispatcher
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Closure|null  $queueResolver
-     * @return void
      */
     public function __construct(Container $container, ?Closure $queueResolver = null)
     {

--- a/src/Illuminate/Bus/Events/BatchDispatched.php
+++ b/src/Illuminate/Bus/Events/BatchDispatched.php
@@ -10,7 +10,6 @@ class BatchDispatched
      * Create a new event instance.
      *
      * @param  \Illuminate\Bus\Batch  $batch  The batch instance.
-     * @return void
      */
     public function __construct(
         public Batch $batch,

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -59,7 +59,6 @@ class PendingBatch
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Illuminate\Support\Collection  $jobs
-     * @return void
      */
     public function __construct(Container $container, Collection $jobs)
     {

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -17,7 +17,6 @@ class UniqueLock
      * Create a new unique lock manager instance.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @return void
      */
     public function __construct(Cache $cache)
     {

--- a/src/Illuminate/Bus/UpdatedBatchJobCounts.php
+++ b/src/Illuminate/Bus/UpdatedBatchJobCounts.php
@@ -23,7 +23,6 @@ class UpdatedBatchJobCounts
      *
      * @param  int  $pendingJobs
      * @param  int  $failedJobs
-     * @return void
      */
     public function __construct(int $pendingJobs = 0, int $failedJobs = 0)
     {

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -25,7 +25,6 @@ class ApcStore extends TaggableStore
      *
      * @param  \Illuminate\Cache\ApcWrapper  $apc
      * @param  string  $prefix
-     * @return void
      */
     public function __construct(ApcWrapper $apc, $prefix = '')
     {

--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -20,7 +20,6 @@ class ArrayLock extends Lock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct($store, $name, $seconds, $owner = null)
     {

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -35,7 +35,6 @@ class ArrayStore extends TaggableStore implements LockProvider
      * Create a new Array store.
      *
      * @param  bool  $serializesValues
-     * @return void
      */
     public function __construct($serializesValues = false)
     {

--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -18,7 +18,6 @@ class CacheLock extends Lock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct($store, $name, $seconds, $owner = null)
     {

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -41,7 +41,6 @@ class CacheManager implements FactoryContract
      * Create a new Cache manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -45,7 +45,6 @@ class ClearCommand extends Command
      *
      * @param  \Illuminate\Cache\CacheManager  $cache
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(CacheManager $cache, Filesystem $files)
     {

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -34,7 +34,6 @@ class ForgetCommand extends Command
      * Create a new cache clear command instance.
      *
      * @param  \Illuminate\Cache\CacheManager  $cache
-     * @return void
      */
     public function __construct(CacheManager $cache)
     {

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -44,7 +44,6 @@ class DatabaseLock extends Lock
      * @param  int  $seconds
      * @param  string|null  $owner
      * @param  array  $lottery
-     * @return void
      */
     public function __construct(Connection $connection, $table, $name, $seconds, $owner = null, $lottery = [2, 100], $defaultTimeoutInSeconds = 86400)
     {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -76,7 +76,6 @@ class DatabaseStore implements LockProvider, Store
      * @param  string  $prefix
      * @param  string  $lockTable
      * @param  array  $lockLottery
-     * @return void
      */
     public function __construct(
         ConnectionInterface $connection,

--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -18,7 +18,6 @@ class DynamoDbLock extends Lock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct(DynamoDbStore $dynamo, $name, $seconds, $owner = null)
     {

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -67,7 +67,6 @@ class DynamoDbStore implements LockProvider, Store
      * @param  string  $valueAttribute
      * @param  string  $expirationAttribute
      * @param  string  $prefix
-     * @return void
      */
     public function __construct(
         DynamoDbClient $dynamo,

--- a/src/Illuminate/Cache/Events/CacheEvent.php
+++ b/src/Illuminate/Cache/Events/CacheEvent.php
@@ -31,7 +31,6 @@ abstract class CacheEvent
      * @param  string|null  $storeName
      * @param  string  $key
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $key, array $tags = [])
     {

--- a/src/Illuminate/Cache/Events/CacheHit.php
+++ b/src/Illuminate/Cache/Events/CacheHit.php
@@ -18,7 +18,6 @@ class CacheHit extends CacheEvent
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $key, $value, array $tags = [])
     {

--- a/src/Illuminate/Cache/Events/KeyWriteFailed.php
+++ b/src/Illuminate/Cache/Events/KeyWriteFailed.php
@@ -26,7 +26,6 @@ class KeyWriteFailed extends CacheEvent
      * @param  mixed  $value
      * @param  int|null  $seconds
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
     {

--- a/src/Illuminate/Cache/Events/KeyWritten.php
+++ b/src/Illuminate/Cache/Events/KeyWritten.php
@@ -26,7 +26,6 @@ class KeyWritten extends CacheEvent
      * @param  mixed  $value
      * @param  int|null  $seconds
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
     {

--- a/src/Illuminate/Cache/Events/RetrievingManyKeys.php
+++ b/src/Illuminate/Cache/Events/RetrievingManyKeys.php
@@ -17,7 +17,6 @@ class RetrievingManyKeys extends CacheEvent
      * @param  string|null  $storeName
      * @param  array  $keys
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $keys, array $tags = [])
     {

--- a/src/Illuminate/Cache/Events/WritingKey.php
+++ b/src/Illuminate/Cache/Events/WritingKey.php
@@ -26,7 +26,6 @@ class WritingKey extends CacheEvent
      * @param  mixed  $value
      * @param  int|null  $seconds
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $key, $value, $seconds = null, $tags = [])
     {

--- a/src/Illuminate/Cache/Events/WritingManyKeys.php
+++ b/src/Illuminate/Cache/Events/WritingManyKeys.php
@@ -33,7 +33,6 @@ class WritingManyKeys extends CacheEvent
      * @param  array  $values
      * @param  int|null  $seconds
      * @param  array  $tags
-     * @return void
      */
     public function __construct($storeName, $keys, $values, $seconds = null, $tags = [])
     {

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -48,7 +48,6 @@ class FileStore implements Store, LockProvider
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $directory
      * @param  int|null  $filePermission
-     * @return void
      */
     public function __construct(Filesystem $files, $directory, $filePermission = null)
     {

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -46,7 +46,6 @@ abstract class Lock implements LockContract
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct($name, $seconds, $owner = null)
     {

--- a/src/Illuminate/Cache/MemcachedLock.php
+++ b/src/Illuminate/Cache/MemcachedLock.php
@@ -18,7 +18,6 @@ class MemcachedLock extends Lock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct($memcached, $name, $seconds, $owner = null)
     {

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -37,7 +37,6 @@ class MemcachedStore extends TaggableStore implements LockProvider
      *
      * @param  \Memcached  $memcached
      * @param  string  $prefix
-     * @return void
      */
     public function __construct($memcached, $prefix = '')
     {

--- a/src/Illuminate/Cache/PhpRedisLock.php
+++ b/src/Illuminate/Cache/PhpRedisLock.php
@@ -13,7 +13,6 @@ class PhpRedisLock extends RedisLock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct(PhpRedisConnection $redis, string $name, int $seconds, ?string $owner = null)
     {

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -32,7 +32,6 @@ class RateLimiter
      * Create a new rate limiter instance.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @return void
      */
     public function __construct(Cache $cache)
     {

--- a/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
+++ b/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
@@ -9,7 +9,6 @@ class GlobalLimit extends Limit
      *
      * @param  int  $maxAttempts
      * @param  int  $decaySeconds
-     * @return void
      */
     public function __construct(int $maxAttempts, int $decaySeconds = 60)
     {

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -38,7 +38,6 @@ class Limit
      * @param  mixed  $key
      * @param  int  $maxAttempts
      * @param  int  $decaySeconds
-     * @return void
      */
     public function __construct($key = '', int $maxAttempts = 60, int $decaySeconds = 60)
     {

--- a/src/Illuminate/Cache/RateLimiting/Unlimited.php
+++ b/src/Illuminate/Cache/RateLimiting/Unlimited.php
@@ -7,7 +7,6 @@ class Unlimited extends GlobalLimit
     /**
      * Create a new limit instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Cache/RateLimiting/Unlimited.php
+++ b/src/Illuminate/Cache/RateLimiting/Unlimited.php
@@ -6,7 +6,6 @@ class Unlimited extends GlobalLimit
 {
     /**
      * Create a new limit instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -18,7 +18,6 @@ class RedisLock extends Lock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @return void
      */
     public function __construct($redis, $name, $seconds, $owner = null)
     {

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -51,7 +51,6 @@ class RedisStore extends TaggableStore implements LockProvider
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
      * @param  string  $prefix
      * @param  string  $connection
-     * @return void
      */
     public function __construct(Redis $redis, $prefix = '', $connection = 'default')
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -69,7 +69,6 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
      * @param  array  $config
-     * @return void
      */
     public function __construct(Store $store, array $config = [])
     {

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -25,7 +25,6 @@ class TagSet
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
      * @param  array  $names
-     * @return void
      */
     public function __construct(Store $store, array $names = [])
     {

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -22,7 +22,6 @@ class TaggedCache extends Repository
      *
      * @param  \Illuminate\Contracts\Cache\Store  $store
      * @param  \Illuminate\Cache\TagSet  $tags
-     * @return void
      */
     public function __construct(Store $store, TagSet $tags)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -37,7 +37,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Create a new collection.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
-     * @return void
      */
     public function __construct($items = [])
     {

--- a/src/Illuminate/Collections/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Collections/HigherOrderCollectionProxy.php
@@ -31,7 +31,6 @@ class HigherOrderCollectionProxy
      *
      * @param  \Illuminate\Support\Enumerable<TKey, TValue>  $collection
      * @param  string  $method
-     * @return void
      */
     public function __construct(Enumerable $collection, $method)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -39,7 +39,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Create a new lazy collection instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $source
-     * @return void
      */
     public function __construct($source = null)
     {

--- a/src/Illuminate/Collections/MultipleItemsFoundException.php
+++ b/src/Illuminate/Collections/MultipleItemsFoundException.php
@@ -19,7 +19,6 @@ class MultipleItemsFoundException extends RuntimeException
      * @param  int  $count
      * @param  int  $code
      * @param  \Throwable|null  $previous
-     * @return void
      */
     public function __construct($count, $code = 0, $previous = null)
     {

--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -36,7 +36,6 @@ class HigherOrderWhenProxy
      * Create a new proxy instance.
      *
      * @param  mixed  $target
-     * @return void
      */
     public function __construct($target)
     {

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -23,7 +23,6 @@ class Repository implements ArrayAccess, ConfigContract
      * Create a new configuration repository.
      *
      * @param  array  $items
-     * @return void
      */
     public function __construct(array $items = [])
     {

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -63,7 +63,6 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  \Illuminate\Contracts\Container\Container  $laravel
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  string  $version
-     * @return void
      */
     public function __construct(Container $laravel, Dispatcher $events, $version)
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -86,7 +86,6 @@ class Command extends SymfonyCommand
 
     /**
      * Create a new console command instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -87,7 +87,6 @@ class Command extends SymfonyCommand
     /**
      * Create a new console command instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -28,7 +28,6 @@ class ContainerCommandLoader implements CommandLoaderInterface
      *
      * @param  \Psr\Container\ContainerInterface  $container
      * @param  array  $commandMap
-     * @return void
      */
     public function __construct(ContainerInterface $container, array $commandMap)
     {

--- a/src/Illuminate/Console/Events/ArtisanStarting.php
+++ b/src/Illuminate/Console/Events/ArtisanStarting.php
@@ -10,7 +10,6 @@ class ArtisanStarting
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Application  $artisan  The Artisan application instance.
-     * @return void
      */
     public function __construct(
         public Application $artisan,

--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -14,7 +14,6 @@ class CommandFinished
      * @param  \Symfony\Component\Console\Input\InputInterface  $input  The console input implementation.
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output  The command output implementation.
      * @param  int  $exitCode  The command exit code.
-     * @return void
      */
     public function __construct(
         public string $command,

--- a/src/Illuminate/Console/Events/CommandStarting.php
+++ b/src/Illuminate/Console/Events/CommandStarting.php
@@ -13,7 +13,6 @@ class CommandStarting
      * @param  string  $command  The command name.
      * @param  \Symfony\Component\Console\Input\InputInterface  $input  The console input implementation.
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output  The command output implementation.
-     * @return void
      */
     public function __construct(
         public string $command,

--- a/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
@@ -10,7 +10,6 @@ class ScheduledBackgroundTaskFinished
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event that ran.
-     * @return void
      */
     public function __construct(
         public Event $task,

--- a/src/Illuminate/Console/Events/ScheduledTaskFailed.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFailed.php
@@ -12,7 +12,6 @@ class ScheduledTaskFailed
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event that failed.
      * @param  \Throwable  $exception  The exception that was thrown.
-     * @return void
      */
     public function __construct(
         public Event $task,

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -11,7 +11,6 @@ class ScheduledTaskFinished
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event that ran.
      * @param  float  $runtime  The runtime of the scheduled event.
-     * @return void
      */
     public function __construct(
         public Event $task,

--- a/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
@@ -10,7 +10,6 @@ class ScheduledTaskSkipped
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event being run.
-     * @return void
      */
     public function __construct(
         public Event $task,

--- a/src/Illuminate/Console/Events/ScheduledTaskStarting.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskStarting.php
@@ -10,7 +10,6 @@ class ScheduledTaskStarting
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task  The scheduled event being run.
-     * @return void
      */
     public function __construct(
         public Event $task,

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -121,7 +121,6 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      * Create a new generator command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -19,7 +19,6 @@ abstract class MigrationGeneratorCommand extends Command
      * Create a new migration generator command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -40,7 +40,6 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
      */
     public function __construct(InputInterface $input, OutputInterface $output)
     {

--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -26,7 +26,6 @@ class CacheEventMutex implements EventMutex, CacheAware
      * Create a new overlapping strategy.
      *
      * @param  \Illuminate\Contracts\Cache\Factory  $cache
-     * @return void
      */
     public function __construct(Cache $cache)
     {

--- a/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
@@ -25,7 +25,6 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
      * Create a new scheduling strategy.
      *
      * @param  \Illuminate\Contracts\Cache\Factory  $cache
-     * @return void
      */
     public function __construct(Cache $cache)
     {

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -96,7 +96,6 @@ class Event
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $command
      * @param  \DateTimeZone|string|null  $timezone
-     * @return void
      */
     public function __construct(EventMutex $mutex, $command, $timezone = null)
     {

--- a/src/Illuminate/Console/Scheduling/ScheduleInterruptCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleInterruptCommand.php
@@ -35,7 +35,6 @@ class ScheduleInterruptCommand extends Command
      * Create a new schedule interrupt command.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @return void
      */
     public function __construct(Cache $cache)
     {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -86,7 +86,6 @@ class ScheduleRunCommand extends Command
     /**
      * Create a new command instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -85,7 +85,6 @@ class ScheduleRunCommand extends Command
 
     /**
      * Create a new command instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -32,7 +32,6 @@ class Signals
      * Create a new signal registrar instance.
      *
      * @param  \Symfony\Component\Console\SignalRegistry\SignalRegistry  $registry
-     * @return void
      */
     public function __construct($registry)
     {

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -30,7 +30,6 @@ abstract class Component
      * Creates a new component instance.
      *
      * @param  \Illuminate\Console\OutputStyle  $output
-     * @return void
      */
     public function __construct($output)
     {

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -33,7 +33,6 @@ class Factory
      * Creates a new factory instance.
      *
      * @param  \Illuminate\Console\OutputStyle  $output
-     * @return void
      */
     public function __construct($output)
     {

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -33,7 +33,6 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  string|array  $concrete
-     * @return void
      */
     public function __construct(Container $container, $concrete)
     {

--- a/src/Illuminate/Container/RewindableGenerator.php
+++ b/src/Illuminate/Container/RewindableGenerator.php
@@ -27,7 +27,6 @@ class RewindableGenerator implements Countable, IteratorAggregate
      *
      * @param  callable  $generator
      * @param  callable|int  $count
-     * @return void
      */
     public function __construct(callable $generator, $count)
     {

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -48,7 +48,6 @@ class ModelIdentifier
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
-     * @return void
      */
     public function __construct($class, $id, array $relations, $connection)
     {

--- a/src/Illuminate/Contracts/Queue/EntityNotFoundException.php
+++ b/src/Illuminate/Contracts/Queue/EntityNotFoundException.php
@@ -11,7 +11,6 @@ class EntityNotFoundException extends InvalidArgumentException
      *
      * @param  string  $type
      * @param  mixed  $id
-     * @return void
      */
     public function __construct($type, $id)
     {

--- a/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php
+++ b/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php
@@ -18,7 +18,6 @@ class AddQueuedCookiesToResponse
      * Create a new CookieQueue instance.
      *
      * @param  \Illuminate\Contracts\Cookie\QueueingFactory  $cookies
-     * @return void
      */
     public function __construct(CookieJar $cookies)
     {

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -45,7 +45,6 @@ class EncryptCookies
      * Create a new CookieGuard instance.
      *
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
-     * @return void
      */
     public function __construct(EncrypterContract $encrypter)
     {

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -25,7 +25,6 @@ class Manager
      * Create a new database capsule manager.
      *
      * @param  \Illuminate\Container\Container|null  $container
-     * @return void
      */
     public function __construct(?Container $container = null)
     {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -208,7 +208,6 @@ class Connection implements ConnectionInterface
      * @param  string  $database
      * @param  string  $tablePrefix
      * @param  array  $config
-     * @return void
      */
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {

--- a/src/Illuminate/Database/ConnectionResolver.php
+++ b/src/Illuminate/Database/ConnectionResolver.php
@@ -22,7 +22,6 @@ class ConnectionResolver implements ConnectionResolverInterface
      * Create a new connection resolver instance.
      *
      * @param  array<string, \Illuminate\Database\ConnectionInterface>  $connections
-     * @return void
      */
     public function __construct(array $connections = [])
     {

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -26,7 +26,6 @@ class ConnectionFactory
      * Create a new connection factory instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -41,7 +41,6 @@ class FreshCommand extends Command
      * Create a new fresh command instance.
      *
      * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-     * @return void
      */
     public function __construct(Migrator $migrator)
     {

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -35,7 +35,6 @@ class InstallCommand extends Command
      * Create a new migration install command instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
-     * @return void
      */
     public function __construct(MigrationRepositoryInterface $repository)
     {

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -64,7 +64,6 @@ class MigrateCommand extends BaseCommand implements Isolatable
      *
      * @param  \Illuminate\Database\Migrations\Migrator  $migrator
      * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @return void
      */
     public function __construct(Migrator $migrator, Dispatcher $dispatcher)
     {

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -51,7 +51,6 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      *
      * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
      * @param  \Illuminate\Support\Composer  $composer
-     * @return void
      */
     public function __construct(MigrationCreator $creator, Composer $composer)
     {

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -39,7 +39,6 @@ class ResetCommand extends BaseCommand
      * Create a new migration rollback command instance.
      *
      * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-     * @return void
      */
     public function __construct(Migrator $migrator)
     {

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -39,7 +39,6 @@ class RollbackCommand extends BaseCommand
      * Create a new migration rollback command instance.
      *
      * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-     * @return void
      */
     public function __construct(Migrator $migrator)
     {

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -36,7 +36,6 @@ class StatusCommand extends BaseCommand
      * Create a new migration rollback command instance.
      *
      * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-     * @return void
      */
     public function __construct(Migrator $migrator)
     {

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -40,7 +40,6 @@ class SeedCommand extends Command
      * Create a new database seed command instance.
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
-     * @return void
      */
     public function __construct(Resolver $resolver)
     {

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -69,7 +69,6 @@ class DatabaseManager implements ConnectionResolverInterface
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Database\Connectors\ConnectionFactory  $factory
-     * @return void
      */
     public function __construct($app, ConnectionFactory $factory)
     {

--- a/src/Illuminate/Database/DatabaseTransactionRecord.php
+++ b/src/Illuminate/Database/DatabaseTransactionRecord.php
@@ -38,7 +38,6 @@ class DatabaseTransactionRecord
      * @param  string  $connection
      * @param  int  $level
      * @param  \Illuminate\Database\DatabaseTransactionRecord|null  $parent
-     * @return void
      */
     public function __construct($connection, $level, ?DatabaseTransactionRecord $parent = null)
     {

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -29,7 +29,6 @@ class DatabaseTransactionsManager
 
     /**
      * Create a new database transactions manager instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -30,7 +30,6 @@ class DatabaseTransactionsManager
     /**
      * Create a new database transactions manager instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/CollectedBy.php
@@ -11,7 +11,6 @@ class CollectedBy
      * Create a new attribute instance.
      *
      * @param  class-string<\Illuminate\Database\Eloquent\Collection<*, *>>  $collectionClass
-     * @return void
      */
     public function __construct(public string $collectionClass)
     {

--- a/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
@@ -11,7 +11,6 @@ class ObservedBy
      * Create a new attribute instance.
      *
      * @param  array|string  $classes
-     * @return void
      */
     public function __construct(public array|string $classes)
     {

--- a/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
@@ -11,7 +11,6 @@ class ScopedBy
      * Create a new attribute instance.
      *
      * @param  array|string  $classes
-     * @return void
      */
     public function __construct(public array|string $classes)
     {

--- a/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseFactory.php
@@ -11,7 +11,6 @@ class UseFactory
      * Create a new attribute instance.
      *
      * @param  class-string<\Illuminate\Database\Eloquent\Factories\Factory>  $factoryClass
-     * @return void
      */
     public function __construct(public string $factoryClass)
     {

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -59,7 +59,6 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $event
-     * @return void
      */
     public function __construct($model, $event)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -168,7 +168,6 @@ class Builder implements BuilderContract
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return void
      */
     public function __construct(QueryBuilder $query)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -37,7 +37,6 @@ class Attribute
      *
      * @param  callable|null  $get
      * @param  callable|null  $set
-     * @return void
      */
     public function __construct(?callable $get = null, ?callable $set = null)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -34,7 +34,6 @@ class BelongsToManyRelationship
      * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $factory
      * @param  callable|array  $pivot
      * @param  string  $relationship
-     * @return void
      */
     public function __construct($factory, $pivot, $relationship)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -33,7 +33,6 @@ class BelongsToRelationship
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model  $factory
      * @param  string  $relationship
-     * @return void
      */
     public function __construct($factory, $relationship)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/CrossJoinSequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/CrossJoinSequence.php
@@ -10,7 +10,6 @@ class CrossJoinSequence extends Sequence
      * Create a new cross join sequence instance.
      *
      * @param  array  ...$sequences
-     * @return void
      */
     public function __construct(...$sequences)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -146,7 +146,6 @@ abstract class Factory
      * @param  string|null  $connection
      * @param  \Illuminate\Support\Collection|null  $recycle
      * @param  bool  $expandRelationships
-     * @return void
      */
     public function __construct(
         $count = null,

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -28,7 +28,6 @@ class Relationship
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
      * @param  string  $relationship
-     * @return void
      */
     public function __construct(Factory $factory, $relationship)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -31,7 +31,6 @@ class Sequence implements Countable
      * Create a new sequence instance.
      *
      * @param  mixed  ...$sequence
-     * @return void
      */
     public function __construct(...$sequence)
     {

--- a/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
+++ b/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
@@ -26,7 +26,6 @@ class HigherOrderBuilderProxy
      *
      * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
      * @param  string  $method
-     * @return void
      */
     public function __construct(Builder $builder, $method)
     {

--- a/src/Illuminate/Database/Eloquent/InvalidCastException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidCastException.php
@@ -33,7 +33,6 @@ class InvalidCastException extends RuntimeException
      * @param  object  $model
      * @param  string  $column
      * @param  string  $castType
-     * @return void
      */
     public function __construct($model, $column, $castType)
     {

--- a/src/Illuminate/Database/Eloquent/MissingAttributeException.php
+++ b/src/Illuminate/Database/Eloquent/MissingAttributeException.php
@@ -11,7 +11,6 @@ class MissingAttributeException extends OutOfBoundsException
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
-     * @return void
      */
     public function __construct($model, $key)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -248,7 +248,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Create a new Eloquent model instance.
      *
      * @param  array  $attributes
-     * @return void
      */
     public function __construct(array $attributes = [])
     {

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -47,7 +47,6 @@ class ModelInspector
      * Create a new model inspector instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct(Application $app)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -59,7 +59,6 @@ class BelongsTo extends Relation
      * @param  string  $foreignKey
      * @param  string  $ownerKey
      * @param  string  $relationName
-     * @return void
      */
     public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -151,7 +151,6 @@ class BelongsToMany extends Relation
      * @param  string  $parentKey
      * @param  string  $relatedKey
      * @param  string|null  $relationName
-     * @return void
      */
     public function __construct(
         Builder $query,

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -41,7 +41,6 @@ abstract class HasOneOrMany extends Relation
      * @param  TDeclaringModel  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
-     * @return void
      */
     public function __construct(Builder $query, Model $parent, $foreignKey, $localKey)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -77,7 +77,6 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  string  $secondKey
      * @param  string  $localKey
      * @param  string  $secondLocalKey
-     * @return void
      */
     public function __construct(Builder $query, Model $farParent, Model $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -37,7 +37,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
-     * @return void
      */
     public function __construct(Builder $query, Model $parent, $type, $id, $localKey)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -83,7 +83,6 @@ class MorphTo extends BelongsTo
      * @param  string|null  $ownerKey
      * @param  string  $type
      * @param  string  $relation
-     * @return void
      */
     public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -51,7 +51,6 @@ class MorphToMany extends BelongsToMany
      * @param  string  $relatedKey
      * @param  string|null  $relationName
      * @param  bool  $inverse
-     * @return void
      */
     public function __construct(
         Builder $query,

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -88,7 +88,6 @@ abstract class Relation implements BuilderContract
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
      * @param  TDeclaringModel  $parent
-     * @return void
      */
     public function __construct(Builder $query, Model $parent)
     {

--- a/src/Illuminate/Database/Events/ConnectionEvent.php
+++ b/src/Illuminate/Database/Events/ConnectionEvent.php
@@ -22,7 +22,6 @@ abstract class ConnectionEvent
      * Create a new event instance.
      *
      * @param  \Illuminate\Database\Connection  $connection
-     * @return void
      */
     public function __construct($connection)
     {

--- a/src/Illuminate/Database/Events/DatabaseRefreshed.php
+++ b/src/Illuminate/Database/Events/DatabaseRefreshed.php
@@ -11,7 +11,6 @@ class DatabaseRefreshed implements MigrationEventContract
      *
      * @param  string|null  $database
      * @param  bool  $seeding
-     * @return void
      */
     public function __construct(
         public ?string $database = null,

--- a/src/Illuminate/Database/Events/MigrationEvent.php
+++ b/src/Illuminate/Database/Events/MigrationEvent.php
@@ -26,7 +26,6 @@ abstract class MigrationEvent implements MigrationEventContract
      *
      * @param  \Illuminate\Database\Migrations\Migration  $migration
      * @param  string  $method
-     * @return void
      */
     public function __construct(Migration $migration, $method)
     {

--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -11,7 +11,6 @@ abstract class MigrationsEvent implements MigrationEventContract
      *
      * @param  string  $method  The migration method that was invoked.
      * @param  array<string, mixed>  $options  The options provided when the migration method was invoked.
-     * @return void
      */
     public function __construct(
         public $method,

--- a/src/Illuminate/Database/Events/MigrationsPruned.php
+++ b/src/Illuminate/Database/Events/MigrationsPruned.php
@@ -32,7 +32,6 @@ class MigrationsPruned
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
-     * @return void
      */
     public function __construct(Connection $connection, string $path)
     {

--- a/src/Illuminate/Database/Events/ModelPruningFinished.php
+++ b/src/Illuminate/Database/Events/ModelPruningFinished.php
@@ -8,7 +8,6 @@ class ModelPruningFinished
      * Create a new event instance.
      *
      * @param  array<class-string>  $models  The class names of the models that were pruned.
-     * @return void
      */
     public function __construct(
         public $models,

--- a/src/Illuminate/Database/Events/ModelPruningStarting.php
+++ b/src/Illuminate/Database/Events/ModelPruningStarting.php
@@ -8,7 +8,6 @@ class ModelPruningStarting
      * Create a new event instance.
      *
      * @param  array<class-string>  $models  The class names of the models that will be pruned.
-     * @return void
      */
     public function __construct(
         public $models

--- a/src/Illuminate/Database/Events/ModelsPruned.php
+++ b/src/Illuminate/Database/Events/ModelsPruned.php
@@ -9,7 +9,6 @@ class ModelsPruned
      *
      * @param  string  $model  The class name of the model that was pruned.
      * @param  int  $count  The number of pruned records.
-     * @return void
      */
     public function __construct(
         public $model,

--- a/src/Illuminate/Database/Events/NoPendingMigrations.php
+++ b/src/Illuminate/Database/Events/NoPendingMigrations.php
@@ -10,7 +10,6 @@ class NoPendingMigrations implements MigrationEvent
      * Create a new event instance.
      *
      * @param  string  $method  The migration method that was called.
-     * @return void
      */
     public function __construct(
         public $method,

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -46,7 +46,6 @@ class QueryExecuted
      * @param  array  $bindings
      * @param  float|null  $time
      * @param  \Illuminate\Database\Connection  $connection
-     * @return void
      */
     public function __construct($sql, $bindings, $time, $connection)
     {

--- a/src/Illuminate/Database/Events/SchemaDumped.php
+++ b/src/Illuminate/Database/Events/SchemaDumped.php
@@ -30,7 +30,6 @@ class SchemaDumped
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
-     * @return void
      */
     public function __construct($connection, $path)
     {

--- a/src/Illuminate/Database/Events/SchemaLoaded.php
+++ b/src/Illuminate/Database/Events/SchemaLoaded.php
@@ -30,7 +30,6 @@ class SchemaLoaded
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
-     * @return void
      */
     public function __construct($connection, $path)
     {

--- a/src/Illuminate/Database/Events/StatementPrepared.php
+++ b/src/Illuminate/Database/Events/StatementPrepared.php
@@ -9,7 +9,6 @@ class StatementPrepared
      *
      * @param  \Illuminate\Database\Connection  $connection  The database connection instance.
      * @param  \PDOStatement  $statement  The PDO statement.
-     * @return void
      */
     public function __construct(
         public $connection,

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -22,7 +22,6 @@ abstract class Grammar
      * Create a new grammar instance.
      *
      * @param  \Illuminate\Database\Connection  $connection
-     * @return void
      */
     public function __construct(Connection $connection)
     {

--- a/src/Illuminate/Database/LazyLoadingViolationException.php
+++ b/src/Illuminate/Database/LazyLoadingViolationException.php
@@ -25,7 +25,6 @@ class LazyLoadingViolationException extends RuntimeException
      *
      * @param  object  $model
      * @param  string  $relation
-     * @return void
      */
     public function __construct($model, $relation)
     {

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -32,7 +32,6 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  string  $table
-     * @return void
      */
     public function __construct(Resolver $resolver, $table)
     {

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -35,7 +35,6 @@ class MigrationCreator
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $customStubPath
-     * @return void
      */
     public function __construct(Filesystem $files, $customStubPath)
     {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -100,7 +100,6 @@ class Migrator
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
-     * @return void
      */
     public function __construct(
         MigrationRepositoryInterface $repository,

--- a/src/Illuminate/Database/MultipleRecordsFoundException.php
+++ b/src/Illuminate/Database/MultipleRecordsFoundException.php
@@ -19,7 +19,6 @@ class MultipleRecordsFoundException extends RuntimeException
      * @param  int  $count
      * @param  int  $code
      * @param  \Throwable|null  $previous
-     * @return void
      */
     public function __construct($count, $code = 0, $previous = null)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -252,7 +252,6 @@ class Builder implements BuilderContract
     /**
      * Create a new query builder instance.
      *
-     * @return void
      */
     public function __construct(
         ConnectionInterface $connection,

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -251,7 +251,6 @@ class Builder implements BuilderContract
 
     /**
      * Create a new query builder instance.
-     *
      */
     public function __construct(
         ConnectionInterface $connection,

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -14,7 +14,6 @@ class Expression implements ExpressionContract
      * Create a new raw query expression.
      *
      * @param  TValue  $value
-     * @return void
      */
     public function __construct(
         protected $value

--- a/src/Illuminate/Database/Query/IndexHint.php
+++ b/src/Illuminate/Database/Query/IndexHint.php
@@ -23,7 +23,6 @@ class IndexHint
      *
      * @param  string  $type
      * @param  string  $index
-     * @return void
      */
     public function __construct($type, $index)
     {

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -54,7 +54,6 @@ class JoinClause extends Builder
      * @param  \Illuminate\Database\Query\Builder  $parentQuery
      * @param  string  $type
      * @param  string  $table
-     * @return void
      */
     public function __construct(Builder $parentQuery, $type, $table)
     {

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -37,7 +37,6 @@ class QueryException extends PDOException
      * @param  string  $sql
      * @param  array  $bindings
      * @param  \Throwable  $previous
-     * @return void
      */
     public function __construct($connectionName, $sql, array $bindings, Throwable $previous)
     {

--- a/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
+++ b/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
@@ -17,7 +17,6 @@ class SQLiteDatabaseDoesNotExistException extends InvalidArgumentException
      * Create a new exception instance.
      *
      * @param  string  $path
-     * @return void
      */
     public function __construct($path)
     {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -96,7 +96,6 @@ class Blueprint
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $table
      * @param  \Closure|null  $callback
-     * @return void
      */
     public function __construct(Connection $connection, $table, ?Closure $callback = null)
     {

--- a/src/Illuminate/Database/Schema/BlueprintState.php
+++ b/src/Illuminate/Database/Schema/BlueprintState.php
@@ -57,7 +57,6 @@ class BlueprintState
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Database\Connection  $connection
-     * @return void
      */
     public function __construct(Blueprint $blueprint, Connection $connection)
     {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -57,7 +57,6 @@ class Builder
      * Create a new database Schema manager.
      *
      * @param  \Illuminate\Database\Connection  $connection
-     * @return void
      */
     public function __construct(Connection $connection)
     {

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -18,7 +18,6 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  array  $attributes
-     * @return void
      */
     public function __construct(Blueprint $blueprint, $attributes = [])
     {

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -49,7 +49,6 @@ abstract class SchemaState
      * @param  \Illuminate\Database\Connection  $connection
      * @param  \Illuminate\Filesystem\Filesystem|null  $files
      * @param  callable|null  $processFactory
-     * @return void
      */
     public function __construct(Connection $connection, ?Filesystem $files = null, ?callable $processFactory = null)
     {

--- a/src/Illuminate/Encryption/MissingAppKeyException.php
+++ b/src/Illuminate/Encryption/MissingAppKeyException.php
@@ -10,7 +10,6 @@ class MissingAppKeyException extends RuntimeException
      * Create a new exception instance.
      *
      * @param  string  $message
-     * @return void
      */
     public function __construct($message = 'No application encryption key has been specified.')
     {

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -88,7 +88,6 @@ class CallQueuedListener implements ShouldQueue
      * @param  class-string  $class
      * @param  string  $method
      * @param  array  $data
-     * @return void
      */
     public function __construct($class, $method, $data)
     {

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -71,7 +71,6 @@ class Dispatcher implements DispatcherContract
      * Create a new event dispatcher instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
-     * @return void
      */
     public function __construct(?ContainerContract $container = null)
     {

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -20,7 +20,6 @@ class NullDispatcher implements DispatcherContract
      * Create a new event dispatcher instance that does not fire.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @return void
      */
     public function __construct(DispatcherContract $dispatcher)
     {

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -49,7 +49,6 @@ class QueuedClosure
      * Create a new queued closure event listener resolver.
      *
      * @param  \Closure  $closure
-     * @return void
      */
     public function __construct(Closure $closure)
     {

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -25,7 +25,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
      * @param  \League\Flysystem\AwsS3V3\AwsS3V3Adapter  $adapter
      * @param  array  $config
      * @param  \Aws\S3\S3Client  $client
-     * @return void
      */
     public function __construct(FilesystemOperator $driver, S3Adapter $adapter, array $config, S3Client $client)
     {

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -97,7 +97,6 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @param  \League\Flysystem\FilesystemOperator  $driver
      * @param  \League\Flysystem\FilesystemAdapter  $adapter
      * @param  array  $config
-     * @return void
      */
     public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config = [])
     {

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -52,7 +52,6 @@ class FilesystemManager implements FactoryContract
      * Create a new filesystem manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -32,7 +32,6 @@ class LockableFile
      *
      * @param  string  $path
      * @param  string  $mode
-     * @return void
      */
     public function __construct($path, $mode)
     {

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -36,7 +36,6 @@ class AliasLoader
      * Create a new AliasLoader instance.
      *
      * @param  array  $aliases
-     * @return void
      */
     private function __construct($aliases)
     {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -212,7 +212,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * Create a new Illuminate application instance.
      *
      * @param  string|null  $basePath
-     * @return void
      */
     public function __construct($basePath = null)
     {

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -61,7 +61,6 @@ class PendingChain
      *
      * @param  mixed  $job
      * @param  array  $chain
-     * @return void
      */
     public function __construct($job, $chain)
     {

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -31,7 +31,6 @@ class PendingDispatch
      * Create a new pending job dispatch.
      *
      * @param  mixed  $job
-     * @return void
      */
     public function __construct($job)
     {

--- a/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
@@ -35,7 +35,6 @@ class CacheBasedMaintenanceMode implements MaintenanceMode
      * @param  \Illuminate\Contracts\Cache\Factory  $cache
      * @param  string  $store
      * @param  string  $key
-     * @return void
      */
     public function __construct(Factory $cache, string $store, string $key)
     {

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -13,7 +13,6 @@ class Exceptions
      * Create a new exception handling configuration instance.
      *
      * @param  \Illuminate\Foundation\Exceptions\Handler  $handler
-     * @return void
      */
     public function __construct(public Handler $handler)
     {

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -53,7 +53,6 @@ class AboutCommand extends Command
      * Create a new command instance.
      *
      * @param  \Illuminate\Support\Composer  $composer
-     * @return void
      */
     public function __construct(Composer $composer)
     {

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -48,7 +48,6 @@ class CliDumper extends BaseCliDumper
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  string  $basePath
      * @param  string  $compiledViewPath
-     * @return void
      */
     public function __construct($output, $basePath, $compiledViewPath)
     {

--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -30,7 +30,6 @@ class ClosureCommand extends Command
      *
      * @param  string  $signature
      * @param  \Closure  $callback
-     * @return void
      */
     public function __construct($signature, Closure $callback)
     {

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -37,7 +37,6 @@ class ConfigCacheCommand extends Command
      * Create a new config cache command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -34,7 +34,6 @@ class ConfigClearCommand extends Command
      * Create a new config clear command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -46,7 +46,6 @@ class EnvironmentDecryptCommand extends Command
      * Create a new command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -45,7 +45,6 @@ class EnvironmentEncryptCommand extends Command
      * Create a new command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -34,7 +34,6 @@ class EventClearCommand extends Command
      * Create a new config clear command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -131,7 +131,6 @@ class Kernel implements KernelContract
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     * @return void
      */
     public function __construct(Application $app, Dispatcher $events)
     {

--- a/src/Illuminate/Foundation/Console/QueuedCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedCommand.php
@@ -22,7 +22,6 @@ class QueuedCommand implements ShouldQueue
      * Create a new job instance.
      *
      * @param  array  $data
-     * @return void
      */
     public function __construct($data)
     {

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -36,7 +36,6 @@ class RouteCacheCommand extends Command
      * Create a new route command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -34,7 +34,6 @@ class RouteClearCommand extends Command
      * Create a new route clear command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -76,7 +76,6 @@ class RouteListCommand extends Command
      * Create a new route command instance.
      *
      * @param  \Illuminate\Routing\Router  $router
-     * @return void
      */
     public function __construct(Router $router)
     {

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -79,7 +79,6 @@ class VendorPublishCommand extends Command
      * Create a new command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -35,7 +35,6 @@ class ViewClearCommand extends Command
      * Create a new config clear command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -15,7 +15,6 @@ class LocaleUpdated
      * Create a new event instance.
      *
      * @param  string  $locale
-     * @return void
      */
     public function __construct($locale)
     {

--- a/src/Illuminate/Foundation/Events/PublishingStubs.php
+++ b/src/Illuminate/Foundation/Events/PublishingStubs.php
@@ -17,7 +17,6 @@ class PublishingStubs
      * Create a new event instance.
      *
      * @param  array  $stubs
-     * @return void
      */
     public function __construct(array $stubs)
     {

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -23,7 +23,6 @@ class VendorTagPublished
      *
      * @param  string  $tag
      * @param  array  $paths
-     * @return void
      */
     public function __construct($tag, $paths)
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -184,7 +184,6 @@ class Handler implements ExceptionHandlerContract
      * Create a new exception handler instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -47,7 +47,6 @@ class Exception
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Foundation\Exceptions\Renderer\Listener  $listener
      * @param  string  $basePath
-     * @return void
      */
     public function __construct(FlattenException $exception, Request $request, Listener $listener, string $basePath)
     {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -44,7 +44,6 @@ class Frame
      * @param  array<string, string>  $classMap
      * @param  array{file: string, line: int, class?: string, type?: string, function?: string}  $frame
      * @param  string  $basePath
-     * @return void
      */
     public function __construct(FlattenException $exception, array $classMap, array $frame, string $basePath)
     {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -63,7 +63,6 @@ class BladeMapper
      *
      * @param  \Illuminate\Contracts\View\Factory  $factory
      * @param  \Illuminate\View\Compilers\BladeCompiler  $bladeCompiler
-     * @return void
      */
     public function __construct(Factory $factory, BladeCompiler $bladeCompiler)
     {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -61,7 +61,6 @@ class Renderer
      * @param  \Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer  $htmlErrorRenderer
      * @param  \Illuminate\Foundation\Exceptions\Renderer\Mappers\BladeMapper  $bladeMapper
      * @param  string  $basePath
-     * @return void
      */
     public function __construct(
         Factory $viewFactory,

--- a/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/ReportableHandler.php
@@ -27,7 +27,6 @@ class ReportableHandler
      * Create a new reportable handler instance.
      *
      * @param  callable  $callback
-     * @return void
      */
     public function __construct(callable $callback)
     {

--- a/src/Illuminate/Foundation/Http/Events/RequestHandled.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestHandled.php
@@ -23,7 +23,6 @@ class RequestHandled
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Http\Response  $response
-     * @return void
      */
     public function __construct($request, $response)
     {

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -53,7 +53,6 @@ class HtmlDumper extends BaseHtmlDumper
      *
      * @param  string  $basePath
      * @param  string  $compiledViewPath
-     * @return void
      */
     public function __construct($basePath, $compiledViewPath)
     {

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -119,7 +119,6 @@ class Kernel implements KernelContract
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Routing\Router  $router
-     * @return void
      */
     public function __construct(Application $app, Router $router)
     {

--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -21,7 +21,6 @@ class HandlePrecognitiveRequests
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -39,7 +39,6 @@ class PreventRequestsDuringMaintenance
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct(Application $app)
     {

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -60,7 +60,6 @@ class VerifyCsrfToken
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
-     * @return void
      */
     public function __construct(Application $app, Encrypter $encrypter)
     {

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -50,7 +50,6 @@ class PackageManifest
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $basePath
      * @param  string  $manifestPath
-     * @return void
      */
     public function __construct(Filesystem $files, $basePath, $manifestPath)
     {

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -35,7 +35,6 @@ class ProviderRepository
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $manifestPath
-     * @return void
      */
     public function __construct(ApplicationContract $app, Filesystem $files, $manifestPath)
     {

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
@@ -15,7 +15,6 @@ class DatabaseTransactionsManager extends BaseManager
      * Create a new database transaction manager instance.
      *
      * @param  array  $connectionsTransacting
-     * @return void
      */
     public function __construct(array $connectionsTransacting)
     {

--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -17,7 +17,6 @@ class Wormhole
      * Create a new wormhole instance.
      *
      * @param  int  $value
-     * @return void
      */
     public function __construct($value)
     {

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -40,7 +40,6 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      * Create a new hasher instance.
      *
      * @param  array  $options
-     * @return void
      */
     public function __construct(array $options = [])
     {

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -34,7 +34,6 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      * Create a new hasher instance.
      *
      * @param  array  $options
-     * @return void
      */
     public function __construct(array $options = [])
     {

--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -26,7 +26,6 @@ class ConnectionFailed
      *
      * @param  \Illuminate\Http\Client\Request  $request
      * @param  \Illuminate\Http\Client\ConnectionException  $exception
-     * @return void
      */
     public function __construct(Request $request, ConnectionException $exception)
     {

--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -17,7 +17,6 @@ class RequestSending
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Client\Request  $request
-     * @return void
      */
     public function __construct(Request $request)
     {

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -26,7 +26,6 @@ class ResponseReceived
      *
      * @param  \Illuminate\Http\Client\Request  $request
      * @param  \Illuminate\Http\Client\Response  $response
-     * @return void
      */
     public function __construct(Request $request, Response $response)
     {

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -84,7 +84,6 @@ class Factory
      * Create a new factory instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
-     * @return void
      */
     public function __construct(?Dispatcher $dispatcher = null)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -220,7 +220,6 @@ class PendingRequest
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
      * @param  array  $middleware
-     * @return void
      */
     public function __construct(?Factory $factory = null, $middleware = [])
     {

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -34,7 +34,6 @@ class Pool
      * Create a new requests pool.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
-     * @return void
      */
     public function __construct(?Factory $factory = null)
     {

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -30,7 +30,6 @@ class Request implements ArrayAccess
      * Create a new request instance.
      *
      * @param  \Psr\Http\Message\RequestInterface  $request
-     * @return void
      */
     public function __construct($request)
     {

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -24,7 +24,6 @@ class RequestException extends HttpClientException
      * Create a new exception instance.
      *
      * @param  \Illuminate\Http\Client\Response  $response
-     * @return void
      */
     public function __construct(Response $response)
     {

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -51,7 +51,6 @@ class Response implements ArrayAccess, Stringable
      * Create a new response instance.
      *
      * @param  \Psr\Http\Message\MessageInterface  $response
-     * @return void
      */
     public function __construct($response)
     {

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -35,7 +35,6 @@ class ResponseSequence
      * Create a new response sequence.
      *
      * @param  array  $responses
-     * @return void
      */
     public function __construct(array $responses)
     {

--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -20,7 +20,6 @@ class HttpResponseException extends RuntimeException
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @param  \Throwable  $previous
-     * @return void
      */
     public function __construct(Response $response, ?Throwable $previous = null)
     {

--- a/src/Illuminate/Http/Exceptions/MalformedUrlException.php
+++ b/src/Illuminate/Http/Exceptions/MalformedUrlException.php
@@ -8,7 +8,6 @@ class MalformedUrlException extends HttpException
 {
     /**
      * Create a new exception instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Http/Exceptions/MalformedUrlException.php
+++ b/src/Illuminate/Http/Exceptions/MalformedUrlException.php
@@ -9,7 +9,6 @@ class MalformedUrlException extends HttpException
     /**
      * Create a new exception instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -14,7 +14,6 @@ class PostTooLargeException extends HttpException
      * @param  \Throwable|null  $previous
      * @param  array  $headers
      * @param  int  $code
-     * @return void
      */
     public function __construct($message = '', ?Throwable $previous = null, array $headers = [], $code = 0)
     {

--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -14,7 +14,6 @@ class ThrottleRequestsException extends TooManyRequestsHttpException
      * @param  \Throwable|null  $previous
      * @param  array  $headers
      * @param  int  $code
-     * @return void
      */
     public function __construct($message = '', ?Throwable $previous = null, array $headers = [], $code = 0)
     {

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -23,7 +23,6 @@ class JsonResponse extends BaseJsonResponse
      * @param  array  $headers
      * @param  int  $options
      * @param  bool  $json
-     * @return void
      */
     public function __construct($data = null, $status = 200, $headers = [], $options = 0, $json = false)
     {

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -28,7 +28,6 @@ class HandleCors
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Fruitcake\Cors\CorsService  $cors
-     * @return void
      */
     public function __construct(Container $container, CorsService $cors)
     {

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -32,7 +32,6 @@ class TrustHosts
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct(Application $app)
     {

--- a/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
@@ -23,7 +23,6 @@ class AnonymousResourceCollection extends ResourceCollection
      *
      * @param  mixed  $resource
      * @param  string  $collects
-     * @return void
      */
     public function __construct($resource, $collects)
     {

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -53,7 +53,6 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Create a new resource instance.
      *
      * @param  mixed  $resource
-     * @return void
      */
     public function __construct($resource)
     {

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -45,7 +45,6 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      * Create a new resource instance.
      *
      * @param  mixed  $resource
-     * @return void
      */
     public function __construct($resource)
     {

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -19,7 +19,6 @@ class ResourceResponse implements Responsable
      * Create a new resource response.
      *
      * @param  mixed  $resource
-     * @return void
      */
     public function __construct($resource)
     {

--- a/src/Illuminate/Http/Resources/MergeValue.php
+++ b/src/Illuminate/Http/Resources/MergeValue.php
@@ -18,7 +18,6 @@ class MergeValue
      * Create a new merge value instance.
      *
      * @param  \Illuminate\Support\Collection|\JsonSerializable|array  $data
-     * @return void
      */
     public function __construct($data)
     {

--- a/src/Illuminate/Http/StreamedEvent.php
+++ b/src/Illuminate/Http/StreamedEvent.php
@@ -17,7 +17,6 @@ class StreamedEvent
     /**
      * Create a new streamed event instance.
      *
-     * @return void
      */
     public function __construct(string $event, mixed $data)
     {

--- a/src/Illuminate/Http/StreamedEvent.php
+++ b/src/Illuminate/Http/StreamedEvent.php
@@ -16,7 +16,6 @@ class StreamedEvent
 
     /**
      * Create a new streamed event instance.
-     *
      */
     public function __construct(string $event, mixed $data)
     {

--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -39,7 +39,6 @@ class File extends UploadedFile
      *
      * @param  string  $name
      * @param  resource  $tempFile
-     * @return void
      */
     public function __construct($name, $tempFile)
     {

--- a/src/Illuminate/Log/Events/MessageLogged.php
+++ b/src/Illuminate/Log/Events/MessageLogged.php
@@ -31,7 +31,6 @@ class MessageLogged
      * @param  string  $level
      * @param  string  $message
      * @param  array  $context
-     * @return void
      */
     public function __construct($level, $message, array $context = [])
     {

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -69,7 +69,6 @@ class LogManager implements LoggerInterface
      * Create a new Log manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -41,7 +41,6 @@ class Logger implements LoggerInterface
      *
      * @param  \Psr\Log\LoggerInterface  $logger
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
-     * @return void
      */
     public function __construct(LoggerInterface $logger, ?Dispatcher $dispatcher = null)
     {

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -37,7 +37,6 @@ class Attachment
      * Create a mail attachment.
      *
      * @param  \Closure  $resolver
-     * @return void
      */
     private function __construct(Closure $resolver)
     {

--- a/src/Illuminate/Mail/Events/MessageSending.php
+++ b/src/Illuminate/Mail/Events/MessageSending.php
@@ -11,7 +11,6 @@ class MessageSending
      *
      * @param  \Symfony\Component\Mime\Email  $message  The Symfony Email instance.
      * @param  array  $data  The message data.
-     * @return void
      */
     public function __construct(
         public Email $message,

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -16,7 +16,6 @@ class MessageSent
      *
      * @param  \Illuminate\Mail\SentMessage  $sent  The message that was sent.
      * @param  array  $data  The message data.
-     * @return void
      */
     public function __construct(
         public SentMessage $sent,

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -59,7 +59,6 @@ class MailManager implements FactoryContract
      * Create a new Mail manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Mail/Mailables/Address.php
+++ b/src/Illuminate/Mail/Mailables/Address.php
@@ -23,7 +23,6 @@ class Address
      *
      * @param  string  $address
      * @param  string|null  $name
-     * @return void
      */
     public function __construct(string $address, ?string $name = null)
     {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -95,7 +95,6 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  \Illuminate\Contracts\View\Factory  $views
      * @param  \Symfony\Component\Mailer\Transport\TransportInterface  $transport
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $events
-     * @return void
      */
     public function __construct(string $name, Factory $views, TransportInterface $transport, ?Dispatcher $events = null)
     {

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -39,7 +39,6 @@ class Markdown
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
      * @param  array  $options
-     * @return void
      */
     public function __construct(ViewFactory $view, array $options = [])
     {

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -38,7 +38,6 @@ class Message
      * Create a new message instance.
      *
      * @param  \Symfony\Component\Mime\Email  $message
-     * @return void
      */
     public function __construct(Email $message)
     {

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -50,7 +50,6 @@ class PendingMail
      * Create a new mailable mailer instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
-     * @return void
      */
     public function __construct(MailerContract $mailer)
     {

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -52,7 +52,6 @@ class SendQueuedMailable
      * Create a new job instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
-     * @return void
      */
     public function __construct(MailableContract $mailable)
     {

--- a/src/Illuminate/Mail/SentMessage.php
+++ b/src/Illuminate/Mail/SentMessage.php
@@ -24,7 +24,6 @@ class SentMessage
      * Create a new SentMessage instance.
      *
      * @param  \Symfony\Component\Mailer\SentMessage  $sentMessage
-     * @return void
      */
     public function __construct(SymfonySentMessage $sentMessage)
     {

--- a/src/Illuminate/Mail/TextMessage.php
+++ b/src/Illuminate/Mail/TextMessage.php
@@ -22,7 +22,6 @@ class TextMessage
      * Create a new text message instance.
      *
      * @param  \Illuminate\Mail\Message  $message
-     * @return void
      */
     public function __construct($message)
     {

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -20,7 +20,6 @@ class ArrayTransport implements Stringable, TransportInterface
 
     /**
      * Create a new array transport instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -21,7 +21,6 @@ class ArrayTransport implements Stringable, TransportInterface
     /**
      * Create a new array transport instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -23,7 +23,6 @@ class LogTransport implements Stringable, TransportInterface
      * Create a new log transport instance.
      *
      * @param  \Psr\Log\LoggerInterface  $logger
-     * @return void
      */
     public function __construct(LoggerInterface $logger)
     {

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -33,7 +33,6 @@ class SesTransport extends AbstractTransport implements Stringable
      *
      * @param  \Aws\Ses\SesClient  $ses
      * @param  array  $options
-     * @return void
      */
     public function __construct(SesClient $ses, $options = [])
     {

--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -33,7 +33,6 @@ class SesV2Transport extends AbstractTransport implements Stringable
      *
      * @param  \Aws\SesV2\SesV2Client  $ses
      * @param  array  $options
-     * @return void
      */
     public function __construct(SesV2Client $ses, $options = [])
     {

--- a/src/Illuminate/Notifications/Action.php
+++ b/src/Illuminate/Notifications/Action.php
@@ -23,7 +23,6 @@ class Action
      *
      * @param  string  $text
      * @param  string  $url
-     * @return void
      */
     public function __construct($text, $url)
     {

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -21,7 +21,6 @@ class BroadcastChannel
      * Create a new broadcast channel.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     * @return void
      */
     public function __construct(Dispatcher $events)
     {

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -36,7 +36,6 @@ class MailChannel
      *
      * @param  \Illuminate\Contracts\Mail\Factory  $mailer
      * @param  \Illuminate\Mail\Markdown  $markdown
-     * @return void
      */
     public function __construct(MailFactory $mailer, Markdown $markdown)
     {

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -20,7 +20,6 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      * @param  mixed  $notifiable  The notifiable entity who received the notification.
      * @param  \Illuminate\Notifications\Notification  $notification  The notification instance.
      * @param  array  $data  The notification data.
-     * @return void
      */
     public function __construct(
         public $notifiable,

--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -16,7 +16,6 @@ class NotificationFailed
      * @param  \Illuminate\Notifications\Notification  $notification  The notification instance.
      * @param  string  $channel  The channel name.
      * @param  array  $data  The data needed to process this failure.
-     * @return void
      */
     public function __construct(
         public $notifiable,

--- a/src/Illuminate/Notifications/Events/NotificationSending.php
+++ b/src/Illuminate/Notifications/Events/NotificationSending.php
@@ -15,7 +15,6 @@ class NotificationSending
      * @param  mixed  $notifiable  The notifiable entity who received the notification.
      * @param  \Illuminate\Notifications\Notification  $notification  The notification instance.
      * @param  string  $channel  The channel name.
-     * @return void
      */
     public function __construct(
         public $notifiable,

--- a/src/Illuminate/Notifications/Events/NotificationSent.php
+++ b/src/Illuminate/Notifications/Events/NotificationSent.php
@@ -16,7 +16,6 @@ class NotificationSent
      * @param  \Illuminate\Notifications\Notification  $notification  The notification instance.
      * @param  string  $channel  The channel name.
      * @param  mixed  $response  The channel's response.
-     * @return void
      */
     public function __construct(
         public $notifiable,

--- a/src/Illuminate/Notifications/Messages/BroadcastMessage.php
+++ b/src/Illuminate/Notifications/Messages/BroadcastMessage.php
@@ -19,7 +19,6 @@ class BroadcastMessage
      * Create a new message instance.
      *
      * @param  array  $data
-     * @return void
      */
     public function __construct(array $data)
     {

--- a/src/Illuminate/Notifications/Messages/DatabaseMessage.php
+++ b/src/Illuminate/Notifications/Messages/DatabaseMessage.php
@@ -15,7 +15,6 @@ class DatabaseMessage
      * Create a new database message.
      *
      * @param  array  $data
-     * @return void
      */
     public function __construct(array $data = [])
     {

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -51,7 +51,6 @@ class NotificationSender
      * @param  \Illuminate\Contracts\Bus\Dispatcher  $bus
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  string|null  $locale
-     * @return void
      */
     public function __construct($manager, $bus, $events, $locale = null)
     {

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -71,7 +71,6 @@ class SendQueuedNotifications implements ShouldQueue
      * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
      * @param  \Illuminate\Notifications\Notification  $notification
      * @param  array|null  $channels
-     * @return void
      */
     public function __construct($notifiables, $notification, ?array $channels = null)
     {

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -39,7 +39,6 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
      * @param  int  $perPage
      * @param  \Illuminate\Pagination\Cursor|null  $cursor
      * @param  array  $options  (path, query, fragment, pageName)
-     * @return void
      */
     public function __construct($items, $perPage, $cursor = null, array $options = [])
     {

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,7 +47,6 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @param  int  $perPage
      * @param  int|null  $currentPage
      * @param  array  $options  (path, query, fragment, pageName)
-     * @return void
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -39,7 +39,6 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      * @param  int  $perPage
      * @param  int|null  $currentPage
      * @param  array  $options  (path, query, fragment, pageName)
-     * @return void
      */
     public function __construct($items, $perPage, $currentPage = null, array $options = [])
     {

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -17,7 +17,6 @@ class UrlWindow
      * Create a new URL window instance.
      *
      * @param  \Illuminate\Contracts\Pagination\LengthAwarePaginator  $paginator
-     * @return void
      */
     public function __construct(PaginatorContract $paginator)
     {

--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -26,7 +26,6 @@ class Hub implements HubContract
      * Create a new Hub instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
-     * @return void
      */
     public function __construct(?Container $container = null)
     {

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -52,7 +52,6 @@ class Pipeline implements PipelineContract
      * Create a new class instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
-     * @return void
      */
     public function __construct(?Container $container = null)
     {

--- a/src/Illuminate/Process/Exceptions/ProcessFailedException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessFailedException.php
@@ -18,7 +18,6 @@ class ProcessFailedException extends RuntimeException
      * Create a new exception instance.
      *
      * @param  \Illuminate\Contracts\Process\ProcessResult  $result
-     * @return void
      */
     public function __construct(ProcessResult $result)
     {

--- a/src/Illuminate/Process/Exceptions/ProcessTimedOutException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessTimedOutException.php
@@ -20,7 +20,6 @@ class ProcessTimedOutException extends RuntimeException
      *
      * @param  \Symfony\Component\Process\Exception\ProcessTimedOutException  $original
      * @param  \Illuminate\Contracts\Process\ProcessResult  $result
-     * @return void
      */
     public function __construct(SymfonyTimeoutException $original, ProcessResult $result)
     {

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -60,7 +60,6 @@ class FakeInvokedProcess implements InvokedProcessContract
      *
      * @param  string  $command
      * @param  \Illuminate\Process\FakeProcessDescription  $process
-     * @return void
      */
     public function __construct(string $command, FakeProcessDescription $process)
     {

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -43,7 +43,6 @@ class FakeProcessResult implements ProcessResultContract
      * @param  int  $exitCode
      * @param  array|string  $output
      * @param  array|string  $errorOutput
-     * @return void
      */
     public function __construct(string $command = '', int $exitCode = 0, array|string $output = '', array|string $errorOutput = '')
     {

--- a/src/Illuminate/Process/FakeProcessSequence.php
+++ b/src/Illuminate/Process/FakeProcessSequence.php
@@ -32,7 +32,6 @@ class FakeProcessSequence
      * Create a new fake process sequence instance.
      *
      * @param  array  $processes
-     * @return void
      */
     public function __construct(array $processes = [])
     {

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -20,7 +20,6 @@ class InvokedProcess implements InvokedProcessContract
      * Create a new invoked process instance.
      *
      * @param  \Symfony\Component\Process\Process  $process
-     * @return void
      */
     public function __construct(Process $process)
     {

--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -18,7 +18,6 @@ class InvokedProcessPool implements Countable
      * Create a new invoked process pool.
      *
      * @param  array  $invokedProcesses
-     * @return void
      */
     public function __construct(array $invokedProcesses)
     {

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -97,7 +97,6 @@ class PendingProcess
      * Create a new pending process instance.
      *
      * @param  \Illuminate\Process\Factory  $factory
-     * @return void
      */
     public function __construct(Factory $factory)
     {

--- a/src/Illuminate/Process/Pipe.php
+++ b/src/Illuminate/Process/Pipe.php
@@ -37,7 +37,6 @@ class Pipe
      *
      * @param  \Illuminate\Process\Factory  $factory
      * @param  callable  $callback
-     * @return void
      */
     public function __construct(Factory $factory, callable $callback)
     {

--- a/src/Illuminate/Process/Pool.php
+++ b/src/Illuminate/Process/Pool.php
@@ -37,7 +37,6 @@ class Pool
      *
      * @param  \Illuminate\Process\Factory  $factory
      * @param  callable  $callback
-     * @return void
      */
     public function __construct(Factory $factory, callable $callback)
     {

--- a/src/Illuminate/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Process/ProcessPoolResults.php
@@ -18,7 +18,6 @@ class ProcessPoolResults implements ArrayAccess
      * Create a new process pool result set.
      *
      * @param  array  $results
-     * @return void
      */
     public function __construct(array $results)
     {

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -19,7 +19,6 @@ class ProcessResult implements ProcessResultContract
      * Create a new process result instance.
      *
      * @param  \Symfony\Component\Process\Process  $process
-     * @return void
      */
     public function __construct(Process $process)
     {

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -48,7 +48,6 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  int  $timeToRun
      * @param  int  $blockFor
      * @param  bool  $dispatchAfterCommit
-     * @return void
      */
     public function __construct(
         $pheanstalk,

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -40,7 +40,6 @@ class CallQueuedClosure implements ShouldQueue
      * Create a new job instance.
      *
      * @param  \Laravel\SerializableClosure\SerializableClosure  $closure
-     * @return void
      */
     public function __construct($closure)
     {

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -41,7 +41,6 @@ class CallQueuedHandler
      *
      * @param  \Illuminate\Contracts\Bus\Dispatcher  $dispatcher
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
      */
     public function __construct(Dispatcher $dispatcher, Container $container)
     {

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -26,7 +26,6 @@ class Manager
      * Create a new queue capsule manager.
      *
      * @param  \Illuminate\Container\Container|null  $container
-     * @return void
      */
     public function __construct(?Container $container = null)
     {

--- a/src/Illuminate/Queue/Connectors/DatabaseConnector.php
+++ b/src/Illuminate/Queue/Connectors/DatabaseConnector.php
@@ -18,7 +18,6 @@ class DatabaseConnector implements ConnectorInterface
      * Create a new connector instance.
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
-     * @return void
      */
     public function __construct(ConnectionResolverInterface $connections)
     {

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -26,7 +26,6 @@ class RedisConnector implements ConnectorInterface
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
      * @param  string|null  $connection
-     * @return void
      */
     public function __construct(Redis $redis, $connection = null)
     {

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -47,7 +47,6 @@ class ListenCommand extends Command
      * Create a new queue listen command.
      *
      * @param  \Illuminate\Queue\Listener  $listener
-     * @return void
      */
     public function __construct(Listener $listener)
     {

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -47,7 +47,6 @@ class MonitorCommand extends Command
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $manager
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     * @return void
      */
     public function __construct(Factory $manager, Dispatcher $events)
     {

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -37,7 +37,6 @@ class RestartCommand extends Command
      * Create a new queue restart command.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @return void
      */
     public function __construct(Cache $cache)
     {

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -89,7 +89,6 @@ class WorkCommand extends Command
      *
      * @param  \Illuminate\Queue\Worker  $worker
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @return void
      */
     public function __construct(Worker $worker, Cache $cache)
     {

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -51,7 +51,6 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $default
      * @param  int  $retryAfter
      * @param  bool  $dispatchAfterCommit
-     * @return void
      */
     public function __construct(
         Connection $database,

--- a/src/Illuminate/Queue/Events/JobAttempted.php
+++ b/src/Illuminate/Queue/Events/JobAttempted.php
@@ -10,7 +10,6 @@ class JobAttempted
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
      * @param  bool  $exceptionOccurred  Indicates if an exception occurred while processing the job.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobExceptionOccurred.php
+++ b/src/Illuminate/Queue/Events/JobExceptionOccurred.php
@@ -10,7 +10,6 @@ class JobExceptionOccurred
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
      * @param  \Throwable  $exception  The exception instance.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobFailed.php
+++ b/src/Illuminate/Queue/Events/JobFailed.php
@@ -10,7 +10,6 @@ class JobFailed
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
      * @param  \Throwable  $exception  The exception that caused the job to fail.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobPopped.php
+++ b/src/Illuminate/Queue/Events/JobPopped.php
@@ -9,7 +9,6 @@ class JobPopped
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job|null  $job  The job instance.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobPopping.php
+++ b/src/Illuminate/Queue/Events/JobPopping.php
@@ -8,7 +8,6 @@ class JobPopping
      * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobProcessed.php
+++ b/src/Illuminate/Queue/Events/JobProcessed.php
@@ -9,7 +9,6 @@ class JobProcessed
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobProcessing.php
+++ b/src/Illuminate/Queue/Events/JobProcessing.php
@@ -9,7 +9,6 @@ class JobProcessing
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -13,7 +13,6 @@ class JobQueued
      * @param  \Closure|string|object  $job  The job instance.
      * @param  string  $payload  The job payload.
      * @param  int|null  $delay  The amount of time the job was delayed.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -12,7 +12,6 @@ class JobQueueing
      * @param  \Closure|string|object  $job  The job instance.
      * @param  string  $payload  The job payload.
      * @param  int|null  $delay  The number of seconds the job was delayed.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobReleasedAfterException.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterException.php
@@ -9,7 +9,6 @@ class JobReleasedAfterException
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobRetryRequested.php
+++ b/src/Illuminate/Queue/Events/JobRetryRequested.php
@@ -15,7 +15,6 @@ class JobRetryRequested
      * Create a new event instance.
      *
      * @param  \stdClass  $job  The job instance.
-     * @return void
      */
     public function __construct(
         public $job,

--- a/src/Illuminate/Queue/Events/JobTimedOut.php
+++ b/src/Illuminate/Queue/Events/JobTimedOut.php
@@ -9,7 +9,6 @@ class JobTimedOut
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/Looping.php
+++ b/src/Illuminate/Queue/Events/Looping.php
@@ -9,7 +9,6 @@ class Looping
      *
      * @param  string  $connectionName  The connection name.
      * @param  string  $queue  The queue name.
-     * @return void
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/QueueBusy.php
+++ b/src/Illuminate/Queue/Events/QueueBusy.php
@@ -10,7 +10,6 @@ class QueueBusy
      * @param  string  $connection  The connection name.
      * @param  string  $queue  The queue name.
      * @param  int  $size  The size of the queue.
-     * @return void
      */
     public function __construct(
         public $connection,

--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -9,7 +9,6 @@ class WorkerStopping
      *
      * @param  int  $status  The worker exit status.
      * @param  \Illuminate\Queue\WorkerOptions|null  $workerOptions  The worker options.
-     * @return void
      */
     public function __construct(
         public $status = 0,

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -35,7 +35,6 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  string  $database
      * @param  string  $table
-     * @return void
      */
     public function __construct(ConnectionResolverInterface $resolver, $database, $table)
     {

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -35,7 +35,6 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  string  $database
      * @param  string  $table
-     * @return void
      */
     public function __construct(ConnectionResolverInterface $resolver, $database, $table)
     {

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -38,7 +38,6 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
      * @param  \Aws\DynamoDb\DynamoDbClient  $dynamo
      * @param  string  $applicationName
      * @param  string  $table
-     * @return void
      */
     public function __construct(DynamoDbClient $dynamo, $applicationName, $table)
     {

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -36,7 +36,6 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
      * @param  string  $path
      * @param  int  $limit
      * @param  \Closure|null  $lockProviderResolver
-     * @return void
      */
     public function __construct($path, $limit = 100, ?Closure $lockProviderResolver = null)
     {

--- a/src/Illuminate/Queue/InvalidPayloadException.php
+++ b/src/Illuminate/Queue/InvalidPayloadException.php
@@ -18,7 +18,6 @@ class InvalidPayloadException extends InvalidArgumentException
      *
      * @param  string|null  $message
      * @param  mixed  $value
-     * @return void
      */
     public function __construct($message = null, $value = null)
     {

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -31,7 +31,6 @@ class BeanstalkdJob extends Job implements JobContract
      * @param  \Pheanstalk\Contract\JobIdInterface  $job
      * @param  string  $connectionName
      * @param  string  $queue
-     * @return void
      */
     public function __construct(Container $container, $pheanstalk, JobIdInterface $job, $connectionName, $queue)
     {

--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -30,7 +30,6 @@ class DatabaseJob extends Job implements JobContract
      * @param  \stdClass  $job
      * @param  string  $connectionName
      * @param  string  $queue
-     * @return void
      */
     public function __construct(Container $container, DatabaseQueue $database, $job, $connectionName, $queue)
     {

--- a/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
@@ -19,7 +19,6 @@ class DatabaseJobRecord
      * Create a new job record instance.
      *
      * @param  \stdClass  $record
-     * @return void
      */
     public function __construct($record)
     {

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -45,7 +45,6 @@ class RedisJob extends Job implements JobContract
      * @param  string  $reserved
      * @param  string  $connectionName
      * @param  string  $queue
-     * @return void
      */
     public function __construct(Container $container, RedisQueue $redis, $job, $reserved, $connectionName, $queue)
     {

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -30,7 +30,6 @@ class SqsJob extends Job implements JobContract
      * @param  array  $job
      * @param  string  $connectionName
      * @param  string  $queue
-     * @return void
      */
     public function __construct(Container $container, SqsClient $sqs, array $job, $connectionName, $queue)
     {

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -28,7 +28,6 @@ class SyncJob extends Job implements JobContract
      * @param  string  $payload
      * @param  string  $connectionName
      * @param  string  $queue
-     * @return void
      */
     public function __construct(Container $container, $payload, $connectionName, $queue)
     {

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -49,7 +49,6 @@ class Listener
      * Create a new queue listener.
      *
      * @param  string  $commandPath
-     * @return void
      */
     public function __construct($commandPath)
     {

--- a/src/Illuminate/Queue/ListenerOptions.php
+++ b/src/Illuminate/Queue/ListenerOptions.php
@@ -23,7 +23,6 @@ class ListenerOptions extends WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      * @param  int  $rest
-     * @return void
      */
     public function __construct($name = 'default', $environment = null, $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1, $force = false, $rest = 0)
     {

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -36,7 +36,6 @@ class RateLimited
      * Create a new middleware instance.
      *
      * @param  \BackedEnum|\UnitEnum|string  $limiterName
-     * @return void
      */
     public function __construct($limiterName)
     {

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -29,7 +29,6 @@ class RateLimitedWithRedis extends RateLimited
      * Create a new middleware instance.
      *
      * @param  string  $limiterName
-     * @return void
      */
     public function __construct($limiterName)
     {

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -76,7 +76,6 @@ class ThrottlesExceptions
      *
      * @param  int  $maxAttempts
      * @param  int  $decaySeconds
-     * @return void
      */
     public function __construct($maxAttempts = 10, $decaySeconds = 600)
     {

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -51,7 +51,6 @@ class WithoutOverlapping
      * @param  string  $key
      * @param  \DateTimeInterface|int|null  $releaseAfter
      * @param  \DateTimeInterface|int  $expiresAfter
-     * @return void
      */
     public function __construct($key = '', $releaseAfter = 0, $expiresAfter = 0)
     {

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -37,7 +37,6 @@ class QueueManager implements FactoryContract, MonitorContract
      * Create a new queue manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -75,7 +75,6 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  int|null  $blockFor
      * @param  bool  $dispatchAfterCommit
      * @param  int  $migrationBatchSize
-     * @return void
      */
     public function __construct(
         Redis $redis,

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -46,7 +46,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $prefix
      * @param  string  $suffix
      * @param  bool  $dispatchAfterCommit
-     * @return void
      */
     public function __construct(
         SqsClient $sqs,

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -16,7 +16,6 @@ class SyncQueue extends Queue implements QueueContract
      * Create a new sync queue instance.
      *
      * @param  bool  $dispatchAfterCommit
-     * @return void
      */
     public function __construct($dispatchAfterCommit = false)
     {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -106,7 +106,6 @@ class Worker
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $exceptions
      * @param  callable  $isDownForMaintenance
      * @param  callable|null  $resetScope
-     * @return void
      */
     public function __construct(
         QueueManager $manager,

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -95,7 +95,6 @@ class WorkerOptions
      * @param  int  $maxJobs
      * @param  int  $maxTime
      * @param  int  $rest
-     * @return void
      */
     public function __construct(
         $name = 'default',

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -35,7 +35,6 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  \Redis  $client
      * @param  callable|null  $connector
      * @param  array  $config
-     * @return void
      */
     public function __construct($client, ?callable $connector = null, array $config = [])
     {

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -23,7 +23,6 @@ class PredisConnection extends Connection implements ConnectionContract
      * Create a new Predis connection.
      *
      * @param  \Predis\Client  $client
-     * @return void
      */
     public function __construct($client)
     {

--- a/src/Illuminate/Redis/Events/CommandExecuted.php
+++ b/src/Illuminate/Redis/Events/CommandExecuted.php
@@ -46,7 +46,6 @@ class CommandExecuted
      * @param  array  $parameters
      * @param  float|null  $time
      * @param  \Illuminate\Redis\Connections\Connection  $connection
-     * @return void
      */
     public function __construct($command, $parameters, $time, $connection)
     {

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -44,7 +44,6 @@ class ConcurrencyLimiter
      * @param  string  $name
      * @param  int  $maxLocks
      * @param  int  $releaseAfter
-     * @return void
      */
     public function __construct($redis, $name, $maxLocks, $releaseAfter)
     {

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
@@ -56,7 +56,6 @@ class ConcurrencyLimiterBuilder
      *
      * @param  \Illuminate\Redis\Connections\Connection  $connection
      * @param  string  $name
-     * @return void
      */
     public function __construct($connection, $name)
     {

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -56,7 +56,6 @@ class DurationLimiter
      * @param  string  $name
      * @param  int  $maxLocks
      * @param  int  $decay
-     * @return void
      */
     public function __construct($redis, $name, $maxLocks, $decay)
     {

--- a/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
@@ -56,7 +56,6 @@ class DurationLimiterBuilder
      *
      * @param  \Illuminate\Redis\Connections\Connection  $connection
      * @param  string  $name
-     * @return void
      */
     public function __construct($connection, $name)
     {

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -64,7 +64,6 @@ class RedisManager implements Factory
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  string  $driver
      * @param  array  $config
-     * @return void
      */
     public function __construct($app, $driver, array $config)
     {

--- a/src/Illuminate/Routing/CallableDispatcher.php
+++ b/src/Illuminate/Routing/CallableDispatcher.php
@@ -21,7 +21,6 @@ class CallableDispatcher implements CallableDispatcherContract
      * Create a new callable dispatcher instance.
      *
      * @param  \Illuminate\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -54,7 +54,6 @@ class CompiledRouteCollection extends AbstractRouteCollection
      *
      * @param  array  $compiled
      * @param  array  $attributes
-     * @return void
      */
     public function __construct(array $compiled, array $attributes)
     {

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -21,7 +21,6 @@ class ControllerDispatcher implements ControllerDispatcherContract
      * Create a new controller dispatcher instance.
      *
      * @param  \Illuminate\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Routing/ControllerMiddlewareOptions.php
+++ b/src/Illuminate/Routing/ControllerMiddlewareOptions.php
@@ -15,7 +15,6 @@ class ControllerMiddlewareOptions
      * Create a new middleware option instance.
      *
      * @param  array  $options
-     * @return void
      */
     public function __construct(array &$options)
     {

--- a/src/Illuminate/Routing/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Middleware.php
@@ -11,7 +11,6 @@ class Middleware
      * Create a new controller middleware definition.
      *
      * @param  \Closure|string|array  $middleware
-     * @return void
      */
     public function __construct(public Closure|string|array $middleware, public ?array $only = null, public ?array $except = null)
     {

--- a/src/Illuminate/Routing/Events/PreparingResponse.php
+++ b/src/Illuminate/Routing/Events/PreparingResponse.php
@@ -9,7 +9,6 @@ class PreparingResponse
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request  The request instance.
      * @param  mixed  $response  The response instance.
-     * @return void
      */
     public function __construct(
         public $request,

--- a/src/Illuminate/Routing/Events/ResponsePrepared.php
+++ b/src/Illuminate/Routing/Events/ResponsePrepared.php
@@ -9,7 +9,6 @@ class ResponsePrepared
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request  The request instance.
      * @param  \Symfony\Component\HttpFoundation\Response  $response  The response instance.
-     * @return void
      */
     public function __construct(
         public $request,

--- a/src/Illuminate/Routing/Events/RouteMatched.php
+++ b/src/Illuminate/Routing/Events/RouteMatched.php
@@ -9,7 +9,6 @@ class RouteMatched
      *
      * @param  \Illuminate\Routing\Route  $route  The route instance.
      * @param  \Illuminate\Http\Request  $request  The request instance.
-     * @return void
      */
     public function __construct(
         public $route,

--- a/src/Illuminate/Routing/Events/Routing.php
+++ b/src/Illuminate/Routing/Events/Routing.php
@@ -8,7 +8,6 @@ class Routing
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Request  $request  The request instance.
-     * @return void
      */
     public function __construct(
         public $request,

--- a/src/Illuminate/Routing/Exceptions/BackedEnumCaseNotFoundException.php
+++ b/src/Illuminate/Routing/Exceptions/BackedEnumCaseNotFoundException.php
@@ -11,7 +11,6 @@ class BackedEnumCaseNotFoundException extends RuntimeException
      *
      * @param  string  $backedEnumClass
      * @param  string  $case
-     * @return void
      */
     public function __construct($backedEnumClass, $case)
     {

--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -8,7 +8,6 @@ class InvalidSignatureException extends HttpException
 {
     /**
      * Create a new exception instance.
-     *
      */
     public function __construct()
     {

--- a/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
+++ b/src/Illuminate/Routing/Exceptions/InvalidSignatureException.php
@@ -9,7 +9,6 @@ class InvalidSignatureException extends HttpException
     /**
      * Create a new exception instance.
      *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
@@ -19,7 +19,6 @@ class StreamedResponseException extends RuntimeException
      * Create a new exception instance.
      *
      * @param  \Throwable  $originalException
-     * @return void
      */
     public function __construct(Throwable $originalException)
     {

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -19,7 +19,6 @@ class SubstituteBindings
      * Create a new bindings substitutor.
      *
      * @param  \Illuminate\Contracts\Routing\Registrar  $router
-     * @return void
      */
     public function __construct(Registrar $router)
     {

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -35,7 +35,6 @@ class ThrottleRequests
      * Create a new request throttler.
      *
      * @param  \Illuminate\Cache\RateLimiter  $limiter
-     * @return void
      */
     public function __construct(RateLimiter $limiter)
     {

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -35,7 +35,6 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      *
      * @param  \Illuminate\Cache\RateLimiter  $limiter
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RateLimiter $limiter, Redis $redis)
     {

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -51,7 +51,6 @@ class PendingResourceRegistration
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return void
      */
     public function __construct(ResourceRegistrar $registrar, $name, $controller, array $options)
     {

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -51,7 +51,6 @@ class PendingSingletonResourceRegistration
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return void
      */
     public function __construct(ResourceRegistrar $registrar, $name, $controller, array $options)
     {

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -28,7 +28,6 @@ class Redirector
      * Create a new Redirector instance.
      *
      * @param  \Illuminate\Routing\UrlGenerator  $generator
-     * @return void
      */
     public function __construct(UrlGenerator $generator)
     {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -62,7 +62,6 @@ class ResourceRegistrar
      * Create a new resource registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
-     * @return void
      */
     public function __construct(Router $router)
     {

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -40,7 +40,6 @@ class ResponseFactory implements FactoryContract
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
      * @param  \Illuminate\Routing\Redirector  $redirector
-     * @return void
      */
     public function __construct(ViewFactory $view, Redirector $redirector)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -170,7 +170,6 @@ class Route
      * @param  array|string  $methods
      * @param  string  $uri
      * @param  \Closure|array  $action
-     * @return void
      */
     public function __construct($methods, $uri, $action)
     {

--- a/src/Illuminate/Routing/RouteFileRegistrar.php
+++ b/src/Illuminate/Routing/RouteFileRegistrar.php
@@ -15,7 +15,6 @@ class RouteFileRegistrar
      * Create a new route file registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
-     * @return void
      */
     public function __construct(Router $router)
     {

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -17,7 +17,6 @@ class RouteParameterBinder
      * Create a new Route parameter binder instance.
      *
      * @param  \Illuminate\Routing\Route  $route
-     * @return void
      */
     public function __construct($route)
     {

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -95,7 +95,6 @@ class RouteRegistrar
      * Create a new route registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
-     * @return void
      */
     public function __construct(Router $router)
     {

--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -23,7 +23,6 @@ class RouteUri
      *
      * @param  string  $uri
      * @param  array  $bindingFields
-     * @return void
      */
     public function __construct(string $uri, array $bindingFields = [])
     {

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -55,7 +55,6 @@ class RouteUrlGenerator
      *
      * @param  \Illuminate\Routing\UrlGenerator  $url
      * @param  \Illuminate\Http\Request  $request
-     * @return void
      */
     public function __construct($url, $request)
     {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -140,7 +140,6 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Container\Container|null  $container
-     * @return void
      */
     public function __construct(Dispatcher $events, ?Container $container = null)
     {

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -11,7 +11,6 @@ class SortedMiddleware extends Collection
      *
      * @param  array  $priorityMap
      * @param  \Illuminate\Support\Collection|array  $middlewares
-     * @return void
      */
     public function __construct(array $priorityMap, $middlewares)
     {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -124,7 +124,6 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  \Illuminate\Routing\RouteCollectionInterface  $routes
      * @param  \Illuminate\Http\Request  $request
      * @param  string|null  $assetRoot
-     * @return void
      */
     public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = null)
     {

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -17,7 +17,6 @@ class ViewController extends Controller
      * Create a new controller instance.
      *
      * @param  \Illuminate\Contracts\Routing\ResponseFactory  $response
-     * @return void
      */
     public function __construct(ResponseFactory $response)
     {

--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -27,7 +27,6 @@ class ArraySessionHandler implements SessionHandlerInterface
      * Create a new array driven handler instance.
      *
      * @param  int  $minutes
-     * @return void
      */
     public function __construct($minutes)
     {

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -26,7 +26,6 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @param  int  $minutes
-     * @return void
      */
     public function __construct(CacheContract $cache, $minutes)
     {

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -45,7 +45,6 @@ class CookieSessionHandler implements SessionHandlerInterface
      * @param  \Illuminate\Contracts\Cookie\QueueingFactory  $cookie
      * @param  int  $minutes
      * @param  bool  $expireOnClose
-     * @return void
      */
     public function __construct(CookieJar $cookie, $minutes, $expireOnClose = false)
     {

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -57,7 +57,6 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      * @param  string  $table
      * @param  int  $minutes
      * @param  \Illuminate\Contracts\Container\Container|null  $container
-     * @return void
      */
     public function __construct(ConnectionInterface $connection, $table, $minutes, ?Container $container = null)
     {

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -23,7 +23,6 @@ class EncryptedStore extends Store
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
      * @param  string|null  $id
      * @param  string  $serialization
-     * @return void
      */
     public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null, $serialization = 'php')
     {

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -36,7 +36,6 @@ class FileSessionHandler implements SessionHandlerInterface
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $path
      * @param  int  $minutes
-     * @return void
      */
     public function __construct(Filesystem $files, $path, $minutes)
     {

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -28,7 +28,6 @@ class AuthenticateSession implements AuthenticatesSessions
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
-     * @return void
      */
     public function __construct(AuthFactory $auth)
     {

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -33,7 +33,6 @@ class StartSession
      *
      * @param  \Illuminate\Session\SessionManager  $manager
      * @param  callable|null  $cacheFactoryResolver
-     * @return void
      */
     public function __construct(SessionManager $manager, ?callable $cacheFactoryResolver = null)
     {

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -69,7 +69,6 @@ class Store implements Session
      * @param  \SessionHandlerInterface  $handler
      * @param  string|null  $id
      * @param  string  $serialization
-     * @return void
      */
     public function __construct($name, SessionHandlerInterface $handler, $id = null, $serialization = 'php')
     {

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -21,7 +21,6 @@ class SymfonySessionDecorator implements SessionInterface
      * Create a new session decorator.
      *
      * @param  \Illuminate\Contracts\Session\Session  $store
-     * @return void
      */
     public function __construct(Session $store)
     {

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -29,7 +29,6 @@ class Composer
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string|null  $workingPath
-     * @return void
      */
     public function __construct(Filesystem $files, $workingPath = null)
     {

--- a/src/Illuminate/Support/DefaultProviders.php
+++ b/src/Illuminate/Support/DefaultProviders.php
@@ -13,7 +13,6 @@ class DefaultProviders
 
     /**
      * Create a new default provider collection.
-     *
      */
     public function __construct(?array $providers = null)
     {

--- a/src/Illuminate/Support/DefaultProviders.php
+++ b/src/Illuminate/Support/DefaultProviders.php
@@ -14,7 +14,6 @@ class DefaultProviders
     /**
      * Create a new default provider collection.
      *
-     * @return void
      */
     public function __construct(?array $providers = null)
     {

--- a/src/Illuminate/Support/Defer/DeferredCallback.php
+++ b/src/Illuminate/Support/Defer/DeferredCallback.php
@@ -10,7 +10,6 @@ class DeferredCallback
      * Create a new deferred callback instance.
      *
      * @param  callable  $callback
-     * @return void
      */
     public function __construct(public $callback, public ?string $name = null, public bool $always = false)
     {

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -33,7 +33,6 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      * Create a new fluent instance.
      *
      * @param  iterable<TKey, TValue>  $attributes
-     * @return void
      */
     public function __construct($attributes = [])
     {

--- a/src/Illuminate/Support/HigherOrderTapProxy.php
+++ b/src/Illuminate/Support/HigherOrderTapProxy.php
@@ -15,7 +15,6 @@ class HigherOrderTapProxy
      * Create a new tap proxy instance.
      *
      * @param  mixed  $target
-     * @return void
      */
     public function __construct($target)
     {

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -18,7 +18,6 @@ class HtmlString implements Htmlable, Stringable
      * Create a new HTML string instance.
      *
      * @param  string  $html
-     * @return void
      */
     public function __construct($html = '')
     {

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -46,7 +46,6 @@ class Lottery
      *
      * @param  int|float  $chances
      * @param  int|null  $outOf
-     * @return void
      */
     public function __construct($chances, $outOf = null)
     {

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -40,7 +40,6 @@ abstract class Manager
      * Create a new manager instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -29,7 +29,6 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      * Create a new message bag instance.
      *
      * @param  array  $messages
-     * @return void
      */
     public function __construct(array $messages = [])
     {

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -47,7 +47,6 @@ abstract class MultipleInstanceManager
      * Create a new manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -24,7 +24,6 @@ class Once
      * Create a new once instance.
      *
      * @param  \WeakMap<object, array<string, mixed>>  $values
-     * @return void
      */
     protected function __construct(protected WeakMap $values)
     {

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -13,7 +13,6 @@ class Onceable
      * @param  string  $hash
      * @param  object|null  $object
      * @param  callable  $callable
-     * @return void
      */
     public function __construct(
         public string $hash,

--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -23,7 +23,6 @@ class Optional implements ArrayAccess
      * Create a new optional instance.
      *
      * @param  mixed  $value
-     * @return void
      */
     public function __construct($value)
     {

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -76,7 +76,6 @@ abstract class ServiceProvider
      * Create a new service provider instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -80,7 +80,6 @@ class Sleep
      * Create a new class instance.
      *
      * @param  int|float|\DateInterval  $duration
-     * @return void
      */
     public function __construct($duration)
     {

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -27,7 +27,6 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Create a new instance of the class.
      *
      * @param  string  $value
-     * @return void
      */
     public function __construct($value = '')
     {

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -37,7 +37,6 @@ class BatchFake extends Batch
      * @param  \Carbon\CarbonImmutable  $createdAt
      * @param  \Carbon\CarbonImmutable|null  $cancelledAt
      * @param  \Carbon\CarbonImmutable|null  $finishedAt
-     * @return void
      */
     public function __construct(
         string $id,

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -86,7 +86,6 @@ class BusFake implements Fake, QueueingDispatcher
      * @param  \Illuminate\Contracts\Bus\QueueingDispatcher  $dispatcher
      * @param  array|string  $jobsToFake
      * @param  \Illuminate\Bus\BatchRepository|null  $batchRepository
-     * @return void
      */
     public function __construct(QueueingDispatcher $dispatcher, $jobsToFake = [], ?BatchRepository $batchRepository = null)
     {

--- a/src/Illuminate/Support/Testing/Fakes/ChainedBatchTruthTest.php
+++ b/src/Illuminate/Support/Testing/Fakes/ChainedBatchTruthTest.php
@@ -17,7 +17,6 @@ class ChainedBatchTruthTest
      * Create a new truth test instance.
      *
      * @param  \Closure  $callback
-     * @return void
      */
     public function __construct(Closure $callback)
     {

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -51,7 +51,6 @@ class EventFake implements Dispatcher, Fake
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @param  array|string  $eventsToFake
-     * @return void
      */
     public function __construct(Dispatcher $dispatcher, $eventsToFake = [])
     {

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -39,7 +39,6 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      *
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
      * @param  list<class-string<\Throwable>>  $exceptions
-     * @return void
      */
     public function __construct(
         protected ExceptionHandler $handler,

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -51,7 +51,6 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * Create a new mail fake.
      *
      * @param  MailManager  $manager
-     * @return void
      */
     public function __construct(MailManager $manager)
     {

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -19,7 +19,6 @@ class PendingBatchFake extends PendingBatch
      *
      * @param  \Illuminate\Support\Testing\Fakes\BusFake  $bus
      * @param  \Illuminate\Support\Collection  $jobs
-     * @return void
      */
     public function __construct(BusFake $bus, Collection $jobs)
     {

--- a/src/Illuminate/Support/Testing/Fakes/PendingChainFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingChainFake.php
@@ -21,7 +21,6 @@ class PendingChainFake extends PendingChain
      * @param  \Illuminate\Support\Testing\Fakes\BusFake  $bus
      * @param  mixed  $job
      * @param  array  $chain
-     * @return void
      */
     public function __construct(BusFake $bus, $job, $chain)
     {

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -11,7 +11,6 @@ class PendingMailFake extends PendingMail
      * Create a new instance.
      *
      * @param  \Illuminate\Support\Testing\Fakes\MailFake  $mailer
-     * @return void
      */
     public function __construct($mailer)
     {

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -66,7 +66,6 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  array  $jobsToFake
      * @param  \Illuminate\Queue\QueueManager|null  $queue
-     * @return void
      */
     public function __construct($app, $jobsToFake = [], $queue = null)
     {

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -23,7 +23,6 @@ class ValidatedInput implements ValidatedData
      * Create a new validated input container.
      *
      * @param  array  $input
-     * @return void
      */
     public function __construct(array $input)
     {

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -32,7 +32,6 @@ class AssertableJsonString implements ArrayAccess, Countable
      * Create a new assertable JSON string instance.
      *
      * @param  \Illuminate\Contracts\Support\Jsonable|\JsonSerializable|array|string  $jsonable
-     * @return void
      */
     public function __construct($jsonable)
     {

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -54,7 +54,6 @@ trait RunsInParallel
      *
      * @param  \ParaTest\Runners\PHPUnit\Options|\ParaTest\Options  $options
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
      */
     public function __construct($options, OutputInterface $output)
     {

--- a/src/Illuminate/Testing/Constraints/ArraySubset.php
+++ b/src/Illuminate/Testing/Constraints/ArraySubset.php
@@ -25,7 +25,6 @@ class ArraySubset extends Constraint
      *
      * @param  iterable  $subset
      * @param  bool  $strict
-     * @return void
      */
     public function __construct(iterable $subset, bool $strict = false)
     {

--- a/src/Illuminate/Testing/Constraints/CountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/CountInDatabase.php
@@ -34,7 +34,6 @@ class CountInDatabase extends Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  int  $expectedCount
-     * @return void
      */
     public function __construct(Connection $database, int $expectedCount)
     {

--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -34,7 +34,6 @@ class HasInDatabase extends Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  array<string, mixed>  $data
-     * @return void
      */
     public function __construct(Connection $database, array $data)
     {

--- a/src/Illuminate/Testing/Constraints/NotSoftDeletedInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/NotSoftDeletedInDatabase.php
@@ -41,7 +41,6 @@ class NotSoftDeletedInDatabase extends Constraint
      * @param  \Illuminate\Database\Connection  $database
      * @param  array  $data
      * @param  string  $deletedAtColumn
-     * @return void
      */
     public function __construct(Connection $database, array $data, string $deletedAtColumn)
     {

--- a/src/Illuminate/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Testing/Constraints/SeeInOrder.php
@@ -25,7 +25,6 @@ class SeeInOrder extends Constraint
      * Create a new constraint instance.
      *
      * @param  string  $content
-     * @return void
      */
     public function __construct($content)
     {

--- a/src/Illuminate/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/SoftDeletedInDatabase.php
@@ -41,7 +41,6 @@ class SoftDeletedInDatabase extends Constraint
      * @param  \Illuminate\Database\Connection  $database
      * @param  array  $data
      * @param  string  $deletedAtColumn
-     * @return void
      */
     public function __construct(Connection $database, array $data, string $deletedAtColumn)
     {

--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -40,7 +40,6 @@ class AssertableJson implements Arrayable
      *
      * @param  array  $props
      * @param  string|null  $path
-     * @return void
      */
     protected function __construct(array $props, ?string $path = null)
     {

--- a/src/Illuminate/Testing/ParallelConsoleOutput.php
+++ b/src/Illuminate/Testing/ParallelConsoleOutput.php
@@ -29,7 +29,6 @@ class ParallelConsoleOutput extends ConsoleOutput
      * Create a new Parallel ConsoleOutput instance.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
      */
     public function __construct($output)
     {

--- a/src/Illuminate/Testing/ParallelTesting.php
+++ b/src/Illuminate/Testing/ParallelTesting.php
@@ -67,7 +67,6 @@ class ParallelTesting
      * Create a new parallel testing instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
      */
     public function __construct(Container $container)
     {

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -80,7 +80,6 @@ class PendingCommand
      * @param  \Illuminate\Contracts\Container\Container  $app
      * @param  string  $command
      * @param  array  $parameters
-     * @return void
      */
     public function __construct(PHPUnitTestCase $test, Container $app, $command, $parameters)
     {

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -32,7 +32,6 @@ class TestComponent implements Stringable
      *
      * @param  \Illuminate\View\Component  $component
      * @param  \Illuminate\View\View  $view
-     * @return void
      */
     public function __construct($component, $view)
     {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -71,7 +71,6 @@ class TestResponse implements ArrayAccess
      *
      * @param  TResponse  $response
      * @param  \Illuminate\Http\Request|null  $request
-     * @return void
      */
     public function __construct($response, $request = null)
     {

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -34,7 +34,6 @@ class TestView implements Stringable
      * Create a new test view instance.
      *
      * @param  \Illuminate\View\View  $view
-     * @return void
      */
     public function __construct(View $view)
     {

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -42,7 +42,6 @@ class FileLoader implements Loader
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  array|string  $path
-     * @return void
      */
     public function __construct(Filesystem $files, array|string $path)
     {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -84,7 +84,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      *
      * @param  \Illuminate\Contracts\Translation\Loader  $loader
      * @param  string  $locale
-     * @return void
      */
     public function __construct(Loader $loader, $locale)
     {

--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -42,7 +42,6 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
      * Create a new Closure based validation rule.
      *
      * @param  \Closure  $callback
-     * @return void
      */
     public function __construct($callback)
     {

--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -19,7 +19,6 @@ class FilterEmailValidation implements EmailValidation
      * Create a new validation instance.
      *
      * @param  int  $flags
-     * @return void
      */
     public function __construct($flags = null)
     {

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -33,7 +33,6 @@ class ConditionalRules
      * @param  callable|bool  $condition
      * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $rules
      * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule|\Illuminate\Contracts\Validation\Rule|\Closure|array|string  $defaultRules
-     * @return void
      */
     public function __construct($condition, $rules, $defaultRules = [])
     {

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -25,7 +25,6 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
      * Create a new database presence verifier.
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $db
-     * @return void
      */
     public function __construct(ConnectionResolverInterface $db)
     {

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -85,7 +85,6 @@ class Factory implements FactoryContract
      *
      * @param  \Illuminate\Contracts\Translation\Translator  $translator
      * @param  \Illuminate\Contracts\Container\Container|null  $container
-     * @return void
      */
     public function __construct(Translator $translator, ?Container $container = null)
     {

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -53,7 +53,6 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
      * Create a new explicit Invokable validation rule.
      *
      * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule  $invokable
-     * @return void
      */
     protected function __construct(ValidationRule|InvokableRule $invokable)
     {

--- a/src/Illuminate/Validation/NestedRules.php
+++ b/src/Illuminate/Validation/NestedRules.php
@@ -17,7 +17,6 @@ class NestedRules implements CompilableRules
      * Create a new nested rule instance.
      *
      * @param  callable  $callback
-     * @return void
      */
     public function __construct(callable $callback)
     {

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -27,7 +27,6 @@ class NotPwnedVerifier implements UncompromisedVerifier
      *
      * @param  \Illuminate\Http\Client\Factory  $factory
      * @param  int|null  $timeout
-     * @return void
      */
     public function __construct($factory, $timeout = null)
     {

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -20,7 +20,6 @@ class ArrayRule implements Stringable
      * Create a new array rule instance.
      *
      * @param  array|null  $keys
-     * @return void
      */
     public function __construct($keys = null)
     {

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -44,7 +44,6 @@ trait DatabaseRule
      *
      * @param  string  $table
      * @param  string  $column
-     * @return void
      */
     public function __construct($table, $column = 'NULL')
     {

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -20,7 +20,6 @@ class Dimensions implements Stringable
      * Create a new dimensions rule instance.
      *
      * @param  array  $constraints
-     * @return void
      */
     public function __construct(array $constraints = [])
     {

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -45,7 +45,6 @@ class Enum implements Rule, ValidatorAwareRule
      * Create a new rule instance.
      *
      * @param  class-string  $type
-     * @return void
      */
     public function __construct($type)
     {

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -8,7 +8,6 @@ class ImageFile extends File
      * Create a new image file rule instance.
      *
      * @param  bool  $allowSvg
-     * @return void
      */
     public function __construct($allowSvg = false)
     {

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -27,7 +27,6 @@ class In implements Stringable
      * Create a new in rule instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
-     * @return void
      */
     public function __construct($values)
     {

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -27,7 +27,6 @@ class NotIn implements Stringable
      * Create a new "not in" rule instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
-     * @return void
      */
     public function __construct($values)
     {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -111,7 +111,6 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      * Create a new rule instance.
      *
      * @param  int  $min
-     * @return void
      */
     public function __construct($min)
     {

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -18,7 +18,6 @@ class RequiredIf implements Stringable
      * Create a new required validation rule based on a condition.
      *
      * @param  callable|bool  $condition
-     * @return void
      */
     public function __construct($condition)
     {

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -49,7 +49,6 @@ class ValidationException extends Exception
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @param  \Symfony\Component\HttpFoundation\Response|null  $response
      * @param  string  $errorBag
-     * @return void
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -35,7 +35,6 @@ class ValidationRuleParser
      * Create a new validation rule parser.
      *
      * @param  array  $data
-     * @return void
      */
     public function __construct(array $data)
     {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -335,7 +335,6 @@ class Validator implements ValidatorContract
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $attributes
-     * @return void
      */
     public function __construct(
         Translator $translator,

--- a/src/Illuminate/View/AnonymousComponent.php
+++ b/src/Illuminate/View/AnonymousComponent.php
@@ -23,7 +23,6 @@ class AnonymousComponent extends Component
      *
      * @param  string  $view
      * @param  array  $data
-     * @return void
      */
     public function __construct($view, $data)
     {

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -17,7 +17,6 @@ class AppendableAttributeValue implements Stringable
      * Create a new appendable attribute value.
      *
      * @param  mixed  $value
-     * @return void
      */
     public function __construct($value)
     {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -54,7 +54,6 @@ class ComponentTagCompiler
      * @param  array  $aliases
      * @param  array  $namespaces
      * @param  \Illuminate\View\Compilers\BladeCompiler|null  $blade
-     * @return void
      */
     public function __construct(array $aliases = [], array $namespaces = [], ?BladeCompiler $blade = null)
     {

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -31,7 +31,6 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      * Create a new component attribute bag instance.
      *
      * @param  array  $attributes
-     * @return void
      */
     public function __construct(array $attributes = [])
     {

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -27,7 +27,6 @@ class ComponentSlot implements Htmlable, Stringable
      *
      * @param  string  $contents
      * @param  array  $attributes
-     * @return void
      */
     public function __construct($contents = '', $attributes = [])
     {

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -34,7 +34,6 @@ class DynamicComponent extends Component
      * Create a new component instance.
      *
      * @param  string  $component
-     * @return void
      */
     public function __construct(string $component)
     {

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -40,7 +40,6 @@ class CompilerEngine extends PhpEngine
      *
      * @param  \Illuminate\View\Compilers\CompilerInterface  $compiler
      * @param  \Illuminate\Filesystem\Filesystem|null  $files
-     * @return void
      */
     public function __construct(CompilerInterface $compiler, ?Filesystem $files = null)
     {

--- a/src/Illuminate/View/Engines/FileEngine.php
+++ b/src/Illuminate/View/Engines/FileEngine.php
@@ -18,7 +18,6 @@ class FileEngine implements Engine
      * Create a new file engine instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -19,7 +19,6 @@ class PhpEngine implements Engine
      * Create a new file engine instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -110,7 +110,6 @@ class Factory implements FactoryContract
      * @param  \Illuminate\View\Engines\EngineResolver  $engines
      * @param  \Illuminate\View\ViewFinderInterface  $finder
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     * @return void
      */
     public function __construct(EngineResolver $engines, ViewFinderInterface $finder, Dispatcher $events)
     {

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -48,7 +48,6 @@ class FileViewFinder implements ViewFinderInterface
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  array  $paths
      * @param  array|null  $extensions
-     * @return void
      */
     public function __construct(Filesystem $files, array $paths, ?array $extensions = null)
     {

--- a/src/Illuminate/View/InvokableComponentVariable.php
+++ b/src/Illuminate/View/InvokableComponentVariable.php
@@ -23,7 +23,6 @@ class InvokableComponentVariable implements DeferringDisplayableValue, IteratorA
      * Create a new variable instance.
      *
      * @param  \Closure  $callable
-     * @return void
      */
     public function __construct(Closure $callable)
     {

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -19,7 +19,6 @@ class ShareErrorsFromSession
      * Create a new error binder instance.
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
-     * @return void
      */
     public function __construct(ViewFactory $view)
     {

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -67,7 +67,6 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
      * @param  string  $view
      * @param  string  $path
      * @param  mixed  $data
-     * @return void
      */
     public function __construct(Factory $factory, Engine $engine, $view, $path, $data = [])
     {


### PR DESCRIPTION
PHP constructors don't really return anything, so the docblock is kind of unnecessary. this also brings consistency since we have some that use the tag and some that do not.

we have a total of 557 constructors in the framework, so we definitely used it more than we didn't, but my personal opinion is this direction makes more sense.

https://docs.phpdoc.org/guide/references/phpdoc/tags/return.html#return https://github.com/laravel/framework/issues/702
https://www.php.net/manual/en/language.oop5.decon.php

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
