### PR TITLE
[12.x] Fix return type annotation in decrementPendingJobs method

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -106,7 +106,7 @@ class BatchFake extends Batch
      * Decrement the pending jobs for the batch.
      *
      * @param  string  $jobId
-     * @return \Illuminate\Bus\UpdatedBatchJobCounts
+     * @return void
      */
     public function decrementPendingJobs(string $jobId)
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes the return type annotation in the decrementPendingJobs method. The method currently has no implementation and appears to be a placeholder, but its documentation incorrectly states it returns an \Illuminate\Bus\UpdatedBatchJobCounts instance.