### PR TITLE
[12.x] Fix return type annotation in compile method

### DIFF
--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -56,7 +56,7 @@ abstract class Component
      *
      * @param  string  $view
      * @param  array  $data
-     * @return void
+     * @return string
      */
     protected function compile($view, $data)
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes the incorrect return type annotation in the compile method. The method was documented to return void, but it actually returns the compiled view contents as a string.
