### PR TITLE
[12.x] feat: Add `whereNull` and `whereNotNull` to `Assertablejson`

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -100,7 +100,19 @@ trait Matching
      */
     public function whereNull(string $key): self
     {
-        return $this->where($key, null);
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        PHPUnit::assertNull(
+            $actual,
+            sprintf(
+                'Property [%s] should be null.',
+                $this->dotPath($key),
+            )
+        );
+
+        return $this;
     }
 
     /**
@@ -118,7 +130,7 @@ trait Matching
         PHPUnit::assertNotNull(
             $actual,
             sprintf(
-                'Property [%s] should not be null',
+                'Property [%s] should not be null.',
                 $this->dotPath($key),
             )
         );

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -104,6 +104,29 @@ trait Matching
     }
 
     /**
+     * Asserts that the property is null.
+     *
+     * @param  string  $key
+     * @return $this
+     */
+    public function whereNotNull(string $key): self
+    {
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        PHPUnit::assertNotNull(
+            $actual,
+            sprintf(
+                'Property [%s] should not be null',
+                $this->dotPath($key),
+            )
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that all properties match their expected values.
      *
      * @param  array  $bindings

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -116,7 +116,7 @@ trait Matching
     }
 
     /**
-     * Asserts that the property is null.
+     * Asserts that the property is not null.
      *
      * @param  string  $key
      * @return $this

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -93,6 +93,17 @@ trait Matching
     }
 
     /**
+     * Asserts that the property is null.
+     *
+     * @param  string  $key
+     * @return $this
+     */
+    public function whereNull(string $key): self
+    {
+        return $this->where($key, null);
+    }
+
+    /**
      * Asserts that all properties match their expected values.
      *
      * @param  array  $bindings

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -596,7 +596,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+        $this->expectExceptionMessage('Property [bar] should be null.');
 
         $assert->whereNull('bar');
     }
@@ -629,7 +629,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] should not be null');
+        $this->expectExceptionMessage('Property [bar] should not be null.');
 
         $assert->whereNotNull('bar');
     }

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -589,7 +589,7 @@ class AssertTest extends TestCase
         $assert->whereNull('bar');
     }
 
-    public function testAssertWhereNullFailsWhenDoesNotMatchValue()
+    public function testAssertWhereNullFailsWhenNotNull()
     {
         $assert = AssertableJson::fromArray([
             'bar' => 'value',
@@ -611,6 +611,39 @@ class AssertTest extends TestCase
         $this->expectExceptionMessage('Property [baz] does not exist.');
 
         $assert->whereNull('baz');
+    }
+
+    public function testAssertWhereNotNullMatchesValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $assert->whereNotNull('bar');
+    }
+
+    public function testAssertWhereNotNullFailsWhenNull()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => null,
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] should not be null');
+
+        $assert->whereNotNull('bar');
+    }
+
+    public function testAssertWhereNotNullFailsWhenMissing()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->whereNotNull('baz');
     }
 
     public function testAssertWhereContainsFailsWithEmptyValue()

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -580,6 +580,39 @@ class AssertTest extends TestCase
         $assert->where('bar', BackedEnum::test_empty);
     }
 
+    public function testAssertWhereNullMatchesValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => null,
+        ]);
+
+        $assert->whereNull('bar');
+    }
+
+    public function testAssertWhereNullFailsWhenDoesNotMatchValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+
+        $assert->whereNull('bar');
+    }
+
+    public function testAssertWhereNullFailsWhenMissing()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->whereNull('baz');
+    }
+
     public function testAssertWhereContainsFailsWithEmptyValue()
     {
         $assert = AssertableJson::fromArray([]);


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have added two new methods to `Assertablejson`:
- `whereNull` asserts value is null.
- `whereNotNull` asserts values is not null.

```php
$json->whereNotNull('id')
    ->whereNull('avatar');
```