### PR TITLE
Added property with file path to `MigrationStarted` and `MigrationEnded` migration events

### DIFF
--- a/src/Illuminate/Database/Events/MigrationEvent.php
+++ b/src/Illuminate/Database/Events/MigrationEvent.php
@@ -22,14 +22,23 @@ abstract class MigrationEvent implements MigrationEventContract
     public $method;
 
     /**
+     * The path to the migration file that was called.
+     *
+     * @var string
+     */
+    public $file;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Database\Migrations\Migration  $migration
      * @param  string  $method
+     * @param  string  $file
      */
-    public function __construct(Migration $migration, $method)
+    public function __construct(Migration $migration, $method, $file)
     {
         $this->method = $method;
         $this->migration = $migration;
+        $this->file = $file;
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -240,7 +240,7 @@ class Migrator
             return $this->pretendToRun($migration, 'up');
         }
 
-        $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));
+        $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up', $file));
 
         // Once we have run a migrations class, we will log that it was run in this
         // repository so that we don't try to run it next time we do a migration
@@ -403,7 +403,7 @@ class Migrator
             return $this->pretendToRun($instance, 'down');
         }
 
-        $this->write(Task::class, $name, fn () => $this->runMigration($instance, 'down'));
+        $this->write(Task::class, $name, fn () => $this->runMigration($instance, 'down', $file));
 
         // Once we have successfully run the migration "down" we will remove it from
         // the migration repository so it will be considered to have not been run
@@ -418,19 +418,19 @@ class Migrator
      * @param  string  $method
      * @return void
      */
-    protected function runMigration($migration, $method)
+    protected function runMigration($migration, $method, $file)
     {
         $connection = $this->resolveConnection(
             $migration->getConnection()
         );
 
-        $callback = function () use ($connection, $migration, $method) {
+        $callback = function () use ($connection, $migration, $method, $file) {
             if (method_exists($migration, $method)) {
-                $this->fireMigrationEvent(new MigrationStarted($migration, $method));
+                $this->fireMigrationEvent(new MigrationStarted($migration, $method, $file));
 
                 $this->runMethod($connection, $migration, $method);
 
-                $this->fireMigrationEvent(new MigrationEnded($migration, $method));
+                $this->fireMigrationEvent(new MigrationEnded($migration, $method, $file));
             }
         };
 


### PR DESCRIPTION
The situation is very simple:

1. Migration classes are anonymous;
2. When sending the `MigrationStarted` and `MigrationEnded` events, which indicate the start and end of a particular migration, contain the migration instance itself and the start method - `up` or `down`;
3. without the file parameter, it is impossible to determine the source of the file without using reflection.

```php
return new ReflectionClass($migration)->getFileName();
```

Considering that the reference to the executable class is located next to the object at the moment of calling the event, it would be more logical to pass the path to the file as a parameter.

This will improve the mechanism for interacting with migrations, allowing you to perform some action when a particular migration is triggered.