### PR TITLE
Add `ShouldntReportOnRequest` Contract for Conditional Exception Reporting

### DIFF
--- a/src/Illuminate/Contracts/Debug/ShouldntReportOnRequest.php
+++ b/src/Illuminate/Contracts/Debug/ShouldntReportOnRequest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Debug;
+
+interface ShouldntReportOnRequest
+{
+    //
+}

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -14,6 +14,7 @@ use Illuminate\Console\View\Components\Error;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Contracts\Debug\ShouldntReport;
+use Illuminate\Contracts\Debug\ShouldntReportOnRequest;
 use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -405,6 +406,12 @@ class Handler implements ExceptionHandlerContract
         }
 
         if ($e instanceof ShouldntReport) {
+            return true;
+        }
+
+        $isRunningInConsole = app()->runningInConsole();
+
+        if (! $isRunningInConsole && $e instanceof ShouldntReportOnRequest) {
             return true;
         }
 


### PR DESCRIPTION
**Title:** Add `ShouldntReportOnRequest` Contract for Conditional Exception Reporting

**Description:**  
This pull request introduces a new contract, `ShouldntReportOnRequest`, which extends the existing exception reporting logic in Laravel. The new contract ensures that an exception is marked as non-reportable *only* when `app()->runningInConsole()` returns `false` (i.e., in a web request context). This is inspired by the existing `ShouldntReport` contract but addresses a specific use case where conditional reporting is beneficial.

**Motivation and Benefits to End Users:**  
In the current implementation, exceptions implementing `ShouldntReport` are universally excluded from reporting, regardless of context. While this works well for web requests—where end users typically see a flash error or notice an action didn’t complete as expected—it can lead to silent failures in console contexts, such as queue jobs or cron commands. For example:  
- In a web request, an unhandled `ShouldntReport` exception might display a user-friendly error message.  
- In a console context (e.g., a queue job), the same exception causes the command or job to fail silently, with no feedback or logging, potentially masking critical issues. In a queue system, the job may move to the failed queue, but the underlying error remains unreported.

The new `ShouldntReportOnRequest` contract allows developers to define exceptions that are suppressed during web requests but still reported in console contexts. This provides better visibility into failures in background processes, improving debugging and reliability for end users relying on queues, scheduled tasks, or CLI commands.

**Non-Breaking Change:**  
- This change introduces a new contract and does not modify the behavior of the existing `ShouldntReport` contract or any core reporting logic.  
- It is fully opt-in; existing implementations remain unaffected unless developers explicitly adopt `ShouldntReportOnRequest`.  
- No existing features, workflows, or tests are altered by this addition.

**How It Makes Building Web Applications Easier:**  
- Developers gain finer control over exception reporting without needing to write custom logic to differentiate between request and console contexts.  
- It reduces the risk of silent failures in critical background processes, making applications more robust and easier to maintain.  
- It aligns with Laravel’s philosophy of providing expressive, context-aware tools, saving developers time and effort when handling exceptions across different environments.

**Implementation Details:**  
- Adds a new `ShouldntReportOnRequest` contract in the appropriate namespace.  
- The contract can be implemented by exception classes, with the reporting logic checking `app()->runningInConsole()` to determine reportability.  
- Documentation and usage examples will be included to guide developers.

Feedback is welcome! This addition aims to enhance Laravel’s exception handling flexibility while maintaining its simplicity and reliability.