### PR TITLE
[12.x] Improve syntax highlighting for stub type files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@
 *.md diff=markdown
 *.php diff=php
 
+*.stub linguist-language=php
+*.neon.dist linguist-language=neon
+
 /.github export-ignore
 /bin export-ignore
 /tests export-ignore


### PR DESCRIPTION
This PR adds proper syntax highlighting for `.stub` files by configuring them to be recognized as PHP files in GitHub and other platforms that support [Linguist](https://github.com/github-linguist/linguist).

The project contains 82 `.stub` files that lack proper syntax highlighting on GitHub. Without PHP syntax coloring, it's difficult to identify code structures, spot errors, and understand the code at a glance during reviews.

Before:

<img src="https://github.com/user-attachments/assets/00bca1e9-12c6-44f6-ae89-6668e3258478" width="500"/>

After:

<img src="https://github.com/user-attachments/assets/720900da-e719-4f93-b67b-938fca1c735e" width="500"/>

