### PR TITLE
[POC] Add `static::any()` Model Event for Any Database Change

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -221,8 +221,8 @@ trait HasEvents
             return false;
         }
 
-        if (in_array($event, ['retrieved', 'created', 'updated', 'saved',  'deleted', 'restored', 'replicating'])) {            
-            $this->fireModelEvent('any');
+        if (in_array($event, ['retrieved', 'updated', 'saved',  'deleted', 'restored', 'replicating'])) {            
+            $this->fireModelEvent('any', $halt);
         }
 
         return ! empty($result) ? $result : static::$dispatcher->{$method}(

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -221,6 +221,10 @@ trait HasEvents
             return false;
         }
 
+        if (in_array($event, ['retrieved', 'created', 'updated', 'saved',  'deleted', 'restored', 'replicating'])) {            
+            $this->fireModelEvent('any');
+        }
+
         return ! empty($result) ? $result : static::$dispatcher->{$method}(
             "eloquent.{$event}: ".static::class, $this
         );


### PR DESCRIPTION
**This PR is POC**

**Problem:**  
Currently, to perform an action on any model change, you must register multiple events:

```php
static::saved(function () { /* ... */ });
static::deleted(function () { /* ... */ });
// And so on...
```

Solution:
This PR adds a new any event that fires after all major model changes (create, update, delete, restore). Now you can simply:

```php
static::any(function () { /* ... */ });
```