### PR TITLE
 [11.x] Add CacheFlushed Event

### DIFF
--- a/src/Illuminate/Cache/Events/CacheEvent.php
+++ b/src/Illuminate/Cache/Events/CacheEvent.php
@@ -14,7 +14,7 @@ abstract class CacheEvent
     /**
      * The key of the event.
      *
-     * @var string
+     * @var string|null
      */
     public $key;
 
@@ -29,11 +29,11 @@ abstract class CacheEvent
      * Create a new event instance.
      *
      * @param  string|null  $storeName
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  array  $tags
      * @return void
      */
-    public function __construct($storeName, $key, array $tags = [])
+    public function __construct($storeName, $key = null, array $tags = [])
     {
         $this->storeName = $storeName;
         $this->key = $key;

--- a/src/Illuminate/Cache/Events/CacheEvent.php
+++ b/src/Illuminate/Cache/Events/CacheEvent.php
@@ -14,7 +14,7 @@ abstract class CacheEvent
     /**
      * The key of the event.
      *
-     * @var string|null
+     * @var string
      */
     public $key;
 
@@ -29,11 +29,11 @@ abstract class CacheEvent
      * Create a new event instance.
      *
      * @param  string|null  $storeName
-     * @param  string|null  $key
+     * @param  string  $key
      * @param  array  $tags
      * @return void
      */
-    public function __construct($storeName, $key = null, array $tags = [])
+    public function __construct($storeName, $key, array $tags = [])
     {
         $this->storeName = $storeName;
         $this->key = $key;

--- a/src/Illuminate/Cache/Events/CacheFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheFlushed extends CacheEvent
+{
+    //
+}

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheFlushing extends CacheEvent
+{
+    //
+}

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -581,6 +581,7 @@ class Repository implements ArrayAccess, CacheContract
         if ($result) {
             $this->event(new CacheFlushed($this->getName()));
         }
+
         return $result;
     }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -7,6 +7,7 @@ use BadMethodCallException;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -576,10 +577,12 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function clear(): bool
     {
+        $this->event(new CacheFlushing($this->getName(), ''));
+
         $result = $this->store->flush();
 
         if ($result) {
-            $this->event(new CacheFlushed($this->getName()));
+            $this->event(new CacheFlushed($this->getName(), ''));
         }
 
         return $result;

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use BadMethodCallException;
 use Closure;
 use DateTimeInterface;
+use Illuminate\Cache\Events\CacheFlushed;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -575,7 +576,12 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function clear(): bool
     {
-        return $this->store->flush();
+        $result = $this->store->flush();
+
+        if ($result) {
+            $this->event(new CacheFlushed($this->getName()));
+        }
+        return $result;
     }
 
     /**

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -219,6 +221,44 @@ class CacheEventsTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(ForgettingKey::class, ['key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgetFailed::class, ['key' => 'baz']));
         $this->assertFalse($repository->forget('baz'));
+    }
+
+    public function testFlushTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushing::class, [
+                'storeName' => 'array',
+            ])
+        );
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushed::class, [
+                'storeName' => 'array',
+            ])
+        );
+        $this->assertTrue($repository->clear());
+    }
+
+    public function testFlushFailureDoesNotDispatchEvent()
+    {
+        $dispatcher = $this->getDispatcher();
+
+        // Create a store that fails to flush
+        $failingStore = m::mock(Store::class);
+        $failingStore->shouldReceive('flush')->andReturn(false);
+
+        $repository = new Repository($failingStore, ['store' => 'array']);
+        $repository->setEventDispatcher($dispatcher);
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushing::class, [
+                'storeName' => 'array',
+            ])
+        );
+        $this->assertFalse($repository->clear());
     }
 
     protected function assertEventMatches($eventClass, $properties = [])

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
-use Illuminate\Cache\Events\CacheFlushed;
-use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -221,44 +219,6 @@ class CacheEventsTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(ForgettingKey::class, ['key' => 'baz']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgetFailed::class, ['key' => 'baz']));
         $this->assertFalse($repository->forget('baz'));
-    }
-
-    public function testFlushTriggersEvents()
-    {
-        $dispatcher = $this->getDispatcher();
-        $repository = $this->getRepository($dispatcher);
-
-        $dispatcher->shouldReceive('dispatch')->once()->with(
-            $this->assertEventMatches(CacheFlushing::class, [
-                'storeName' => 'array',
-            ])
-        );
-
-        $dispatcher->shouldReceive('dispatch')->once()->with(
-            $this->assertEventMatches(CacheFlushed::class, [
-                'storeName' => 'array',
-            ])
-        );
-        $this->assertTrue($repository->clear());
-    }
-
-    public function testFlushFailureDoesNotDispatchEvent()
-    {
-        $dispatcher = $this->getDispatcher();
-
-        // Create a store that fails to flush
-        $failingStore = m::mock(Store::class);
-        $failingStore->shouldReceive('flush')->andReturn(false);
-
-        $repository = new Repository($failingStore, ['store' => 'array']);
-        $repository->setEventDispatcher($dispatcher);
-
-        $dispatcher->shouldReceive('dispatch')->once()->with(
-            $this->assertEventMatches(CacheFlushing::class, [
-                'storeName' => 'array',
-            ])
-        );
-        $this->assertFalse($repository->clear());
     }
 
     protected function assertEventMatches($eventClass, $properties = [])

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -229,7 +229,7 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with(
             $this->assertEventMatches(CacheFlushed::class, [
-                'storeName' => 'array'
+                'storeName' => 'array',
             ])
         );
         $this->assertTrue($repository->clear());
@@ -238,7 +238,7 @@ class CacheEventsTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->once()->with(
             $this->assertEventMatches(CacheFlushed::class, [
                 'storeName' => 'array',
-                'tags' => ['taylor']
+                'tags' => ['taylor'],
             ])
         );
         $this->assertTrue($taggedRepository->clear());

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -260,7 +260,6 @@ class CacheEventsTest extends TestCase
         $this->assertFalse($repository->clear());
     }
 
-
     protected function assertEventMatches($eventClass, $properties = [])
     {
         return m::on(function ($event) use ($eventClass, $properties) {

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -85,6 +87,17 @@ class SupportFacadesEventTest extends TestCase
 
         Event::assertDispatched(RetrievingKey::class);
         Event::assertDispatched(CacheMissed::class);
+    }
+
+    public function testCacheFlushDispatchesEvent()
+    {
+        $arrayRepository = Cache::store('array');
+        Event::fake();
+
+        $arrayRepository->clear();
+
+        Event::assertDispatched(CacheFlushing::class);
+        Event::assertDispatched(CacheFlushed::class);
     }
 
     protected function getCacheConfig()

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Events\CacheFlushed;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -85,6 +86,16 @@ class SupportFacadesEventTest extends TestCase
 
         Event::assertDispatched(RetrievingKey::class);
         Event::assertDispatched(CacheMissed::class);
+    }
+
+    public function testCacheFlushDispatchesEvent()
+    {
+        $arrayRepository = Cache::store('array');
+        Event::fake();
+
+        $arrayRepository->clear();
+
+        Event::assertDispatched(CacheFlushed::class);
     }
 
     protected function getCacheConfig()

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Cache\CacheManager;
-use Illuminate\Cache\Events\CacheFlushed;
-use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -87,17 +85,6 @@ class SupportFacadesEventTest extends TestCase
 
         Event::assertDispatched(RetrievingKey::class);
         Event::assertDispatched(CacheMissed::class);
-    }
-
-    public function testCacheFlushDispatchesEvent()
-    {
-        $arrayRepository = Cache::store('array');
-        Event::fake();
-
-        $arrayRepository->clear();
-
-        Event::assertDispatched(CacheFlushing::class);
-        Event::assertDispatched(CacheFlushed::class);
     }
 
     protected function getCacheConfig()

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -95,6 +96,7 @@ class SupportFacadesEventTest extends TestCase
 
         $arrayRepository->clear();
 
+        Event::assertDispatched(CacheFlushing::class);
         Event::assertDispatched(CacheFlushed::class);
     }
 


### PR DESCRIPTION
**Description:**  
Introduces `CacheFlushed` event dispatching when calling `$cache->flush()`. Enables monitoring of full cache clearance for logging, auditing, or reactive workflows. Maintains backward compatibility.  

This PR resolves this [issue](https://github.com/laravel/framework/issues/55101) in Laravel Version 11
