### PR TITLE
[12.x] Only call the ob_flush function if there is active buffer in eventStream

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -150,7 +150,10 @@ class ResponseFactory implements FactoryContract
                 echo 'data: '.$message;
                 echo "\n\n";
 
-                ob_flush();
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
+
                 flush();
             }
 
@@ -166,7 +169,10 @@ class ResponseFactory implements FactoryContract
                 echo 'data: '.$endStreamWith;
                 echo "\n\n";
 
-                ob_flush();
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
+
                 flush();
             }
         }, 200, array_merge($headers, [


### PR DESCRIPTION
### Fixed

- Check the buffer level before flushing it to avoid the "no active buffer" error

---

Context:

When ob_flush() is called without first calling ob_start(), it fails saying there's no active buffer. We need to check the buffer level before flushing it to avoid this issue. [This is also how Livewire does it](https://github.com/livewire/livewire/blob/main/src/Features/SupportStreaming/SupportStreaming.php#L36-L38).
