### PR TITLE
[12.x] Prefer `new Collection` over `Collection::make`

### DIFF
--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -31,7 +31,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
             ->makePartial()
             ->shouldAllowMockingProtectedMethods()
             ->shouldReceive('getArrayableRelations')->andReturn([
-                'arrayable_relation' => Collection::make(['foo' => 'bar']),
+                'arrayable_relation' => new Collection(['foo' => 'bar']),
                 'invalid_relation' => 'invalid',
                 'null_relation' => null,
             ])

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -416,10 +416,10 @@ class DatabaseEloquentCollectionTest extends TestCase
         $four->id = 2;
         $four->someAttribute = '4';
 
-        $duplicates = Collection::make([$one, $two, $three, $four])->duplicates()->all();
+        $duplicates = (new Collection([$one, $two, $three, $four]))->duplicates()->all();
         $this->assertSame([1 => $two, 2 => $three], $duplicates);
 
-        $duplicates = Collection::make([$one, $two, $three, $four])->duplicatesStrict()->all();
+        $duplicates = (new Collection([$one, $two, $three, $four]))->duplicatesStrict()->all();
         $this->assertSame([1 => $two, 2 => $three], $duplicates);
     }
 
@@ -484,10 +484,10 @@ class DatabaseEloquentCollectionTest extends TestCase
         $four->id = 2;
         $four->someAttribute = '4';
 
-        $uniques = Collection::make([$one, $two, $three, $four])->unique()->all();
+        $uniques = (new Collection([$one, $two, $three, $four]))->unique()->all();
         $this->assertSame([$three, $four], $uniques);
 
-        $uniques = Collection::make([$one, $two, $three, $four])->unique(null, true)->all();
+        $uniques = (new Collection([$one, $two, $three, $four]))->unique(null, true)->all();
         $this->assertSame([$three, $four], $uniques);
     }
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -99,7 +99,7 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $post = Post::first();
         $post->some_default_value = 200;
 
-        Collection::make([$post])->loadCount('comments');
+        (new Collection([$post]))->loadCount('comments');
 
         $this->assertSame(200, $post->some_default_value);
         $this->assertSame('2', (string) $post->comments_count);

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -90,7 +90,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
 
         $project = $project->fresh();
 
-        $class = new PivotSerializationTestCollectionClass(DatabaseCollection::make($project->collaborators->map->pivot));
+        $class = new PivotSerializationTestCollectionClass(new DatabaseCollection($project->collaborators->map->pivot));
         $class = unserialize(serialize($class));
 
         $this->assertEquals($project->collaborators[0]->pivot->user_id, $class->pivots[0]->user_id);
@@ -108,7 +108,7 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
 
         $project = $project->fresh();
 
-        $class = new PivotSerializationTestCollectionClass(DatabaseCollection::make($project->tags->map->pivot));
+        $class = new PivotSerializationTestCollectionClass(new DatabaseCollection($project->tags->map->pivot));
         $class = unserialize(serialize($class));
 
         $this->assertEquals($project->tags[0]->pivot->tag_id, $class->pivots[0]->tag_id);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1448,7 +1448,7 @@ class ResourceTest extends TestCase
 
     public function testKeysArePreservedInAnAnonymousCollectionIfTheResourceIsFlaggedToPreserveKeys()
     {
-        $data = Collection::make([
+        $data = (new Collection([
             [
                 'id' => 1,
                 'authorId' => 5,
@@ -1464,7 +1464,7 @@ class ResourceTest extends TestCase
                 'authorId' => 42,
                 'bookId' => 12,
             ],
-        ])->keyBy->id;
+        ]))->keyBy->id;
 
         Route::get('/', function () use ($data) {
             return ResourceWithPreservedKeys::collection($data);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -20,7 +20,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         [$closure, $recorder] = $this->makeGeneratorFunctionWithRecorder();
 
-        LazyCollection::make($closure);
+        new LazyCollection($closure);
 
         $this->assertEquals([], $recorder->all());
     }
@@ -28,7 +28,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     public function testMakeWithLazyCollectionIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {
-            LazyCollection::make($collection);
+            new LazyCollection($collection);
         });
     }
 
