### PR TITLE
[12.x] Fix: update return type annotation for response helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -825,7 +825,7 @@ if (! function_exists('response')) {
      * @param  \Illuminate\Contracts\View\View|string|array|null  $content
      * @param  int  $status
      * @param  array  $headers
-     * @return ($content is null ? \Illuminate\Contracts\Routing\ResponseFactory : \Illuminate\Http\Response)
+     * @return \Illuminate\Http\Response|\Illuminate\Contracts\Routing\ResponseFactory
      */
     function response($content = null, $status = 200, array $headers = [])
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using the `response()` helper in my Controller for returning a Response with the Status 202 Accepted without any content, my IDE said there must be an error with my types since the `response()` helper will return a `ResponseFactory` if the first Parameter `$content` is null, and my Controller Method was set to return a `Response`

Taking a closer look at the helper function revealed that the definition in the Docblock is in contrary to the actual execution of the code. It will only return a `ResponseFactory` if there are no arguments provided with the function. There are cases where the `$content` can be null and Arguments will be provided.

To my current knowlegde there is no ability given within PHPStan to provide a more detailed explanation on when which type will be returned. Instead of having a wrong explanation within the Docblocks, I would prefer a more unprecise one. 

Therefore I request to change the `@return` annotation into a union type, with the response coming first, as it would be the most expected and common return type.

Users would benefit in not getting errors by the IDE for proper usage, but will be challenged to look up and understand the functionality of the method itself in case of Problems. However, I find that to be useful in making people understand what they are working with on a daily basis.
