### PR TITLE
[12.x] Add onlyInMaintenanceMode Method to Scheduler Events

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -268,8 +268,14 @@ class Event
      */
     public function isDue($app)
     {
-        if (! $this->runsInMaintenanceMode() && $app->isDownForMaintenance()) {
-            return false;
+        if ($app->isDownForMaintenance()) {
+            if (! $this->runsInMaintenanceMode()) {
+                return false;
+            }
+        } else {
+            if (! $this->runsInLiveMode()) {
+                return false;
+            }
         }
 
         return $this->expressionPasses() &&
@@ -283,7 +289,17 @@ class Event
      */
     public function runsInMaintenanceMode()
     {
-        return $this->evenInMaintenanceMode;
+        return $this->evenInMaintenanceMode || $this->onlyInMaintenanceMode;
+    }
+
+    /**
+     * Determine if the event can run when the application is in live mode.
+     *
+     * @return bool
+     */
+    public function runsInLiveMode()
+    {
+        return ! $this->onlyInMaintenanceMode;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -49,6 +49,13 @@ trait ManagesAttributes
     public $evenInMaintenanceMode = false;
 
     /**
+     * Indicates if the command should run only in maintenance mode.
+     *
+     * @var bool
+     */
+    public $onlyInMaintenanceMode = false;
+
+    /**
      * Indicates if the command should not overlap itself.
      *
      * @var bool
@@ -131,6 +138,18 @@ trait ManagesAttributes
     public function evenInMaintenanceMode()
     {
         $this->evenInMaintenanceMode = true;
+
+        return $this;
+    }
+
+    /**
+     * State that the command should run only in maintenance mode.
+     *
+     * @return $this
+     */
+    public function onlyInMaintenanceMode()
+    {
+        $this->onlyInMaintenanceMode = true;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
+++ b/src/Illuminate/Console/Scheduling/PendingEventAttributes.php
@@ -62,6 +62,10 @@ class PendingEventAttributes
             $event->evenInMaintenanceMode();
         }
 
+        if ($this->onlyInMaintenanceMode) {
+            $event->onlyInMaintenanceMode();
+        }
+
         if ($this->withoutOverlapping) {
             $event->withoutOverlapping($this->expiresAt);
         }

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -185,7 +185,7 @@ class SubMinuteSchedulingTest extends TestCase
         Config::set('app.maintenance.store', 'array');
         Carbon::setTestNow(now()->startOfMinute());
         Sleep::fake();
-        Sleep::whenFakingSleep(function ($duration)  {
+        Sleep::whenFakingSleep(function ($duration) {
             Carbon::setTestNow(now()->add($duration));
         });
         $this->artisan('up');
@@ -207,7 +207,7 @@ class SubMinuteSchedulingTest extends TestCase
         Config::set('app.maintenance.store', 'array');
         Carbon::setTestNow(now()->startOfMinute());
         Sleep::fake();
-        Sleep::whenFakingSleep(function ($duration)  {
+        Sleep::whenFakingSleep(function ($duration) {
             Carbon::setTestNow(now()->add($duration));
         });
         $this->artisan('down');


### PR DESCRIPTION
### **Description:**  
This PR introduces a new `onlyInMaintenanceMode()` method that allows scheduled tasks to run **only when the application is in maintenance mode**. 

### **Why?**  
Currently, Laravel has `evenInMaintenanceMode()`, which allows jobs to run **even when the app is in maintenance mode**, but there is no way to schedule tasks that should run **only** during maintenance mode. This feature provides that functionality. 

### **Example Usage:**  
```php
$schedule->command('some:command')->onlyInMaintenanceMode()->everyMinute();
```
This command **only runs while Laravel is in maintenance mode**. 
