### PR TITLE
[12.x] Fix: Support taggeable store flushed cache events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushed.php
@@ -2,23 +2,19 @@
 
 namespace Illuminate\Cache\Events;
 
-class CacheFlushed
+class CacheFlushed extends CacheEvent
 {
-    /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public $storeName;
-
     /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
+     * @param  array  $tags
      * @return void
      */
-    public function __construct($storeName)
+    public function __construct($storeName, array $tags = [])
     {
         $this->storeName = $storeName;
+        $this->tags = $tags;
+        $this->key = '';
     }
 }

--- a/src/Illuminate/Cache/Events/CacheFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushed.php
@@ -13,8 +13,6 @@ class CacheFlushed extends CacheEvent
      */
     public function __construct($storeName, array $tags = [])
     {
-        $this->storeName = $storeName;
-        $this->tags = $tags;
-        $this->key = '';
+        parent::__construct($storeName, '', $tags);
     }
 }

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -13,8 +13,6 @@ class CacheFlushing extends CacheEvent
      */
     public function __construct($storeName, array $tags = [])
     {
-        $this->storeName = $storeName;
-        $this->tags = $tags;
-        $this->key = '';
+        parent::__construct($storeName, '', $tags);
     }
 }

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -2,23 +2,19 @@
 
 namespace Illuminate\Cache\Events;
 
-class CacheFlushing
+class CacheFlushing extends CacheEvent
 {
-    /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public $storeName;
-
     /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
+     * @param  array  $tags
      * @return void
      */
-    public function __construct($storeName)
+    public function __construct($storeName, array $tags = [])
     {
         $this->storeName = $storeName;
+        $this->tags = $tags;
+        $this->key = '';
     }
 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\Events\CacheFlushed;
+
 class RedisTaggedCache extends TaggedCache
 {
     /**
@@ -107,6 +109,7 @@ class RedisTaggedCache extends TaggedCache
     {
         $this->flushValues();
         $this->tags->flush();
+        $this->event(new CacheFlushed($this->getName()));
 
         return true;
     }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 
 class RedisTaggedCache extends TaggedCache
 {
@@ -107,8 +108,11 @@ class RedisTaggedCache extends TaggedCache
      */
     public function flush()
     {
+        $this->event(new CacheFlushing($this->getName()));
+
         $this->flushValues();
         $this->tags->flush();
+
         $this->event(new CacheFlushed($this->getName()));
 
         return true;

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache extends Repository
@@ -78,7 +79,10 @@ class TaggedCache extends Repository
      */
     public function flush()
     {
+        $this->event(new CacheFlushing($this->getName()));
+
         $this->tags->reset();
+
         $this->event(new CacheFlushed($this->getName()));
 
         return true;

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\Events\CacheFlushed;
 use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache extends Repository
@@ -78,6 +79,7 @@ class TaggedCache extends Repository
     public function flush()
     {
         $this->tags->reset();
+        $this->event(new CacheFlushed($this->getName()));
 
         return true;
     }


### PR DESCRIPTION
`Barryvdh\Debugbar\DataCollector\CacheCollector::onCacheEvent(): Argument #1 ($event) must be of type Illuminate\Cache\Events\CacheEvent, Illuminate\Cache\Events\CacheFlushed given, called in /var/www/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php on line 460`

I think it would be more consistent if it extended from `Illuminate\Cache\Events\CacheEvent`, look laravel debugbar [DataCollector/CacheCollector.php#L33](https://github.com/barryvdh/laravel-debugbar/blob/376ebb18f6f5dd6cc4c978f65ffe9e39476ba785/src/DataCollector/CacheCollector.php#L33)

---- 

also there is a TaggeableStore (`tags`), 
but it does not allow adding tags as an argument

```php
$cache->tags(['my_tag'])->flush();
```

https://github.com/laravel/framework/blob/dd16215c362ca2a3f4146db0078afbfbe7e18cb2/src/Illuminate/Cache/Events/CacheEvent.php#L35
https://github.com/laravel/framework/blob/dd16215c362ca2a3f4146db0078afbfbe7e18cb2/src/Illuminate/Cache/TaggedCache.php#L104-L113

----

it seems I'll have to highlight the signature.

# * @param  \Illuminate\Cache\Events\CacheEvent  $event
https://github.com/laravel/framework/blob/46ac7829eba556031fa5f540f3771d52fa4117a2/src/Illuminate/Cache/TaggedCache.php#L107


