### PR TITLE
[12.x] Types: PasswordBroker::reset

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -91,7 +91,7 @@ class PasswordBroker implements PasswordBrokerContract
      *
      * @param  array  $credentials
      * @param  \Closure  $callback
-     * @return mixed
+     * @return string
      */
     public function reset(#[\SensitiveParameter] array $credentials, Closure $callback)
     {

--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Auth\PasswordBroker;
  * @method static string getDefaultDriver()
  * @method static void setDefaultDriver(string $name)
  * @method static string sendResetLink(array $credentials, \Closure|null $callback = null)
- * @method static mixed reset(array $credentials, \Closure $callback)
+ * @method static string reset(array $credentials, \Closure $callback)
  * @method static \Illuminate\Contracts\Auth\CanResetPassword|null getUser(array $credentials)
  * @method static string createToken(\Illuminate\Contracts\Auth\CanResetPassword $user)
  * @method static void deleteToken(\Illuminate\Contracts\Auth\CanResetPassword $user)


### PR DESCRIPTION
Hey, this method is currently marked as returning `mixed` - when it actually returns `string`.
```php
/**
 * Reset the password for the given token.
 *
 * @param  array  $credentials
 * @param  \Closure  $callback
 * @return mixed
 */
public function reset(#[\SensitiveParameter] array $credentials, Closure $callback)
{
    // $user is CanResetPassword|string
    $user = $this->validateReset($credentials);

    // ...

    if (! $user instanceof CanResetPasswordContract) {
        // $user is string
        return $user;
    }
    
    // ...

    // also a string
    return static::PASSWORD_RESET;
}
```

I haven't changed the interface, as this `PasswordBroker` happening to return a `string` doesn't necessarily (although probably does) mean they all have to.