### PR TITLE
Better return types for `Illuminate\Queue\Jobs\Job::getJobId()` and `Illuminate\Queue\Jobs\DatabaseJob::getJobId()` methods

### DIFF
--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -78,7 +78,7 @@ class DatabaseJob extends Job implements JobContract
     /**
      * Get the job identifier.
      *
-     * @return string
+     * @return string|int
      */
     public function getJobId()
     {

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -67,7 +67,7 @@ abstract class Job
     /**
      * Get the job identifier.
      *
-     * @return string
+     * @return string|int|null
      */
     abstract public function getJobId();
 


### PR DESCRIPTION
Based on the silence at <https://github.com/laravel/framework/issues/55080> I guess the correct smallest data type from implementation. Based on observation and method `Illuminate\Database\Query\Builder::find` I changed `Illuminate\Queue\Jobs\DatabaseJob::getJobId` to `string|int` and based on all implementations of `Illuminate\Queue\Jobs\Job::getJobId` in this repository I changed its return type to `string|int|null` (as DB job returns `stdClass::$id`, both should be `mixed`).

**Benefit to end users** - this version will not lead to fatal errors (if other annotations are correct).

**Children MUST respect it's parent.** You can't expand parents return type in it's children, you only can make the children return more specific, for more information visit <https://en.wikipedia.org/wiki/Inheritance_(object-oriented_programming)>.