### PR TITLE
[12.x] Add caching to getDateFormat()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -181,6 +181,14 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
+     * The cache of date formats by connection
+     *
+     * @var array
+     */
+    protected static $dateFormatByConnectionCache = [];
+
+
+    /**
      * The encrypter instance that is used to encrypt attributes.
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter|null
@@ -1603,7 +1611,17 @@ trait HasAttributes
      */
     public function getDateFormat()
     {
-        return $this->dateFormat ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
+        if ($this->dateFormat) {
+            return $this->dateFormat;
+        }
+
+        $connectionName = $this->getConnectionName();
+
+        if (! isset(self::$dateFormatByConnectionCache[$connectionName])) {
+            self::$dateFormatByConnectionCache[$connectionName] = $this->getConnection()->getQueryGrammar()->getDateFormat();
+        }
+
+        return self::$dateFormatByConnectionCache[$connectionName];
     }
 
     /**


### PR DESCRIPTION
Resolving a connection to get the default date format is rather expensive and unnecessary when connection types are consistent.

getDateFormat() is called frequently when dealing with date casts, including basic model timestamps and this adds a major overhead to that process.

Add a new static variable to cache the date format by connection name and to improve the execution time of this function.

Breaking changes concerns: 
Conflict with $dateFormatByConnectionCache static variable (low)


Benefit to end users:
Performance improvement to Eloquent date casts.  I've benchmarked a 10% improvement to hydrating large data sets with models that only have the basic timestamps