@@ -55,7 +55,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testChunkWhileIsLazy()
     {
-        $collection = LazyCollection::make(['A', 'A', 'B', 'B', 'C', 'C', 'C']);
+        $collection = new LazyCollection(['A', 'A', 'B', 'B', 'C', 'C', 'C']);
 
         $this->assertDoesNotEnumerateCollection($collection, function ($collection) {
             $collection->chunkWhile(function ($current, $key, $chunk) {
@@ -78,7 +78,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testCollapseIsLazy()
     {
-        $collection = LazyCollection::make([
+        $collection = new LazyCollection([
             [1, 2, 3],
             [4, 5, 6],
             [7, 8, 9],

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -16,7 +16,7 @@ class SupportLazyCollectionTest extends TestCase
 {
     public function testCanCreateEmptyCollection()
     {
-        $this->assertSame([], LazyCollection::make()->all());
+        $this->assertSame([], (new LazyCollection())->all());
         $this->assertSame([], LazyCollection::empty()->all());
     }
 
@@ -24,13 +24,13 @@ class SupportLazyCollectionTest extends TestCase
     {
         $array = [1, 2, 3];
 
-        $data = LazyCollection::make($array);
+        $data = new LazyCollection($array);
 
         $this->assertSame($array, $data->all());
 
         $array = ['a' => 1, 'b' => 2, 'c' => 3];
 
-        $data = LazyCollection::make($array);
+        $data = new LazyCollection($array);
 
         $this->assertSame($array, $data->all());
     }
@@ -39,20 +39,20 @@ class SupportLazyCollectionTest extends TestCase
     {
         $array = [1, 2, 3];
 
-        $data = LazyCollection::make(Collection::make($array));
+        $data = new LazyCollection(new Collection($array));
 
         $this->assertSame($array, $data->all());
 
         $array = ['a' => 1, 'b' => 2, 'c' => 3];
 
-        $data = LazyCollection::make(Collection::make($array));
+        $data = new LazyCollection(new Collection($array));
 
         $this->assertSame($array, $data->all());
     }
 
     public function testCanCreateCollectionFromGeneratorFunction()
     {
-        $data = LazyCollection::make(function () {
+        $data = new LazyCollection(function () {
             yield 1;
             yield 2;
             yield 3;
@@ -60,7 +60,7 @@ class SupportLazyCollectionTest extends TestCase
 
         $this->assertSame([1, 2, 3], $data->all());
 
-        $data = LazyCollection::make(function () {
+        $data = new LazyCollection(function () {
             yield 'a' => 1;
             yield 'b' => 2;
             yield 'c' => 3;
@@ -75,7 +75,7 @@ class SupportLazyCollectionTest extends TestCase
 
     public function testCanCreateCollectionFromNonGeneratorFunction()
     {
-        $data = LazyCollection::make(function () {
+        $data = new LazyCollection(function () {
             return 'laravel';
         });
 
@@ -90,16 +90,16 @@ class SupportLazyCollectionTest extends TestCase
             yield 1;
         };
 
-        LazyCollection::make($generateNumber());
+        new LazyCollection($generateNumber());
     }
 
     public function testEager()
     {
         $source = [1, 2, 3, 4, 5];
 
-        $data = LazyCollection::make(function () use (&$source) {
+        $data = (new LazyCollection(function () use (&$source) {
             yield from $source;
-        })->eager();
+        }))->eager();
 
         $source[] = 6;
 
@@ -110,9 +110,9 @@ class SupportLazyCollectionTest extends TestCase
     {
         $source = [1, 2, 3, 4];
 
-        $collection = LazyCollection::make(function () use (&$source) {
+        $collection = (new LazyCollection(function () use (&$source) {
             yield from $source;
-        })->remember();
+        }))->remember();
 
         $this->assertSame([1, 2, 3, 4], $collection->all());
 
@@ -125,9 +125,9 @@ class SupportLazyCollectionTest extends TestCase
     {
         $source = [1, 2, 3, 4];
 
-        $collection = LazyCollection::make(function () use (&$source) {
+        $collection = (new LazyCollection(function () use (&$source) {
             yield from $source;
-        })->remember();
+        }))->remember();
 
         $a = $collection->getIterator();
         $b = $collection->getIterator();
@@ -168,10 +168,10 @@ class SupportLazyCollectionTest extends TestCase
 
     public function testRememberWithDuplicateKeys()
     {
-        $collection = LazyCollection::make(function () {
+        $collection = (new LazyCollection(function () {
             yield 'key' => 1;
             yield 'key' => 2;
-        })->remember();
+        }))->remember();
 
         $results = $collection->map(function ($value, $key) {
             return [$key, $value];

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -57,8 +57,8 @@ class SupportMessageBagTest extends TestCase
     public function testMessageBagsCanConvertToArrays()
     {
         $container = new MessageBag([
-            Collection::make(['foo', 'bar']),
-            Collection::make(['baz', 'qux']),
+            new Collection(['foo', 'bar']),
+            new Collection(['baz', 'qux']),
         ]);
         $this->assertSame([['foo', 'bar'], ['baz', 'qux']], $container->getMessages());
     }

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1068,8 +1068,8 @@ class CustomCollection extends Collection
 {
 }
 
-// assertType('CustomCollection<int, User>', CustomCollection::make([new User]));
-assertType('Illuminate\Support\Collection<int, User>', CustomCollection::make([new User])->toBase());
+// assertType('CustomCollection<int, User>', new CustomCollection([new User]));
+assertType('Illuminate\Support\Collection<int, User>', (new CustomCollection([new User]))->toBase());
 
 assertType('bool', $collection->offsetExists(0));
 assertType('bool', isset($collection[0]));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -36,12 +36,12 @@ assertType('Illuminate\Support\LazyCollection<int, int>', new LazyCollection($it
 assertType('Illuminate\Support\LazyCollection<int, string>', new LazyCollection($traversable));
 assertType('Illuminate\Support\LazyCollection<int, User>', new LazyCollection($generator));
 
-assertType('Illuminate\Support\LazyCollection<int, string>', LazyCollection::make(['string']));
-assertType('Illuminate\Support\LazyCollection<string, User>', LazyCollection::make(['string' => new User]));
-assertType('Illuminate\Support\LazyCollection<int, User>', LazyCollection::make($arrayable));
-assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::make($iterable));
-assertType('Illuminate\Support\LazyCollection<int, string>', LazyCollection::make($traversable));
-assertType('Illuminate\Support\LazyCollection<int, User>', LazyCollection::make($generator));
+assertType('Illuminate\Support\LazyCollection<int, string>', new LazyCollection(['string']));
+assertType('Illuminate\Support\LazyCollection<string, User>', new LazyCollection(['string' => new User]));
+assertType('Illuminate\Support\LazyCollection<int, User>', new LazyCollection($arrayable));
+assertType('Illuminate\Support\LazyCollection<int, int>', new LazyCollection($iterable));
+assertType('Illuminate\Support\LazyCollection<int, string>', new LazyCollection($traversable));
+assertType('Illuminate\Support\LazyCollection<int, User>', new LazyCollection($generator));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection::times(10, function ($int) {
     // assertType('int', $int);
@@ -879,11 +879,11 @@ class CustomLazyCollection extends LazyCollection
 {
 }
 
-// assertType('CustomLazyCollection<int, User>', CustomLazyCollection::make([new User]));
+// assertType('CustomLazyCollection<int, User>', new CustomLazyCollection([new User]));
 
 assertType('array<int, mixed>', $collection->toArray());
-assertType('array<string, mixed>', LazyCollection::make(['string' => 'string'])->toArray());
-assertType('array<int, mixed>', LazyCollection::make([1, 2])->toArray());
+assertType('array<string, mixed>', (new LazyCollection(['string' => 'string']))->toArray());
+assertType('array<int, mixed>', (new LazyCollection([1, 2]))->toArray());
 
 assertType('Traversable<int, User>', $collection->getIterator());
 foreach ($collection as $int => $user) {


### PR DESCRIPTION
Prefer `new LazyCollection` over `LazyCollection::make`
and
Prefer `new Collection` over `Collection::make`

Removing the middleman to simplify the call stack.

Continuation of #55059