### PR TITLE
Replace conditional logic with PHP match expression for control structure

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -46,7 +46,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $source instanceof Closure,
             $source instanceof self => $source,
 
-            is_null($source) => static::empty(),
+            $source === null => static::empty(),
 
             $source instanceof Generator => throw new InvalidArgumentException(
                 'Generators should not be passed directly to LazyCollection. Instead, pass a generator function.'

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -42,17 +42,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function __construct($source = null)
     {
-        if ($source instanceof Closure || $source instanceof self) {
-            $this->source = $source;
-        } elseif (is_null($source)) {
-            $this->source = static::empty();
-        } elseif ($source instanceof Generator) {
-            throw new InvalidArgumentException(
+        $this->source = match (true) {
+            $source instanceof Closure,
+            $source instanceof self => $source,
+
+            is_null($source) => static::empty(),
+
+            $source instanceof Generator => throw new InvalidArgumentException(
                 'Generators should not be passed directly to LazyCollection. Instead, pass a generator function.'
-            );
-        } else {
-            $this->source = $this->getArrayableItems($source);
-        }
+            ),
+
+            default => $this->getArrayableItems($source),
+        };
     }
 
     /**


### PR DESCRIPTION
this part of the code didn’t use PHP’s match feature, and due to its structure, it improve in PHP control structures. 

According to the documentation, this section has been modified to fix this issue and make it more readable:
https://www.php.net/manual/en/control-structures.match.php