### PR TITLE
[12.x] Fix Concurrency::run to preserve callback result order

### DIFF
--- a/src/Illuminate/Concurrency/ForkDriver.php
+++ b/src/Illuminate/Concurrency/ForkDriver.php
@@ -25,6 +25,8 @@ class ForkDriver implements Driver
         /** @phpstan-ignore class.notFound */
         $results = Fork::new()->run(...$values);
 
+        ksort($results);
+
         return array_combine($keys, $results);
     }
 

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -137,14 +137,17 @@ PHP);
         [$first, $second, $third] = Concurrency::driver($driver)->run([
             function () {
                 usleep(1000000);
+
                 return 'first';
             },
             function () {
                 usleep(500000);
+
                 return 'second';
             },
             function () {
                 usleep(200000);
+
                 return 'third';
             },
         ]);

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Process\Factory as ProcessFactory;
 use Illuminate\Support\Facades\Concurrency;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 #[RequiresOperatingSystem('Linux|DAR')]
@@ -118,6 +119,39 @@ PHP);
                 'Invalid payload'
             ),
         ]);
+    }
+
+    public static function getConcurrencyDrivers() : array
+    {
+        return [
+            ['sync'],
+            ['process'],
+            // spatie/fork package is not included by default
+            // ['fork'],
+        ];
+    }
+
+    #[DataProvider('getConcurrencyDrivers')]
+    public function testRunPreservesCallbackOrder(string $driver)
+    {
+        [$first, $second, $third] = Concurrency::driver($driver)->run([
+            function () {
+                usleep(1000000);
+                return 'first';
+            },
+            function () {
+                usleep(500000);
+                return 'second';
+            },
+            function () {
+                usleep(200000);
+                return 'third';
+            },
+        ]);
+
+        $this->assertEquals('first', $first);
+        $this->assertEquals('second', $second);
+        $this->assertEquals('third', $third);
     }
 }
 

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -121,7 +121,7 @@ PHP);
         ]);
     }
 
-    public static function getConcurrencyDrivers() : array
+    public static function getConcurrencyDrivers(): array
     {
         return [
             ['sync'],


### PR DESCRIPTION
### Problem

The current implementation of `Concurrency::run()` with `fork` driver does not preserve the original order of callbacks when returning results. This leads to incorrect variable assignment when destructuring the return value, as shown in the documentation example:

```php
[$userCount, $orderCount] = Concurrency::run([
    fn () => DB::table('users')->count(),
    fn () => DB::table('orders')->count(),
]);
```

If the second callback completes before the first, the results array may be returned in a different order, causing `$userCount` and `$orderCount` to be swapped.

### Solution

This PR modifies the `ForkDriver::run` method to associate results with their original keys and return them in the original order after all tasks are completed.