### PR TITLE
[12.x] feat: add `BelongsToMany::withAllPivots` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -76,7 +76,7 @@ class BelongsToMany extends Relation
     /**
      * The pivot table columns to retrieve.
      *
-     * @var array<string|\Illuminate\Contracts\Database\Query\Expression>
+     * @var list<string|\Illuminate\Contracts\Database\Query\Expression>
      */
     protected $pivotColumns = [];
 
@@ -142,6 +142,13 @@ class BelongsToMany extends Relation
      * @var TAccessor
      */
     protected $accessor = 'pivot';
+
+    /**
+     * The cache of the pivot columns in the pivot table.
+     *
+     * @var array<string, list<string>>
+     */
+    protected static array $pivotColumnsCache = [];
 
     /**
      * Create a new belongs to many relationship instance.
@@ -926,8 +933,8 @@ class BelongsToMany extends Relation
     /**
      * Get the select columns for the relation query.
      *
-     * @param  array  $columns
-     * @return array
+     * @param  list<string>  $columns
+     * @return list<string>
      */
     protected function shouldSelect(array $columns = ['*'])
     {
@@ -943,7 +950,7 @@ class BelongsToMany extends Relation
      *
      * "pivot_" is prefixed at each column for easy removal later.
      *
-     * @return array
+     * @return list<string>
      */
     protected function aliasedPivotColumns()
     {
@@ -1657,7 +1664,7 @@ class BelongsToMany extends Relation
     /**
      * Get the pivot columns for this relationship.
      *
-     * @return array
+     * @return list<string|\Illuminate\Contracts\Database\Query\Expression>
      */
     public function getPivotColumns()
     {
@@ -1668,7 +1675,7 @@ class BelongsToMany extends Relation
      * Qualify the given column name by the pivot table.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
-     * @return string|\Illuminate\Contracts\Database\Query\Expression
+     * @return ($column is string ? string : \Illuminate\Contracts\Database\Query\Expression)
      */
     public function qualifyPivotColumn($column)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -600,6 +600,31 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Retrieve all the pivot columns.
+     *
+     * @return $this
+     */
+    public function withAllPivots(): static
+    {
+        $columns = static::$pivotColumnsCache[$this->table] ?? null;
+
+        if ($columns === null) {
+            $columns = $this->getConnection()
+                ->getSchemaBuilder()
+                ->getColumnListing($this->table);
+            static::$pivotColumnsCache[$this->table] = $columns;
+        }
+
+        $this->pivotColumns = [...$this->pivotColumns, ...$columns];
+
+        if (in_array($this->createdAt(), $columns, true)) {
+            $this->withTimestamps = true;
+        }
+
+        return $this;
+    }
+
+    /**
      * Get all of the IDs from the given mixed value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -175,7 +175,7 @@ class MorphToMany extends BelongsToMany
      *
      * "pivot_" is prefixed at each column for easy removal later.
      *
-     * @return array
+     * @return list<string>
      */
     protected function aliasedPivotColumns()
     {


### PR DESCRIPTION
Hello!

When defining BelongsToMany relations, I generally want **all** the pivot columns to be loaded (if it's not needed in the app then why is it on the table?). Currently, this means that the entire list needs to be manually specified via `withPivot` **on both sides of the relation**, e.g.,

```php
    public function features(): BelongsToMany
    {
        return $this->belongsToMany(Feature::class)
            ->using(FeatureValue::class)
            ->withPivot([
                'bool_value',
                'date_value',
                'datetime_value',
                'id',
                'int_value',
                'string_value',
            ])
            ->withTimestamps();
    }
```

This also means that the developer needs to remember to update both lists if a new pivot column is ever added.

However, what I would like to do is just call a single method that loads all the pivot columns:

```php
    public function features(): BelongsToMany
    {
        return $this->belongsToMany(Feature::class)
            ->using(FeatureValue::class)
            ->withAllPivots();
    }
```

Thanks!