### PR TITLE
Job naming prefix in case of shared hosting

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -226,7 +226,7 @@ trait ManagesAttributes
      */
     public function description($description)
     {
-        $this->description = $description;
+        $this->description = env("APP_SCHEDULER_PREFIX", "") . $description;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -226,7 +226,7 @@ trait ManagesAttributes
      */
     public function description($description)
     {
-        $this->description = env("APP_SCHEDULER_PREFIX", "") . $description;
+        $this->description = config('scheduler_prefix', '') . $description;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -226,7 +226,7 @@ trait ManagesAttributes
      */
     public function description($description)
     {
-        $this->description = config('scheduler_prefix', '') . $description;
+        $this->description = config('app.scheduler_prefix', '').$description;
 
         return $this;
     }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Console;
 
+use Illuminate\Config\Repository as Config;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\CacheEventMutex;
@@ -31,6 +32,10 @@ class ConsoleEventSchedulerTest extends TestCase
         $container->instance(SchedulingMutex::class, m::mock(CacheSchedulingMutex::class));
 
         $container->instance(Schedule::class, $this->schedule = new Schedule(m::mock(EventMutex::class)));
+
+        $container->singleton('config', function () {
+            return $this->createConfig();
+        });
     }
 
     protected function tearDown(): void
@@ -143,6 +148,20 @@ class ConsoleEventSchedulerTest extends TestCase
         $schedule->call('path/to/command');
         $events = $schedule->events();
         $this->assertSame('Asia/Tokyo', $events[0]->timezone);
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'app' => [
+                'scheduler_prefix' => env('SCHEDULER_PREFIX', ''),
+            ],
+        ]);
     }
 }
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
+use Illuminate\Config\Repository as Config;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
@@ -13,6 +15,21 @@ use function Illuminate\Support\php_binary;
 
 class EventTest extends TestCase
 {
+    /**
+     * @var \Illuminate\Console\Scheduling\Schedule
+     */
+    private $schedule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = Container::getInstance();
+        $container->singleton('config', function () {
+            return $this->createConfig();
+        });
+    }
+
     protected function tearDown(): void
     {
         m::close();
@@ -103,5 +120,19 @@ class EventTest extends TestCase
         });
 
         $this->assertSame('fancy-command-description', $event->mutexName());
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'app' => [
+                'scheduler_prefix' => env('SCHEDULER_PREFIX', ''),
+            ],
+        ]);
     }
 }

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Illuminate\Tests\Console\Scheduling;
 
+use Illuminate\Config\Repository as Config;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\SchedulingMutex;
@@ -33,6 +34,9 @@ final class ScheduleTest extends TestCase
         $this->container->instance(EventMutex::class, $this->eventMutex);
         $this->schedulingMutex = m::mock(SchedulingMutex::class);
         $this->container->instance(SchedulingMutex::class, $this->schedulingMutex);
+        $this->container->singleton('config', function () {
+            return $this->createConfig();
+        });
     }
 
     #[DataProvider('jobHonoursDisplayNameIfMethodExistsProvider')]
@@ -66,5 +70,19 @@ final class ScheduleTest extends TestCase
         $scheduledJob = $schedule->job(JobToTestWithSchedule::class);
         self::assertSame(JobToTestWithSchedule::class, $scheduledJob->description);
         self::assertFalse($this->container->resolved(JobToTestWithSchedule::class));
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'app' => [
+                'scheduler_prefix' => env('SCHEDULER_PREFIX', ''),
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
Possibility for prefixing name of jobs, so that if you have a shared hosting and 2 jobs with the same name that should run "onOneServer", it would still run for both environments. In case you don't have the property set in the env, the functionality will be the same without affecting current changes.

In order to solve this now, I have to add the prefix for each command in Kernel.
