### PR TITLE
[12.x] Adds new make:action command

### DIFF
--- a/src/Illuminate/Foundation/Console/ActionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ActionMakeCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:action')]
+class ActionMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:action';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new action class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Action';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/action.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Actions';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the action already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -38,6 +38,7 @@ class StubPublishCommand extends Command
         }
 
         $stubs = [
+            __DIR__.'/stubs/action.stub' => 'action.stub',
             __DIR__.'/stubs/cast.inbound.stub' => 'cast.inbound.stub',
             __DIR__.'/stubs/cast.stub' => 'cast.stub',
             __DIR__.'/stubs/class.stub' => 'class.stub',

--- a/src/Illuminate/Foundation/Console/stubs/action.stub
+++ b/src/Illuminate/Foundation/Console/stubs/action.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Facades\DB;
+
+class {{ class }}
+{
+
+    /**
+     * Create a new class instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+    
+    /**
+     * Execute the action.
+     * @param array<string, mixed> $attributes
+     */
+    public function execute(array $attributes)
+    {
+        return DB::transaction(function () use ($attributes) {
+            
+        });
+    }
+} 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -29,6 +29,7 @@ use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Console\ActionMakeCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
@@ -181,6 +182,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $devCommands = [
+        'ActionMake' => ActionMakeCommand::class,
         'ApiInstall' => ApiInstallCommand::class,
         'BroadcastingInstall' => BroadcastingInstallCommand::class,
         'CacheTable' => CacheTableCommand::class,

--- a/tests/Integration/Generators/ActionMakeCommandTest.php
+++ b/tests/Integration/Generators/ActionMakeCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Integration\Generators;
+
+use Illuminate\Tests\Integration\Generators\TestCase;
+
+class ActionMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Actions/FooAction.php',
+    ];
+
+    public function testItCanGenerateActionFile()
+    {
+        $this->artisan('make:action', ['name' => 'FooAction'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Actions;',
+            'class FooAction',
+            'use Illuminate\Support\Facades\DB;',
+            'public function execute(array $attributes)',
+        ], 'app/Actions/FooAction.php');
+    }
+
+    public function testItCanGenerateActionFileInActionsFolder()
+    {
+        $actionsFolderPath = app_path('Actions');
+
+        /** @var \Illuminate\Filesystem\Filesystem $files */
+        $files = $this->app['files'];
+
+        $files->ensureDirectoryExists($actionsFolderPath);
+
+        $this->artisan('make:action', ['name' => 'FooAction'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Actions;',
+            'class FooAction',
+        ], 'app/Actions/FooAction.php');
+
+        $files->deleteDirectory($actionsFolderPath);
+    }
+}
+


### PR DESCRIPTION
This PR introduces a new `make:action` command to quickly generate classes following the action pattern. I find this useful because people often create these files manually, and having an Artisan command makes the process much faster and more consistent. 
 
So basically, running:
```sh
php artisan make:action FooAction
```
Generates:
```php
namespace App\Actions;

use Illuminate\Support\Facades\DB;

class FooAction
{
    public function __construct()
    {
        //
    }

    public function execute(array $attributes)
    {
        return DB::transaction(function () use ($attributes) {
            // do your thing here
        });
    }
}
```
Btw: The stub automatically wraps the logic within a DB::transaction. This ensures that actions only run if everything goes well, preventing partial executions  -- either everything succeeds, or nothing changes. That said, I'm open to comments (this is my first PR!!!🚀) 
