### PR TITLE
[12.x] Add resource helper functions to Model/Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Illuminate\Http\Resources\TransformsToResourceCollection;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -24,7 +25,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * @use \Illuminate\Support\Traits\EnumeratesValues<TKey, TValue>
      */
-    use EnumeratesValues, Macroable;
+    use EnumeratesValues, Macroable, TransformsToResourceCollection;
 
     /**
      * The items contained in the collection.

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -846,7 +846,6 @@ class Collection extends BaseCollection implements QueueableCollection
         return $model->newModelQuery()->whereKey($this->modelKeys());
     }
 
-
     /**
      * Create a new resource collection instance for the given resource.
      *

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -851,6 +851,8 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  class-string<JsonResource>|null  $resourceClass
      * @return ResourceCollection
+     *
+     * @throws \Throwable
      */
     public function toResourceCollection(?string $resourceClass = null): ResourceCollection
     {
@@ -865,6 +867,8 @@ class Collection extends BaseCollection implements QueueableCollection
      * Guess the resource collection for the items.
      *
      * @return ResourceCollection
+     *
+     * @throws \Throwable
      */
     protected function guessResourceCollection(): ResourceCollection
     {
@@ -874,14 +878,14 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $model = $this->first();
 
-        assert(is_object($model), 'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), \Exception::class,'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
         $basename = class_basename($className);
 
         $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
 
-        assert(class_exists($resourceClass), sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use LogicException;
@@ -842,5 +844,17 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         return $model->newModelQuery()->whereKey($this->modelKeys());
+    }
+
+
+    /**
+     * Create a new resource collection instance for the given resource.
+     *
+     * @param class-string<JsonResource> $resourceClass
+     * @return ResourceCollection
+     */
+    public function toResourceCollection(string $resourceClass): ResourceCollection
+    {
+        return $resourceClass::collection($this);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -881,12 +881,21 @@ class Collection extends BaseCollection implements QueueableCollection
         throw_unless(is_object($model), \Exception::class,'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
-        $basename = class_basename($className);
-
-        $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
+        $resourceClass = $this->guessResourceClassName($model);
 
         throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
+    }
+
+    /**
+     * Guess the resource class name for the given model.
+     *
+     * @param  object  $model
+     * @return class-string<JsonResource>
+     */
+    protected function guessResourceClassName(object $model): string
+    {
+        return sprintf('App\Http\Resources\%sResource', class_basename($model));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -878,12 +878,12 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $model = $this->first();
 
-        throw_unless(is_object($model), \Exception::class, 'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), \LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
         $resourceClass = $this->guessResourceClassName($model);
 
-        throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -878,7 +878,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $model = $this->first();
 
-        throw_unless(is_object($model), \Exception::class,'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), \Exception::class, 'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
         $resourceClass = $this->guessResourceClassName($model);

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -850,7 +850,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Create a new resource collection instance for the given resource.
      *
-     * @param class-string<JsonResource> $resourceClass
+     * @param  class-string<JsonResource>  $resourceClass
      * @return ResourceCollection
      */
     public function toResourceCollection(string $resourceClass): ResourceCollection

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -6,8 +6,6 @@ use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
-use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use LogicException;
@@ -844,58 +842,5 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         return $model->newModelQuery()->whereKey($this->modelKeys());
-    }
-
-    /**
-     * Create a new resource collection instance for the given resource.
-     *
-     * @param  class-string<JsonResource>|null  $resourceClass
-     * @return ResourceCollection
-     *
-     * @throws \Throwable
-     */
-    public function toResourceCollection(?string $resourceClass = null): ResourceCollection
-    {
-        if ($resourceClass === null) {
-            return $this->guessResourceCollection();
-        }
-
-        return $resourceClass::collection($this);
-    }
-
-    /**
-     * Guess the resource collection for the items.
-     *
-     * @return ResourceCollection
-     *
-     * @throws \Throwable
-     */
-    protected function guessResourceCollection(): ResourceCollection
-    {
-        if ($this->isEmpty()) {
-            return new ResourceCollection($this);
-        }
-
-        $model = $this->first();
-
-        throw_unless(is_object($model), \LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
-
-        $className = get_class($model);
-        $resourceClass = $this->guessResourceClassName($model);
-
-        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
-
-        return $resourceClass::collection($this);
-    }
-
-    /**
-     * Guess the resource class name for the given model.
-     *
-     * @param  object  $model
-     * @return class-string<JsonResource>
-     */
-    protected function guessResourceClassName(object $model): string
-    {
-        return sprintf('App\Http\Resources\%sResource', class_basename($model));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\TransformsToResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -40,7 +40,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
         Concerns\PreventsCircularRecursion,
-        ForwardsCalls;
+        ForwardsCalls,
+        TransformsToResource;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
 
@@ -2459,50 +2460,5 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->bootIfNotBooted();
 
         $this->initializeTraits();
-    }
-
-    /**
-     * Create a new resource object for the given resource.
-     *
-     * @param  class-string<JsonResource>|null  $resourceClass
-     * @return JsonResource
-     *
-     * @throws \Throwable
-     */
-    public function toResource(?string $resourceClass = null): JsonResource
-    {
-        if ($resourceClass === null) {
-            return $this->guessResource();
-        }
-
-        return $resourceClass::make($this);
-    }
-
-    /**
-     * Guess the resource class for the model.
-     *
-     * @return JsonResource
-     *
-     * @throws \Throwable
-     */
-    protected function guessResource(): JsonResource
-    {
-        $className = get_class($this);
-
-        $resourceClass = $this->guessResourceName();
-
-        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
-
-        return $resourceClass::make($this);
-    }
-
-    /**
-     * Guess the resource class name for the model.
-     *
-     * @return class-string<JsonResource>
-     */
-    protected function guessResourceName(): string
-    {
-        return sprintf('App\Http\Resources\%sResource', class_basename($this));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2464,11 +2464,32 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Create a new resource object for the given resource.
      *
-     * @param  class-string<JsonResource>  $resourceClass
+     * @param  class-string<JsonResource>|null  $resourceClass
      * @return JsonResource
      */
-    public function toResource(string $resourceClass): JsonResource
+    public function toResource(?string $resourceClass = null): JsonResource
     {
+        if ($resourceClass === null) {
+            return $this->guessResource();
+        }
+
+        return $resourceClass::make($this);
+    }
+
+    /**
+     * Guess the resource class for the model.
+     *
+     * @return JsonResource
+     */
+    protected function guessResource(): JsonResource
+    {
+        $className = get_class($this);
+        $basename = class_basename($className);
+
+        $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
+
+        assert(class_exists($resourceClass), sprintf('Failed to find resource class for model [%s].', $className));
+
         return $resourceClass::make($this);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2464,7 +2464,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Create a new resource object for the given resource.
      *
-     * @param class-string<JsonResource> $resourceClass
+     * @param  class-string<JsonResource>  $resourceClass
      * @return JsonResource
      */
     public function toResource(string $resourceClass): JsonResource

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2466,6 +2466,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  class-string<JsonResource>|null  $resourceClass
      * @return JsonResource
+     *
+     * @throws \Throwable
      */
     public function toResource(?string $resourceClass = null): JsonResource
     {
@@ -2480,6 +2482,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Guess the resource class for the model.
      *
      * @return JsonResource
+     *
+     * @throws \Throwable
      */
     protected function guessResource(): JsonResource
     {
@@ -2488,7 +2492,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
 
-        assert(class_exists($resourceClass), sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::make($this);
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2491,7 +2491,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $resourceClass = $this->guessResourceName();
 
-        throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::make($this);
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -2458,5 +2459,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->bootIfNotBooted();
 
         $this->initializeTraits();
+    }
+
+    /**
+     * Create a new resource object for the given resource.
+     *
+     * @param class-string<JsonResource> $resourceClass
+     * @return JsonResource
+     */
+    public function toResource(string $resourceClass): JsonResource
+    {
+        return $resourceClass::make($this);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2488,12 +2488,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected function guessResource(): JsonResource
     {
         $className = get_class($this);
-        $basename = class_basename($className);
 
-        $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
+        $resourceClass = $this->guessResourceName();
 
         throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::make($this);
+    }
+
+    /**
+     * Guess the resource class name for the model.
+     *
+     * @return class-string<JsonResource>
+     */
+    protected function guessResourceName(): string
+    {
+        return sprintf('App\Http\Resources\%sResource', class_basename($this));
     }
 }

--- a/src/Illuminate/Http/Resources/TransformsToResource.php
+++ b/src/Illuminate/Http/Resources/TransformsToResource.php
@@ -56,7 +56,6 @@ trait TransformsToResource
             return [];
         }
 
-        // Get everything after the "Models" namespace...
         $relativeNamespace = Str::after($modelClass, '\\Models\\');
 
         $relativeNamespace = Str::contains($relativeNamespace, '\\')

--- a/src/Illuminate/Http/Resources/TransformsToResource.php
+++ b/src/Illuminate/Http/Resources/TransformsToResource.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+trait TransformsToResource
+{
+    /**
+     * Create a new resource object for the given resource.
+     *
+     * @param  class-string<JsonResource>|null  $resourceClass
+     * @return JsonResource
+     *
+     * @throws \Throwable
+     */
+    public function toResource(?string $resourceClass = null): JsonResource
+    {
+        if ($resourceClass === null) {
+            return $this->guessResource();
+        }
+
+        return $resourceClass::make($this);
+    }
+
+    /**
+     * Guess the resource class for the model.
+     *
+     * @return JsonResource
+     *
+     * @throws \Throwable
+     */
+    protected function guessResource(): JsonResource
+    {
+        $className = get_class($this);
+
+        $resourceClass = static::guessResourceName();
+
+        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
+
+        return $resourceClass::make($this);
+    }
+
+    /**
+     * Guess the resource class name for the model.
+     *
+     * @return class-string<JsonResource>
+     */
+    public static function guessResourceName(): string
+    {
+        return sprintf('App\Http\Resources\%sResource', class_basename(static::class));
+    }
+}

--- a/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
+++ b/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
@@ -48,10 +48,12 @@ trait TransformsToResourceCollection
 
         throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
 
-        $resourceClass = $className::guessResourceName();
+        foreach ($className::guessResourceName() as $resourceClass) {
+            if (is_string($resourceClass) && class_exists($resourceClass)) {
+                return $resourceClass::collection($this);
+            }
+        }
 
-        throw_unless(class_exists($resourceClass), LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
-
-        return $resourceClass::collection($this);
+        throw new LogicException(sprintf('Failed to find resource class for model [%s].', $className));
     }
 }

--- a/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
+++ b/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Http\Resources;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+trait TransformsToResourceCollection
+{
+    /**
+     * Create a new resource collection instance for the given resource.
+     *
+     * @param  class-string<JsonResource>|null  $resourceClass
+     * @return ResourceCollection
+     *
+     * @throws \Throwable
+     */
+    public function toResourceCollection(?string $resourceClass = null): ResourceCollection
+    {
+        if ($resourceClass === null) {
+            return $this->guessResourceCollection();
+        }
+
+        return $resourceClass::collection($this);
+    }
+
+    /**
+     * Guess the resource collection for the items.
+     *
+     * @return ResourceCollection
+     *
+     * @throws \Throwable
+     */
+    protected function guessResourceCollection(): ResourceCollection
+    {
+        if ($this->isEmpty()) {
+            return new ResourceCollection($this);
+        }
+
+        $model = $this->items[0] ?? null;
+
+        throw_unless(is_object($model), \LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
+
+        /** @var class-string<Model> $className */
+        $className = get_class($model);
+        $resourceClass = $className::guessResourceName();
+
+        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
+
+        return $resourceClass::collection($this);
+    }
+}

--- a/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
+++ b/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http\Resources;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use LogicException;
 
 trait TransformsToResourceCollection
 {
@@ -40,16 +41,16 @@ trait TransformsToResourceCollection
 
         $model = $this->items[0] ?? null;
 
-        throw_unless(is_object($model), \LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
 
         /** @var class-string<Model> $className */
         $className = get_class($model);
 
-        throw_unless(method_exists($className, 'guessResourceName'), \LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
+        throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
 
         $resourceClass = $className::guessResourceName();
 
-        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
     }

--- a/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
+++ b/src/Illuminate/Http/Resources/TransformsToResourceCollection.php
@@ -44,6 +44,9 @@ trait TransformsToResourceCollection
 
         /** @var class-string<Model> $className */
         $className = get_class($model);
+
+        throw_unless(method_exists($className, 'guessResourceName'), \LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
+
         $resourceClass = $className::guessResourceName();
 
         throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -4,6 +4,8 @@ namespace Illuminate\Pagination;
 
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -798,5 +800,16 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     public function __toString()
     {
         return (string) $this->render();
+    }
+
+    /**
+     * Create a paginated resource collection.
+     *
+     * @param class-string<JsonResource> $resourceClass
+     * @return ResourceCollection
+     */
+    public function toResourceCollection(string $resourceClass): ResourceCollection
+    {
+        return $resourceClass::collection($this);
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -805,7 +805,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * Create a paginated resource collection.
      *
-     * @param class-string<JsonResource> $resourceClass
+     * @param  class-string<JsonResource>  $resourceClass
      * @return ResourceCollection
      */
     public function toResourceCollection(string $resourceClass): ResourceCollection

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -4,8 +4,7 @@ namespace Illuminate\Pagination;
 
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Http\Resources\Json\ResourceCollection;
+use Illuminate\Http\Resources\TransformsToResourceCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -22,7 +21,7 @@ use Traversable;
  */
 abstract class AbstractPaginator implements Htmlable, Stringable
 {
-    use ForwardsCalls, Tappable;
+    use ForwardsCalls, Tappable, TransformsToResourceCollection;
 
     /**
      * All of the items being paginated.
@@ -800,61 +799,5 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     public function __toString()
     {
         return (string) $this->render();
-    }
-
-    /**
-     * Create a paginated resource collection.
-     *
-     * @param  class-string<JsonResource>|null  $resourceClass
-     * @return ResourceCollection
-     *
-     * @throws \Throwable
-     */
-    public function toResourceCollection(?string $resourceClass = null): ResourceCollection
-    {
-        if ($resourceClass === null) {
-            return $this->guessResourceCollection();
-        }
-
-        return $resourceClass::collection($this);
-    }
-
-    /**
-     * Guess the resource collection for the items.
-     *
-     * @return ResourceCollection
-     *
-     * @throws \Throwable
-     */
-    protected function guessResourceCollection(): ResourceCollection
-    {
-        $collection = $this->getCollection();
-
-        if ($collection->isEmpty()) {
-            return new ResourceCollection($collection);
-        }
-
-        $model = $collection->first();
-
-        throw_unless(is_object($model), \LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
-
-        $className = get_class($model);
-
-        $resourceClass = $this->guessResourceClassName($model);
-
-        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
-
-        return $resourceClass::collection($this);
-    }
-
-    /**
-     * Guess the resource class name for the model.
-     *
-     * @param  object  $model
-     * @return string
-     */
-    protected function guessResourceClassName(object $model): string
-    {
-        return sprintf('App\Http\Resources\%sResource', class_basename($model));
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -807,6 +807,8 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      *
      * @param  class-string<JsonResource>|null  $resourceClass
      * @return ResourceCollection
+     *
+     * @throws \Throwable
      */
     public function toResourceCollection(?string $resourceClass = null): ResourceCollection
     {
@@ -821,6 +823,8 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      * Guess the resource collection for the items.
      *
      * @return ResourceCollection
+     *
+     * @throws \Throwable
      */
     protected function guessResourceCollection(): ResourceCollection
     {
@@ -832,14 +836,14 @@ abstract class AbstractPaginator implements Htmlable, Stringable
 
         $model = $collection->first();
 
-        assert(is_object($model), 'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), \Exception::class,'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
         $basename = class_basename($className);
 
         $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
 
-        assert(class_exists($resourceClass), sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
     }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -839,12 +839,22 @@ abstract class AbstractPaginator implements Htmlable, Stringable
         throw_unless(is_object($model), \Exception::class,'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
-        $basename = class_basename($className);
 
-        $resourceClass = sprintf('App\Http\Resources\%sResource', $basename);
+        $resourceClass = $this->guessResourceClassName($model);
 
         throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
+    }
+
+    /**
+     * Guess the resource class name for the model.
+     *
+     * @param  object  $model
+     * @return string
+     */
+    protected function guessResourceClassName(object $model): string
+    {
+        return sprintf('App\Http\Resources\%sResource', class_basename($model));
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -836,13 +836,13 @@ abstract class AbstractPaginator implements Htmlable, Stringable
 
         $model = $collection->first();
 
-        throw_unless(is_object($model), \Exception::class, 'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), \LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
 
         $resourceClass = $this->guessResourceClassName($model);
 
-        throw_unless(class_exists($resourceClass), \Exception::class, sprintf('Failed to find resource class for model [%s].', $className));
+        throw_unless(class_exists($resourceClass), \LogicException::class, sprintf('Failed to find resource class for model [%s].', $className));
 
         return $resourceClass::collection($this);
     }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -836,7 +836,7 @@ abstract class AbstractPaginator implements Htmlable, Stringable
 
         $model = $collection->first();
 
-        throw_unless(is_object($model), \Exception::class,'Resource collection guesser expects the collection to contain objects.');
+        throw_unless(is_object($model), \Exception::class, 'Resource collection guesser expects the collection to contain objects.');
 
         $className = get_class($model);
 

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentResourceCollectionTest extends TestCase
+{
+    public function testItGuessesTheResourceName()
+    {
+        $collection = new TestCollection([
+            new TestModel(),
+        ]);
+        $this->assertEquals('App\Http\Resources\TestModelResource', $collection->getGuessedResourceName(new TestModel()));
+    }
+
+    public function testItCanTransformToExplicitResource()
+    {
+        $collection = new Collection([
+            new TestModel(),
+        ]);
+
+        $resource = $collection->toResourceCollection(TestResource::class);
+
+        $this->assertInstanceOf(JsonResource::class, $resource);
+    }
+
+    public function testItThrowsExceptionWhenResourceCannotBeFound()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\TestModel].');
+
+        $collection = new Collection([
+            new TestModel(),
+        ]);
+        $collection->toResourceCollection();
+    }
+
+    public function testItCanGuessResourceWhenNotProvided()
+    {
+        $collection = new Collection([
+            new TestModel(),
+        ]);
+
+        class_alias(TestResource::class, 'App\Http\Resources\TestModelResource');
+
+        $resource = $collection->toResourceCollection();
+
+        $this->assertInstanceOf(JsonResource::class, $resource);
+    }
+}
+
+class TestModel extends Model
+{
+    //
+}
+
+class TestResource extends JsonResource
+{
+    //
+}
+
+class TestCollection extends Collection
+{
+    public function getGuessedResourceName(object $model): string
+    {
+        return $this->guessResourceClassName($model);
+    }
+}

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -9,14 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceCollectionTest extends TestCase
 {
-    public function testItGuessesTheResourceName()
-    {
-        $collection = new EloquentResourceCollectionTestCollection([
-            new EloquentResourceCollectionTestModel(),
-        ]);
-        $this->assertEquals('App\Http\Resources\EloquentResourceCollectionTestModelResource', $collection->getGuessedResourceName(new EloquentResourceCollectionTestModel()));
-    }
-
     public function testItCanTransformToExplicitResource()
     {
         $collection = new Collection([
@@ -61,12 +53,4 @@ class EloquentResourceCollectionTestModel extends Model
 class EloquentResourceCollectionTestResource extends JsonResource
 {
     //
-}
-
-class EloquentResourceCollectionTestCollection extends Collection
-{
-    public function getGuessedResourceName(object $model): string
-    {
-        return $this->guessResourceClassName($model);
-    }
 }

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -11,19 +11,19 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
 {
     public function testItGuessesTheResourceName()
     {
-        $collection = new TestCollection([
-            new TestModel(),
+        $collection = new EloquentResourceCollectionTestCollection([
+            new EloquentResourceCollectionTestModel(),
         ]);
-        $this->assertEquals('App\Http\Resources\TestModelResource', $collection->getGuessedResourceName(new TestModel()));
+        $this->assertEquals('App\Http\Resources\EloquentResourceCollectionTestModelResource', $collection->getGuessedResourceName(new EloquentResourceCollectionTestModel()));
     }
 
     public function testItCanTransformToExplicitResource()
     {
         $collection = new Collection([
-            new TestModel(),
+            new EloquentResourceCollectionTestModel(),
         ]);
 
-        $resource = $collection->toResourceCollection(TestResource::class);
+        $resource = $collection->toResourceCollection(EloquentResourceCollectionTestResource::class);
 
         $this->assertInstanceOf(JsonResource::class, $resource);
     }
@@ -31,10 +31,10 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\TestModel].');
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\EloquentResourceCollectionTestModel].');
 
         $collection = new Collection([
-            new TestModel(),
+            new EloquentResourceCollectionTestModel(),
         ]);
         $collection->toResourceCollection();
     }
@@ -42,10 +42,10 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
     public function testItCanGuessResourceWhenNotProvided()
     {
         $collection = new Collection([
-            new TestModel(),
+            new EloquentResourceCollectionTestModel(),
         ]);
 
-        class_alias(TestResource::class, 'App\Http\Resources\TestModelResource');
+        class_alias(EloquentResourceCollectionTestResource::class, 'App\Http\Resources\EloquentResourceCollectionTestModelResource');
 
         $resource = $collection->toResourceCollection();
 
@@ -53,17 +53,17 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
     }
 }
 
-class TestModel extends Model
+class EloquentResourceCollectionTestModel extends Model
 {
     //
 }
 
-class TestResource extends JsonResource
+class EloquentResourceCollectionTestResource extends JsonResource
 {
     //
 }
 
-class TestCollection extends Collection
+class EloquentResourceCollectionTestCollection extends Collection
 {
     public function getGuessedResourceName(object $model): string
     {

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceCollectionTest extends TestCase
@@ -23,7 +24,7 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\EloquentResourceCollectionTestModel].');
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel].');
 
         $collection = new Collection([
             new EloquentResourceCollectionTestModel(),
@@ -37,17 +38,12 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
             new EloquentResourceCollectionTestModel(),
         ]);
 
-        class_alias(EloquentResourceCollectionTestResource::class, 'App\Http\Resources\EloquentResourceCollectionTestModelResource');
+        class_alias(EloquentResourceCollectionTestResource::class, 'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceCollectionTestModelResource');
 
         $resource = $collection->toResourceCollection();
 
         $this->assertInstanceOf(JsonResource::class, $resource);
     }
-}
-
-class EloquentResourceCollectionTestModel extends Model
-{
-    //
 }
 
 class EloquentResourceCollectionTestResource extends JsonResource

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -30,7 +30,7 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\EloquentResourceCollectionTestModel].');
 
         $collection = new Collection([

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -40,6 +40,18 @@ class DatabaseEloquentResourceModelTest extends TestCase
         $this->assertSame($model, $resource->resource);
     }
 
+    public function testItCanGuessResourceWhenNotProvidedWithNonResourceSuffix()
+    {
+        $model = new EloquentResourceTestResourceModelWithGuessableResource();
+
+        class_alias(EloquentResourceTestJsonResource::class, 'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModelWithGuessableResource');
+
+        $resource = $model->toResource();
+
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource);
+        $this->assertSame($model, $resource->resource);
+    }
+
     public function testItCanGuessResourceName()
     {
         $model = new EloquentResourceTestResourceModel();

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentResourceModelTest extends TestCase
+{
+    public function testItCanTransformToExplicitResource()
+    {
+        $model = new TestResourceModel();
+        $resource = $model->toResource(TestJsonResource::class);
+
+        $this->assertInstanceOf(TestJsonResource::class, $resource);
+        $this->assertSame($model, $resource->resource);
+    }
+
+    public function testItThrowsExceptionWhenResourceCannotBeFound()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\TestResourceModel].');
+
+        $model = new TestResourceModel();
+        $model->toResource();
+    }
+
+    public function testItCanGuessResourceWhenNotProvided()
+    {
+        $model = new TestResourceModelWithGuessableResource();
+
+        class_alias(TestJsonResource::class, 'App\Http\Resources\TestResourceModelWithGuessableResourceResource');
+
+        $resource = $model->toResource();
+
+        $this->assertInstanceOf(TestJsonResource::class, $resource);
+        $this->assertSame($model, $resource->resource);
+    }
+
+    public function testItCanGuessResourceName()
+    {
+        $model = new TestResourceModel();
+        $this->assertEquals('App\Http\Resources\TestResourceModelResource', $model->getGuessedResourceName());
+    }
+
+}
+
+class TestResourceModel extends Model
+{
+    public function getGuessedResourceName(): string
+    {
+        return $this->guessResourceName();
+    }
+}
+
+class TestResourceModelWithGuessableResource extends Model
+{
+}
+
+class TestJsonResource extends JsonResource
+{
+}

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithGuessableResource;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceModelTest extends TestCase
@@ -20,7 +22,7 @@ class DatabaseEloquentResourceModelTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\EloquentResourceTestResourceModel].');
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel].');
 
         $model = new EloquentResourceTestResourceModel();
         $model->toResource();
@@ -30,7 +32,7 @@ class DatabaseEloquentResourceModelTest extends TestCase
     {
         $model = new EloquentResourceTestResourceModelWithGuessableResource();
 
-        class_alias(EloquentResourceTestJsonResource::class, 'App\Http\Resources\EloquentResourceTestResourceModelWithGuessableResourceResource');
+        class_alias(EloquentResourceTestJsonResource::class, 'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModelWithGuessableResourceResource');
 
         $resource = $model->toResource();
 
@@ -41,18 +43,8 @@ class DatabaseEloquentResourceModelTest extends TestCase
     public function testItCanGuessResourceName()
     {
         $model = new EloquentResourceTestResourceModel();
-        $this->assertEquals('App\Http\Resources\EloquentResourceTestResourceModelResource', $model::guessResourceName());
+        $this->assertEquals('Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModelResource', $model::guessResourceName());
     }
-}
-
-class EloquentResourceTestResourceModel extends Model
-{
-    //
-}
-
-class EloquentResourceTestResourceModelWithGuessableResource extends Model
-{
-    //
 }
 
 class EloquentResourceTestJsonResource extends JsonResource

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -41,16 +41,13 @@ class DatabaseEloquentResourceModelTest extends TestCase
     public function testItCanGuessResourceName()
     {
         $model = new EloquentResourceTestResourceModel();
-        $this->assertEquals('App\Http\Resources\EloquentResourceTestResourceModelResource', $model->getGuessedResourceName());
+        $this->assertEquals('App\Http\Resources\EloquentResourceTestResourceModelResource', $model::guessResourceName());
     }
 }
 
 class EloquentResourceTestResourceModel extends Model
 {
-    public function getGuessedResourceName(): string
-    {
-        return $this->guessResourceName();
-    }
+    //
 }
 
 class EloquentResourceTestResourceModelWithGuessableResource extends Model

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -43,7 +43,10 @@ class DatabaseEloquentResourceModelTest extends TestCase
     public function testItCanGuessResourceName()
     {
         $model = new EloquentResourceTestResourceModel();
-        $this->assertEquals('Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModelResource', $model::guessResourceName());
+        $this->assertEquals([
+            'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModelResource',
+            'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModel'
+        ], $model::guessResourceName());
     }
 }
 

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -19,7 +19,7 @@ class DatabaseEloquentResourceModelTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\EloquentResourceTestResourceModel].');
 
         $model = new EloquentResourceTestResourceModel();

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -10,43 +10,42 @@ class DatabaseEloquentResourceModelTest extends TestCase
 {
     public function testItCanTransformToExplicitResource()
     {
-        $model = new TestResourceModel();
-        $resource = $model->toResource(TestJsonResource::class);
+        $model = new EloquentResourceTestResourceModel();
+        $resource = $model->toResource(EloquentResourceTestJsonResource::class);
 
-        $this->assertInstanceOf(TestJsonResource::class, $resource);
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource);
         $this->assertSame($model, $resource->resource);
     }
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\TestResourceModel].');
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Database\EloquentResourceTestResourceModel].');
 
-        $model = new TestResourceModel();
+        $model = new EloquentResourceTestResourceModel();
         $model->toResource();
     }
 
     public function testItCanGuessResourceWhenNotProvided()
     {
-        $model = new TestResourceModelWithGuessableResource();
+        $model = new EloquentResourceTestResourceModelWithGuessableResource();
 
-        class_alias(TestJsonResource::class, 'App\Http\Resources\TestResourceModelWithGuessableResourceResource');
+        class_alias(EloquentResourceTestJsonResource::class, 'App\Http\Resources\EloquentResourceTestResourceModelWithGuessableResourceResource');
 
         $resource = $model->toResource();
 
-        $this->assertInstanceOf(TestJsonResource::class, $resource);
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource);
         $this->assertSame($model, $resource->resource);
     }
 
     public function testItCanGuessResourceName()
     {
-        $model = new TestResourceModel();
-        $this->assertEquals('App\Http\Resources\TestResourceModelResource', $model->getGuessedResourceName());
+        $model = new EloquentResourceTestResourceModel();
+        $this->assertEquals('App\Http\Resources\EloquentResourceTestResourceModelResource', $model->getGuessedResourceName());
     }
-
 }
 
-class TestResourceModel extends Model
+class EloquentResourceTestResourceModel extends Model
 {
     public function getGuessedResourceName(): string
     {
@@ -54,10 +53,12 @@ class TestResourceModel extends Model
     }
 }
 
-class TestResourceModelWithGuessableResource extends Model
+class EloquentResourceTestResourceModelWithGuessableResource extends Model
 {
+    //
 }
 
-class TestJsonResource extends JsonResource
+class EloquentResourceTestJsonResource extends JsonResource
 {
+    //
 }

--- a/tests/Database/Fixtures/Models/EloquentResourceCollectionTestModel.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceCollectionTestModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentResourceCollectionTestModel extends Model
+{
+    //
+}

--- a/tests/Database/Fixtures/Models/EloquentResourceTestResourceModel.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceTestResourceModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentResourceTestResourceModel extends Model
+{
+    //
+}

--- a/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithGuessableResource.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithGuessableResource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentResourceTestResourceModelWithGuessableResource extends Model
+{
+    //
+}

--- a/tests/Pagination/Fixtures/Models/PaginatorResourceTestModel.php
+++ b/tests/Pagination/Fixtures/Models/PaginatorResourceTestModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Pagination\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+class PaginatorResourceTestModel extends Model
+{
+    //
+}

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Pagination\LengthAwarePaginator;
+use PHPUnit\Framework\TestCase;
+
+class PaginatorResourceTest extends TestCase
+{
+    public function testItGuessesTheResourceName()
+    {
+        $paginator = new TestPaginator([
+            new TestModel(),
+        ], 1, 1);
+
+        $this->assertEquals('App\Http\Resources\TestModelResource', $paginator->getGuessedResourceName(new TestModel()));
+    }
+
+    public function testItCanTransformToExplicitResource()
+    {
+        $paginator = new TestPaginator([
+            new TestModel(),
+        ], 1, 1);
+
+        $resource = $paginator->toResourceCollection(TestResource::class);
+
+        $this->assertInstanceOf(JsonResource::class, $resource);
+    }
+
+    public function testItThrowsExceptionWhenResourceCannotBeFound()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\TestModel].');
+
+        $paginator = new TestPaginator([
+            new TestModel(),
+        ], 1, 1);
+
+        $paginator->toResourceCollection();
+    }
+
+    public function testItCanGuessResourceWhenNotProvided()
+    {
+        $paginator = new TestPaginator([
+            new TestModel(),
+        ], 1, 1);
+
+        class_alias(TestResource::class, 'App\Http\Resources\TestModelResource');
+
+        $resource = $paginator->toResourceCollection();
+
+        $this->assertInstanceOf(JsonResource::class, $resource);
+    }
+}
+
+class TestModel extends Model
+{
+    //
+}
+
+class TestResource extends JsonResource
+{
+    //
+}
+
+class TestPaginator extends LengthAwarePaginator
+{
+    public function getGuessedResourceName(object $model): string
+    {
+        return $this->guessResourceClassName($model);
+    }
+}

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -31,7 +31,7 @@ class PaginatorResourceTest extends TestCase
 
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\PaginatorResourceTestModel].');
 
         $paginator = new PaginatorResourceTestPaginator([

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Pagination;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel;
 use PHPUnit\Framework\TestCase;
 
 class PaginatorResourceTest extends TestCase
@@ -23,7 +24,7 @@ class PaginatorResourceTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\PaginatorResourceTestModel].');
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\Fixtures\Models\PaginatorResourceTestModel].');
 
         $paginator = new PaginatorResourceTestPaginator([
             new PaginatorResourceTestModel(),
@@ -38,17 +39,12 @@ class PaginatorResourceTest extends TestCase
             new PaginatorResourceTestModel(),
         ], 1, 1, 1);
 
-        class_alias(PaginatorResourceTestResource::class, 'App\Http\Resources\PaginatorResourceTestModelResource');
+        class_alias(PaginatorResourceTestResource::class, 'Illuminate\Tests\Pagination\Fixtures\Http\Resources\PaginatorResourceTestModelResource');
 
         $resource = $paginator->toResourceCollection();
 
         $this->assertInstanceOf(JsonResource::class, $resource);
     }
-}
-
-class PaginatorResourceTestModel extends Model
-{
-    //
 }
 
 class PaginatorResourceTestResource extends JsonResource

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -11,20 +11,20 @@ class PaginatorResourceTest extends TestCase
 {
     public function testItGuessesTheResourceName()
     {
-        $paginator = new TestPaginator([
-            new TestModel(),
-        ], 1, 1);
+        $paginator = new PaginatorResourceTestPaginator([
+            new PaginatorResourceTestModel(),
+        ], 1, 1, 1);
 
-        $this->assertEquals('App\Http\Resources\TestModelResource', $paginator->getGuessedResourceName(new TestModel()));
+        $this->assertEquals('App\Http\Resources\PaginatorResourceTestModelResource', $paginator->getGuessedResourceName(new PaginatorResourceTestModel()));
     }
 
     public function testItCanTransformToExplicitResource()
     {
-        $paginator = new TestPaginator([
-            new TestModel(),
-        ], 1, 1);
+        $paginator = new PaginatorResourceTestPaginator([
+            new PaginatorResourceTestModel(),
+        ], 1, 1, 1);
 
-        $resource = $paginator->toResourceCollection(TestResource::class);
+        $resource = $paginator->toResourceCollection(PaginatorResourceTestResource::class);
 
         $this->assertInstanceOf(JsonResource::class, $resource);
     }
@@ -32,22 +32,22 @@ class PaginatorResourceTest extends TestCase
     public function testItThrowsExceptionWhenResourceCannotBeFound()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\TestModel].');
+        $this->expectExceptionMessage('Failed to find resource class for model [Illuminate\Tests\Pagination\PaginatorResourceTestModel].');
 
-        $paginator = new TestPaginator([
-            new TestModel(),
-        ], 1, 1);
+        $paginator = new PaginatorResourceTestPaginator([
+            new PaginatorResourceTestModel(),
+        ], 1, 1, 1);
 
         $paginator->toResourceCollection();
     }
 
     public function testItCanGuessResourceWhenNotProvided()
     {
-        $paginator = new TestPaginator([
-            new TestModel(),
-        ], 1, 1);
+        $paginator = new PaginatorResourceTestPaginator([
+            new PaginatorResourceTestModel(),
+        ], 1, 1, 1);
 
-        class_alias(TestResource::class, 'App\Http\Resources\TestModelResource');
+        class_alias(PaginatorResourceTestResource::class, 'App\Http\Resources\PaginatorResourceTestModelResource');
 
         $resource = $paginator->toResourceCollection();
 
@@ -55,17 +55,17 @@ class PaginatorResourceTest extends TestCase
     }
 }
 
-class TestModel extends Model
+class PaginatorResourceTestModel extends Model
 {
     //
 }
 
-class TestResource extends JsonResource
+class PaginatorResourceTestResource extends JsonResource
 {
     //
 }
 
-class TestPaginator extends LengthAwarePaginator
+class PaginatorResourceTestPaginator extends LengthAwarePaginator
 {
     public function getGuessedResourceName(object $model): string
     {

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -9,15 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class PaginatorResourceTest extends TestCase
 {
-    public function testItGuessesTheResourceName()
-    {
-        $paginator = new PaginatorResourceTestPaginator([
-            new PaginatorResourceTestModel(),
-        ], 1, 1, 1);
-
-        $this->assertEquals('App\Http\Resources\PaginatorResourceTestModelResource', $paginator->getGuessedResourceName(new PaginatorResourceTestModel()));
-    }
-
     public function testItCanTransformToExplicitResource()
     {
         $paginator = new PaginatorResourceTestPaginator([
@@ -67,8 +58,5 @@ class PaginatorResourceTestResource extends JsonResource
 
 class PaginatorResourceTestPaginator extends LengthAwarePaginator
 {
-    public function getGuessedResourceName(object $model): string
-    {
-        return $this->guessResourceClassName($model);
-    }
+    //
 }


### PR DESCRIPTION
This PR adds a couple of helper functions that will make generating resource instances a lot more fluent.

Currently we need to do this:

```php
UserResource::make(User::find(1));

// or

UserResource::collection(User::query()->active()->paginate());
```

After change:

```php
User::find(1)->toResource(UserResource::class);

User::query()->active()->paginate()->toResourceCollection(UserResource::class);
```

