### PR TITLE
[12.x] Fix type nullability on PasswordBroker.events property

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -30,7 +30,7 @@ class PasswordBroker implements PasswordBrokerContract
     /**
      * The event dispatcher instance.
      *
-     * @var \Illuminate\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected $events;
 


### PR DESCRIPTION
Per constructor, this property may be null:
https://github.com/laravel/framework/blob/c0c2441137b012995ba686f4ed2642de132bd914/src/Illuminate/Auth/Passwords/PasswordBroker.php#L37-L49

It is also called in a nullsafe manner:
https://github.com/laravel/framework/blob/c0c2441137b012995ba686f4ed2642de132bd914/src/Illuminate/Auth/Passwords/PasswordBroker.php#L84

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
