### PR TITLE
[12.x] Fix `preg_match()` Deprecation Warning 

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -200,7 +200,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Generate an absolute URL to the given path.
      *
-     * @param  string|null  $path
+     * @param  string  $path
      * @param  mixed  $extra
      * @param  bool|null  $secure
      * @return string
@@ -265,7 +265,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Generate the URL to an application asset.
      *
-     * @param  string|null  $path
+     * @param  string  $path
      * @param  bool|null  $secure
      * @return string
      */
@@ -666,16 +666,12 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Determine if the given path is a valid URL.
      *
-     * @param  string|null  $path
+     * @param  string  $path
      * @return bool
      */
     public function isValidUrl($path)
     {
-        if ($path === null) {
-            return false;
-        }
-
-        if (is_string($path) && ! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
+        if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', (string) $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -671,6 +671,10 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
+        if($path === null){
+            return false;
+        }
+        
         if (is_string($path) && ! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -200,7 +200,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Generate an absolute URL to the given path.
      *
-     * @param  string  $path
+     * @param  string|null  $path
      * @param  mixed  $extra
      * @param  bool|null  $secure
      * @return string
@@ -265,7 +265,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Generate the URL to an application asset.
      *
-     * @param  string  $path
+     * @param  string|null  $path
      * @param  bool|null  $secure
      * @return string
      */

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -666,7 +666,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Determine if the given path is a valid URL.
      *
-     * @param  string  $path
+     * @param  string|null  $path
      * @return bool
      */
     public function isValidUrl($path)

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -671,7 +671,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
-        if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
+        if (is_string($path) && ! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -671,10 +671,10 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
-        if($path === null){
+        if ($path === null) {
             return false;
         }
-        
+
         if (is_string($path) && ! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }


### PR DESCRIPTION
Fix `preg_match()` deprecation warning  by handling null values in `isValidUrl ` method.

![image](https://github.com/user-attachments/assets/e3e73ca5-0892-4e82-be3b-0aea4b5721a3)
