### PR TITLE
[12.x] Broken HTTP typehints

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -793,7 +793,7 @@ class PendingRequest
      * Issue a POST request to the given URL.
      *
      * @param  string  $url
-     * @param  array|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable  $data
+     * @param  array|object|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable|null  $data
      * @return \Illuminate\Http\Client\Response
      *
      * @throws \Illuminate\Http\Client\ConnectionException

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -547,7 +547,7 @@ class HttpClientTest extends TestCase
                 && $request->hasHeader('Content-Type', 'application/json')
                 && $request->hasHeader('X-Test-Header', 'foo')
                 && $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz'])
-                && $request->json() == (object)[]; // or compare to `new \stdClass()`
+                && $request->body() === '{}';
         });
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -519,17 +519,18 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
+        $this->factory->asJson();
+
         $this->factory->withHeaders([
             'X-Test-Header' => 'foo',
-            'X-Test-ArrayHeader' => ['bar', 'baz'],
         ])->post('http://foo.com/json', null);
 
         $this->factory->assertSent(function (Request $request) {
+            // Because we're sending JSON, json_encode(null) => "null".
+            // So the raw body is literally the string "null"
             return $request->url() === 'http://foo.com/json'
                 && $request->hasHeader('Content-Type', 'application/json')
-                && $request->hasHeader('X-Test-Header', 'foo')
-                && $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz'])
-                && $request->json() === null;
+                && $request->body() === 'null';
         });
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -515,6 +515,42 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSendNullData()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', null);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json'
+                && $request->hasHeader('Content-Type', 'application/json')
+                && $request->hasHeader('X-Test-Header', 'foo')
+                && $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz'])
+                && $request->json() === null;
+        });
+    }
+
+    public function testCanSendEmptyObjectData()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', (object)[]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json'
+                && $request->hasHeader('Content-Type', 'application/json')
+                && $request->hasHeader('X-Test-Header', 'foo')
+                && $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz'])
+                && $request->json() == (object)[]; // or compare to `new \stdClass()`
+        });
+    }
+
     public function testCanSendFormData()
     {
         $this->factory->fake();


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/framework/issues/55150 issue.

It adds type hints to Http::post method.

If there is need, I can modify put, patch... methods.

