### PR TITLE
[12.x] fix: Macroable - Parent's macros get overriden by descendants

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -66,7 +66,7 @@ trait Macroable
 
     /**
      * Get a registered macro.
-     * 
+     *
      * @param  string  $name
      * @return object|callable|null
      */

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -61,7 +61,7 @@ trait Macroable
      */
     public static function hasMacro($name)
     {
-        return isset(static::$macros[static::class][$name]) || (($parent = get_parent_class(static::class)) && $parent::hasMacro($name));
+        return isset(static::$macros[static::class][$name]) || (($parent = get_parent_class(static::class)) && method_exists($parent, 'macro') && $parent::hasMacro($name));
     }
 
     /**
@@ -72,7 +72,7 @@ trait Macroable
      */
     public static function getMacro($method)
     {
-        return static::$macros[static::class][$method] ?? (($parent = get_parent_class(static::class)) ? $parent::getMacro($method) : null);
+        return static::$macros[static::class][$method] ?? (($parent = get_parent_class(static::class)) && method_exists($parent, 'macro') ? $parent::getMacro($method) : null);
     }
 
     /**

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -162,18 +162,18 @@ class SupportMacroableTest extends TestCase
 
     public function testMacroInheritance()
     {
-        EmptyMacroable::macro('inherit', function () {
+        MacroableParent::macro('inherit', function () {
             return 'original';
         });
-        EmptyMacroable::macro('override', function () {
+        MacroableParent::macro('override', function () {
             return 'original';
         });
-        EmptyMacroableChild::macro('override', function () {
+        MacroableChild::macro('override', function () {
             return 'overridden';
         });
 
-        $parent = new EmptyMacroable;
-        $child = new EmptyMacroableChild;
+        $parent = new MacroableParent;
+        $child = new MacroableChild;
 
         $this->assertSame('original', $parent->inherit());
         $this->assertSame('original', $child->inherit());
@@ -185,11 +185,6 @@ class SupportMacroableTest extends TestCase
 class EmptyMacroable
 {
     use Macroable;
-}
-
-class EmptyMacroableChild extends EmptyMacroable
-{
-    //
 }
 
 class TestMacroable
@@ -226,4 +221,17 @@ class TestMixin
             return 'foo';
         };
     }
+}
+
+class EmptyClass
+{
+}
+
+class MacroableParent extends EmptyClass
+{
+    use Macroable;
+}
+
+class MacroableChild extends MacroableParent
+{
 }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -159,11 +159,37 @@ class SupportMacroableTest extends TestCase
 
         $this->assertSame('newMethod', $this->macroable::existingMethod());
     }
+
+    public function testMacroInheritance()
+    {
+        EmptyMacroable::macro('inherit', function () {
+            return 'original';
+        });
+        EmptyMacroable::macro('override', function () {
+            return 'original';
+        });
+        EmptyMacroableChild::macro('override', function () {
+            return 'overridden';
+        });
+
+        $parent = new EmptyMacroable;
+        $child = new EmptyMacroableChild;
+
+        $this->assertSame('original', $parent->inherit());
+        $this->assertSame('original', $child->inherit());
+        $this->assertSame('original', $parent->override());
+        $this->assertSame('overridden', $child->override());
+    }
 }
 
 class EmptyMacroable
 {
     use Macroable;
+}
+
+class EmptyMacroableChild extends EmptyMacroable
+{
+    //
 }
 
 class TestMacroable


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/45391

This change makes it possible to override macros on a child class without affecting the parent class.