### PR TITLE
[12.x] Introduce a method to retrieve a boolean environment variable (`Env::getBoolean()`)

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -115,6 +115,24 @@ class Env
     }
 
     /**
+     * Get the value of a boolean environment variable.
+     *
+     * @throws \RuntimeException
+     */
+    public static function getBoolean(string $key, ?bool $default = null): bool
+    {
+        $value = ($default === null)
+            ? self::getOrFail($key)
+            : self::get($key, $default);
+
+        if (! is_bool($value)) {
+            throw new RuntimeException("Environment variable [$key] is not boolean.");
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the possible option for this environment variable.
      *
      * @param  string  $key

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1232,6 +1232,32 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('some-value', Env::getOrFail('required-exists'));
     }
 
+    public function testBooleanEnvReturnsValue(): void
+    {
+        $_SERVER['foo'] = 'true';
+        $this->assertSame(true, Env::getBoolean('foo'));
+    }
+
+    public function testBooleanEnvReturnsDefaultValue(): void
+    {
+        $this->assertSame(true, Env::getBoolean('boolean-does-not-exist', true));
+    }
+
+    public function testBooleanEnvVariableThrowsAnExceptionWhenNotFound(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('[boolean-does-not-exist] has no value'));
+
+        Env::getBoolean('boolean-does-not-exist');
+    }
+
+    public function testBooleanEnvVariableThrowsAnExceptionWhenNotBoolean(): void
+    {
+        $_SERVER['foo'] = 'bar';
+        $this->expectExceptionObject(new RuntimeException('Environment variable [foo] is not boolean.'));
+
+        Env::getBoolean('foo');
+    }
+
     public function testLiteral(): void
     {
         $this->assertEquals(1, literal(1));


### PR DESCRIPTION
This PR adds an `Illuminate\Support\Env::getBoolean($key, $default = null)` method, that retrieves an environment variable as boolean (or fails if it's not a boolean).

## The problem

Booleans are common in environment variables and configuration variables. To reduce the space for errors, it would be nice to be able to ensure that a certain variable is a boolean.

Currently, this is often done at the configuration level with type casts, like (from `config/app.php`):

```
'debug' => (bool) env('APP_DEBUG', false),
```

While this ensures that a configuration variable is boolean, the environment variable may not be so. The casting can potentially lead to errors, for instance:

* if there is a typo (`VARIABLE=fasle`: it will evaluate to `true`)
* if a different expression is used (`VARIABLE=no`: it will evaluate to `true`)
* if the variable is empty (`VARIABLE=`: it will evaluate to `false`)

Instead, `Env::getBoolean()` will throw an error in any of these cases.

A default value can be provided; otherwise, if the environment variable is not set it will throw an error.

## Some choices made in this PR
### Default value

A boolean variable has no obvious default value (might be `true` or `false` depending on the semantics), and returning `null` would defeat the point of ensuring a boolean value. Therefore, `Env::getBoolean()` will throw an error if the variable is unset, unless a default (boolean) value is explicitly provided. If the method returns, then the return value is a boolean.

### Interpreting boolean-like values

Values others than `true` and `false` are sometimes used to express boolean semantics: for instance, `0` for `false` or `1` for `true`. For instance, the `boolean()` method of `FormRequest` has a more flexible approach (Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false). My view is that, in the case of environment variables, restricting to actual boolean values (without making additional guesses compared to a plain `env()`) is best - there is more control on environment files than on form requests.

### Naming

I was unsure whether to name this method `boolean()` or `getBoolean()`. The `FormRequest` class has a similar method called `boolean()`; but I've opted for consistency with the `get()` and `getOrFail()` method in the `Env` class.

### Boolean vs other types

In this PR I'm focusing on booleans, among all potential types. One could introduce similar methods for other types, like integers or floats; I'm focusing on booleans as in my experience they are possibly the most common type in environment variables (not considering strings), and, in my personal opinion, the ones that provide the highest benefit with the lowest added complexity. Of course, if deemed useful, I can look into other types.
