### PR TITLE
[12.x] adds make builder command

### DIFF
--- a/src/Illuminate/Foundation/Console/BuilderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/BuilderMakeCommand.php
@@ -107,7 +107,7 @@ class BuilderMakeCommand extends GeneratorCommand
 
             $replacements['{{ modelGenericPhpdoc }}'] = <<<EOT
             /**
-             * @template TModelClass of $modelNamespace
+             * @template TModel of $modelNamespace
              *
              * @extends Builder<$modelNamespace>
              */

--- a/src/Illuminate/Foundation/Console/BuilderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/BuilderMakeCommand.php
@@ -76,7 +76,7 @@ class BuilderMakeCommand extends GeneratorCommand
         return $rootNamespace.'\Models\Builders';
     }
 
-     /**
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name
@@ -93,7 +93,7 @@ class BuilderMakeCommand extends GeneratorCommand
         );
     }
 
-     /**
+    /**
      * Build the replacements for a model.
      *
      * @return array<string, string>
@@ -105,7 +105,7 @@ class BuilderMakeCommand extends GeneratorCommand
         if ($this->option('model')) {
             $modelNamespace = $this->option('model');
 
-            $replacements["{{ modelGenericPhpdoc }}"] = <<<EOT
+            $replacements['{{ modelGenericPhpdoc }}'] = <<<EOT
             /**
              * @template TModelClass of $modelNamespace
              *

--- a/src/Illuminate/Foundation/Console/BuilderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/BuilderMakeCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:builder')]
+class BuilderMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:builder';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new builder class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Builder';
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($rawName) ||
+               $this->files->exists($this->getPath($this->qualifyClass($rawName)));
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/builder.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Models\Builders';
+    }
+
+     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $replace = $this->buildModelReplacements();
+
+        return str_replace(
+            array_keys($replace), array_values($replace), parent::buildClass($name)
+        );
+    }
+
+     /**
+     * Build the replacements for a model.
+     *
+     * @return array<string, string>
+     */
+    protected function buildModelReplacements()
+    {
+        $replacements = [];
+
+        if ($this->option('model')) {
+            $modelNamespace = $this->option('model');
+
+            $replacements["{{ modelGenericPhpdoc }}"] = <<<EOT
+            /**
+             * @template TModelClass of $modelNamespace
+             *
+             * @extends Builder<$modelNamespace>
+             */
+            EOT;
+        } else {
+            $replacements["{{ modelGenericPhpdoc }}\n"] = '';
+            $replacements["{{ modelGenericPhpdoc }}\r\n"] = '';
+        }
+
+        return $replacements;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_REQUIRED, 'The model that the builder applies to'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the event already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/builder.stub
+++ b/src/Illuminate/Foundation/Console/stubs/builder.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+
+{{ modelGenericPhpdoc }}
+class {{ class }} extends Builder
+{
+    //
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ApiInstallCommand;
 use Illuminate\Foundation\Console\BroadcastingInstallCommand;
+use Illuminate\Foundation\Console\BuilderMakeCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
@@ -183,6 +184,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected $devCommands = [
         'ApiInstall' => ApiInstallCommand::class,
         'BroadcastingInstall' => BroadcastingInstallCommand::class,
+        'BuilderMake' => BuilderMakeCommand::class,
         'CacheTable' => CacheTableCommand::class,
         'CastMake' => CastMakeCommand::class,
         'ChannelList' => ChannelListCommand::class,

--- a/tests/Integration/Generators/BuilderMakeCommandTest.php
+++ b/tests/Integration/Generators/BuilderMakeCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class BuilderMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Models/Builders/FooBuilder.php',
+        'app/Models/Builders/Foo/BarBuilder.php',
+    ];
+
+    public function testItCanGenerateBuilderFile()
+    {
+        $this->artisan('make:builder', ['name' => 'FooBuilder'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Models\Builders;',
+            'use Illuminate\Database\Eloquent\Builder;',
+            'class FooBuilder extends Builder',
+        ], 'app/Models/Builders/FooBuilder.php');
+
+        $this->assertFilenameNotExists('app/Models/Builders/Foo/BarBuilder.php');
+    }
+
+    public function testItCanGenerateBuilderFileWithNamespace()
+    {
+        $this->artisan('make:builder', ['name' => 'Foo\BarBuilder'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Models\Builders\Foo;',
+            'use Illuminate\Database\Eloquent\Builder;',
+            'class BarBuilder extends Builder',
+        ], 'app/Models/Builders/Foo/BarBuilder.php');
+
+        $this->assertFilenameNotExists('app/Models/Builders/FooBuilder.php');
+    }
+}


### PR DESCRIPTION
This pull request introduces a new console command to generate builder classes in the Laravel framework. The changes include the addition of the `BuilderMakeCommand` class, updates to the `ArtisanServiceProvider` to register the new command, and a new test class to verify the functionality.

# Example
```bash
php artisan make:builder PostBuilder
php artisan make:builder PostBuilder --model=\\App\\Models\\Post
```

I'm up for adding `--builder` flag for `make:model` command