### PR TITLE
[11.x] Fix missing `return $this` for `assertOnlyJsonValidationErrors`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -994,6 +994,8 @@ class TestResponse implements ArrayAccess
         $unexpectedErrorKeys = Arr::except($jsonErrors, $expectedErrorKeys);
 
         PHPUnit::withResponse($this)->assertTrue(count($unexpectedErrorKeys) === 0, 'Response has unexpected validation errors: '.collect($unexpectedErrorKeys)->keys()->map(fn ($key) => "'{$key}'")->join(', '));
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The `assertOnlyJsonValidationErrors` does not return `$this` even though it is type hinted to return `$this`.

https://github.com/laravel/framework/blob/32bbb68aface162f5e827790bd3c675fbd15a686/src/Illuminate/Testing/TestResponse.php#L979-L997