### PR TITLE
[12.x] Fix: can() method does not work for route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -204,6 +204,23 @@ class RouteRegistrar
      */
     public function group($callback)
     {
+        if (isset($this->attributes['can'])) {
+            $canParams = $this->attributes['can'];
+            $ability = $canParams[0];
+
+            if(is_array($canParams)) {
+                $models = array_slice($canParams, 1);
+
+                $middleware = 'can:' . implode(',', array_merge([$ability], $models));
+
+                if (!isset($this->attributes['middleware'])) {
+                    $this->attributes['middleware'] = [];
+                }
+
+                $this->attributes['middleware'][] = $middleware;
+            }
+        }
+
         $this->router->group($this->attributes, $callback);
 
         return $this;
@@ -288,6 +305,10 @@ class RouteRegistrar
         if (in_array($method, $this->allowedAttributes)) {
             if ($method === 'middleware') {
                 return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
+            }
+
+            if ($method === 'can') {
+                return $this->attribute($method, $parameters);
             }
 
             return $this->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -208,12 +208,12 @@ class RouteRegistrar
             $canParams = $this->attributes['can'];
             $ability = $canParams[0];
 
-            if(is_array($canParams)) {
+            if (is_array($canParams)) {
                 $models = array_slice($canParams, 1);
 
-                $middleware = 'can:' . implode(',', array_merge([$ability], $models));
+                $middleware = 'can:'.implode(',', array_merge([$ability], $models));
 
-                if (!isset($this->attributes['middleware'])) {
+                if (! isset($this->attributes['middleware'])) {
                     $this->attributes['middleware'] = [];
                 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1213,6 +1213,35 @@ class RoutingRouteTest extends TestCase
         );
     }
 
+    public function testCanMiddlewareAppliedToGroup()
+    {
+        $router = $this->getRouter();
+
+        // Apply 'can' outside the group
+        $router->prefix('blog')
+            ->can('access', 'blog')
+            ->group(function () use ($router) {
+                $router->get('/', function () {
+                    return 'Blog Home';
+                });
+
+                $router->get('/dashboard', function () {
+                    return 'Dashboard';
+                });
+            });
+
+        $routes = $router->getRoutes()->getRoutes();
+
+        foreach ($routes as $route) {
+            $this->assertContains(
+                'can:access,blog',
+                $route->getAction('middleware') ?? []
+            );
+        }
+
+        $this->assertSame('blog', $routes[0]->getPrefix());
+    }
+
     public function testCurrentRouteUses()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
## Description

This PR fixes the issue where the `can()` method does not attach authorization middleware to route groups. The problem occurs because the `can` attribute set by `RouteRegistrar::can()` was not being converted to middleware when applied at the group level.

Related Issue:
#55114 

### Changes

1. **RouteRegistrar Update**  
   Modified `group()` method in `Illuminate\Routing\RouteRegistrar` to convert `can` attributes to proper middleware: