### PR TITLE
[12.x] Fix except() method to support casted values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2021,7 +2021,7 @@ trait HasAttributes
 
         foreach ($this->getAttributes() as $key => $value) {
             if (! in_array($key, $attributes)) {
-                $results[$key] = $value;
+                $results[$key] = $this->getAttribute($key);
             }
         }
 


### PR DESCRIPTION
### Overview
This PR updates the `except()` method https://github.com/laravel/framework/pull/55072 to correctly handle casted values, ensuring consistency with only().

As @decadence mentioned https://github.com/laravel/framework/pull/55072#issuecomment-2739535697 previously, `except()` used `getAttributes(),` which returned raw database values instead of applying attribute casts. This has been fixed by adding `$this->getAttribute($value)`, ensuring filtered attributes retain their correct casted forms.