### PR TITLE
[12.x] assertThrowsNothing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -213,4 +213,31 @@ trait InteractsWithExceptionHandling
 
         return $this;
     }
+
+    /**
+     * Assert that the given callback does not throw an exception.
+     *
+     * @param  \Closure  $test
+     * @return $this
+     */
+    protected function assertThrowsNothing(Closure $test)
+    {
+        try {
+            $test();
+
+            $thrown = false;
+        } catch (Throwable $exception) {
+            $thrown = true;
+
+            $exceptionClass = get_class($exception);
+            $exceptionMessage = $exception->getMessage();
+        }
+
+        Assert::assertTrue(
+            ! $thrown,
+            sprintf('Failed asserting that no exception was thrown as exception of type %s with message %s was thrown.', $exceptionClass ?? null, $exceptionMessage ?? null)
+        );
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -220,7 +220,7 @@ trait InteractsWithExceptionHandling
      * @param  \Closure  $test
      * @return $this
      */
-    protected function assertThrowsNothing(Closure $test)
+    protected function assertDoesntThrow(Closure $test)
     {
         try {
             $test();
@@ -235,7 +235,7 @@ trait InteractsWithExceptionHandling
 
         Assert::assertTrue(
             ! $thrown,
-            sprintf('Failed asserting that no exception was thrown as exception of type %s with message %s was thrown.', $exceptionClass ?? null, $exceptionMessage ?? null)
+            sprintf('Unexpected exception of type %s with message %s was thrown.', $exceptionClass ?? null, $exceptionMessage ?? null)
         );
 
         return $this;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -571,6 +571,35 @@ class FoundationExceptionsHandlerTest extends TestCase
         }
     }
 
+    public function testAssertNoExceptionIsThrown()
+    {
+        try {
+            $this->assertThrowsNothing(function () {
+                throw new Exception;
+            });
+
+            $testFailed = true;
+        } catch (AssertionFailedError) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrowsNothing failed: thrown exception was not detected.');
+        }
+
+        try {
+            $this->assertThrowsNothing(function () { });
+
+            $testFailed = false;
+        } catch (AssertionFailedError) {
+            $testFailed = true;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrowsNothing failed: exception was detected while no exception was thrown.');
+        }
+    }
+
     public function testItReportsDuplicateExceptions()
     {
         $reported = [];

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -574,7 +574,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     public function testAssertNoExceptionIsThrown()
     {
         try {
-            $this->assertThrowsNothing(function () {
+            $this->assertDoesntThrow(function () {
                 throw new Exception;
             });
 
@@ -584,11 +584,11 @@ class FoundationExceptionsHandlerTest extends TestCase
         }
 
         if ($testFailed) {
-            Assert::fail('assertThrowsNothing failed: thrown exception was not detected.');
+            Assert::fail('assertDoesntThrow failed: thrown exception was not detected.');
         }
 
         try {
-            $this->assertThrowsNothing(function () { });
+            $this->assertDoesntThrow(function () { });
 
             $testFailed = false;
         } catch (AssertionFailedError) {
@@ -596,7 +596,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         }
 
         if ($testFailed) {
-            Assert::fail('assertThrowsNothing failed: exception was detected while no exception was thrown.');
+            Assert::fail('assertDoesntThrow failed: exception was detected while no exception was thrown.');
         }
     }
 


### PR DESCRIPTION
Sometimes I assert multiple situations in a single test, for example, different situations in which an exception should be thrown or not. The different situations where an exception is thrown are easy to assert thanks to the `assertThrows` method. This PR introduces the inverse method `assertThrowsNothing` method so you can easily and explicitly assert situations where you want to be sure that no exception is thrown.

```php
$this->assertThrowsNothing(function () {
    throw new Exception(); // fails if an exception is thrown
});
```