### PR TITLE
[11.x] Add Cache Flush Event

### DIFF
--- a/src/Illuminate/Cache/Events/CacheFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheFlushed
+{
+    /**
+     * The name of the cache store.
+     *
+     * @var string|null
+     */
+    public $storeName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @return void
+     */
+    public function __construct($storeName)
+    {
+        $this->storeName = $storeName;
+    }
+}

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheFlushing
+{
+    /**
+     * The name of the cache store.
+     *
+     * @var string|null
+     */
+    public $storeName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $storeName
+     * @return void
+     */
+    public function __construct($storeName)
+    {
+        $this->storeName = $storeName;
+    }
+}

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -6,6 +6,8 @@ use ArrayAccess;
 use BadMethodCallException;
 use Closure;
 use DateTimeInterface;
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -575,7 +577,15 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function clear(): bool
     {
-        return $this->store->flush();
+        $this->event(new CacheFlushing($this->getName()));
+
+        $result = $this->store->flush();
+
+        if ($result) {
+            $this->event(new CacheFlushed($this->getName()));
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
@@ -236,6 +238,44 @@ class CacheEventsTest extends TestCase
 
             return true;
         });
+    }
+
+    public function testFlushTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushing::class, [
+                'storeName' => 'array',
+            ])
+        );
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushed::class, [
+                'storeName' => 'array',
+            ])
+        );
+        $this->assertTrue($repository->clear());
+    }
+
+    public function testFlushFailureDoesNotDispatchEvent()
+    {
+        $dispatcher = $this->getDispatcher();
+
+        // Create a store that fails to flush
+        $failingStore = m::mock(Store::class);
+        $failingStore->shouldReceive('flush')->andReturn(false);
+
+        $repository = new Repository($failingStore, ['store' => 'array']);
+        $repository->setEventDispatcher($dispatcher);
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushing::class, [
+                'storeName' => 'array',
+            ])
+        );
+        $this->assertFalse($repository->clear());
     }
 
     protected function getDispatcher()

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -116,7 +116,7 @@ class SupportFacadesEventTest extends TestCase
 
 class FakeForStub
 {
-public function dispatch()
+    public function dispatch()
     {
         Event::dispatch(EventStub::class);
     }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -87,6 +89,17 @@ class SupportFacadesEventTest extends TestCase
         Event::assertDispatched(CacheMissed::class);
     }
 
+    public function testCacheFlushDispatchesEvent()
+    {
+        $arrayRepository = Cache::store('array');
+        Event::fake();
+
+        $arrayRepository->clear();
+
+        Event::assertDispatched(CacheFlushing::class);
+        Event::assertDispatched(CacheFlushed::class);
+    }
+
     protected function getCacheConfig()
     {
         return [
@@ -103,7 +116,7 @@ class SupportFacadesEventTest extends TestCase
 
 class FakeForStub
 {
-    public function dispatch()
+public function dispatch()
     {
         Event::dispatch(EventStub::class);
     }


### PR DESCRIPTION
**Description:**  
Introduces `CacheFlushed` event dispatching when calling `$cache->flush()`. Enables monitoring of full cache clearance for logging, auditing, or reactive workflows. Maintains backward compatibility.  

This PR resolves this [issue](https://github.com/laravel/framework/issues/55101) for Laravel Version 11
