### PR TITLE
[12.x] Improve docblocks for file related methods of InteractsWithInput

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -240,7 +240,7 @@ trait InteractsWithInput
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return ($key is null ? array<int, \Illuminate\Http\UploadedFile|array<int, \Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]|null)
+     * @return ($key is null ? array<int, \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]> : \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]|null)
      */
     public function file($key = null, $default = null)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -175,7 +175,7 @@ trait InteractsWithInput
     /**
      * Get an array of all of the files on the request.
      *
-     * @return array
+     * @return array<int, \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]>
      */
     public function allFiles()
     {
@@ -187,8 +187,8 @@ trait InteractsWithInput
     /**
      * Convert the given array of Symfony UploadedFiles to custom Laravel UploadedFiles.
      *
-     * @param  array  $files
-     * @return array
+     * @param  array<int, \Symfony\Component\HttpFoundation\File\UploadedFile|\Symfony\Component\HttpFoundation\File\UploadedFile[]>  $files
+     * @return array<int, \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]>
      */
     protected function convertUploadedFiles(array $files)
     {
@@ -240,7 +240,7 @@ trait InteractsWithInput
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]|array|null
+     * @return ($key is null ? array<int, \Illuminate\Http\UploadedFile|array<int, \Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]|null)
      */
     public function file($key = null, $default = null)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -42,7 +42,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * All of the converted files for the request.
      *
-     * @var array
+     * @var array<int, \Illuminate\Http\UploadedFile|\Illuminate\Http\UploadedFile[]>
      */
     protected $convertedFiles;
 


### PR DESCRIPTION
This PR improves the PHPDoc annotations for file-related methods and properties in the `InteractsWithInput` trait and the `Request` class.

- Adds precise generic array types to `allFiles()` and `convertUploadedFiles()`
- Enhances `file()` return type with a conditional PHPStan-style annotation
- Updates the `$convertedFiles` property docblock accordingly

These changes improve static analysis, IDE autocomplete, and developer understanding of the expected data structures, particularly for nested or multiple file uploads.

No functional code changes were made.
