### PR TITLE
[12.x] `Uri` prevent empty query string

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -235,7 +235,7 @@ class Uri implements Htmlable, Responsable, Stringable
             }
         }
 
-        return new static($this->uri->withQuery(Arr::query($newQuery)));
+        return new static($this->uri->withQuery(Arr::query($newQuery) ?: null));
     }
 
     /**

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -188,4 +188,12 @@ class SupportUriTest extends TestCase
             ],
         ], $uri->query()->all());
     }
+
+    public function test_with_query_prevents_empty_query_string()
+    {
+        $uri = Uri::of('https://laravel.com');
+
+        $this->assertEquals('https://laravel.com', (string) $uri);
+        $this->assertEquals('https://laravel.com', (string) $uri->withQuery([]));
+    }
 }


### PR DESCRIPTION
Currently it seems to be impossible to completely remove a query string from a URI. The `league/uri` package requires us to pass in `null` if we want it removed, but since `Arr::query([])` returns an empty string when an empty array is passed we end up with a URI such as `https://laravel.com?`.

Since this might be considered a breaking change we might want to target master instead.

Let me know!