### PR TITLE
[12.x] fix: use contextual bindings in class dependency resolution

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1187,17 +1187,14 @@ class Container implements ArrayAccess, ContainerContract
     {
         $className = Util::getParameterClassName($parameter);
 
-        // First, we check if the dependency has been explicitly bound in the container
-        // and if so, we will resolve it directly from there to respect any explicit
-        // bindings the developer has defined rather than using any default value.
-        if ($this->bound($className)) {
-            return $this->make($className);
-        }
-
-        // If no binding exists, we will check if a default value has been defined for
-        // the parameter. If it has, we should return it to avoid overriding any of
-        // the developer specified default values for the constructor parameters.
-        if ($parameter->isDefaultValueAvailable()) {
+        // First we will check if a default value has been defined for the parameter.
+        // If it has, and no explicit binding exists, we should return it to avoid
+        // overriding any of the developer specified defaults for the parameters.
+        if (
+            $parameter->isDefaultValueAvailable()
+            && ! $this->bound($className)
+            && $this->findInContextualBindings($className) === null
+        ) {
             return $parameter->getDefaultValue();
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1190,11 +1190,9 @@ class Container implements ArrayAccess, ContainerContract
         // First we will check if a default value has been defined for the parameter.
         // If it has, and no explicit binding exists, we should return it to avoid
         // overriding any of the developer specified defaults for the parameters.
-        if (
-            $parameter->isDefaultValueAvailable()
-            && ! $this->bound($className)
-            && $this->findInContextualBindings($className) === null
-        ) {
+        if ($parameter->isDefaultValueAvailable() &&
+            ! $this->bound($className) &&
+            $this->findInContextualBindings($className) === null) {
             return $parameter->getDefaultValue();
         }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -319,6 +319,17 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $instance->default);
     }
 
+    public function testResolutionOfClassWithDefaultParametersAndContextualBindings()
+    {
+        $container = new Container;
+
+        $container->when(ContainerClassWithDefaultValueStub::class)
+            ->needs(ContainerConcreteStub::class)
+            ->give(fn () => new ContainerConcreteStub);
+        $instance = $container->make(ContainerClassWithDefaultValueStub::class);
+        $this->assertInstanceOf(ContainerConcreteStub::class, $instance->default);
+    }
+
     public function testBound()
     {
         $container = new Container;


### PR DESCRIPTION
Hello!

Closes https://github.com/laravel/framework/pull/53522#issuecomment-2737297169

This allows using contextual binds during the resolution of class dependencies, from the linked discussion:


> This seems to have introduced an issue with contextual bindings for optional dependencies. Previously they were resolved but are now ignored (and thus null) following this change.
> 
> For example:
> 
> ```php
> class Foo
> {
>     public function __construct(
>         public ?Carbon $date = null,
>     ) {}
> }
> 
> app()->when(Foo::class)
>   ->needs(Carbon::class)
>   ->give(fn() => Carbon::now());
> 
> $foo = app()->make(Foo::class);
> $foo->date; // NULL
> ```
> I'd expect a contextual binding to count as an explicit binding in the context of the original change.


CC: @jonnyynnoj

Thanks!