### PR TITLE
[12.x] fix(postgres): missing parentheses in whereDate/whereTime for json columns

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -109,8 +109,13 @@ class PostgresGrammar extends Grammar
     protected function whereDate(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
+        $column = $this->wrap($where['column']);
 
-        return $this->wrap($where['column']).'::date '.$where['operator'].' '.$value;
+        if ($this->isJsonSelector($where['column'])) {
+            $column = '('.$column.')';
+        }
+
+        return $column.'::date '.$where['operator'].' '.$value;
     }
 
     /**
@@ -123,8 +128,13 @@ class PostgresGrammar extends Grammar
     protected function whereTime(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
+        $column = $this->wrap($where['column']);
 
-        return $this->wrap($where['column']).'::time '.$where['operator'].' '.$value;
+        if ($this->isJsonSelector($where['column'])) {
+            $column = '('.$column.')';
+        }
+
+        return $column.'::time '.$where['operator'].' '.$value;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -593,6 +593,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'));
         $this->assertSame('select * from "users" where "created_at"::date = NOW()', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereDate('result->created_at', new Raw('NOW()'));
+        $this->assertSame('select * from "users" where ("result"->>\'created_at\')::date = NOW()', $builder->toSql());
     }
 
     public function testWhereDayPostgres()
@@ -624,6 +628,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
         $this->assertSame('select * from "users" where "created_at"::time >= ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereTime('result->created_at', '>=', '22:00');
+        $this->assertSame('select * from "users" where ("result"->>\'created_at\')::time >= ?', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/12341, the cast to `::date` was added to `whereDate`.

This leads to an error with PostgreSQL when passing in json column selectors. For example:
`->whereDate('result->created_at', DB::raw('NOW()'))` will throw a syntax error for type date. The same is true for the `whereTime` function with its `::time` cast.

To fix this, we need to wrap the column identifier in parentheses, when they are json paths.

Current SQL output:
```SQL
select * from "users" where "result"->>'created_at'::date = NOW()
```

Correct SQL output with this commit:
```SQL
select * from "users" where ("result"->>'created_at')::date = NOW()
```

I opted to only add the parentheses when the column is a json path, as this is the only case where the cast is necessary.
This is at the cost of another `str_contains` check. Which should be fine but we could also opt to just always add the parentheses if you want to.

Note: I checked all other functions and these two should be the only ones that are affected by this. The `whereBasic` also does cast to `::text` but PostgreSQL did not complain on text casts.